### PR TITLE
Add ipv6_lla flag for bgp unnumbered

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -166,7 +166,7 @@
      prepend-global-as: {{ not n.replace_global_as|default(True) }} # Don't include iBGP global AS in eBGP advertisements
 {% endif %}
 
-{% elif n[af]==True and af=='ipv6' and n.type == 'ebgp' %}
+{% elif n[af]==True and n.type=='ebgp' %}
 {# BGP unnumbered for IPv6 LLA, only supported for EBGP peers #}
 {% set peer_group = "ebgp-unnumbered" + (('-' + n.local_as|string()) if n.local_as is defined else '') %}
 {{ bgp_peer_group(peer_group,'ebgp',n,None) }}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -1,7 +1,7 @@
-{% macro ip_addresses(name,index,intf,ipv6_ra=True,is_system=False) %}
+{% macro ip_addresses(name,index,intf,is_system=False) %}
 - path: interface[name={{name}}]/subinterface[index={{index}}]
   val:
-   description: {{ intf.name | default( "No description, created in ip_addresses" )|replace('->','~')|regex_replace('[\\[\\]]','') }}
+   description: {{ intf.name | default( "No description" )|replace('->','~')|regex_replace('[\\[\\]]','') }}
 {% if 'ipv4' in intf and intf.ipv4 is string %}
    ipv4:
     address:
@@ -10,13 +10,13 @@
       primary: [null]
 {% endif %}
 {% endif %}
-{% if 'ipv6' in intf %}
+{% if 'ipv6' in intf or 'ipv6_lla' in intf %}
    ipv6:
-{%   if intf.ipv6 is string %}
+{%   if intf.ipv6 is defined and intf.ipv6 is string %}
     address:
     - ip-prefix: "{{ intf.ipv6 }}"
 {%   endif %}
-{% if ipv6_ra %}
+{% if 'ipv6_lla' in intf %}
     neighbor-discovery:
      learn-unsolicited: link-local
     router-advertisement:
@@ -43,7 +43,7 @@ updates:
 {% endif %}
 {% endif %}
 
-{{  ip_addresses('system0',0,loopback,False,True)  }}
+{{  ip_addresses('system0',0,loopback,is_system=True)  }}
 
 {% for l in interfaces|default([]) if l.vlan is not defined and l.subif_index is not defined %}
 {% set if_name_index = l.ifname.split('.') %}
@@ -58,7 +58,6 @@ updates:
    subinterface:
     index: {{ if_index }}
     description: "{{ if_desc }}"
-
 {{ ip_addresses(if_name,if_index,l) }}
 {% endfor %}
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -223,13 +223,14 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
           continue
 
       if rfc8950:
-        extra_data.ipv4_rfc8950 = True                                # Set unnumbered indicate RFC 8950 IPv4 AF
         if not features.bgp.rfc8950:
           common.error(
             text=f'{node.name} (device {node.device}) does not support IPv4 RFC 8950-style AF over IPv6 LLA EBGP sessions (interface {l.name})',
             category=common.IncorrectValue,
             module='bgp')
           continue
+        extra_data.ipv4_rfc8950 = True                                # Set unnumbered indicate RFC 8950 IPv4 AF
+        l.ipv6_lla = True                                             # Mark the interface as requiring ipv6 lla for bgp unnumbered
 
       for k in ('local_as','replace_global_as'):
         local_as_data = data.get_from_box(l,f'bgp.{k}') or data.get_from_box(node,f'bgp.{k}')

--- a/tests/integration/evpn/vxlan-routing-ibgp-over-ebgp-unnumbered.yml
+++ b/tests/integration/evpn/vxlan-routing-ibgp-over-ebgp-unnumbered.yml
@@ -82,6 +82,4 @@ links:
 
 - r1:
   r2:
-  prefix: # Use eBGP unnumbered, remove when using ospf or isis
-    ipv4: True
-    ipv6: True
+  unnumbered: True # Use eBGP unnumbered, remove when using ospf or isis

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -265,6 +265,7 @@ nodes:
       ifname: swp1
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 1
       name: test -> x1
       neighbors:
@@ -278,6 +279,7 @@ nodes:
     - ifindex: 2
       ifname: swp2
       ipv4: true
+      ipv6_lla: true
       linkindex: 2
       name: test -> x1
       neighbors:
@@ -290,6 +292,7 @@ nodes:
       ifname: swp3
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 3
       name: test -> x2
       neighbors:
@@ -392,6 +395,7 @@ nodes:
       ifname: swp1
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 1
       name: x1 -> test
       neighbors:
@@ -405,6 +409,7 @@ nodes:
     - ifindex: 2
       ifname: swp2
       ipv4: true
+      ipv6_lla: true
       linkindex: 2
       name: x1 -> test
       neighbors:
@@ -460,6 +465,7 @@ nodes:
       ifname: swp1
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 3
       name: x2 -> test
       neighbors:

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -118,6 +118,7 @@ nodes:
       ifname: swp1
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 1
       name: r1 -> r2
       neighbors:
@@ -181,6 +182,7 @@ nodes:
       ifname: swp1
       ipv4: true
       ipv6: true
+      ipv6_lla: true
       linkindex: 1
       name: r2 -> r1
       neighbors:


### PR DESCRIPTION
Context: https://github.com/ipspace/netlab/pull/463

Instead of assuming ```ipv6: True``` for BGP unnumbered, have the bgp module flag the interface as requiring ipv6_lla enabled.
This avoids triggering (e.g.) ospfv3 for such topologies

TODO: Documentation, will add if accepted