### PR TITLE
evpn/vxlan vni enhancements

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -42,7 +42,7 @@ The following table describes per-platform support of individual VXLAN features:
 
 * **vxlan.domain** -- Ingress replication domain. Optional, default: **global**. Use this parameter when you want to build several isolated bridging domains within your lab.
 * **vxlan.flooding** -- A mechanism used to implement VXLAN flooding. Optional, default: **static**.
-* **vxlan.vlans** -- list of VLANs to be mapped into VXLAN VNIs.  Optional, defaults to all VLANs with **vni** attribute. All VLANs listed in **vxlan.vlans** list must have a **vni** attribute.
+* **vxlan.vlans** -- list of VLANs to be mapped into VXLAN VNIs.  Optional, defaults to all VLANs with numeric **vni** attribute. All VLANs listed in **vxlan.vlans** list must have a **vni** attribute.
 * **vxlan.use_v6_vtep** -- Use the IPv6 Loopback address as VTEP address. To be used on the devices where you need to explicitly set the local VTEP address, or with *static* flooding to generate the flooding list with IPv6 addresses.
 
 The only supported value for **vxlan.flooding** parameter is **static** -- statically configured ingress replication
@@ -60,7 +60,7 @@ All global parameters can also be used as node parameters.
 You can select VLANs that should be extended with VXLAN transport in two ways:
 
 * Specify a list of VLAN names in **vxlan.vlans** global- or node-level parameters. VLANs specified in that list must be valid VLAN names but do not have to be present on every node.
-* Select VLANs based on the presence of **vni** attribute.
+* Select VLANs based on the presence of **vni** attribute. Use a 'False' value to avoid allocating a **vni** to a given VLAN
 
 You can set the **vni** attribute for individual VLANs, or have it assigned automatically. By default, all global VLANs get a **vni** attribute, and are thus extended over VXLAN transport. This behavior is controlled with **defaults.vlan.auto_vni** global default.
 

--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -60,7 +60,7 @@ All global parameters can also be used as node parameters.
 You can select VLANs that should be extended with VXLAN transport in two ways:
 
 * Specify a list of VLAN names in **vxlan.vlans** global- or node-level parameters. VLANs specified in that list must be valid VLAN names but do not have to be present on every node.
-* Select VLANs based on the presence of **vni** attribute. Use a 'False' value to avoid allocating a **vni** to a given VLAN
+* Select VLANs based on the presence of **vni** attribute. Use 'True' to force auto-assignment, 'False' to avoid allocating a **vni** to a given VLAN
 
 You can set the **vni** attribute for individual VLANs, or have it assigned automatically. By default, all global VLANs get a **vni** attribute, and are thus extended over VXLAN transport. This behavior is controlled with **defaults.vlan.auto_vni** global default.
 

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -86,7 +86,7 @@ def vrf_transit_vni(topology: Box) -> None:
     if vrf_data is None:                                        # Skip empty VRF definitions
       continue
     vni = data.get_from_box(vrf_data,'evpn.transit_vni')
-    if not isinstance(vni,int) or type(vni).__name__!="int":             # Note that isinstance(bool_var,int) is True
+    if not isinstance(vni,int) or type(vni).__name__!="int":    # Note that isinstance(bool_var,int) is True
       continue
     if vni in vni_list:
       common.error(

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -78,12 +78,15 @@ def vrf_transit_vni(topology: Box) -> None:
   if not 'vrfs' in topology:
     return
 
+  # import list of L2 VNIs from vlan module, to check for conflicts
+  from . import vlan
+
   vni_list: typing.List[int] = []
   for vrf_name,vrf_data in topology.vrfs.items():               # First pass: build a list of statically configured VNIs
     if vrf_data is None:                                        # Skip empty VRF definitions
       continue
     vni = data.get_from_box(vrf_data,'evpn.transit_vni')
-    if not isinstance(vni,int) or type(vni)!="int":             # Note that isinstance(bool_var,int) is True
+    if not isinstance(vni,int) or type(vni).__name__!="int":             # Note that isinstance(bool_var,int) is True
       continue
     if vni in vni_list:
       common.error(
@@ -91,6 +94,12 @@ def vrf_transit_vni(topology: Box) -> None:
         common.IncorrectValue,
         'evpn')
       continue
+    elif vni in vlan.vlan_ids.vni:
+      common.error(
+        f'VRF {vrf_name} is using an EVPN transit VNI that is also used as L2 VNI {vni}',
+        common.IncorrectValue,
+        'evpn')
+      continue  
     vni_list.append( vni )                                      # Insert it to detect duplicates elsewhere
 
   vni_start = topology.defaults.evpn.start_transit_vni
@@ -117,7 +126,7 @@ def vrf_irb_setup(node: Box, topology: Box) -> None:
       continue
 
     g_vrf = topology.vrfs[vrf_name]                             # Pointer to global VRF data, will come useful in a second
-    if 'transit_vni' in g_vrf.get('evpn',{}):                   # Transit VNI in global VRF => symmetrical IRB
+    if data.get_from_box(g_vrf,'evpn.transit_vni'):             # Transit VNI in global VRF => symmetrical IRB
       if not features.evpn.irb:                                 # ... does this device support IRB?
         common.error(
           f'VRF {vrf_name} on {node.name} uses symmetrical EVPN IRB which is not supported by {node.device} device',

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -174,8 +174,8 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
       common.error(f'VLAN ID {vdata.id} for VLAN {vname} in {obj_name} must be between 2 and 4094',common.IncorrectValue,'vlan')
       continue
 
-    if not 'vni' in vdata:                                          # When VNI is not defined
-      vni_default = topology.defaults.vlan.start_vni + vdata.id     # ... try to build VNI from VLAN ID
+    if not 'vni' in vdata or (isinstance(vdata.vni,bool) and vdata.vni==True):  # When VNI is not defined or set to 'True'
+      vni_default = topology.defaults.vlan.start_vni + vdata.id                 # ... try to build VNI from VLAN ID
       if not vni_default in vlan_ids.vni:                           # Is the VNI free?
         vdata.vni = vni_default                                     # ... great, take it
         vlan_ids.vni.add(vni_default)                               # ... and add it to the list of used VNIs
@@ -184,7 +184,7 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
     if not isinstance(vdata.vni,int):                               # Not done yet, we still have to validate the VNI type and range
       common.error(f'VNI {vdata.vni} for VLAN {vname} in {obj_name} must be an integer',common.IncorrectValue,'vlan')
       continue
-    elif vdata.vni==False:                                          # Allow user to explicitly not assign a VNI using 'False'
+    elif isinstance(vdata.vni,bool) and vdata.vni==False:           # Allow user to explicitly not assign a VNI using 'False'
       vdata.pop('vni')
     elif vdata.vni < 2 or vdata.vni > 16777215:
       common.error(f'VNI {vdata.vni} for VLAN {vname} in {obj_name} must be between 2 and 16777215',common.IncorrectValue,'vlan')

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -51,7 +51,7 @@ def build_vlan_id_set(obj: Box, attr: str, objname: str) -> set:
       common.fatal(f'Found a "vlans" setting that is not a dictionary in {objname}','vlan')
       return set()
 
-    return { v[attr] for v in obj.vlans.values() if isinstance(v,dict) and attr in v and v[attr] is not None }
+    return { v[attr] for v in obj.vlans.values() if isinstance(v,dict) and attr in v and v[attr] is not None and not isinstance(v[attr],bool) }
   return set()
 
 def populate_vlan_id_set(topology: Box) -> None:
@@ -184,7 +184,9 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
     if not isinstance(vdata.vni,int):                               # Not done yet, we still have to validate the VNI type and range
       common.error(f'VNI {vdata.vni} for VLAN {vname} in {obj_name} must be an integer',common.IncorrectValue,'vlan')
       continue
-    if vdata.vni < 2 or vdata.vni > 16777215:
+    elif vdata.vni==False:                                          # Allow user to explicitly not assign a VNI using 'False'
+      vdata.pop('vni')
+    elif vdata.vni < 2 or vdata.vni > 16777215:
       common.error(f'VNI {vdata.vni} for VLAN {vname} in {obj_name} must be between 2 and 16777215',common.IncorrectValue,'vlan')
       continue
 


### PR DESCRIPTION
Allow users to specify ```vni: False``` for vlans to avoid auto-allocation of a vni.
This simplifies the implicit construction of vxlan.vlans in topologies with large numbers of vlans and/or varying vlans per node

Honor the global vlan.auto_vni setting: When ```False``` don't auto-assign vnis (unless requested using ```vni: True```)

* Fix type check on __name__
* Use 'data.get_from_box' to get evpn.transit_vni, for asymmetric case evpn: can be None (evpn enabled but no transit_vni)
* Check transit VNIs against list of L2 VNIs from vlan module, error if overlap
* Allow explicit ```vni: True``` similar to transit_vni allocation