### PR TITLE
Fix corner case of evpn to ipv6 lla peers

### DIFF
--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -17,10 +17,11 @@ router bgp {{ bgp.as }}
 
 {% for n in bgp.neighbors if n.evpn|default(False) %}
 {%  for af in ['ipv4','ipv6'] if af in n %}
-  neighbor {{ n[af] }} activate
-{%       if bgp.rr|default('') and not n.rr|default('') %}
-  neighbor {{ n[af] }} route-reflector-client
-{%       endif %}
+{%   set peer = n[af] if n[af] is string else n.local_if|default('?') %}
+  neighbor {{ peer }} activate
+{%   if bgp.rr|default('') and not n.rr|default('') %}
+  neighbor {{ peer }} route-reflector-client
+{%   endif %}
 {%  endfor %}
 {% endfor %}
 


### PR DESCRIPTION
Potentially more common than hierarchical route reflectors, but still quite rare.  If people want to try this, at least it won't fail because of the tooling