### PR TITLE
Changed containerlab download url in install script

### DIFF
--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -79,7 +79,7 @@ echo "Install Docker Engine"
 $SUDO apt-get update
 $SUDO apt-get install -y $FLAG_QUIET docker-ce docker-ce-cli containerd.io
 echo "Install containerlab"
-$SUDO bash -c "$(curl -sL https://get-clab.srlinux.dev)"
+$SUDO bash -c "$(curl -sL https://get.containerlab.dev)"
 set +e
 G="$(groups $USER|grep docker)"
 set -e


### PR DESCRIPTION
Hi,
I faced an error during installation test phase, when running "netlab test clab"

```
Step 1: Checking virtualization provider installation
============================================================
Error executing containerlab version:
  [Errno 2] No such file or directory: 'containerlab'
Fatal error in netlab: containerlab version failed, aborting
```

I figured out that the current url called in installation script is not resolving anymore.

```
~$ dig get-clab.srlinux.dev +answer +noall
~$
```

Containerlab website points to a new location now: https://get.containerlab.dev
Source: https://containerlab.dev/install/
