### PR TITLE
Proposal: Allow user to disable ebgp peer creation per vrf

### DIFF
--- a/netsim/ansible/templates/vrf/srlinux.j2
+++ b/netsim/ansible/templates/vrf/srlinux.j2
@@ -10,7 +10,7 @@ updates:
 {% if 'ospf' in vdata %}
 {{ ospf_config(0,'ipv4' if vdata.af.ipv4|default(0) else 'ipv6',vname,vdata.ospf,vdata.ospf.interfaces)}}
 {% endif %}
-{% if 'bgp' in vdata %}
+{% if vdata.bgp|default(False) %}
 {{ bgp_config(vname,vrf.as,bgp.router_id,vdata.bgp,vdata) }}
 {% endif %}
 {% endfor %}

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -168,7 +168,7 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
           print( f"bgp: Not adding ebgp neighbor within vrf: bgp = False in local node vrf {l.vrf}" )
         continue
       elif vrf_bgp==True:
-        node.vrfs[l.vrf].bgp = {}  # Replace with dict
+        node.vrfs[l.vrf].bgp = { 'neighbors': [] }  # Replace with non-empty dict
       elif not vrf_bgp and data.get_from_box(topology,f"vrfs.{l.vrf}.bgp")==False: # or globally per vrf
         if common.WARNING:
           print( f"bgp: Not adding ebgp neighbor within vrf: bgp = False in global vrf {l.vrf}" )

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -169,7 +169,7 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
         continue
       elif vrf_bgp==True:
         node.vrfs[l.vrf].bgp = {}  # Replace with dict
-      elif vrf_bgp is not defined and data.get_from_box(topology,f"vrfs.{l.vrf}.bgp")==False: # or globally per vrf
+      elif not vrf_bgp and data.get_from_box(topology,f"vrfs.{l.vrf}.bgp")==False: # or globally per vrf
         if common.WARNING:
           print( f"bgp: Not adding ebgp neighbor within vrf: bgp = False in global vrf {l.vrf}" )
         continue

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -163,9 +163,15 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
 
     if 'vrf' in l:        # VRF neighbor
       vrf_bgp = data.get_from_box(node,f"vrfs.{l.vrf}.bgp")                           # Allow user to set 'bgp: False' within a vrf, per node
-      if vrf_bgp==False or data.get_from_box(topology,f"vrfs.{l.vrf}.bgp")==False:    # or globally per vrf
+      if vrf_bgp==False:
         if common.WARNING:
-          print( f"bgp: Not adding ebgp neighbor within vrf {l.vrf}: bgp = False" )
+          print( f"bgp: Not adding ebgp neighbor within vrf: bgp = False in local node vrf {l.vrf}" )
+        continue
+      elif vrf_bgp==True:
+        node.vrfs[l.vrf].bgp = {}  # Replace with dict
+      elif vrf_bgp is not defined and data.get_from_box(topology,f"vrfs.{l.vrf}.bgp")==False: # or globally per vrf
+        if common.WARNING:
+          print( f"bgp: Not adding ebgp neighbor within vrf: bgp = False in global vrf {l.vrf}" )
         continue
 
     node_as =  node.bgp.get("as")                                     # Get our real AS number and the AS number of the peering session


### PR DESCRIPTION
Currently, the code builds ebgp sessions between all neighbors with a different AS, within each VRF.
This results in several parallel peering sessions on trunk ports with multiple vlans

This patch allows the user to avoid ebgp sessions for a given vrf by setting ```bgp: False``` within that vrf, locally per node or globally

TODO (if accepted):
* Update other platform templates to handle ```bgp: False``` in vrfs