### PR TITLE
Fix check for routed native vlan support

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -362,14 +362,15 @@ whether the native vlan is configured as 'mode: route', and if so whether the de
 def check_native_vlan_routed(link: Box, native_vlan: str, topology: Box) -> None:
   for intf in link.interfaces:
     node = topology.nodes[intf.node]
-    vlan_mode = interface_vlan_mode(native_vlan,intf,node,topology)
-    if vlan_mode == "route":
-      features = devices.get_device_features(node,topology.defaults)
-      if not features.vlan.native_routed:
-        common.error(
-          f'Node {intf.node} does not support routed native VLANs ({native_vlan})\n... link {link}',
-          common.IncorrectValue,
-          'vlan')
+    if 'vlan' in node.get('module',[]):   # Is vlan module used on this node?
+      vlan_mode = interface_vlan_mode(native_vlan,intf,node,topology)
+      if vlan_mode == "route":
+        features = devices.get_device_features(node,topology.defaults)
+        if not features.vlan.native_routed:
+          common.error(
+            f'Node {intf.node} does not support routed native VLANs ({native_vlan})\n... link {link}',
+            common.IncorrectValue,
+            'vlan')
 
 """
 copy_vlan_attributes: copy prefix and link type from vlan to link


### PR DESCRIPTION
Move the check earlier, before any transformation logic removes the native vlan

With this patch:
```
netlab create -d srlinux -p clab  integration/vlan/vlan-routed-native.yml 
IncorrectValue in vlan: Node ros does not support routed native VLANs (red)
... link {'vlan': {'trunk': {'red': {}, 'blue': {}}, 'native': 'red'}, 'interfaces': [{'node': 's2', 'vlan': {'trunk': {'red': {}, 'blue': {}}, 'native': 'red'}}, {'node': 'ros', 'vlan': {'trunk': {'red': {}, 'blue': {}}, 'native': 'red'}}], 'linkindex': 2}
Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting
```

Without it, no error is generated