### PR TITLE
Add explicit support for bgp large communities (RFC8092)

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -261,7 +261,7 @@ The propagation of BGP communities over IBGP and EBGP sessions is controlled wit
 
 The value of **bgp.community** attribute could be:
 
-* A string: **standard** or **extended** -- only specified communities will be propagated to IBGP and EBGP neighbors. In the following example, R1 propagates standard communities to all its neighbors.
+* A string: **standard** or **extended** or **large** -- only specified communities will be propagated to IBGP and EBGP neighbors. In the following example, R1 propagates standard communities to all its neighbors.
 
 ```
 nodes:
@@ -270,7 +270,7 @@ nodes:
       community: standard
 ```
 
-* A list of strings (**standard** and/or **extended**) -- all communities specified in the list will be propagated to IBGP and EBGP neighbors. Most network operating systems will be configured with **both** configuration keyword if you specify `['standard','extended']` as the value. In the following example, R1 propagates standard and extended communities to all its neighbors.
+* A list of strings (**standard** and/or **extended** and/or **large**) -- all communities specified in the list will be propagated to IBGP and EBGP neighbors. Most network operating systems will be configured with **both** configuration keyword if you specify `['standard','extended']` as the value. In the following example, R1 propagates standard and extended communities to all its neighbors.
 
 ```
 nodes:
@@ -279,12 +279,12 @@ nodes:
       community: [standard, extended]
 ```
 
-* A dictionary with two keys: **ibgp** and **ebgp**. The value of each key could be a string or a list (see above). The following example sets a network-wide default -- send standard and extended communities to IBGP neighbors, and standard communities to EBGP neighbors (this is the global default set in global **topology-defaults.yml** file).
+* A dictionary with two keys: **ibgp** and **ebgp**. The value of each key could be a string or a list (see above). The following example sets a network-wide default -- send standard, extended and large (see RFC8092) communities to IBGP neighbors, and standard communities to EBGP neighbors (this is the global default set in global **topology-defaults.yml** file).
 
 ```
 bgp:
   community: 
-    ibgp: [standard, extended]
+    ibgp: [standard, extended, large]
     ebgp: [standard]
 ```
 

--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -297,6 +297,9 @@ nodes:
       community: []
 ```
 
+Note that on some platforms (e.g. some Cisco devices) 'standard' may imply 'large', while on others (like Nokia SR OS) they can be configured separately.
+Others (like Nokia SR Linux) may not support the enabling/disabling of 'extended' communities.
+
 ## Related Plugins
 
 ```eval_rst

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -121,7 +121,8 @@
 {% set list = vrf_bgp.community[ type ] %}
    send-community:
     standard: {{ 'standard' in list }}
-    large: {{ 'extended' in list }}
+    large: {{ 'large' in list }}
+    _annotate: "Explicit 'extended' setting ({{ 'extended' in list }}) is not supported"
 {% endif %}
 {% if transport_ip %}
    transport:

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -42,7 +42,7 @@ def check_bgp_parameters(node: Box) -> None:
           parent=node.bgp.community,
           path=f'nodes.{node.name}.bgp.community',
           key=k,
-          valid_values=['standard','extended'],
+          valid_values=['standard','extended','large'], # Support large communities as defined in RFC8092
           module='bgp')
 
 BGP_VALID_AF: typing.Final[list] = ['ipv4','ipv6']

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -41,7 +41,7 @@ bgp:
   advertise_roles: [ stub ]
   advertise_loopback: True
   community:
-    ibgp: [ standard, extended ]
+    ibgp: [ standard, extended, large ]
     ebgp: [ standard ]
   no_propagate: [ ebgp_role, advertise_roles, rr_list, as_list ]
   transform_after: [ vlan ]

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -17,6 +17,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -167,6 +168,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -221,6 +223,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -333,6 +336,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -424,6 +428,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -117,6 +118,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:
@@ -231,6 +233,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:
@@ -342,6 +345,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:
@@ -431,6 +435,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -55,6 +56,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -111,6 +113,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -22,6 +22,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -188,6 +189,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -247,6 +249,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -306,6 +309,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -365,6 +369,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -421,6 +426,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -513,6 +519,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -587,6 +594,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   ebgp_role: ''
   next_hop_self: true
   rr_list:
@@ -116,6 +117,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -194,6 +196,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -272,6 +275,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -357,6 +361,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -19,6 +19,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -181,6 +182,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -228,6 +230,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -275,6 +278,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -356,6 +360,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -437,6 +442,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -507,6 +513,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
   sessions:
     ipv4:
@@ -97,6 +98,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -186,6 +188,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:
@@ -252,6 +255,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -194,6 +195,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -359,6 +361,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -436,6 +439,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -492,6 +496,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv6: true
       neighbors:
       - activate:
@@ -542,6 +547,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -16,6 +16,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -94,6 +95,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -150,6 +152,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -224,6 +227,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -133,6 +134,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.1
@@ -269,6 +271,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.2
@@ -522,6 +525,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -239,6 +240,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -307,6 +309,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -420,6 +423,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -527,6 +531,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -634,6 +639,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -732,6 +738,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -10,6 +10,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -64,6 +65,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -130,6 +132,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   g1:
@@ -107,6 +108,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.5

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -47,6 +48,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -86,6 +88,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -125,6 +128,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -164,6 +168,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -203,6 +208,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -242,6 +248,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -89,6 +90,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -42,6 +43,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/module-node-only.yml
+++ b/tests/topology/expected/module-node-only.yml
@@ -9,6 +9,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -49,6 +50,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -90,6 +91,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -122,6 +123,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -245,6 +247,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -320,6 +323,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -180,6 +181,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -245,6 +247,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -390,6 +393,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -500,6 +504,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:
@@ -608,6 +613,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       ipv6: true
       neighbors:

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -6,6 +6,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -65,6 +66,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.1
@@ -111,6 +113,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -132,6 +133,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -229,6 +231,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:
@@ -362,6 +365,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -7,6 +7,7 @@ bgp:
     ibgp:
     - standard
     - extended
+    - large
   next_hop_self: true
 groups:
   as65000:
@@ -105,6 +106,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.1
@@ -252,6 +254,7 @@ nodes:
         ibgp:
         - standard
         - extended
+        - large
       ipv4: true
       neighbors:
       - activate:


### PR DESCRIPTION
On some Cisco devices 'standard' implies also 'large' (see e.g. [here](https://content.cisco.com/chapter.sjs?uri=/searchable/chapter/content/en/us/td/docs/switches/lan/catalyst9300/software/release/17-5/configuration_guide/rtng/b_175_rtng_9300_cg/configuring_bgp_large_community.html.xml)) but on other platforms (like SR OS and SR Linux) they are configured separately

* Update documentation
* Update topology defaults