### PR TITLE
frr ipv6 disabled fixes

### DIFF
--- a/netsim/ansible/templates/bgp/frr.bgp-config.j2
+++ b/netsim/ansible/templates/bgp/frr.bgp-config.j2
@@ -22,7 +22,7 @@ router bgp {{ bgp.as }}
     Create neighbors
 #}
 {% for af in ['ipv4','ipv6'] %}
-{%   for n in bgp.neighbors if n[af] is defined %}
+{%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or af=='ipv6') %}
 {%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }}{{ ' interface' if peer!=n[af] else '' }} remote-as {{ n.as }}
   neighbor {{ peer }} description {{ n.name }}

--- a/netsim/ansible/templates/bgp/frr.bgp-config.j2
+++ b/netsim/ansible/templates/bgp/frr.bgp-config.j2
@@ -52,7 +52,6 @@ router bgp {{ bgp.as }}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !
-! {{ bgp.neighbors }}
 {%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or af=='ipv6') and n.activate[af] is defined and n.activate[af] %}
 {%     set peer = n[af] if n[af] is string else n.local_if %}
   neighbor {{ peer }} activate

--- a/netsim/ansible/templates/bgp/frr.bgp-config.j2
+++ b/netsim/ansible/templates/bgp/frr.bgp-config.j2
@@ -22,7 +22,7 @@ router bgp {{ bgp.as }}
     Create neighbors
 #}
 {% for af in ['ipv4','ipv6'] %}
-{%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or af=='ipv6') %}
+{%   for n in bgp.neighbors if n[af] is defined %}
 {%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }}{{ ' interface' if peer!=n[af] else '' }} remote-as {{ n.as }}
   neighbor {{ peer }} description {{ n.name }}
@@ -52,7 +52,7 @@ router bgp {{ bgp.as }}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !
-{%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or af=='ipv6') and n.activate[af] is defined and n.activate[af] %}
+{%   for n in bgp.neighbors if n[af] is defined and n.activate[af] is defined and n.activate[af] %}
 {%     set peer = n[af] if n[af] is string else n.local_if %}
   neighbor {{ peer }} activate
 {%     if 'ibgp' in n.type %}

--- a/netsim/ansible/templates/bgp/frr.bgp-config.j2
+++ b/netsim/ansible/templates/bgp/frr.bgp-config.j2
@@ -52,8 +52,9 @@ router bgp {{ bgp.as }}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !
-{%   for n in bgp.neighbors if n[af] is defined and n.activate[af] is defined and n.activate[af] %}
-{%     set peer = n[af] if af in n and n[af] is string else n.local_if %}
+! {{ bgp.neighbors }}
+{%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or af=='ipv6') and n.activate[af] is defined and n.activate[af] %}
+{%     set peer = n[af] if n[af] is string else n.local_if %}
   neighbor {{ peer }} activate
 {%     if 'ibgp' in n.type %}
 {%       if bgp.next_hop_self is defined and bgp.next_hop_self %}

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -58,7 +58,9 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
+{% if 'ipv6' in af and af.ipv6 %}
 ipv6 forwarding
+{% endif %}
 !
 {% if loopback is defined %}
 interface lo0
@@ -81,13 +83,17 @@ interface {{ l.ifname }}
 {% endif %}
 {% if l.ipv4 is defined and (l.ipv4 is string or loopback.ipv4 is defined) %}
  ip address {{ l.ipv4 if l.ipv4 is string else loopback.ipv4 }}
+{% else %}
+ ! no ip address
 {% endif %}
 {% if l.ipv6 is defined %}
-{% if l.ipv6 is string %}
+{%  if l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
-{% endif %}
+{%  endif %}
  ipv6 nd ra-interval 5
  no ipv6 nd suppress-ra
+{% else %}
+ ipv6 nd suppress-ra
 {% endif %}
 {% if l.bandwidth is defined %}
  bandwidth {{ l.bandwidth  }}

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -93,6 +93,7 @@ interface {{ l.ifname }}
  ipv6 nd ra-interval 5
  no ipv6 nd suppress-ra
 {% else %}
+ ! Note, currently does not take for OS configured interfaces; known issue
  ipv6 nd suppress-ra
 {% endif %}
 {% if l.bandwidth is defined %}
@@ -103,3 +104,10 @@ interface {{ l.ifname }}
 do write
 CONFIG
 vtysh -f /tmp/config
+
+# Workaround for FRR issue with disabling ipv6 (https://github.com/FRRouting/frr/issues/7738)
+{% for l in interfaces if l.type in ['lan','p2p','stub'] and (l.ipv6 is not defined or l.ipv6==False) %}
+echo 1 >/proc/sys/net/ipv6/conf/{{ l.ifname }}/disable_ipv6
+{% endfor %}
+
+exit 0

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -87,7 +87,7 @@ interface {{ l.ifname }}
  ! no ip address
 {% endif %}
 {% if l.ipv6 is defined %}
-{%  if l.ipv6|ipv6 %}
+{%  if l.ipv6 is string and l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
 {%  endif %}
  ipv6 nd ra-interval 5

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -58,7 +58,7 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
-{% if 'ipv6' in af and af.ipv6 %}
+{% if 'ipv6' in af %}
 ipv6 forwarding
 {% endif %}
 !
@@ -106,7 +106,7 @@ CONFIG
 vtysh -f /tmp/config
 
 # Workaround for FRR issue with disabling ipv6 (https://github.com/FRRouting/frr/issues/7738)
-{% for l in interfaces if l.type in ['lan','p2p','stub'] and (l.ipv6 is not defined or l.ipv6==False) %}
+{% for l in interfaces if l.type in ['lan','p2p','stub'] and l.ipv6 is not defined %}
 echo 1 >/proc/sys/net/ipv6/conf/{{ l.ifname }}/disable_ipv6
 {% endfor %}
 


### PR DESCRIPTION
* Disable ipv6 ND when ipv6 is not configured (frr bug prevents this from getting applied)
* Don't enable ipv6 forwarding when ipv6 is disabled
* Explicitly disable ipv6 on interfaces without ipv6 enabled, under Linux