### PR TITLE
srlinux refactor templates and add vxlan l3 vrf support

### DIFF
--- a/docs/dev/config/vlan.md
+++ b/docs/dev/config/vlan.md
@@ -73,7 +73,7 @@ devices:
     features:
       vlan:
         model: router
-        svi_interface_name: "{ifname}.{vlan}"
+        svi_interface_name: "irb0.{vlan}"
         subif_name: "{ifname}.{subif_index}"
   vyos:
     features:

--- a/docs/dev/config/vlan.md
+++ b/docs/dev/config/vlan.md
@@ -73,7 +73,7 @@ devices:
     features:
       vlan:
         model: router
-        svi_interface_name: "irb0.{vlan}"
+        svi_interface_name: "vlan{vlan}"
         subif_name: "{ifname}.{subif_index}"
   vyos:
     features:

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -23,7 +23,7 @@ The following table describes per-platform support of individual VXLAN features:
 | Operating system   | VXLAN<br>transport | VLAN-based<br>service | VLAN Bundle<br>service | Asymmetric<br>IRB | Symmetric<br>IRB |
 | ------------------ | :-: | :-: | :-: | :-: | :-: |
 | Arista EOS         | ✅  | ✅  | ✅  |  ❌  | ✅  |
-| Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  |  ❌  |
+| Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  |  ✅  |
 | Nokia SR OS        |  ❌  |  ❌  |  ❌  |  ❌  |  ❌  |
 | FRR                |  ❌  |  ❌  |  ❌  |  ❌  |  ❌  |
 | VyOS               |  ✅  |  ✅  |  ❌  |  ❌  |  ✅  |
@@ -56,7 +56,8 @@ EVPN module supports these default/global/node parameters:
 
 * **evpn.session** (global or node parameter): A list of BGP session types on which the EVPN address family is enabled (default: `ibgp`)
 * **evpn.vlan_bundle_service** (global or node parameter): Use VLAN bundle service for VLANs within a VRF (default: `False`)
-* **evpn.start_transit_vni** (system default parameter) -- the first symmetric IRB transit VNI
+* **evpn.start_transit_vni** (system default parameter) -- the first symmetric IRB transit VNI, range 4096..16777215
+* **evpn.start_transit_evi** (system default parameter) -- the first symmetric IRB transit EVI, range 1..65535
 
 ### VLAN-Based Service Parameters
 
@@ -85,6 +86,6 @@ The default value of VRF EVPN Instance identifier is the VLAN ID of the first VL
 IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addresses:
 
 * Asymmetric IRB requires no extra parameters[^NS]
-* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. That parameter could be set to an integer value or to *True* in which case the EVPN configuration module assigns a VNI to the VRF.
+* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter, and an optional **evpn.transit_evi** parameter. Those parameters could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns VNI/EVI values to the VRF.
 
 [^NS]: Asymmetric IRB is not supported at the moment

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -57,7 +57,6 @@ EVPN module supports these default/global/node parameters:
 * **evpn.session** (global or node parameter): A list of BGP session types on which the EVPN address family is enabled (default: `ibgp`)
 * **evpn.vlan_bundle_service** (global or node parameter): Use VLAN bundle service for VLANs within a VRF (default: `False`)
 * **evpn.start_transit_vni** (system default parameter) -- the first symmetric IRB transit VNI, range 4096..16777215
-* **evpn.start_transit_evi** (system default parameter) -- the first symmetric IRB transit EVI, range 1..65535
 
 ### VLAN-Based Service Parameters
 
@@ -86,6 +85,6 @@ The default value of VRF EVPN Instance identifier is the VLAN ID of the first VL
 IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addresses:
 
 * Asymmetric IRB requires no extra parameters[^NS]
-* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter, and an optional **evpn.transit_evi** parameter. Those parameters could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns VNI/EVI values to the VRF.
+* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. This parameter could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns a VNI to the VRF. Note that the EVI value used in this case is currently based on the VRF ID (vrfidx)
 
 [^NS]: Asymmetric IRB is not supported at the moment

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -1,26 +1,29 @@
-{% macro ip_addresses(intf,ipv6_ra,is_system) %}
+{% macro ip_addresses(name,index,intf,ipv6_ra=True,is_system=False) %}
+- path: interface[name={{name}}]/subinterface[index={{index}}]
+  val:
+   description: {{ intf.name | default( "No description" )|replace('->','~')|regex_replace('[\\[\\]]','') }}
 {% if 'ipv4' in intf and intf.ipv4 is string %}
-    ipv4:
-     address:
-     - ip-prefix: "{{ intf.ipv4 }}"
+   ipv4:
+    address:
+    - ip-prefix: "{{ intf.ipv4 }}"
 {% if not is_system %}
-       primary: [null]
+      primary: [null]
 {% endif %}
 {% endif %}
 {% if 'ipv6' in intf %}
-    ipv6:
+   ipv6:
 {%   if intf.ipv6 is string %}
-     address:
-     - ip-prefix: "{{ intf.ipv6 }}"
+    address:
+    - ip-prefix: "{{ intf.ipv6 }}"
 {%   endif %}
 {% if ipv6_ra %}
-     neighbor-discovery:
-      learn-unsolicited: link-local
-     router-advertisement:
-      router-role:
-       admin-state: enable             # no ipv6 nd suppress-ra
-       # min-advertisement-interval: 5 # Leave at platform default 200..600
-       # max-advertisement-interval: 5
+    neighbor-discovery:
+     learn-unsolicited: link-local
+    router-advertisement:
+     router-role:
+      admin-state: enable             # no ipv6 nd suppress-ra
+      # min-advertisement-interval: 5 # Leave at platform default 200..600
+      # max-advertisement-interval: 5
 {% endif %}
 {% endif %}
 {% endmacro %}
@@ -39,14 +42,13 @@ updates:
    _annotate_default-ip-mtu: "Custom system wide setting, overrides default 1500"
 {% endif %}
 {% endif %}
-- path: interface[name=system0]/subinterface[index=0]
-  val:
-{{  ip_addresses(loopback,False,True)  }}
 
-{% for l in interfaces|default([]) %}
+{{  ip_addresses('system0',0,loopback,False,True)  }}
+
+{% for l in interfaces|default([]) if l.vlan is not defined or l.vlan.mode|default('irb')=='route' %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}
-{% set if_index = if_name_index[1] if if_name_index|length > 1 else l.vlan.access_id|default(0) if l.vlan is defined else '0' %}
+{% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
 {% set vlan = l.vlan.access|default(l.vlan.access_id|default('routed')|string()) if l.vlan is defined else l.ifname %}
 {% set if_desc = l.name|default( "vlan " + vlan )|replace('->','~')|regex_replace('[\\[\\]]','') %}
 - path: interface[name={{ if_name }}]
@@ -54,29 +56,14 @@ updates:
 {% if l.mtu is defined %} # min 1500; max 9412 for 7220, 9500 for 7250 platforms
    mtu {{ [l.mtu + 14,1500]|max }} # TODO not supported on loopback interfaces
 {% endif %}
-{% if l.subif_index is not defined %}{# Skip trunk parent interfaces #}
-{% if l.type in ["vlan_member"] %}
-   vlan-tagging: True
-{% endif %}
+{% if l.subif_index is defined %}{# Trunk parent interfaces #}
+   description: "Trunk {{ if_desc }}"
+{% else %}
    subinterface:
     index: {{ if_index }}
     description: "{{ if_desc }}"
-{% if l.vlan is defined and l.type in ["vlan_member","lan"] %}
-    type: {{ 'bridged' if l.vlan.access is defined and vlans[ l.vlan.access ].mode|default('irb') in ['bridge','irb'] else 'routed' }}
-{%  if l.type in ["vlan_member"] %}
-    vlan:
-     encap:
-{%    if l.vlan.access_id is defined %}
-      single-tagged:
-       vlan-id: "{{ l.vlan.access_id }}"
-{%    else %}
-      untagged: { }
-{%    endif %}
-{%  endif %}
-{% endif %}
-{{  ip_addresses(l,True,False) }}
-{% else %}
-   description: "Trunk {{ if_desc }}"
+
+{{ ip_addresses(if_name,if_index,l) }}
 {% endif %}
 {% endfor %}
 

--- a/netsim/ansible/templates/ospf/srlinux.macro.j2
+++ b/netsim/ansible/templates/ospf/srlinux.macro.j2
@@ -22,15 +22,10 @@
          - interface-name: system0.0
            passive: True
 {%     endif %}
-{%     for l in vrf_interfaces if (l.vlan is not defined or l.vlan.mode|default('bridge')=='route') and l.subif_index is not defined %}
-{%     set ifname = l.ifname if '.' in l.ifname else (l.ifname+'.0') %}
+{%     for l in vrf_interfaces if (l.vlan is not defined or l.vlan.mode|default('irb')!='bridge') and l.subif_index is not defined %}
+{%     set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
 {%     if 'ospf' not in l %}
        # OSPF not configured on external interface {{ ifname }}
-       - area-id: {{ ospf.area }}
-         interface:
-         - interface-name: {{ ifname }}
-           admin-state: disable
-           _annotate_admin-state: "Disabled: external interface"
 {%     else %}
        - area-id: {{ l.ospf.area }}
          interface:

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -40,10 +40,18 @@ updates:
   val:
    interface:
    - name: {{ ifname }}.{{ vlan }}
+
+{% if ifname=="irb0" %}
+- path: network-instance[name={{ i.vrf|default('default') }}]
+  val:
+   interface:
+   - name: {{ ifname }}.{{ vlan }}
+{% endif %}
+
 {% endmacro %}
 
 {% for l in interfaces|default([]) if l.vlan is defined %}
-{%  if l.type in ['svi'] and l.vlan.mode|default('irb') != 'bridge' %}
+{%  if l.type in ['svi'] and l.vlan.mode|default('irb') == 'irb' %}
 {%    set vlan = l.ifname[4:]|int %}
 {{    add_interface( l.ifname, "irb0", vlan, l ) }}
 {%  elif l.type in ['lan','vlan_member'] %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -1,20 +1,53 @@
+{% from "templates/initial/srlinux.j2" import ip_addresses with context %}
+
 updates:
 {# Create mac-vrfs for L2 VLANs, add IRB interface if any #}
 {% if vlans is defined %}
 {% for vname,vdata in vlans.items() if vdata.mode|default('irb') != 'route' %}
-{% set irb_ifname = "irb0." + vdata.id | string() %}
-- path: network-instance[name=vlan_{{ vname }}]
+{# Use only vlan.id in name, such that svi interfaces can be associated #}
+- path: network-instance[name=vlan{{ vdata.id }}]
   val:
    type: mac-vrf
-   interface:
-{% for l in interfaces|default([]) %}
-{%  if l.type in ['lan'] and l.vlan is defined and l.vlan.access == vname %}
-   - name: {{ l.ifname }}.{{ l.vlan.access_id }}
-{%  elif l.type in ['vlan_member'] and l.vlan is defined and l.vlan.access|default('?') == vname %}
-   - name: {{ l.ifname }}
-{%  elif l.type=='svi' and l.ifname == irb_ifname and (l.vlan is not defined or l.vlan.mode|default('irb') == 'irb') %}
-   - name: {{ l.ifname }}
-{%  endif %}
-{% endfor %}
+   description: "VLAN {{ vname }}"
 {% endfor %}
 {% endif %}
+
+{% macro add_interface(macvrf,ifname,vlan,i) %}
+- path: interface[name={{ifname}}]
+  val:
+{% if i.type in ["vlan_member"] %}
+   vlan-tagging: True
+{% endif %}
+   subinterface:
+   - index: {{ vlan }}
+{%   if ifname!="irb0" %}
+     type: bridged
+{%    if i.type in ["vlan_member"] %}
+     vlan:
+      encap:
+{%     if i.vlan.access_id is defined %}
+       single-tagged:
+        vlan-id: "{{ i.vlan.access_id }}"
+{%     else %}
+       untagged: { }
+{%     endif %}
+{%    endif %}
+{% endif %}
+
+{{ ip_addresses(ifname,vlan,i) }}
+
+- path: network-instance[name={{ macvrf }}]
+  val:
+   interface:
+   - name: {{ ifname }}.{{ vlan }}
+{% endmacro %}
+
+{% for l in interfaces|default([]) if l.vlan is defined %}
+{%  if l.type in ['svi'] and l.vlan.mode|default('irb') != 'bridge' %}
+{%    set vlan = l.ifname[4:]|int %}
+{{    add_interface( l.ifname, "irb0", vlan, l ) }}
+{%  elif l.type in ['lan','vlan_member'] %}
+{%    set vlan = l.vlan.access_id %}
+{{    add_interface( "vlan" + vlan|string, l.parent_ifname|default(l.ifname), vlan, l ) }}
+{%  endif %}
+{% endfor %}

--- a/netsim/ansible/templates/vrf/srlinux.j2
+++ b/netsim/ansible/templates/vrf/srlinux.j2
@@ -2,10 +2,24 @@
 {% from "templates/bgp/srlinux.macro.j2" import bgp_config with context %}
 updates:
 {% for vname,vdata in vrfs.items() %}
+
+- path: network-instance[name={{vname}}]
+  val:
+   type: ip-vrf
+
 {% if 'ospf' in vdata %}
 {{ ospf_config(0,'ipv4' if vdata.af.ipv4|default(0) else 'ipv6',vname,vdata.ospf,vdata.ospf.interfaces)}}
 {% endif %}
 {% if 'bgp' in vdata %}
 {{ bgp_config(vname,vrf.as,bgp.router_id,vdata.bgp,vdata) }}
 {% endif %}
+{% endfor %}
+
+# Associate irb interfaces with the corresponding vrf
+{% for i in interfaces if i.type=='svi' and 'vrf' in i and i.vlan.mode|default('irb')=='irb' %}
+{%  set vlan = i.ifname[4:]|int %}
+- path: network-instance[name={{ i.vrf }}]
+  val:
+   interface:
+   - name: irb0.{{ vlan }}
 {% endfor %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -1,29 +1,44 @@
-updates:
-{% if vxlan.vlans is defined %}
-{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
-{%     set vlan = vlans[vname] %}
-- path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{vlan.id}}]
+{% macro vxlan_interface(vrf,index,type,vni,evi) %}
+- path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{index}}]
   val:
-   type: bridged
+   type: {{ type }}
    ingress:
-    vni: {{ vlan.vni }}
+    vni: {{ vni }}
    egress:
     source-ip: use-system-ipv4-address
     
-- path: network-instance[name=vlan_{{vname}}]
+- path: network-instance[name={{vrf}}]
   val:
-   type: mac-vrf
+   type: {{ 'mac-vrf' if type=='bridged' else 'ip-vrf' }}
    vxlan-interface:
-   - name: vxlan0.{{ vlan.id }}
+   - name: vxlan0.{{ index }}
    protocols:
     bgp-vpn:
      bgp-instance:
      - id: 1
+       route-target:
+        _annotate: "For compatibility with frr, override auto-derived RT based on EVI {{evi}} with VNI {{vni}}"
+        import-rt: "target:{{ bgp.as }}:{{ vni }}"
+        export-rt: "target:{{ bgp.as }}:{{ vni }}"
     bgp-evpn:
      bgp-instance:
      - id: 1
-       evi: {{ vlan.evpn.evi }}
+       evi: {{ evi }}
        ecmp: 8
-       vxlan-interface: vxlan0.{{ vlan.id }}
+       vxlan-interface: vxlan0.{{ index }}
+{% endmacro %}
+
+updates:
+{% if vlans is defined and vxlan.vlans is defined %}
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%     set vlan = vlans[vname] %}
+{{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi) }}
 {%   endfor %}
+{% endif %}
+
+{# Symmetric IRB interfaces #}
+{% if vrfs is defined %}
+{% for vname,vdata in vrfs.items() if 'evpn' in vdata and 'transit_vni' in vdata.evpn and 'transit_evi' in vdata.evpn %}
+{{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.evpn.transit_evi) }}
+{% endfor %}
 {% endif %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -36,9 +36,9 @@ updates:
 {%   endfor %}
 {% endif %}
 
-{# Symmetric IRB interfaces #}
+{# Symmetric IRB interfaces, note using VRF ID as transit EVI value #}
 {% if vrfs is defined %}
-{% for vname,vdata in vrfs.items() if 'evpn' in vdata and 'transit_vni' in vdata.evpn and 'transit_evi' in vdata.evpn %}
-{{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.evpn.transit_evi) }}
+{% for vname,vdata in vrfs.items() if 'evpn' in vdata and 'transit_vni' in vdata.evpn %}
+{{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.vrfidx) }}
 {% endfor %}
 {% endif %}

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -78,24 +78,25 @@ def vrf_transit_vni(topology: Box) -> None:
   if not 'vrfs' in topology:
     return
 
-  def check_for_duplicates(v: str):
+  def check_for_duplicates(param: str) -> typing.List[int]:
     vni_list: typing.List[int] = []
     for vrf_name,vrf_data in topology.vrfs.items():               # First pass: build a list of statically configured VNIs
       if vrf_data is None:                                        # Skip empty VRF definitions
         continue
-      vni = data.get_from_box(vrf_data,f'evpn.transit_{v}')
+      vni = data.get_from_box(vrf_data,param)
       if not isinstance(vni,int):
         continue
       if vni in vni_list:
         common.error(
-          f'VRF {vrf_name} is using the same EVPN transit {v} as another VRF',
+          f'VRF {vrf_name} is using the same {param} value as another VRF',
           common.IncorrectValue,
           'evpn')
         continue
       vni_list.append( vni )
     return vni_list
-  vni_list = check_for_duplicates('vni')
-  evi_list = check_for_duplicates('evi')
+
+  vni_list = check_for_duplicates('evpn.transit_vni')
+  evi_list = check_for_duplicates('evpn.transit_evi')
 
   vni_start = topology.defaults.evpn.start_transit_vni
   evi_start = topology.defaults.evpn.start_transit_evi

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -66,7 +66,7 @@ def vlan_aware_bundle_service(vlan: Box, vname: str, node: Box, topology: Box) -
   evpn.vlan_ids.append(topology.vlans[vname].id)                    # ... and a VLAN ID to list of EVPN-enabled VLAN tags
 
 """
-Set transit VNI/EVI values for symmetrical IRB VRFs
+Set transit VNI values for symmetrical IRB VRFs
 """
 def get_next_vni(start_vni: int, used_vni_list: typing.List[int]) -> int:
   while True:
@@ -78,28 +78,22 @@ def vrf_transit_vni(topology: Box) -> None:
   if not 'vrfs' in topology:
     return
 
-  def check_for_duplicates(param: str) -> typing.List[int]:
-    vni_list: typing.List[int] = []
-    for vrf_name,vrf_data in topology.vrfs.items():               # First pass: build a list of statically configured VNIs
-      if vrf_data is None:                                        # Skip empty VRF definitions
-        continue
-      vni = data.get_from_box(vrf_data,param)
-      if not isinstance(vni,int):
-        continue
-      if vni in vni_list:
-        common.error(
-          f'VRF {vrf_name} is using the same {param} value as another VRF',
-          common.IncorrectValue,
-          'evpn')
-        continue
-      vni_list.append( vni )
-    return vni_list
-
-  vni_list = check_for_duplicates('evpn.transit_vni')
-  evi_list = check_for_duplicates('evpn.transit_evi')
+  vni_list: typing.List[int] = []
+  for vrf_name,vrf_data in topology.vrfs.items():               # First pass: build a list of statically configured VNIs
+    if vrf_data is None:                                        # Skip empty VRF definitions
+      continue
+    vni = data.get_from_box(vrf_data,'evpn.transit_vni')
+    if not isinstance(vni,int):
+      continue
+    if vni in vni_list:
+      common.error(
+        f'VRF {vrf_name} is using the same EVPN transit VNI as another VRF',
+        common.IncorrectValue,
+        'evpn')
+      continue
+    vni_list.append( vni )                                      # Insert it to detect duplicates elsewhere
 
   vni_start = topology.defaults.evpn.start_transit_vni
-  evi_start = topology.defaults.evpn.start_transit_evi
   for vrf_name,vrf_data in topology.vrfs.items():               # Second pass: set transit VNI values for VRFs with "transit_vni: True"
     if vrf_data is None:                                        # Skip empty VRF definitions
       continue
@@ -112,36 +106,14 @@ def vrf_transit_vni(topology: Box) -> None:
                     max_value=16777215,
                     true_value=vni_start)                       # Make sure evpn.transit_vni is an integer
     if transit_vni == vni_start:                                # If we had to assign the default value, increment the default transit VNI
-      if common.DEBUG:
-        print( f"evpn: Auto-assigning transit VNI {transit_vni} to VRF {vrf_name}" )
       vni_start = get_next_vni(vni_start,vni_list)
-
-    transit_evi = data.must_be_int(
-                    vrf_data,
-                    key='evpn.transit_evi',
-                    path=f'vrfs.{vrf_name}',
-                    module='evpn',
-                    min_value=1,
-                    max_value=65535,
-                    true_value=evi_start)                       # Make sure evpn.transit_evi is an integer
-    if transit_vni and not transit_evi:                         # If transit VNI is set, also configure EVI
-      vrf_data.evpn.transit_evi = transit_evi = evi_start
-    if transit_evi == evi_start:                                # If we had to assign the default value, increment the default transit VNI
-      if common.DEBUG:
-        print( f"evpn: Auto-assigning transit EVI {transit_evi} to VRF {vrf_name}" )
-      evi_start = get_next_vni(evi_start,evi_list)
-
 
 def vrf_irb_setup(node: Box, topology: Box) -> None:
   features = devices.get_device_features(node,topology.defaults)
   for vrf_name,vrf_data in node.get('vrfs',{}).items():
     if not 'af' in vrf_data or not 'evpn' in vrf_data:          # VRF without EVPN data or L3 information is definitely not doing IRB
-      if common.DEBUG:
-        print( f"evpn: Skipping IRB configuration in VRF {vrf_name}; no AF or EVPN defined: {vrf_data}" )
       continue
     if not vrf_name in topology.get('vrfs',{}):                 # Makes no sense to configure IRB for local VRF
-      if common.DEBUG:
-        print( f"evpn: Skipping IRB configuration for local-only VRF {vrf_name}: {vrf_data}" )
       continue
 
     g_vrf = topology.vrfs[vrf_name]                             # Pointer to global VRF data, will come useful in a second
@@ -153,8 +125,6 @@ def vrf_irb_setup(node: Box, topology: Box) -> None:
           'evpn')
         continue
       vrf_data.evpn.transit_vni = g_vrf.evpn.transit_vni        # Make transit VNI is copied into the local VRF
-      if 'transit_evi' in g_vrf.evpn:
-        vrf_data.evpn.transit_evi = g_vrf.evpn.transit_evi      # Also copy transit EVI
       vrf_data.pop('ospf',None)                                 # ... and remove OSPF from EVPN IRB VRF
     else:
       if not features.evpn.asymmetrical_irb:                    # ... does this device asymmetrical IRB -- is it supported?

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -119,13 +119,14 @@ srv6:
 evpn: # Enables the EVPN address family towards BGP peers
   requires: [ bgp ]
   supported_on: [ sros, srlinux, frr, eos, vyos, dellos10 ]
-  no_propagate: [ start_transit_vni ]
+  no_propagate: [ start_transit_vni, start_transit_evi ]
   transform_after: [ vlan, vxlan, vrf ]
   session: [ ibgp ]
   start_transit_vni: 200000
+  start_transit_evi: 5000   # Beyond available VLAN IDs
   vlan_bundle_service: False
   attributes:
-    global: [ session, start_transit_vni, vlan_bundle_service ]
+    global: [ session, start_transit_vni, start_transit_evi, vlan_bundle_service ]
     node: [ session, vlan_bundle_service ]
     vlans: [ evpn.evi ]
 
@@ -162,6 +163,7 @@ vlan: # VLAN support
 vxlan: # VXLAN support
   supported_on: [ eos, nxos, vyos, dellos10, srlinux ]
   requires: [ vlan ]
+  config_after: [ vrf ] # For platforms that suppport L3 VXLAN, vrfs must be created first
   domain: global
   flooding: static
   attributes:
@@ -516,7 +518,7 @@ devices:
         ipv4:
           unnumbered: True
         ipv6:
-          lla: True      
+          lla: True
       bgp:
         activate_af: True
         ipv6_lla: True
@@ -713,7 +715,7 @@ devices:
           lla: True
       vlan:
         model: router
-        svi_interface_name: "irb0.{vlan}"
+        svi_interface_name: "vlan{vlan}" # Used as mac-vrf name
         subif_name: "{ifname}.{vlan.access_id}"
         mixed_trunk: True
       bgp:
@@ -724,7 +726,9 @@ devices:
         ipv6_lla: True
         rfc8950: True
       vxlan:
-        requires: [ evpn, vrf ]
+        requires: [ evpn ] # vrf for l3 vxlan
+      evpn:
+        irb: True
       ospf:
         unnumbered: False
       isis:
@@ -732,6 +736,9 @@ devices:
           ipv4: False
           ipv6: True
           network: False
+      vrf:
+        loopback_interface_name: "lo0.{vrfidx}"
+        keep_module: True
     external:
       image: none
     graphite.icon: router

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -119,14 +119,13 @@ srv6:
 evpn: # Enables the EVPN address family towards BGP peers
   requires: [ bgp ]
   supported_on: [ sros, srlinux, frr, eos, vyos, dellos10 ]
-  no_propagate: [ start_transit_vni, start_transit_evi ]
+  no_propagate: [ start_transit_vni ]
   transform_after: [ vlan, vxlan, vrf ]
   session: [ ibgp ]
   start_transit_vni: 200000
-  start_transit_evi: 5000   # Beyond available VLAN IDs
   vlan_bundle_service: False
   attributes:
-    global: [ session, start_transit_vni, start_transit_evi, vlan_bundle_service ]
+    global: [ session, start_transit_vni, vlan_bundle_service ]
     node: [ session, vlan_bundle_service ]
     vlans: [ evpn.evi ]
 


### PR DESCRIPTION
* Add l3 vxlan support using vrf module; configure vxlan after vrf
* Add support for loopbacks in vrfs
* Refactored templates: Move vlan handling to vlan module

Removed evpn.transit_evi, now using vrfidx as suggested. May change to use reserved vlan id in the future