### PR TITLE
Added caveats docs page

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -1,0 +1,66 @@
+# Caveats
+
+## Vendor / Image Caveats
+
+### Cisco<a name="cisco"></a>
+
+* It's possible to run Cisco IOSv/CSR under Virtualbox if you build your own Vagrant boxes.
+* After building Vagrant boxes, edit **devices** section of **topology-defaults.yml** file to add Virtualbox support for individual network devices.
+
+### Cumulus Linux<a name="cumulus"></a>
+
+#### ContainerLab
+
+* *containerlab* could run Cumulus Linux as a container or as a micro-VM with *firecracker* (default, requires KVM). To run Cumulus VX as a pure container, add **runtime: docker** parameter to node data.
+* *netsim-tools* uses Cumulus VX containers created by Michael Kashin and downloaded from his Docker Hub account. Once Nvidia releases an official container image, change the container name with **defaults.providers.clab.devices.cumulus.image.clab** parameter (or by editing the `topology-defaults.yml` file included with *netsim-tools*).
+
+### Fortinet FortiOS<a name="fortinet"></a>
+
+* *FortiOS* VM images by default have a 15 day evaluation license. The VM has [limited capabilities](https://docs.fortinet.com/document/fortigate-private-cloud/6.0.0/fortigate-vm-on-kvm/504166/fortigate-vm-virtual-appliance-evaluation-license) without a license file. It will work for 15 days from first boot, at which point you must install a license file or recreate the vagrant box completely from scratch.
+* Ansible automation of FortiOS requires the installation of the [FortiOS Ansible Collection 2.1.3 or greater](https://galaxy.ansible.com/fortinet/fortios) and a FortiOS version > 6.0.
+* Ansible configuration of OSPF is currently broken due to a [suspected bug](https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/150) in the FortiOS Ansible Collection. To work around this issue, you must manually configure a OSPF network statement by logging in to the device after initial provisioning. For example:
+
+```bash
+vagrant ssh fw
+config router ospf
+config network
+edit 1
+set area 0.0.0.1
+set prefix 0.0.0.0/0
+end
+end
+```
+
+### FRR<a name="frr"></a>
+
+* *containerlab* FRR containers run FRR release 7.5.0 -- the latest release that survives FRR daemon restart during the initial configuration process.
+* FRR project does not create usable Ubuntu packages. Use Cumulus Linux if you'd like to run FRR within a VM.
+
+### Generic Linux<a name="linux"></a>
+
+* *Generic Linux device* is a Linux VM running Ubuntu 20.04 or an Alpine/Python container. To use any other Linux distribution, add **image** attribute with the name of Vagrant box or Docker container to the node data[^1]; the only requirements are working Python environment (to support Ansible playbooks used in **netlab initial** command) and the presence of **ip** command used in initial device configuration. See also [host routing](#host-routing).
+
+[^1]: You can also set the **defaults.devices.linux.image._provider_** attribute to change the Vagrant box for all Linux hosts in your lab.
+
+#### Host Routing
+
+Generic Linux device is an IP host that does not support IP forwarding or IP routing protocols. It uses static routes set up as follows:
+
+* IPv4 default route points to Vagrant management interface (set by Vagrant/DHCP).
+* IPv6 default route points to whichever adjacent device is sending IPv6 Route Advertisement messages (default Linux behavior).
+* IPv4 static routes for all IPv4 address pools defined in lab topology point to the first neighbor on the first non-management interface.
+
+**Corollary:** Linux devices SHOULD have a single P2P link to an adjacent network device. If you encounter problems using any other lab topology, please submit a Pull Request fixing it instead of complaining ;)
+
+#### LLDP
+
+* LLDP on Generic Linux is started in Ubuntu VMs but not in Alpine containers.
+
+### Juniper vSRX<a name="juniper_srx"></a>
+
+* It's possible to run Juniper vSRX under Virtualbox if you build your own Vagrant boxes.
+* After building Vagrant boxes, edit **devices** section of **topology-defaults.yml** file to add Virtualbox support for individual network devices.
+
+### Mikrotik CHR RouterOS<a name="mikrotik"></a>
+
+* LLDP on Mikrotik CHR RouterOS is enabled on all the interfaces.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,5 +76,6 @@ Getting Started
    :hidden:
 
    release.rst
+   caveats.md
    contribute.md
 ..

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -2,21 +2,21 @@
 
 The following virtual network devices are supported by *netsim-tools*:
 
-| Virtual network device | netsim device type |
-| ---------------------- | ------------------ |
-| Arista vEOS            | eos                |
-| Arrcus ArcOS           | arcos              |
-| Cisco IOSv             | iosv               |
-| Cisco CRS 1000v        | csr                |
-| Cisco Nexus 9300v      | nxos               |
-| Cumulus Linux          | cumulus            |
-| Fortinet FortiOS       | fortios            |
-| FRR 7.5.0              | frr                |
-| Generic Linux host     | linux              |
-| Juniper vSRX 3.0       | vsrx               |
-| Mikrotik CHR RouterOS  | routeros           |
-| Nokia SR Linux         | srlinux            |
-| VyOS                   | vyos               |
+| Virtual network device                    | netsim device type |
+| ----------------------------------------- | ------------------ |
+| Arista vEOS                               | eos                |
+| Arrcus ArcOS                              | arcos              |
+| Cisco IOSv                                | iosv               |
+| Cisco CSR 1000v                           | csr                |
+| Cisco Nexus 9300v                         | nxos               |
+| Cumulus Linux                             | cumulus            |
+| Fortinet FortiOS [❗](caveats.md#fortinet) | fortios            |
+| FRR 7.5.0                                 | frr                |
+| Generic Linux host                        | linux              |
+| Juniper vSRX 3.0                          | vsrx               |
+| Mikrotik CHR RouterOS                     | routeros           |
+| Nokia SR Linux                            | srlinux            |
+| VyOS                                      | vyos               |
 
 **Notes:**
 
@@ -53,38 +53,21 @@ See [lab topology overview](topology-overview.md) for more details.
 
 You cannot use all supported network devices with all virtualization providers:
 
-| Virtual network device        | Vagrant<br />Libvirt | Vagrant<br />Virtualbox | Containerlab |
-| ----------------------------- | :------------------: | :---------------------: | :----------: |
-| Arista vEOS                   |          ✅           |            ✅            |      ✅       |
-| Arrcus ArcOS                  |          ✅           |            ❌            |      ❌       |
-| Cisco IOSv                    |          ✅           |            ❌            |      ❌       |
-| Cisco CRS 1000v               |          ✅           |            ❌            |      ❌       |
-| Cisco Nexus 9300v             |          ✅           |            ✅            |      ❌       |
-| Cumulus Linux                 |          ✅           |            ✅            |      ✅       |
-| Fortinet FortiOS              |          ✅           |            ❌            |      ❌       |
-| FRR 7.5.0                     |          ❌           |            ❌            |      ✅       |
-| Generic Linux (Ubuntu/Alpine) |          ✅           |            ✅            |      ✅       |
-| Juniper vSRX 3.0              |          ✅           |            ❌            |      ❌       |
-| Mikrotik CHR RouterOS         |          ✅           |            ❌            |      ❌       |
-| Nokia SR Linux                |          ❌           |            ❌            |      ✅       |
-| VyOS                          |          ✅           |            ❌            |      ❌       |
-
-**Implementation Caveats**
-
-* *containerlab* could run Cumulus Linux as a container or as a micro-VM with *firecracker* (default, requires KVM). To run Cumulus VX as a pure container, add **runtime: docker** parameter to node data.
-* *netsim-tools* uses Cumulus VX containers created by Michael Kashin and downloaded from his Docker Hub account. Once Nvidia releases an official container image, change the container name with **defaults.providers.clab.devices.cumulus.image.clab** parameter (or by editing the `topology-defaults.yml` file included with *netsim-tools*).
-* *containerlab* FRR containers run FRR release 7.5.0 -- the latest release that survives FRR daemon restart during the initial configuration process.
-* FRR project does not create usable Ubuntu packages. Use Cumulus Linux if you'd like to run FRR within a VM.
-* *Generic Linux device* is a Linux VM running Ubuntu 20.04 or an Alpine/Python container. To use any other Linux distribution, add **image** attribute with the name of Vagrant box or Docker container to the node data[^1]; the only requirements are working Python environment (to support Ansible playbooks used in **netlab initial** command) and the presence of **ip** command used in initial device configuration. See also [host routing](#host-routing).
-* *FortiOS* VM images by default have a 15 day evaluation license. The VM has [limited capabilities](https://docs.fortinet.com/document/fortigate-private-cloud/6.0.0/fortigate-vm-on-kvm/504166/fortigate-vm-virtual-appliance-evaluation-license) without a license file. It will work for 15 days from first boot, at which point you must install a license file or recreate the vagrant box completely from scratch.
-
-[^1]: You can also set the **defaults.devices.linux.image._provider_** attribute to change the Vagrant box for all Linux hosts in your lab.
-
-**Notes on Extending Device- or Virtualization Provider Support**
-
-* It's possible to run Cisco IOSv/CSR or Juniper vSRX under Virtualbox if you build your own Vagrant boxes.
-* After building Vagrant boxes, edit **devices** section of **topology-defaults.yml** file to add Virtualbox support for individual network devices.
-* If you feel like building a downloadable Vagrant box for FRR, please send us the box name and we'll add it to **topology-defaults.yml** file.
+| Virtual network device                             | Vagrant<br />Libvirt |   Vagrant<br />Virtualbox    |       Containerlab       |
+| -------------------------------------------------- | :------------------: | :--------------------------: | :----------------------: |
+| Arista vEOS                                        |          ✅           |              ✅               |            ✅             |
+| Arrcus ArcOS                                       |          ✅           |              ❌               |            ❌             |
+| Cisco IOSv                                         |          ✅           |    ❌[⁇](caveats.md#cisco)    |            ❌             |
+| Cisco CSR 1000v                                    |          ✅           |    ❌[⁇](caveats.md#cisco)    |            ❌             |
+| Cisco Nexus 9300v                                  |          ✅           |              ✅               |            ❌             |
+| Cumulus Linux                                      |          ✅           |              ✅               | ✅[❗](caveats.md#cumulus) |
+| Fortinet FortiOS                                   |          ✅           |              ❌               |            ❌             |
+| FRR 7.5.0                                          |          ❌           |              ❌               |   ✅[❗](caveats.md#frr)   |
+| Generic Linux (Ubuntu/Alpine)[⁇](caveats.md#linux) |          ✅           |              ✅               |            ✅             |
+| Juniper vSRX 3.0                                   |          ✅           | ❌[⁇](caveats.md#juniper_srx) |            ❌             |
+| Mikrotik CHR RouterOS                              |          ✅           |              ❌               |            ❌             |
+| Nokia SR Linux                                     |          ❌           |              ❌               |            ✅             |
+| VyOS                                               |          ✅           |              ❌               |            ❌             |
 
 ## Configuration Deployments
 
@@ -109,25 +92,20 @@ Ansible playbooks included with **netsim-tools** can deploy and collect device c
 
 The following system-wide features are configured on supported network operating systems as part of initial device configuration:
 
-| Operating system      | Hostname | IPv4 hosts | LLDP  | Loopback<br />IPv4 address | Loopback<br />IPv6 address |
-| --------------------- | :------: | :--------: | :---: | :------------------------: | :------------------------: |
-| Arista EOS            |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Arrcus ArcOS          |    ✅     |     ❌      |   ✅   |             ✅              |             ✅              |
-| Cisco IOS/IOS XE      |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Cisco Nexus OS        |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Cumulus Linux         |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Fortinet FortiOS      |    ✅     |     ❌      |   ✅   |             ✅              |             ✅              |
-| FRR 7.5.0             |    ✅     |     ❌      |   ❌   |             ✅              |             ✅              |
-| Generic Linux         |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Juniper vSRX 3.0      |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Nokia SR Linux        |    ❌     |     ❌      |   ❌   |             ❌              |             ❌              |
-| VyOS                  |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-| Mikrotik CHR RouterOS |    ✅     |     ✅      |   ✅   |             ✅              |             ✅              |
-
-**Caveats:**
-
-* LLDP on Generic Linux is started in Ubuntu VMs but not in Alpine containers.
-* LLDP on Mikrotik CHR RouterOS is enabled on all the interfaces.
+| Operating system      | Hostname | IPv4 hosts |           LLDP            | Loopback<br />IPv4 address | Loopback<br />IPv6 address |
+| --------------------- | :------: | :--------: | :-----------------------: | :------------------------: | :------------------------: |
+| Arista EOS            |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Arrcus ArcOS          |    ✅     |     ❌      |             ✅             |             ✅              |             ✅              |
+| Cisco IOS/IOS XE      |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Cisco Nexus OS        |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Cumulus Linux         |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Fortinet FortiOS      |    ✅     |     ❌      |             ✅             |             ✅              |             ✅              |
+| FRR 7.5.0             |    ✅     |     ❌      |             ❌             |             ✅              |             ✅              |
+| Generic Linux         |    ✅     |     ✅      |  ✅[❗](caveats.md#linux)   |             ✅              |             ✅              |
+| Juniper vSRX 3.0      |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Nokia SR Linux        |    ❌     |     ❌      |             ❌             |             ❌              |             ❌              |
+| VyOS                  |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
+| Mikrotik CHR RouterOS |    ✅     |     ✅      | ✅[❗](caveats.md#mikrotik) |             ✅              |             ✅              |
 
 The following interface parameters are configured on supported network operating systems as part of initial device configuration:
 
@@ -149,21 +127,21 @@ The following interface parameters are configured on supported network operating
 
 Individual **netsim-tools** [configuration modules](module-reference.md) are supported on these devices:
 
-| Operating system      | OSPF  | IS-IS | EIGRP |  BGP  | SR-MPLS |
-| --------------------- | :---: | :---: | :---: | :---: | :-----: |
-| Arista EOS            |   ✅   |   ✅   |   ❌   |   ✅   |    ✅    |
-| Arrcus ArcOS          |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
-| Cisco IOS             |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
-| Cisco IOS XE          |   ✅   |   ✅   |   ✅   |   ✅   |    ✅    |
-| Cisco Nexus OS        |   ✅   |   ✅   |   ✅   |   ✅   |    ❌    |
-| Cumulus Linux         |   ✅   |   ❌   |   ❌   |   ✅   |    ❌    |
-| Fortinet FortiOS      |   ✅   |   ❌   |   ❌   |   ❌   |    ❌    |
-| FRR 7.5.0             |   ✅   |   ✅   |   ❌   |   ✅   |    ❌    |
-| Generic Linux         |   ❌   |   ❌   |   ❌   |   ❌   |    ❌    |
-| Juniper vSRX 3.0      |   ✅   |   ✅   |   ❌   |   ✅   |    ❌    |
-| Mikrotik CHR RouterOS |   ✅   |   ❌   |   ❌   |   ✅   |    ❌    |
-| Nokia SR Linux        |   ❌   |   ❌   |   ❌   |   ❌   |    ❌    |
-| VyOS                  |   ✅   |   ❌   |   ❌   |   ✅   |    ❌    |
+| Operating system      |           OSPF           | IS-IS | EIGRP |  BGP  | SR-MPLS |
+| --------------------- | :----------------------: | :---: | :---: | :---: | :-----: |
+| Arista EOS            |            ✅             |   ✅   |   ❌   |   ✅   |    ✅    |
+| Arrcus ArcOS          |            ✅             |   ❌   |   ❌   |   ❌   |    ❌    |
+| Cisco IOS             |            ✅             |   ✅   |   ✅   |   ✅   |    ❌    |
+| Cisco IOS XE          |            ✅             |   ✅   |   ✅   |   ✅   |    ✅    |
+| Cisco Nexus OS        |            ✅             |   ✅   |   ✅   |   ✅   |    ❌    |
+| Cumulus Linux         |            ✅             |   ❌   |   ❌   |   ✅   |    ❌    |
+| Fortinet FortiOS      | [❗](caveats.md#fortinet) |   ❌   |   ❌   |   ❌   |    ❌    |
+| FRR 7.5.0             |            ✅             |   ✅   |   ❌   |   ✅   |    ❌    |
+| Generic Linux         |            ❌             |   ❌   |   ❌   |   ❌   |    ❌    |
+| Juniper vSRX 3.0      |            ✅             |   ✅   |   ❌   |   ✅   |    ❌    |
+| Mikrotik CHR RouterOS |            ✅             |   ❌   |   ❌   |   ✅   |    ❌    |
+| Nokia SR Linux        |            ❌             |   ❌   |   ❌   |   ❌   |    ❌    |
+| VyOS                  |            ✅             |   ❌   |   ❌   |   ✅   |    ❌    |
 
 ## IPv6 Support
 
@@ -183,28 +161,3 @@ Core functionality of *netsim-tools* and all multi-protocol routing protocol con
 | Juniper vSRX 3.0      |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Mikrotik CHR RouterOS |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ❌    |
 | VyOS                  |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ❌    |
-
-## Host Routing
-
-Generic Linux device is an IP host that does not support IP forwarding or IP routing protocols. It uses static routes set up as follows:
-
-* IPv4 default route points to Vagrant management interface (set by Vagrant/DHCP).
-* IPv6 default route points to whichever adjacent device is sending IPv6 Route Advertisement messages (default Linux behavior).
-* IPv4 static routes for all IPv4 address pools defined in lab topology point to the first neighbor on the first non-management interface.
-
-**Corollary:** Linux devices SHOULD have a single P2P link to an adjacent network device. If you encounter problems using any other lab topology, please submit a Pull Request fixing it instead of complaining ;)
-
-<!--
-## BGP Support
-
-Some BGP parameters are not supported on all devices:
-
-| Operating system | IPv6 address<br />family |
-| ---------------- | :----------------------: |
-| Arista EOS       |            ❌             |
-| Cisco IOS/IOS XE |            ❌             |
-| Cisco Nexus OS   |            ❌             |
-| Cumulus Linux    |            ❌             |
-| FRR 7.5.0        |            ❌             |
-| Juniper vSRX 3.0 |            ❌             |
--->

--- a/tests/integration/fortinet.yml
+++ b/tests/integration/fortinet.yml
@@ -1,0 +1,40 @@
+#
+# Simple libvirt lab using two Cumulus VX devices and one Fortinet device
+#
+---
+addressing:
+  loopback:
+    ipv4: 10.0.0.0/24
+    ipv6: 2001:db8:0::/48
+  lan:
+    ipv4: 172.16.0.0/16
+    ipv6: 2001:db8:1::/48
+  p2p:
+    ipv4: 10.1.0.0/24
+    ipv6: 2001:db8:2::/48
+
+nodes:
+  fw:
+    device: fortios
+  r1:
+    device: cumulus
+  r2:
+    device: cumulus
+
+links:
+- fw:
+  r1:
+  bandwidth: 100000
+  name: "fw-r1"
+  prefix:
+    ipv4: 192.168.23.0/24
+    ipv6: 2001:db8:cafe:4::/64
+  ospf:
+    cost: 3
+- r1:
+  r2:
+
+module: [ospf]
+ospf:
+  area: 1
+  reference_bandwidth: 1000


### PR DESCRIPTION
* Added caveats.md and migrated caveats listed on platforms.md to this page, appropriately hyperlinking where appropriate
* Added a fortinet topology to the tests directory
* Modified index.rst so the caveats page will show up on the next docs recreation. @ipspace make sure this is where you want caveats to be listed in the hierarchy. 