### PR TITLE
Fix clab mgmt network

### DIFF
--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -16,6 +16,9 @@ topology:
 {%   if n.mgmt.ipv4 is defined %}
       mgmt_ipv4: {{ n.mgmt.ipv4 }}
 {%   endif %}
+{%   if n.mgmt.ipv6 is defined %}
+      mgmt_ipv6: {{ n.mgmt.ipv6 }}
+{%   endif %}
       kind: {{ clab.kind | default(n.device) }}
 {%    if clab.type is defined %}
       type: {{ clab.type }}

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -1,10 +1,21 @@
 name: {{ name }}
 
+mgmt:
+  network: netlab_mgmt
+  ipv4_subnet: {{ defaults.addressing.mgmt.ipv4|default('172.20.20.0/24') }}
+  # Note: 'start' not validated
+{% if defaults.addressing.mgmt.ipv6 is defined %}
+  ipv6_subnet: {{ defaults.addressing.mgmt.ipv6 }}
+{% endif %}
+
 topology:
   nodes:
 {% for name,n in nodes.items() %}
 {%   set clab = n.clab|default({}) %}
     {{ name }}:
+{%   if n.mgmt.ipv4 is defined %}
+      mgmt_ipv4: {{ n.mgmt.ipv4 }}
+{%   endif %}
       kind: {{ clab.kind | default(n.device) }}
 {%    if clab.type is defined %}
       type: {{ clab.type }}


### PR DESCRIPTION
Adhere to the management network settings provided by Netlab, instead of using Containerlab defaults

Specifically, the Netlab default is ipv4-only while Containerlab provides ipv4+ipv6 by default.