### PR TITLE
srlinux template fixes

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -9,4 +9,4 @@ updates:
     accept: {}
 
 {% from "srlinux.macro.j2" import bgp_config with context %}
-{{ bgp_config('default',bgp.as,bgp.router_id,bgp,{}) }}
+{{ bgp_config('default',bgp.as,bgp.router_id,bgp,{ 'af' : af }) }}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -75,7 +75,7 @@
     import-reject-all: False
 
 {# Configure BGP address families globally #}
-{% for af in ['ipv4','ipv6'] if vrf_bgp[af]|default(0) %}
+{% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
    {{ af }}-unicast:
     admin-state: enable
     multipath:

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -89,7 +89,7 @@
 {{ bgp_export_prefix(vrf,loopback[af]) }}
 {% endif %}
 
-{% for l in interfaces|default([]) if l.bgp.advertise|default(0) and l[af]|default(False) and l.vrf|default('default')==vrf %}
+{% for l in interfaces|default([]) if l.bgp.advertise|default(0) and l[af]|default(False) is string and l.vrf|default('default')==vrf %}
 {{ bgp_export_prefix(vrf,l[af]|ipaddr('address')|ipaddr('host')) }}
 {% endfor %}
 

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -1,24 +1,15 @@
-{% macro bgp_policy(vrf,is_import,communities) %}
+{% macro bgp_policy(vrf,is_import,communities,vrf_context) %}
 {% set name = vrf + "_" + ('import' if is_import else 'export') %}
 
-{% if communities %}
-- path: routing-policy/community-set[name={{name}}]
-  val:
-   member:
-{% for c in communities %}
-   - "target:{{c}}"
-{% endfor -%}
-{% endif %}
-
 {% macro accept() %}
-{%    if is_import or not communities %}
+{% if is_import or not communities %}
       accept: { }
-{%    else %}
-      accept:
-       bgp:
-        communities:
-         add: "{{ name }}"
-{%    endif %}
+{% else %}
+      accept: { }
+      # bgp:
+      #  communities:
+      #   add: "{{ name }}"
+{% endif %}
 {% endmacro %}
 
 - path: routing-policy/prefix-set[name={{vrf}}_export]
@@ -30,27 +21,28 @@
    default-action: 
     reject: { }
    statement:
-{%   if not is_import %}
+{% if is_import %}
+{%  for c in communities|default([]) %}
+   - sequence-id: {{ 10 + loop.index }}
+     match:
+      bgp:
+       community-set: "C{{ c|replace(':','_') }}"
+     action:
+{{    accept() }}       
+{%  endfor %}
+{% else %}
    - sequence-id: 5
      match:
       protocol: bgp
       _annotate_protocol: "Accept and propagate prefixes received via BGP"
      action:
 {{    accept() }}
-{% endif %}
    - sequence-id: 10
-{%   if is_import %}
-{%    if communities %}   
-     match:
-      bgp:
-       community-set: "{{ name }}"
-{%    endif %}
-{%   else %}
      match:
       prefix-set: "{{ vrf }}_export"
-{%   endif %}
      action:
 {{    accept() }}
+{% endif %}
 {% endmacro %}
 
 {% macro bgp_export_prefix(vrf,prefix) %}
@@ -65,13 +57,13 @@
 
 {% if 'import' in vrf_context %}
 {% set import_policy = vrf + "_import" %}
-{{ bgp_policy(vrf,1,vrf_context.import) }}
+{{ bgp_policy(vrf,1,vrf_context.import,vrf_context) }}
 {% else %}
 {% set import_policy = "accept_all" %}
 {% endif -%}
 
 {% set export_policy = vrf + "_export" %}
-{{ bgp_policy(vrf,0,vrf_context.export|default({})) }}
+{{ bgp_policy(vrf,0,vrf_context.export|default({}),vrf_context) }}
 
 - path: network-instance[name={{vrf}}]/protocols/bgp
   val:
@@ -92,12 +84,12 @@
 {% endfor %}
 
 {# Create route export policies #}
-{% for af in ['ipv4','ipv6'] if vrf_bgp[af]|default(0) %}
+{% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
 {% if loopback[af] is defined and bgp.advertise_loopback and vrf=='default' %}
 {{ bgp_export_prefix(vrf,loopback[af]) }}
 {% endif %}
 
-{% for l in interfaces|default([]) if l.bgp.advertise|default(0) and l[af]|default(False) is string and l.vrf|default('default')==vrf %}
+{% for l in interfaces|default([]) if l.bgp.advertise|default(0) and l[af]|default(False) and l.vrf|default('default')==vrf %}
 {{ bgp_export_prefix(vrf,l[af]|ipaddr('address')|ipaddr('host')) }}
 {% endfor %}
 

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -48,7 +48,7 @@ updates:
 {% set vlan_mode = l.vlan.mode|default('irb') %}
 {% if (l.type in ['vlan_member','lan'] and vlan_mode!='route') or (l.type=='svi' and vlan_mode=='irb') %}
 - path: network-instance[name=vlan{{ if_index }}]
-  val: # {{ l }}
+  val:
    type: mac-vrf
 {% if l.name is defined %}
    description: "{{ l.name | replace('->','~')|regex_replace('[\\[\\]]','') }}"

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -19,12 +19,13 @@ updates:
 {% if not (l.vlan.trunk_id is defined and l.vlan.native is not defined) %}{# Skip trunk ports without native vlan #}
    subinterface:
    - index: {{ if_index }}
-{%  if l.type=='vlan_member' or l.vlan.trunk_id is defined %}
+{%  if l.type in ['vlan_member','lan'] or l.vlan.trunk_id is defined %}
 {#   Untagged native vlan only allows type bridged, routing via irb interface #}
      type: {{ 'routed' if l.vlan.mode|default('irb') == 'route' else 'bridged' }}
 {%   if l.name is defined %}
      description: "{{ l.name | replace('->','~')|regex_replace('[\\[\\]]','') }}"
 {%   endif %}
+{%   if l.type=='vlan_member' or l.vlan.trunk_id is defined %}
      vlan:
       encap:
 {%     if l.vlan.native is defined %}
@@ -34,6 +35,7 @@ updates:
        single-tagged:
         vlan-id: "{{ l.vlan.access_id }}"
 {%     endif %}
+{%    endif %}
 {%  endif %}
 
 {%  if l.ipv4 is defined or l.ipv6 is defined %}
@@ -44,7 +46,7 @@ updates:
 {# Create mac-vrf for L2 VLANs, add L2 side of IRB interface if any #}
 {# Use only vlan.id in name, such that svi interfaces (irb0.nnnn) can be associated #}
 {% set vlan_mode = l.vlan.mode|default('irb') %}
-{% if (l.type=='vlan_member' and vlan_mode!='route') or (l.type=='svi' and vlan_mode=='irb') %}
+{% if (l.type in ['vlan_member','lan'] and vlan_mode!='route') or (l.type=='svi' and vlan_mode=='irb') %}
 - path: network-instance[name=vlan{{ if_index }}]
   val: # {{ l }}
    type: mac-vrf

--- a/netsim/ansible/templates/vrf/srlinux.j2
+++ b/netsim/ansible/templates/vrf/srlinux.j2
@@ -10,7 +10,35 @@ updates:
 {% if 'ospf' in vdata %}
 {{ ospf_config(0,'ipv4' if vdata.af.ipv4|default(0) else 'ipv6',vname,vdata.ospf,vdata.ospf.interfaces)}}
 {% endif %}
+
+{# Create an AS path set for this VRF, if vrf.as is set #}
+{% if vdata.as is defined %}
+- path: routing-policy/as-path-set[name={{vname}}]
+  val:
+   expression: "{{ vdata.as }}"
+{% endif %}
+
+{# Creata a community set with a single member for each imported community #}
+{% if vdata.import|default([]) %}
+{%  for c in vdata.import %}
+- path: routing-policy/community-set[name=C{{ c|replace(':','_') }}]
+  val:
+   member:
+   - "{{c}}" # Single member, else matching is AND
+{% endfor -%}
+{% endif %}
+
+{# Create a single community set for all exported communities, to be added upon import #}
+{% if vdata.export|default([]) %}
+- path: routing-policy/community-set[name={{vname}}_export]
+  val:
+   member:
+{%  for c in vdata.export %}
+   - "{{ c }}"
+{%  endfor %}
+{% endif %}
+
 {% if 'bgp' in vdata %}
-{{ bgp_config(vname,vrf.as,bgp.router_id,vdata.bgp,vdata) }}
+{{ bgp_config(vname,bgp.as,bgp.router_id,vdata.bgp,vdata) }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
- add 'lan' interfaces to mac-vrf too
- move communities to vrf module
- check correct .af attribute when exporting routes
- use bgp.as not vrf.as

Note that BGP import/export policies for more advanced topologies may still require custom manual configs