### PR TITLE
Bugfix: 'value' can be None

### DIFF
--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -17,7 +17,7 @@ from .. import addressing
 #
 def node_vlan_check(node: Box, topology: Box) -> bool:
   if not node.vxlan.vlans:            # Create a default list of VLANs if needed
-    node.vxlan.vlans = [ name for name,value in node.vlans.items() if 'vni' in value ]
+    node.vxlan.vlans = [ name for name,value in node.vlans.items() if value and 'vni' in value ]
 
   OK = True
   vlan_list = []


### PR DESCRIPTION
Actually, this may be hiding a deeper issue: Node vlans need to be pulled in from global, before this iteration happens