### PR TITLE
srlinux bgp refactoring

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -40,10 +40,10 @@ More interesting BGP topologies can be created with [custom plugins](../plugins.
 | --------------------- | :-: | :-: | :-: | :-: |
 | Arista EOS            |  ❌  |  ✅ |  ✅ |  ✅ |
 | Cisco IOS/IOS XE      |  ❌  |  ✅ |  ✅ |  ✅ |
-| Cumulus Linux         |  ✅ |  ❌  |  ❌  |  ❌  |
+| Cumulus Linux         |  ✅  |  ❌ |  ❌  |  ❌  |
 | Dell OS10             |  ❌  |  ✅ |  ❌  |  ❌  |
-| FRR 7.5.0             |  ❌  |  ❌  |  ❌  |  ❌  |
-| Nokia SR Linux        |  ✅ |  ✅ |  ❌  |  ❌  |
+| FRR 7.5.0             |  ❌  |  ❌ |  ❌  |  ❌  |
+| Nokia SR Linux        |  ✅  |  ✅ |  ✅  |  ✅  |
 
 ## Global BGP Configuration Parameters
 

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -76,9 +76,9 @@
   val:
    admin-state: enable
    ipv4-unicast:
-    admin-state: {{ 'enable' if neighbor.activate['ipv4'] else 'disable' }}
+    admin-state: {{ 'enable' if 'ipv4' in neighbor.activate and neighbor.activate['ipv4'] else 'disable' }}
    ipv6-unicast:
-    admin-state: {{ 'enable' if neighbor.activate['ipv6'] else 'disable' }}
+    admin-state: {{ 'enable' if 'ipv6' in neighbor.activate and neighbor.activate['ipv6'] else 'disable' }}
    import-policy: {{ import_policy if 'ebgp' in type else 'accept_all' }}
    export-policy: {{ export_policy if 'ebgp' in type else 'accept_all' }}
    timers:
@@ -110,7 +110,7 @@
   Define IPv4 and IPv6 BGP neighbors
 #}
 {% for n in vrf_bgp.neighbors %}
-{% for af in ['ipv4','ipv6'] if n[af] is defined and n.activate is defined and af in n.activate and n.activate[af] %}
+{% for af in ['ipv4','ipv6'] if n[af] is defined and af in n.activate|default([]) and n.activate[af] %}
 
 {% if n[af] is string %}
 {# (Re)create peer group #}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -51,69 +51,7 @@
     export-reject-all: False
     import-reject-all: False
 
-{#
-    Configure BGP Groups
-#}
-   group:
-{% for g in ['ibgp-ipv4','ibgp-ipv6','ebgp','ebgp-unnumbered'] %}
-{% set _type = g[:4] %}
-   - group-name: {{ g }}
-     admin-state: enable
-     import-policy: {{ import_policy if 'ebgp' in g else 'accept_all' }}
-     export-policy: {{ export_policy if 'ebgp' in g else 'accept_all' }}
-     timers:
-      connect-retry: 10
-      _annotate_connect-retry: "Reduce default 120s to 10s"
-      minimum-advertisement-interval: 1
-
-{# BGP communities #}
-{%   if bgp.community[ _type ]|default([]) %}
-{%   set list = bgp.community[ _type ] %}
-     send-community:
-      standard: {{ 'standard' in list or 'both' in list }}
-      large: {{ 'large' in list }}
-{%   endif %}
-
-{# iBGP #}
-{%   if g in ['ibgp-ipv4','ibgp-ipv6'] %}
-     peer-as: {{ _as }}
-     ipv4-unicast:
-      admin-state: {{ 'enable' if g == 'ibgp-ipv4' and 'ipv4' in bgp.address_families['ibgp'] else 'disable' }}
-     ipv6-unicast:
-      admin-state: {{ 'enable' if g == 'ibgp-ipv6' or 'ipv6' in bgp.address_families['ibgp'] else 'disable' }}
-     evpn:
-      admin-state: {{ 'enable' if evpn is defined and 'ibgp' in evpn.session|default([]) else 'disable' }}
-{%   if g[5:] in loopback %}
-     transport:
-      local-address: {{ loopback[ g[5:] ]|default('')|ipaddr('address') }}
-{%   endif %}
-{%   if vrf_bgp.rr|default(0) %}
-     route-reflector:
-      cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
-      client: True
-{%   endif %}
-{%   else %}
-
-{# eBGP #}
-     next-hop-self: {{ 'True' if bgp.next_hop_self|default(False) else 'False' }}
-{%   if g == 'ebgp-unnumbered' %}
-     local-as:
-     - as-number: {{ bgp.underlay_as|default(_as) }}
-       prepend-global-as: false
-     ipv4-unicast:
-      advertise-ipv6-next-hops: true
-      receive-ipv6-next-hops: true
-{%   else %}
-     ipv4-unicast:
-{%   endif %}
-      admin-state: {{ 'enable' if 'ipv4' in bgp.address_families['ebgp'] else 'disable' }}
-     ipv6-unicast:
-      admin-state: {{ 'enable' if 'ipv6' in bgp.address_families['ebgp'] else 'disable' }}
-{%   endif %}
-
-{% endfor %}
-
-{# Configure BGP address families #}
+{# Configure BGP address families globally #}
 {% for af in ['ipv4','ipv6'] if vrf_bgp[af]|default(0) %}
    {{ af }}-unicast:
     admin-state: enable
@@ -133,29 +71,83 @@
 
 {% endfor %}
 
+{% macro bgp_peer_group(name,type,import_policy,export_policy,neighbor,transport_ip) %}
+- path: network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
+  val:
+   admin-state: enable
+   ipv4-unicast:
+    admin-state: {{ 'enable' if neighbor.activate['ipv4'] else 'disable' }}
+   ipv6-unicast:
+    admin-state: {{ 'enable' if neighbor.activate['ipv6'] else 'disable' }}
+   import-policy: {{ import_policy if 'ebgp' in type else 'accept_all' }}
+   export-policy: {{ export_policy if 'ebgp' in type else 'accept_all' }}
+   timers:
+    connect-retry: 10
+    _annotate_connect-retry: "Reduce default 120s to 10s"
+    minimum-advertisement-interval: 1
+   next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
+{% if vrf_bgp.community[ type ]|default([]) %}
+{% set list = vrf_bgp.community[ type ] %}
+   send-community:
+    standard: {{ 'standard' in list }}
+    large: {{ 'extended' in list }}
+{% endif %}
+{% if transport_ip %}
+   transport:
+    local-address: {{ transport_ip }}
+{% endif %}
+{% if 'ibgp' in type %}
+   peer-as: {{ neighbor.as }}
+{%  if vrf_bgp.rr|default(0) %}
+   route-reflector:
+    cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
+    client: True
+{%  endif %}
+{% endif %}
+{% endmacro %}
+
 {#
   Define IPv4 and IPv6 BGP neighbors
 #}
 {% for n in vrf_bgp.neighbors %}
-{% for af in ['ipv4','ipv6'] if n[af] is defined %}
+{% for af in ['ipv4','ipv6'] if n[af] is defined and af in vrf_bgp.sessions and n.type in vrf_bgp.sessions[af] %}
+
 {% if n[af] is string %}
+{# (Re)create peer group #}
+{% set peer_group = 'ebgp' if n.type=='ebgp' else 'ibgp-local-as' if n.type=='localas_ibgp' else ('ibgp-'+af) %}
+{% set transport_ip = loopback[af] if af in loopback and n.type=='ibgp' else None %}
+{{ bgp_peer_group(peer_group,'ibgp' if 'ibgp' in n.type else 'ebgp',n,transport_ip) }}
+
 - path: network-instance[name={{vrf}}]/protocols/bgp/neighbor[peer-address={{n[af]}}]
   val:
    description: {{ n.name }}
-   peer-group: {{ 'ebgp' if n.type=='ebgp' else ('ibgp-'+af) }}
-{% if n.type != 'ibgp' %}
+   peer-group: {{ peer_group }}
+{% if 'ebgp' in n.type %}
    peer-as: {{ n.as }}
+{% elif vrf_bgp.rr|default(False) and n.rr|default(False) %}
+   route-reflector:
+    client: False # Don't reflect routes between ibgp route reflectors
 {% endif %}
 {% if n.local_as is defined %}
    local-as:
    - as-number: {{ n.local_as }}
-{%   if n.type == 'ebgp' %}
-     prepend-global-as: False # Don't include iBGP AS in eBGP advertisements
-{%   endif %}
+     prepend-global-as: {{ not n.replace_global_as|default(True) }} # Don't include iBGP global AS in eBGP advertisements
 {% endif %}
+
 {% elif n[af]==True and af=='ipv6' %}
 {# BGP unnumbered for IPv6 LLA #}
 {% set peer_group = "ebgp-unnumbered" + (('-' + n.local_as|string()) if n.local_as is defined else '') %}
+{{ bgp_peer_group(peer_group,'ebgp','accept_all','accept_all',n,None) }}
+{% if n.local_as is defined %}
+   local-as:
+   - as-number: {{ n.local_as }}
+     prepend-global-as: {{ not n.replace_global_as|default(True) }} # Don't include iBGP AS in eBGP advertisements
+{% endif %}
+{% if 'ipv4' in n.activate|default([]) and n.activate[ 'ipv4' ] %}
+    ipv4-unicast:
+     advertise-ipv6-next-hops: true
+     receive-ipv6-next-hops: true
+{% endif %}
 
 - path: network-instance[name={{vrf}}]/ip-forwarding
   val:
@@ -169,25 +161,9 @@
 - path: network-instance[name={{vrf}}]/protocols/bgp/dynamic-neighbors/interface[interface-name={{if_name}}.{{if_index}}]
   val:
    peer-group: "{{ peer_group }}"
-   allowed-peer-as: [ {{ n.as }}..{{ n.as }} ]
+{% set _as = i.bgp.local_as if 'bgp' in i and 'local_as' in i.bgp else n.as %}
+   allowed-peer-as: [ {{ _as }}..{{ _as }} ]
 
-{% if peer_group != "ebgp-unnumbered" %}
-- path: network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{peer_group}}]
-  val:
-   admin-state: enable
-   import-policy: accept_all
-   export-policy: accept_all
-   timers:
-    connect-retry: 10
-    _annotate_connect-retry: "Reduce default 120s to 10s"
-    minimum-advertisement-interval: 1
-   local-as:
-   - as-number: {{ n.local_as }}
-     prepend-global-as: false
-   ipv4-unicast:
-     advertise-ipv6-next-hops: true
-     receive-ipv6-next-hops: true
-{% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -110,7 +110,7 @@
   Define IPv4 and IPv6 BGP neighbors
 #}
 {% for n in vrf_bgp.neighbors %}
-{% for af in ['ipv4','ipv6'] if n[af] is defined and af in n.activate|default([]) and n.activate[af] %}
+{% for af in ['ipv4','ipv6'] if n[af] is defined %}
 
 {% if n[af] is string %}
 {# (Re)create peer group #}
@@ -144,7 +144,7 @@
      prepend-global-as: {{ not n.replace_global_as|default(True) }} # Don't include iBGP AS in eBGP advertisements
 {% endif %}
 {% if 'ipv4' in n.activate|default([]) and n.activate[ 'ipv4' ] %}
-    ipv4-unicast:
+   ipv4-unicast:
      advertise-ipv6-next-hops: true
      receive-ipv6-next-hops: true
 {% endif %}
@@ -161,8 +161,7 @@
 - path: network-instance[name={{vrf}}]/protocols/bgp/dynamic-neighbors/interface[interface-name={{if_name}}.{{if_index}}]
   val:
    peer-group: "{{ peer_group }}"
-{% set _as = i.bgp.local_as if 'bgp' in i and 'local_as' in i.bgp else n.as %}
-   allowed-peer-as: [ {{ _as }}..{{ _as }} ]
+   allowed-peer-as: [ {{ n.as }}..{{ n.as }} ]
 
 {% endfor %}
 {% endif %}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -110,7 +110,7 @@
   Define IPv4 and IPv6 BGP neighbors
 #}
 {% for n in vrf_bgp.neighbors %}
-{% for af in ['ipv4','ipv6'] if n[af] is defined and af in vrf_bgp.sessions and n.type in vrf_bgp.sessions[af] %}
+{% for af in ['ipv4','ipv6'] if n[af] is defined and n.activate is defined and n.activate[af] %}
 
 {% if n[af] is string %}
 {# (Re)create peer group #}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -71,7 +71,7 @@
 
 {% endfor %}
 
-{% macro bgp_peer_group(name,type,import_policy,export_policy,neighbor,transport_ip) %}
+{% macro bgp_peer_group(name,type,neighbor,transport_ip) %}
 - path: network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
   val:
    admin-state: enable
@@ -110,7 +110,7 @@
   Define IPv4 and IPv6 BGP neighbors
 #}
 {% for n in vrf_bgp.neighbors %}
-{% for af in ['ipv4','ipv6'] if n[af] is defined and n.activate is defined and n.activate[af] %}
+{% for af in ['ipv4','ipv6'] if n[af] is defined and n.activate is defined and af in n.activate and n.activate[af] %}
 
 {% if n[af] is string %}
 {# (Re)create peer group #}
@@ -137,7 +137,7 @@
 {% elif n[af]==True and af=='ipv6' %}
 {# BGP unnumbered for IPv6 LLA #}
 {% set peer_group = "ebgp-unnumbered" + (('-' + n.local_as|string()) if n.local_as is defined else '') %}
-{{ bgp_peer_group(peer_group,'ebgp','accept_all','accept_all',n,None) }}
+{{ bgp_peer_group(peer_group,'ebgp',n,None) }}
 {% if n.local_as is defined %}
    local-as:
    - as-number: {{ n.local_as }}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -40,7 +40,7 @@ updates:
   val:
 {{  ip_addresses(loopback,False,True)  }}
 
-{% for l in interfaces|default([]) if (l.type in ['lan','vlan_member','svi'] or l.vlan is not defined) %}
+{% for l in interfaces|default([]) %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else l.vlan.access_id|default(0) if l.vlan is defined else '0' %}
@@ -83,25 +83,27 @@ updates:
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
+- path: network-instance[name={{ vrf }}]
+  val:
+   type: {{ 'default' if vrf=='default' else 'ip-vrf' }}
+   interface:
    - name: {{ if_name }}.{{ if_index }}
 {% endfor %}
 {% endmacro %}
 
-{# Make sure the default VRF is called 'default' #}
+{# Make sure the default VRF is called 'default', and has system0.0 interface #}
 - path: network-instance[name=default]
   val:
    type: default
    interface:
    - name: system0.0
+
 {{ list_interfaces('default') }}
 
 {% if vrfs is defined %}
 {% for vname,vdata in vrfs.items() %}
-- path: network-instance[name={{ vname }}]
-  val:
-   type: ip-vrf
-   # TODO: vdata.rd, vdata.import/export, vdata.af
-   interface:
+
+# TODO: vdata.rd, vdata.import/export, vdata.af
 {{ list_interfaces(vname) }}
 
 {% endfor %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -9,8 +9,10 @@ updates:
     vni: {{ vlan.vni }}
    egress:
     source-ip: use-system-ipv4-address
+
 - path: network-instance[name=vlan_{{vname}}]
   val:
+   type: mac-vrf
    vxlan-interface:
    - name: vxlan0.{{ vlan.id }}
    protocols:

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -239,9 +239,10 @@ parameters, set neighbor.activate.AF flags
 def activate_bgp_default_af(node: Box, activate: Box, topology: Box) -> None:
   for ngb in node.bgp.neighbors:
     for af in ('ipv4','ipv6'):
-      # if af in ngb: # JvB allow activation of ipv6 over an ipv4 session, and vice versa
-      #  ngb.activate[af] = node.bgp.get(af) and af in activate and ngb.type in activate[af]
-      ngb.activate[af] = af in activate and ngb.type in activate[af]
+      if af in ngb: # JvB by default, activate ipv4 over ipv4 and/or ipv6 over ipv6
+        ngb.activate[af] = node.bgp.get(af) and af in activate and ngb.type in activate[af]
+      elif af=='ipv4' and 'ipv6' not in activate and af in activate and ngb.type in activate[af]:
+        ngb.activate[af] = True # but also allow ipv4-over-ipv6-only
 
 """
 build_bgp_sessions: create BGP session data structure

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -208,7 +208,7 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
       for k in ('local_as','replace_global_as'):
         local_as_data = data.get_from_box(l,f'bgp.{k}') or data.get_from_box(node,f'bgp.{k}')
         if not local_as_data is None:
-          extra_data[k] = local_as_data
+          extra_data[k] = local_as_data # This is the local_as to use towards this neighbor (!)
 
       session_type = 'localas_ibgp' if neighbor_local_as == node_local_as else 'ebgp'
       if session_type == 'localas_ibgp':
@@ -239,8 +239,9 @@ parameters, set neighbor.activate.AF flags
 def activate_bgp_default_af(node: Box, activate: Box, topology: Box) -> None:
   for ngb in node.bgp.neighbors:
     for af in ('ipv4','ipv6'):
-      if af in ngb:
-        ngb.activate[af] = node.bgp.get(af) and af in activate and ngb.type in activate[af]
+      # if af in ngb: # JvB allow activation of ipv6 over an ipv4 session, and vice versa
+      #  ngb.activate[af] = node.bgp.get(af) and af in activate and ngb.type in activate[af]
+      ngb.activate[af] = af in activate and ngb.type in activate[af]
 
 """
 build_bgp_sessions: create BGP session data structure

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -512,12 +512,14 @@ devices:
     external:
       image: none
     graphite.icon: router
-    features:
-      bgp:
-        local_as: True
-        vrf_local_as: True
-        local_as_ibgp: True
-        activate_af: True
+
+    # JvB: Working on these...
+    # features:
+    #   bgp:
+    #     local_as: True
+    #     vrf_local_as: True
+    #     local_as_ibgp: True
+    #     activate_af: True
 
   linux:
     interface_name: eth%d

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -512,6 +512,12 @@ devices:
     external:
       image: none
     graphite.icon: router
+    features:
+      bgp:
+        local_as: True
+        vrf_local_as: True
+        local_as_ibgp: True
+        activate_af: True
 
   linux:
     interface_name: eth%d
@@ -701,7 +707,7 @@ devices:
         local_as_ibgp: True
         activate_af: True
       vxlan:
-        requires: [ evpn ]
+        requires: [ evpn, vrf ]
       ospf:
         unnumbered: False
       isis:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -672,9 +672,10 @@ devices:
       srgb_range_size: 1000
       ipv6_sid_offset: 100
     bgp:
-      address_families:
-        ibgp: [ ipv4, ipv6 ]
-        ebgp: [ ipv4, ipv6 ]      
+      local_as: True
+      vrf_local_as: True
+      local_as_ibgp: True
+      activate_af: True
     bfd:           # SR Linux supports lower BFD timers than the global default
       min_tx: 100
       min_rx: 100

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -671,11 +671,6 @@ devices:
       srgb_range_start: 500000
       srgb_range_size: 1000
       ipv6_sid_offset: 100
-    bgp:
-      local_as: True
-      vrf_local_as: True
-      local_as_ibgp: True
-      activate_af: True
     bfd:           # SR Linux supports lower BFD timers than the global default
       min_tx: 100
       min_rx: 100
@@ -700,6 +695,11 @@ devices:
         svi_interface_name: "irb0.{vlan}"
         subif_name: "{ifname}.{vlan.access_id}"
         mixed_trunk: True
+      bgp:
+        local_as: True
+        vrf_local_as: True
+        local_as_ibgp: True
+        activate_af: True
       vxlan:
         requires: [ evpn ]
       ospf:

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -54,9 +54,6 @@ nodes:
       ipv4: true
     bgp:
       address_families:
-        ebgp:
-        - ipv4
-        - ipv6
         ibgp:
         - ipv4
       advertise_loopback: true


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/369

* Support bgp.local_as, bgp.sessions, bgp.activate, bgp.replace_global_as
* Remove bgp.address_families from srlinux (TBD sros)
* Patch bgp module to also allow ipv4 af activation in an ipv6-only transport session (we may want to change how this is implemented/flagged)