### PR TITLE
Early draft proposal: default gateway flag for vlans

### DIFF
--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -28,6 +28,7 @@
 - name: Generated gNMI config based on {{ config_template }}
   debug:
    msg: "SRL config: {{ lookup('file', tempfile_1.path ) }}"
+   verbosity: 1
 
 # - block:
 #   - name: Copy CLI configuration to SRL node {{ ansible_host }} using SCP
@@ -78,7 +79,7 @@
   register: gnmi_set_result
   tags: [ print_action, always ]
 
-- debug: var=gnmi_set_result
+- debug: var=gnmi_set_result verbosity=1
 
 - local_action:
     module: file

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -93,6 +93,16 @@ interface {{ l.ifname }}
  bandwidth {{ l.bandwidth  }}
 {% endif %}
 !
+
+{# Configure default gateway route(s) if provided #}
+{% if l.gateway is defined and l.gateway.default|default(False) %}
+{%  for af in ['ipv4','ipv6'] %}
+{%   if l.gateway[af] is defined %}
+ip route {{ '0.0.0.0/0' if af=='ipv4' else '::/0' }} {{ l.gateway[af]|ipaddr('address') }} {{ ('vrf ' + l.vrf) if l.vrf is defined else '' }}
+{%   endif %}
+{%  endfor %}
+{% endif %}
+
 {% endfor %}
 do write
 CONFIG

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -530,15 +530,14 @@ def set_default_gateway(link: Box, nodes: Box) -> None:
 
   link.pop('host_count',None)
   if not 'gateway' in link:
-    gateway = None
     for ifdata in link[IFATTR]:
       if nodes[ifdata.node].get('role','') != 'host' and 'ipv4' in ifdata:
         link.gateway.ipv4 = ifdata.ipv4
         break
   else:
-    if not isinstance(ifdata.gateway,dict) or not 'ipv4' in ifdata.gateway:  # pragma: no cover
+    if not isinstance(link.gateway,dict) or not ('ipv4' in link.gateway or 'default' in link.gateway):
       common.error(
-        f'Gateway attribute specified on {link} is not a dictionary with ipv4 key',
+        f'Gateway attribute specified on {link} is not a dictionary with "ipv4" and/or "default" key',
         common.IncorrectValue,
         'links')
 
@@ -550,7 +549,7 @@ def set_default_gateway(link: Box, nodes: Box) -> None:
       for interface in nodes[ifdata.node].interfaces:     # Find the corresponding host interface
         if link.linkindex == interface.linkindex:
           if interface.ifindex == 1:                      # Set the default gateway only on the first host interface
-            interface.gateway = link.gateway
+            interface.gateway = link.gateway + { 'default': True }
 
 """
 Set node.af flags to indicate that the node has IPv4 and/or IPv6 address family configured

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1,5 +1,5 @@
 #
-# VRF module
+# VLAN module
 #
 import typing
 from box import Box
@@ -30,8 +30,8 @@ vlan_link_attr: typing.Final[dict] = {
 }
 
 phy_ifattr: typing.Final[list] = ['bridge','ifindex','parentindex','ifname','linkindex','type','vlan','mtu','_selfloop_ifindex'] # Physical interface attributes
-keep_subif_attr: typing.Final[list] = ['vlan','ifindex','ifname','type']    # Keep these attributes on VLAN subinterfaces
-vlan_link_attr_copy: typing.Final[list] = ['role','unnumbered','pool']      # VLAN attributes to copy to member links
+keep_subif_attr: typing.Final[list] = ['vlan','ifindex','ifname','type']         # Keep these attributes on VLAN subinterfaces
+vlan_link_attr_copy: typing.Final[list] = ['role','unnumbered','pool','gateway'] # VLAN attributes to copy to member links
 
 """
 init_global_vars: Initialize the VLAN ID pool
@@ -887,6 +887,8 @@ def fix_vlan_gateways(topology: Box) -> None:
         for neighbor in intf.get('neighbors',[]):                     # Iterate over all neighbors
           if 'ipv4' in neighbor:                                      # ... until we find one with a usable IPv4
             intf.gateway.ipv4 = neighbor.ipv4                         # Set that address as our gateway
+            # Don't set intf.gateway.default = True here, 
+            # iteration order (vlan id) too implicit for users
             break                                                     # ... and get out of here
 
 class VLAN(_Module):

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -1,10 +1,24 @@
 name: {{ name }}
 
+mgmt:
+  network: netlab_mgmt
+  ipv4_subnet: {{ defaults.addressing.mgmt.ipv4|default('172.20.20.0/24') }}
+  # Note: 'start' not validated
+{% if defaults.addressing.mgmt.ipv6 is defined %}
+  ipv6_subnet: {{ defaults.addressing.mgmt.ipv6 }}
+{% endif %}
+
 topology:
   nodes:
 {% for name,n in nodes.items() %}
 {%   set clab = n.clab|default({}) %}
     {{ name }}:
+{%   if n.mgmt.ipv4 is defined %}
+      mgmt_ipv4: {{ n.mgmt.ipv4 }}
+{%   endif %}
+{%   if n.mgmt.ipv6 is defined %}
+      mgmt_ipv6: {{ n.mgmt.ipv6 }}
+{%   endif %}
       kind: {{ clab.kind | default(n.device) }}
 {%    if clab.type is defined %}
       type: {{ clab.type }}

--- a/tests/integration/evpn/vxlan-bridging-ibgp-over-ebgp.yml
+++ b/tests/integration/evpn/vxlan-bridging-ibgp-over-ebgp.yml
@@ -3,7 +3,7 @@ message: |
   bridging using IBGP-over-EBGP design.
 
   The leaf switches are doing VLAN/VXLAN encap/decap, the
-  spine switches are IP routers running OSPF, BGP, and EVPN.
+  spine switches are pure IP routers running BGP and EVPN.
 
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
@@ -17,8 +17,11 @@ groups:
   hosts:
     members: [ h1, h2, h3, h4 ]
     device: linux
-  switches:
-    members: [ spine, leaf1, leaf2 ]
+  spines:
+    members: [ spine ]
+    module: [ bgp, evpn ]
+  leaves:
+    members: [ leaf1, leaf2 ]
     module: [ vlan, vxlan, bgp, evpn ]
 
 bgp.as: 64999

--- a/tests/integration/evpn/vxlan-routing-ibgp-over-ebgp-unnumbered.yml
+++ b/tests/integration/evpn/vxlan-routing-ibgp-over-ebgp-unnumbered.yml
@@ -1,0 +1,87 @@
+message: |
+  The devices under test are VLAN-to-VXLAN routers between four different access VLANs
+  and VXLAN VNIs, divided amongst 2 tenants. 
+
+  Control plane: EVPN with iBGP-over-eBGP
+  P2P: BGP unnumbered with RFC8950 (ipv6 next hops for ipv4 prefixes)
+
+  * h1 and h2 should be able to ping each other: docker exec -it clab-evpn-h2 ping 172.16.0.3 -c 2
+  * h3 and h4 should be able to ping each other: docker exec -it clab-evpn-h3 ping 172.16.3.6 -c 2
+  * h1 should not be able to reach h3 or h4    : docker exec -it clab-evpn-h1 ping 172.16.3.6 -c 2
+
+provider: clab
+
+defaults:
+  device: frr
+
+groups:
+  server: # Group naming aligns with Containerlab layout conventions, see https://containerlab.dev/cmd/graph/
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  
+  leaf:
+    members: [ r1,r2 ]
+    module: [ vlan,vxlan,bgp,vrf,evpn ] # Could use ospf or isis here, instead of ebgp
+
+vrfs:
+  tenant1:
+    evpn.transit_vni: true # enable symmetric irb
+    loopback: True
+
+  tenant2:
+    evpn.transit_vni: true
+    loopback: True
+
+bgp:
+  as: 65000 # EVPN overlay AS
+  activate: # Address families to activate
+    ipv4: [ ebgp ] # Only activate ipv4 over eBGP, use iBGP for EVPN only. Remove when using ospf or isis
+
+vlans:
+  red1:
+    mode: irb
+    vrf: tenant1
+
+  blue1:
+    mode: irb
+    vrf: tenant1
+
+  red2:
+    mode: irb
+    vrf: tenant2
+
+  blue2:
+    mode: irb
+    vrf: tenant2
+
+nodes:
+  r1:
+    bgp.local_as: 65001
+
+  r2:
+    bgp.local_as: 65002
+
+  h1:
+  h2:
+  h3:
+  h4:
+
+links:
+- h1:
+  r1:
+    vlan.access: red1
+- h2:
+  r2:
+    vlan.access: blue1
+- h3:
+  r1:
+    vlan.access: red2
+- h4:
+  r2:
+    vlan.access: blue2
+
+- r1:
+  r2:
+  prefix: # Use eBGP unnumbered, remove when using ospf or isis
+    ipv4: True
+    ipv6: True


### PR DESCRIPTION
In the context of https://github.com/ipspace/netlab/discussions/467

I realize this is a bit hacky, just to share an idea of what this could look like:

```
vlans:
  internet:
    mode: irb
    vrf: internet
    gateway:
      default: True
```

I experimented with setting ```gateway.default: True``` in fix_vlan_gateways (on the first interface found with ipv4), but the iteration order is based on vlan id and I think that would be non-intuitive for users (too implicit)

Also note the bug fixes in links.py, triggered by copying 'gateway' from vlans