### PR TITLE
srlinux various fixes

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -94,7 +94,7 @@
 {% endif %}
 
 {% for l in interfaces|default([]) if l.bgp.advertise|default(0) and l[af]|default(False) is string and l.vrf|default('default')==vrf %}
-{{ bgp_export_prefix(vrf,l[af]) }}
+{{ bgp_export_prefix(vrf,l[af]|ipaddr('address')|ipaddr('host')) }}
 {% endfor %}
 
 {% for pfx in vrf_bgp.originate|default([]) if af == 'ipv4' %}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -47,8 +47,8 @@ updates:
 
 {% for l in interfaces|default([]) if l.vlan is not defined or l.vlan.mode|default('irb')=='route' %}
 {% set if_name_index = l.ifname.split('.') %}
-{% set if_name = if_name_index[0] %}
-{% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
+{% set if_name = if_name_index[0] if l.type!='stub' else "lo0" %}
+{% set if_index = if_name_index[1] if if_name_index|length > 1 else l.ifindex if l.type=='stub' else '0' %}
 {% set vlan = l.vlan.access|default(l.vlan.access_id|default('routed')|string()) if l.vlan is defined else l.ifname %}
 {% set if_desc = l.name|default( "vlan " + vlan )|replace('->','~')|regex_replace('[\\[\\]]','') %}
 - path: interface[name={{ if_name }}]
@@ -71,8 +71,8 @@ updates:
 {% for l in interfaces|default([]) if (l.vlan is not defined or l.vlan.mode|default('irb') == 'route') 
    and l.subif_index is not defined and l.vrf|default('default')==vrf %}
 {% set if_name_index = l.ifname.split('.') %}
-{% set if_name = if_name_index[0] %}
-{% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
+{% set if_name = if_name_index[0] if l.type!='stub' else "lo0" %}
+{% set if_index = if_name_index[1] if if_name_index|length > 1 else l.ifindex if l.type=='stub' else '0' %}
 - path: network-instance[name={{ vrf }}]
   val:
    type: {{ 'default' if vrf=='default' else 'ip-vrf' }}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -45,7 +45,7 @@ updates:
 
 {{  ip_addresses('system0',0,loopback,False,True)  }}
 
-{% for l in interfaces|default([]) if l.vlan is not defined or l.vlan.mode|default('irb')=='route' %}
+{% for l in interfaces|default([]) if l.vlan is not defined %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] if l.type!='stub' else "lo0" %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else l.ifindex if l.type=='stub' else '0' %}
@@ -56,20 +56,15 @@ updates:
 {% if l.mtu is defined %} # min 1500; max 9412 for 7220, 9500 for 7250 platforms
    mtu {{ [l.mtu + 14,1500]|max }} # TODO not supported on loopback interfaces
 {% endif %}
-{% if l.subif_index is defined %}{# Trunk parent interfaces #}
-   description: "Trunk {{ if_desc }}"
-{% else %}
    subinterface:
     index: {{ if_index }}
     description: "{{ if_desc }}"
 
 {{ ip_addresses(if_name,if_index,l) }}
-{% endif %}
 {% endfor %}
 
 {% macro list_interfaces(vrf) %}
-{% for l in interfaces|default([]) if (l.vlan is not defined or l.vlan.mode|default('irb') == 'route') 
-   and l.subif_index is not defined and l.vrf|default('default')==vrf %}
+{% for l in interfaces|default([]) if l.vlan is not defined and l.vrf|default('default')==vrf %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] if l.type!='stub' else "lo0" %}
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else l.ifindex if l.type=='stub' else '0' %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -13,34 +13,52 @@ updates:
 {% endif %}
 
 {% macro add_interface(macvrf,ifname,vlan,i) %}
-{% set is_l2 = i.vlan.mode|default('irb') == 'bridge' %}
+{% if i.vlan.trunk_id is defined %}
+{%  set native = i.vlan.native|default('not set') %}
+{%  for v in i.vlan.trunk %}
+{%   set type = 'bridged' if v==native or vlans[v].mode=='bridge' else 'routed' %}
 - path: interface[name={{ifname}}]
   val:
-{% if i.type in ["vlan_member"] %}
    vlan-tagging: True
-{% endif %}
+   description: "Trunk port native={{native}}"
    subinterface:
-   - index: {{ vlan }}
-{%   if ifname!="irb0" %}
-     type: {{ 'bridged' if is_l2 else 'routed' }}
-{%    if i.type in ["vlan_member"] %}
+   - index: {{ vlans[v].id }}
+     type: {{ type }}
      vlan:
       encap:
-{%     if i.vlan.access_id is defined %}
+{%     if v != native %}
        single-tagged:
-        vlan-id: "{{ i.vlan.access_id }}"
+        vlan-id: "{{ vlans[v].id }}"
 {%     else %}
+       {# Untagged only allowed for bridged vlans, routing via irb interface #}
        untagged: { }
 {%     endif %}
-{%    endif %}
-{% endif %}
 
-{% if is_l2 %}
+{% if type == 'bridged' %}
 - path: network-instance[name={{ macvrf }}]
   val:
    interface:
    - name: {{ ifname }}.{{ vlan }}
+{% endif %}
+{%  endfor %}
+
 {% else %}
+- path: interface[name={{ifname}}]
+  val:
+   subinterface:
+   - index: {{ vlan }}
+     description: {{ i.name|default("not provided")|replace('->','~')|regex_replace('[\\[\\]]','') }}
+{%   if ifname!="irb0" and i.parent_ifname is not defined %}
+     type: {{ 'bridged' if i.vlan.mode|default('irb')=='bridge' else 'routed' }}
+{%   endif %}
+
+{% if i.vlan.mode|default('irb') == 'bridge' or ifname=="irb0" %}
+- path: network-instance[name={{ macvrf }}]
+  val:
+   interface:
+   - name: {{ ifname }}.{{ vlan }}
+{% endif %}
+{% if i.vlan.mode|default('irb') != 'bridge' %}
 {{  ip_addresses(ifname,vlan,i) }}
 
 {%  if ifname=="irb0" %}
@@ -51,7 +69,7 @@ updates:
    - name: {{ ifname }}.{{ vlan }}
 {%  endif %}
 {% endif %}
-
+{% endif %}
 {% endmacro %}
 
 {% for l in interfaces|default([]) if l.vlan is defined %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -21,7 +21,7 @@ updates:
    subinterface:
    - index: {{ vlan }}
 {%   if ifname!="irb0" %}
-     type: bridged
+     type: {{ 'bridged' if i.vlan.mode|default('irb') == 'bridge' else 'routed' }}
 {%    if i.type in ["vlan_member"] %}
      vlan:
       encap:

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -44,6 +44,7 @@ updates:
 {% if ifname=="irb0" %}
 - path: network-instance[name={{ i.vrf|default('default') }}]
   val:
+   type: {{ 'default' if i.vrf|default('default')=='default' else 'ip-vrf' }}
    interface:
    - name: {{ ifname }}.{{ vlan }}
 {% endif %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -13,6 +13,7 @@ updates:
 {% endif %}
 
 {% macro add_interface(macvrf,ifname,vlan,i) %}
+{% set is_l2 = i.vlan.mode|default('irb') == 'bridge' %}
 - path: interface[name={{ifname}}]
   val:
 {% if i.type in ["vlan_member"] %}
@@ -21,7 +22,7 @@ updates:
    subinterface:
    - index: {{ vlan }}
 {%   if ifname!="irb0" %}
-     type: {{ 'bridged' if i.vlan.mode|default('irb') == 'bridge' else 'routed' }}
+     type: {{ 'bridged' if is_l2 else 'routed' }}
 {%    if i.type in ["vlan_member"] %}
      vlan:
       encap:
@@ -34,19 +35,21 @@ updates:
 {%    endif %}
 {% endif %}
 
-{{ ip_addresses(ifname,vlan,i) }}
-
+{% if is_l2 %}
 - path: network-instance[name={{ macvrf }}]
   val:
    interface:
    - name: {{ ifname }}.{{ vlan }}
+{% else %}
+{{  ip_addresses(ifname,vlan,i) }}
 
-{% if ifname=="irb0" %}
+{%  if ifname=="irb0" %}
 - path: network-instance[name={{ i.vrf|default('default') }}]
   val:
    type: {{ 'default' if i.vrf|default('default')=='default' else 'ip-vrf' }}
    interface:
    - name: {{ ifname }}.{{ vlan }}
+{%  endif %}
 {% endif %}
 
 {% endmacro %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -1,4 +1,4 @@
-{% macro vxlan_interface(vrf,index,type,vni,evi) %}
+{% macro vxlan_interface(vrf,index,type,vni,evi,rd,rts) %}
 - path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{index}}]
   val:
    type: {{ type }}
@@ -16,10 +16,12 @@
     bgp-vpn:
      bgp-instance:
      - id: 1
+       route-distinguisher:
+        rd: "{{ rd }}"
        route-target:
         _annotate: "For compatibility with frr, override auto-derived RT based on EVI {{evi}} with VNI {{vni}}"
-        import-rt: "target:{{ bgp.as }}:{{ vni }}"
-        export-rt: "target:{{ bgp.as }}:{{ vni }}"
+        import-rt: "target:{{ rts.import[0] }}"
+        export-rt: "target:{{ rts.export[0] }}"
     bgp-evpn:
      bgp-instance:
      - id: 1
@@ -32,13 +34,13 @@ updates:
 {% if vlans is defined and vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}
-{{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi) }}
+{{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi,vlan.evpn.rd,vlan.evpn) }}
 {%   endfor %}
 {% endif %}
 
 {# Symmetric IRB interfaces, note using VRF ID as transit EVI value #}
 {% if vrfs is defined %}
 {% for vname,vdata in vrfs.items() if 'evpn' in vdata and 'transit_vni' in vdata.evpn %}
-{{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.vrfidx) }}
+{{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.vrfidx,vdata.rd,vdata) }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
* Configure RT/RD explicitly
* Set ip-vrf type in case it does not exist yet
* Check for both bridged and routed interfaces, only add l2 to mac-vrf and set IPs on non-bridged
* Convert stub interface with /32 address into loopback
* Generate single host prefix for interface ip that is advertised