### PR TITLE
Changes to support ipv6 ebgp unnumbered with rfc8950 ipv4 forwarding

### DIFF
--- a/netsim/addressing.py
+++ b/netsim/addressing.py
@@ -65,6 +65,8 @@ def normalize_prefix(pfx: typing.Union[str,Box]) -> Box:
   for af in 'ipv4','ipv6':
     if af in pfx:
       if not pfx[af] or 'unnumbered' in pfx:
+        if common.DEBUG:
+          print( f"normalize_prefix: Removing {af} prefix {pfx[af]} from {pfx}" )
         del pfx[af]
 
   return pfx

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -1,5 +1,5 @@
 {% macro ip_addresses(intf,ipv6_ra,is_system) %}
-{% if 'ipv4' in intf %}
+{% if 'ipv4' in intf and intf.ipv4 is string %}
     ipv4:
      address:
      - ip-prefix: "{{ intf.ipv4 }}"

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -103,6 +103,8 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, sessions: Box, extra_data: typin
           ngb[af] = intf[af]
         else:
           ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
+    elif af in intf and isinstance(intf[af],bool):
+      ngb[af] = intf[af] # Support ipv6 ebgp sessions with an ipv4 datapath
 
   return ngb if af_count > 0 else None
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -103,8 +103,6 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, sessions: Box, extra_data: typin
           ngb[af] = intf[af]
         else:
           ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
-    elif af in intf and isinstance(intf[af],bool):
-      ngb[af] = intf[af] # Support ipv6 ebgp sessions with an ipv4 datapath
 
   return ngb if af_count > 0 else None
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -690,7 +690,7 @@ devices:
       initial:
         system_mtu: True
         ipv4:
-          unnumbered: False
+          unnumbered: True
         ipv6:
           lla: True
       vlan:


### PR DESCRIPTION
In support of https://github.com/ipspace/netlab/issues/381

My topology:
```
addressing:
  fabric:
    # unnumbered: true # old style
    ipv4: true
    ipv6: true

bgp:
  as: 64999
  # sessions: # Transport sessions to use - leave at default
  #  ipv4: [ ibgp ] # IBGP-v4 over EBGP-v6
  #  ipv6: [ ebgp ]
  activate: # Address families to activate
    ipv4: [ ebgp ] # Only activate ipv4 over eBGP, use iBGP for EVPN only
```