### PR TITLE
Pull in vrfs associated with vlans

### DIFF
--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -343,7 +343,7 @@ class VRF(_Module):
 
   def node_pre_transform(self, node: Box, topology: Box) -> None:
     # Check if any global vrfs need to be pulled in due to being referenced by a vlan
-    vlan_vrfs = [ vdata.vrf for vname,vdata in node.vlans.items() if 'vlans' in node and 'vrf' in vdata ]
+    vlan_vrfs = [ vdata.vrf for vname,vdata in node.get('vlans',{}).items() if 'vrf' in vdata ]
     if not 'vrfs' in node:
       if not vlan_vrfs:  # No local vrfs and no vlan references -> exit
         return
@@ -397,7 +397,7 @@ class VRF(_Module):
     else:
       node.vrfs = node.vrfs or {}     # ... otherwise make sure the 'vrfs' dictionary is not empty
       vrfidx = 100
-      for v in node.vrfs.values():    # We need unique VRF index to create OSPF processes
+      for v in sorted(node.vrfs.values(),key=lambda v: v.id):    # We need unique VRF index to create OSPF processes, assign in sorted order
         v.vrfidx = vrfidx
         vrfidx = vrfidx + 1
 

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -238,7 +238,7 @@ nodes:
         import:
         - '65000:2'
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       red:
         af:
           ipv4: true
@@ -255,7 +255,7 @@ nodes:
         import:
         - '65000:1'
         rd: '65000:1'
-        vrfidx: 101
+        vrfidx: 100
   r2:
     af:
       ipv4: true
@@ -627,7 +627,7 @@ nodes:
         import:
         - '65000:2'
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       red:
         af:
           ipv4: true
@@ -644,7 +644,7 @@ nodes:
         import:
         - '65000:1'
         rd: '65000:1'
-        vrfidx: 101
+        vrfidx: 100
 provider: libvirt
 vlan:
   mode: irb

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -457,7 +457,7 @@ nodes:
         import:
         - '65000:2'
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       green:
         af:
           ipv4: true
@@ -468,7 +468,7 @@ nodes:
         import:
         - '65000:3'
         rd: '65000:3'
-        vrfidx: 101
+        vrfidx: 102
       red:
         af:
           ipv4: true
@@ -478,7 +478,7 @@ nodes:
         import:
         - '65000:1'
         rd: '65000:1'
-        vrfidx: 102
+        vrfidx: 100
   r2:
     af:
       ipv4: true
@@ -638,7 +638,7 @@ nodes:
         import:
         - '65000:2'
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       green:
         af:
           ipv4: true
@@ -649,7 +649,7 @@ nodes:
         import:
         - '65000:3'
         rd: '65000:3'
-        vrfidx: 101
+        vrfidx: 102
       red:
         af:
           ipv4: true
@@ -659,7 +659,7 @@ nodes:
         import:
         - '65000:1'
         rd: '65000:1'
-        vrfidx: 102
+        vrfidx: 100
   s1:
     af:
       ipv4: true
@@ -1136,7 +1136,7 @@ nodes:
         import:
         - '65000:2'
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       green:
         export:
         - '65000:3'
@@ -1144,7 +1144,7 @@ nodes:
         import:
         - '65000:3'
         rd: '65000:3'
-        vrfidx: 101
+        vrfidx: 102
       red:
         export:
         - '65000:1'
@@ -1152,7 +1152,7 @@ nodes:
         import:
         - '65000:1'
         rd: '65000:1'
-        vrfidx: 102
+        vrfidx: 100
 provider: clab
 vlan:
   mode: irb

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -1043,7 +1043,7 @@ nodes:
             vrf: blue
           router_id: 10.0.0.3
         rd: '65000:2'
-        vrfidx: 100
+        vrfidx: 101
       red:
         af:
           ipv4: true
@@ -1080,7 +1080,7 @@ nodes:
             vrf: red
           router_id: 10.0.0.3
         rd: '65000:1'
-        vrfidx: 101
+        vrfidx: 100
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -340,7 +340,7 @@ nodes:
         import:
         - '65001:4'
         rd: '65001:4'
-        vrfidx: 100
+        vrfidx: 101
       red:
         export:
         - '65000:2'
@@ -348,7 +348,7 @@ nodes:
         import:
         - '65000:2'
         rd: null
-        vrfidx: 101
+        vrfidx: 100
   r3:
     af:
       ipv4: true


### PR DESCRIPTION
As illustrated [here](https://github.com/ipspace/netlab/blob/dev/tests/integration/evpn/vxlan-asymmetric-irb.yml#L32) there are cases where vlans get pulled into a node without being referenced from an interface.

Currently, any vrf associated with such a vlan does not get pulled in - while I believe it should

This may be another case of some underlying issue that is better fixed elsewhere - just submitting the case and a straightforward fix to start with

This PR also ensures there is a deterministic order in which local vrfidx values get assigned, by sorting the vrfs on their global id. This avoids a dependency on the order in which vlans (with associated vrfs) appear in the file