### PR TITLE
Support ipv4-over-ipv6 for srlinux devices

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -76,7 +76,9 @@
   val:
    admin-state: enable
    ipv4-unicast:
-    admin-state: {{ 'enable' if 'ipv4' in neighbor.activate and neighbor.activate['ipv4'] else 'disable' }}
+    admin-state: {{ 'enable' if 'ipv4' in neighbor.activate and neighbor.activate['ipv4'] 
+                             or 'ipv6' in neighbor.activate and not neighbor.activate['ipv6'] 
+                    else 'disable' }}
    ipv6-unicast:
     admin-state: {{ 'enable' if 'ipv6' in neighbor.activate and neighbor.activate['ipv6'] else 'disable' }}
    import-policy: {{ import_policy if 'ebgp' in type else 'accept_all' }}


### PR DESCRIPTION
Sample config:
```
bgp:
  as: 64999
  sessions: # Transport sessions to use
    ipv4: [ ibgp ] # IBGP-v4 over EBGP-v6
    ipv6: [ ebgp ]
  activate: # Address families to activate
    ipv4: [ ibgp, ebgp ] # Only activate ipv4
```

This results in an ipv6 lla neighbor with bgp.activate.ipv6 = False (and ipv4 not set). Since at least 1 address family must be activated, the template selects ipv4 for this case