### PR TITLE
Fix routed trunk vlan mode

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -885,7 +885,6 @@ class VLAN(_Module):
           node.vlans[vname] = topology.vlans[vname] + node.vlans[vname]
 
     validate_vlan_attributes(node,topology)
-    print( f"JvB after validate_vlan_attributes: {node.get('vlans',[])}" )
 
   def link_pre_transform(self, link: Box, topology: Box) -> None:
     if link.get('type','') == 'vlan_member':                                      # Skip VLAN member links, we've been there...

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -158,7 +158,7 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
           common.IncorrectValue,
           'vlan')
     else:
-      if default_fwd_mode:                                          # Propagate default VLAN forwarding mode if needed
+      if default_fwd_mode and obj is not topology:                  # Propagate default VLAN forwarding mode if needed
         vdata.mode = default_fwd_mode
 
     if not 'id' in vdata:                                           # When VLAN ID is not defined
@@ -480,6 +480,12 @@ def get_vlan_data(vlan: str, node: Box, topology: Box) -> typing.Optional[Box]:
   return get_from_box(topology,f'vlans.{vlan}') or get_from_box(node,f'vlans.{vlan}')
 
 """
+get_vlan_mode: Get VLAN mode attribute (node or topology), default 'irb'
+"""
+def get_vlan_mode(node: Box, topology: Box) -> str:
+  return get_from_box(node,'vlan.mode') or get_from_box(topology,'vlan.mode') or 'irb'
+
+"""
 update_vlan_neighbor_list: Build a VLAN-wide list of neighbors
 """
 def update_vlan_neighbor_list(vlan: str, phy_if: Box, svi_if: Box, node: Box,topology: Box) -> None:
@@ -518,6 +524,9 @@ def create_node_vlan(node: Box, vlan: str, topology: Box) -> typing.Optional[Box
       common.fatal(                                                 # ... this should have been detected way earlier
         f'Unknown VLAN {vlan} used on node {node.name}','vlan')
       return None
+
+  if not 'mode' in node.vlans[vlan]:                                # Make sure vlan.mode is set
+    node.vlans[vlan].mode = get_vlan_mode(node,topology)
 
   if not 'bridge_group' in node.vlans[vlan]:                        # Set bridge group in VLAN data
     if not node.vlan.max_bridge_group:                              # ... current counter is in node.vlan dictionary
@@ -876,6 +885,7 @@ class VLAN(_Module):
           node.vlans[vname] = topology.vlans[vname] + node.vlans[vname]
 
     validate_vlan_attributes(node,topology)
+    print( f"JvB after validate_vlan_attributes: {node.get('vlans',[])}" )
 
   def link_pre_transform(self, link: Box, topology: Box) -> None:
     if link.get('type','') == 'vlan_member':                                      # Skip VLAN member links, we've been there...


### PR DESCRIPTION
* Not too early, when traversing global topology
* Fill it in when creating per-node vlan dict (if not set)

Fixes https://github.com/ipspace/netlab/issues/418

Note that the pattern of getting a parameter from node / if not from topology / if not default value seems generic, could add a helper method in data