### PR TITLE
frr add native vlan interfaces

### DIFF
--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -3,19 +3,12 @@
 set -e # Exit immediately when any command fails
 #
 {# Create VLAN subinterfaces. No need to set IP addresses, FRR can handle that #}
-{% for i in interfaces if i.type == 'vlan_member' %}
-if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
-  ip link add link {{ i.parent_ifname }} name {{ i.ifname }} type vlan id {{ i.vlan.access_id }}
-  ip link set dev {{ i.ifname }} up
-fi
-{% endfor %}
-
-{# Create VLAN subinterfaces for any native vlans #}
-{% for i in interfaces if i.vlan is defined and i.vlan.native is defined %}
-{% set ifname = i.ifname + ".0" %}
-if [ ! -e /sys/devices/virtual/net/{{ ifname }} ]; then
-  ip link add link {{ i.ifname }} name {{ ifname }} type vlan id 0
-  ip link set dev {{ ifname }} up
+{% for i in interfaces if i.type == 'vlan_member' or (i.vlan is defined and i.vlan.native is defined) %}
+{% set dev = i.ifname + (".0" if i.vlan.native is defined else "") %}
+{% set parent = i.ifname if i.vlan.native is defined else i.parent_ifname %}
+if [ ! -e /sys/devices/virtual/net/{{ dev }} ]; then
+  ip link add link {{ parent }} name {{ dev }} type vlan id {{ 0 if i.vlan.native is defined else i.vlan.access_id }}
+  ip link set dev {{ dev }} up
 fi
 {% endfor %}
 
@@ -39,6 +32,6 @@ fi
 
 {# Add interfaces to VLAN bridges #}
 {% for i in interfaces if i.vlan.access_id is defined and i.vlan.mode|default('') != 'route' %}
-brctl addif vlan{{ i.vlan.access_id }} {{ i.ifname + ('.0' if i.vlan.native is defined else '') }}
+brctl addif vlan{{ i.vlan.access_id }} {{ i.ifname + ('.0' if i.vlan.native is defined else '') }} || true
 {% endfor %}
 exit 0

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -9,6 +9,16 @@ if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   ip link set dev {{ i.ifname }} up
 fi
 {% endfor %}
+
+{# Create VLAN subinterfaces for any native vlans #}
+{% for i in interfaces if i.vlan is defined and i.vlan.native is defined %}
+{% set ifname = i.ifname + ".0" %}
+if [ ! -e /sys/devices/virtual/net/{{ ifname }} ]; then
+  ip link add link {{ i.ifname }} name {{ ifname }} type vlan id 0
+  ip link set dev {{ ifname }} up
+fi
+{% endfor %}
+
 {% for i in interfaces if i.type == 'svi' %}
 if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   brctl addbr {{ i.ifname }}
@@ -29,6 +39,6 @@ fi
 
 {# Add interfaces to VLAN bridges #}
 {% for i in interfaces if i.vlan.access_id is defined and i.vlan.mode|default('') != 'route' %}
-brctl addif vlan{{ i.vlan.access_id }} {{ i.ifname }}
+brctl addif vlan{{ i.vlan.access_id }} {{ i.ifname + ('.0' if i.vlan.native is defined else '') }}
 {% endfor %}
 exit 0

--- a/netsim/ansible/templates/vxlan/frr.j2
+++ b/netsim/ansible/templates/vxlan/frr.j2
@@ -12,7 +12,7 @@ ip link add vxlan{{ vni }} type vxlan \
 fi
 #
 # Add it to the VLAN bridge (create if needed for l3 vnis); disable STP
-if [ ! -e /sys/devices/virtual/net/{{br_name}} ]; then
+if [ ! -e /sys/devices/virtual/net/{{ br_name }} ]; then
 brctl addbr {{ br_name }}
 ip link set up dev {{ br_name }}
 fi

--- a/netsim/ansible/templates/vxlan/frr.j2
+++ b/netsim/ansible/templates/vxlan/frr.j2
@@ -4,17 +4,19 @@ set -e # Exit immediately when any command fails
 #
 
 {% macro create_vxlan_interface(vni,br_name,vrf=None) %}
+if [ ! -e /sys/devices/virtual/net/vxlan{{ vni }} ]; then
 ip link add vxlan{{ vni }} type vxlan \
   id {{ vni }} \
   dstport 4789 \
   local {{ vxlan.vtep }} {{ 'nolearning' if vxlan.flooding|default('') == 'evpn' else '' }}
+fi
 #
 # Add it to the VLAN bridge (create if needed for l3 vnis); disable STP
-if [ ! -e /sys/devices/virtual/net/{{ br_name}} ]; then
+if [ ! -e /sys/devices/virtual/net/{{br_name}} ]; then
 brctl addbr {{ br_name }}
 ip link set up dev {{ br_name }}
 fi
-brctl addif {{ br_name }} vxlan{{ vni }}
+brctl addif {{ br_name }} vxlan{{ vni }} || true
 brctl stp {{ br_name }} off
 ip link set up dev vxlan{{ vni }}
 {% if vrf %}


### PR DESCRIPTION
* Create VLAN devices with ID 0 for native vlans (eth[x].0, for design visibility purposes)
* Idempotency: Don't error out when interface is already associated or VXLAN device exists