### PR TITLE
I'm trying to solve this problem with vlan.mode not being set, I was expecting it to be 'irb' - solved now

### DIFF
--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -253,6 +253,7 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+        mode: bridge
     - bridge: input_3
       ifindex: 3
       ifname: Ethernet3
@@ -261,6 +262,7 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
+        mode: bridge
     - bridge_group: 1
       ifindex: 6
       ifname: Vlan1000
@@ -352,6 +354,7 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+        mode: bridge
     - bridge: input_5
       ifindex: 3
       ifname: Ethernet3
@@ -360,6 +363,7 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
+        mode: bridge
     - bridge_group: 1
       ifindex: 6
       ifname: Vlan1000


### PR DESCRIPTION
In this test case, it should be 'bridge' (reflecting the value from the global vlan)