### PR TITLE
Disable routing protocols per vrf or interface - allow bgp: False

### DIFF
--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -81,6 +81,7 @@ def post_transform(topology: Box) -> None:
   module_transform("post_transform",topology)
   node_transform("post_transform",topology)
   link_transform("post_transform",topology)
+  module_transform("post_transform_cleanup",topology) # JvB: added to cleanup data model after all transformations are done
   reorder_node_modules(topology)               # Make sure modules are configured in dependency order (#86)
 
 # Set default list of modules for nodes without specific module list
@@ -352,9 +353,9 @@ def check_module_parameters(topology: Box) -> None:
                   common.IncorrectValue,
                   'modules')
           else:
-            if type(intf[m]).__name__ != str(mod_attr[m].interface):
+            if type(intf[m]).__name__ not in mod_attr[m].interface:
               common.error(
-                f"Node {n} has invalid value type for attribute {k} for module {m} on link {l}, expected {mod_attr[m].interface}",
+                f"Node {n} has invalid value type '{type(intf[m]).__name__}' for module {m} on link {l}, expected {mod_attr[m].interface}",
                 common.IncorrectValue,
                 'modules')
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -54,8 +54,8 @@ bgp:
       af, as, next_hop_self, rr, rr_cluster_id, originate, advertise_loopback, sessions, activate,
       community, router_id, local_as, replace_global_as ]
     node_copy: [ local_as, replace_global_as ]
-    link: [ advertise ]
-    interface: [ local_as, replace_global_as ]
+    link: [ advertise, bool ]
+    interface: [ local_as, replace_global_as, bool ]
 
 isis:
   supported_on: [ eos, frr, csr, iosv, nxos, vsrx, srlinux, sros, none, vyos ]
@@ -139,8 +139,8 @@ vrf: # Basic VRF support
   transform_after: [ vlan, bgp ]
   as: 65000
   attributes:
-    global: [ as,loopback ]
-    node: [ as,loopback ]
+    global: [ as,loopback,bgp ]
+    node: [ as,loopback,bgp ]
     link: str
     interface: str
     extra:

--- a/tests/topology/expected/bgp-disabled.yml
+++ b/tests/topology/expected/bgp-disabled.yml
@@ -1,0 +1,414 @@
+bgp:
+  advertise_loopback: true
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+groups:
+  as65001:
+    members:
+    - r1
+  as65002:
+    members:
+    - r2
+input:
+- topology/input/bgp-disabled.yml
+- package:topology-defaults.yml
+links:
+- interfaces:
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 1
+    ipv4: 10.1.0.2/30
+    node: r2
+  left:
+    ifname: ethernet-1/1
+    ipv4: 10.1.0.1/30
+    node: r1
+  linkindex: 1
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  right:
+    ifname: ethernet-1/1
+    ipv4: 10.1.0.2/30
+    node: r2
+  role: external
+  type: p2p
+- interfaces:
+  - ifindex: 2
+    ipv4: 10.1.0.5/30
+    node: r1
+    vrf: some_vrf
+  - ifindex: 2
+    ipv4: 10.1.0.6/30
+    node: r2
+  left:
+    ifname: ethernet-1/2
+    ipv4: 10.1.0.5/30
+    node: r1
+  linkindex: 2
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.4/30
+  right:
+    ifname: ethernet-1/2
+    ipv4: 10.1.0.6/30
+    node: r2
+  role: external
+  type: p2p
+- interfaces:
+  - ifindex: 3
+    ipv4: 10.1.0.9/30
+    node: r1
+    vrf: some_vrf_no_bgp
+  - ifindex: 3
+    ipv4: 10.1.0.10/30
+    node: r2
+  left:
+    ifname: ethernet-1/3
+    ipv4: 10.1.0.9/30
+    node: r1
+  linkindex: 3
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.8/30
+  right:
+    ifname: ethernet-1/3
+    ipv4: 10.1.0.10/30
+    node: r2
+  role: external
+  type: p2p
+- interfaces:
+  - ifindex: 4
+    ipv4: 10.1.0.13/30
+    node: r1
+  - ifindex: 4
+    ipv4: 10.1.0.14/30
+    node: r2
+  left:
+    ifname: ethernet-1/4
+    ipv4: 10.1.0.13/30
+    node: r1
+  linkindex: 4
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.12/30
+  right:
+    ifname: ethernet-1/4
+    ipv4: 10.1.0.14/30
+    node: r2
+  role: external
+  type: p2p
+- interfaces:
+  - ifindex: 5
+    ipv4: 10.1.0.17/30
+    node: r1
+  - ifindex: 5
+    ipv4: 10.1.0.18/30
+    node: r2
+  left:
+    ifname: ethernet-1/5
+    ipv4: 10.1.0.17/30
+    node: r1
+  linkindex: 5
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.16/30
+  right:
+    ifname: ethernet-1/5
+    ipv4: 10.1.0.18/30
+    node: r2
+  role: external
+  type: p2p
+module:
+- bgp
+- vrf
+name: input
+nodes:
+  r1:
+    af:
+      ipv4: true
+      vpnv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65001
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - activate:
+          ipv4: true
+        as: 65002
+        ifindex: 1
+        ipv4: 10.1.0.2
+        name: r2
+        type: ebgp
+      next_hop_self: true
+      router_id: 10.0.0.1
+    box: ghcr.io/nokia/srlinux
+    clab:
+      kind: srl
+      type: ixrd2
+    device: srlinux
+    hostname: clab-input-r1
+    id: 1
+    interfaces:
+    - clab:
+        name: e1-1
+      ifindex: 1
+      ifname: ethernet-1/1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      name: r1 -> r2
+      neighbors:
+      - ifname: ethernet-1/1
+        ipv4: 10.1.0.2/30
+        node: r2
+      role: external
+      type: p2p
+    - clab:
+        name: e1-2
+      ifindex: 2
+      ifname: ethernet-1/2
+      ipv4: 10.1.0.5/30
+      linkindex: 2
+      name: r1 -> r2
+      neighbors:
+      - ifname: ethernet-1/2
+        ipv4: 10.1.0.6/30
+        node: r2
+      role: external
+      type: p2p
+      vrf: some_vrf
+    - clab:
+        name: e1-3
+      ifindex: 3
+      ifname: ethernet-1/3
+      ipv4: 10.1.0.9/30
+      linkindex: 3
+      name: r1 -> r2
+      neighbors:
+      - ifname: ethernet-1/3
+        ipv4: 10.1.0.10/30
+        node: r2
+      role: external
+      type: p2p
+      vrf: some_vrf_no_bgp
+    - clab:
+        name: e1-4
+      ifindex: 4
+      ifname: ethernet-1/4
+      ipv4: 10.1.0.13/30
+      linkindex: 4
+      name: r1 -> r2
+      neighbors:
+      - ifname: ethernet-1/4
+        ipv4: 10.1.0.14/30
+        node: r2
+      role: external
+      type: p2p
+    - clab:
+        name: e1-5
+      ifindex: 5
+      ifname: ethernet-1/5
+      ipv4: 10.1.0.17/30
+      linkindex: 5
+      name: r1 -> r2
+      neighbors:
+      - ifname: ethernet-1/5
+        ipv4: 10.1.0.18/30
+        node: r2
+      role: external
+      type: p2p
+    loopback:
+      ipv4: 10.0.0.1/32
+    mgmt:
+      ifname: mgmt0
+      ipv4: 192.168.121.101
+      mac: 08-4F-A9-00-00-01
+    module:
+    - bgp
+    - vrf
+    name: r1
+    vrf:
+      as: 65000
+    vrfs:
+      some_vrf:
+        af:
+          ipv4: true
+        as: 65123
+        bgp:
+          neighbors:
+          - as: 65002
+            ifindex: 2
+            ipv4: 10.1.0.6
+            name: r2
+            type: ebgp
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        rd: '65000:1'
+        vrfidx: 100
+      some_vrf_no_bgp:
+        af:
+          ipv4: true
+        export:
+        - '65000:2'
+        id: 2
+        import:
+        - '65000:2'
+        rd: '65000:2'
+        vrfidx: 101
+  r2:
+    af:
+      ipv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65002
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - activate:
+          ipv4: true
+        as: 65001
+        ifindex: 1
+        ipv4: 10.1.0.1
+        name: r1
+        type: ebgp
+      - activate:
+          ipv4: true
+        as: 65001
+        ifindex: 2
+        ipv4: 10.1.0.5
+        name: r1
+        type: ebgp
+      next_hop_self: true
+      router_id: 10.0.0.2
+    box: ghcr.io/nokia/srlinux
+    clab:
+      kind: srl
+      type: ixrd2
+    device: srlinux
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - clab:
+        name: e1-1
+      ifindex: 1
+      ifname: ethernet-1/1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      name: r2 -> r1
+      neighbors:
+      - ifname: ethernet-1/1
+        ipv4: 10.1.0.1/30
+        node: r1
+      role: external
+      type: p2p
+    - clab:
+        name: e1-2
+      ifindex: 2
+      ifname: ethernet-1/2
+      ipv4: 10.1.0.6/30
+      linkindex: 2
+      name: r2 -> r1
+      neighbors:
+      - ifname: ethernet-1/2
+        ipv4: 10.1.0.5/30
+        node: r1
+        vrf: some_vrf
+      role: external
+      type: p2p
+    - clab:
+        name: e1-3
+      ifindex: 3
+      ifname: ethernet-1/3
+      ipv4: 10.1.0.10/30
+      linkindex: 3
+      name: r2 -> r1
+      neighbors:
+      - ifname: ethernet-1/3
+        ipv4: 10.1.0.9/30
+        node: r1
+        vrf: some_vrf_no_bgp
+      role: external
+      type: p2p
+    - clab:
+        name: e1-4
+      ifindex: 4
+      ifname: ethernet-1/4
+      ipv4: 10.1.0.14/30
+      linkindex: 4
+      name: r2 -> r1
+      neighbors:
+      - ifname: ethernet-1/4
+        ipv4: 10.1.0.13/30
+        node: r1
+      role: external
+      type: p2p
+    - clab:
+        name: e1-5
+      ifindex: 5
+      ifname: ethernet-1/5
+      ipv4: 10.1.0.18/30
+      linkindex: 5
+      name: r2 -> r1
+      neighbors:
+      - ifname: ethernet-1/5
+        ipv4: 10.1.0.17/30
+        node: r1
+      role: external
+      type: p2p
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: mgmt0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - bgp
+    - vrf
+    name: r2
+    vrf:
+      as: 65000
+    vrfs: {}
+provider: clab
+vrf:
+  as: 65000
+vrfs:
+  some_vrf:
+    as: 65123
+    export:
+    - '65000:1'
+    id: 1
+    import:
+    - '65000:1'
+    rd: '65000:1'
+  some_vrf_no_bgp:
+    export:
+    - '65000:2'
+    id: 2
+    import:
+    - '65000:2'
+    rd: '65000:2'

--- a/tests/topology/input/bgp-disabled.yml
+++ b/tests/topology/input/bgp-disabled.yml
@@ -1,0 +1,35 @@
+provider: clab
+
+defaults.device: srlinux
+
+module: [bgp,vrf]
+
+vrfs:
+  some_vrf:
+    as: 65123
+  some_vrf_no_bgp:
+    bgp: False
+
+nodes:
+ r1:
+  bgp.as: 65001
+ r2:
+  bgp.as: 65002
+
+links:
+- r1-r2 # regular ebgp
+- r1:
+    vrf: some_vrf
+  r2:
+
+- r1:
+    vrf: some_vrf_no_bgp
+  r2:
+
+- r1:
+  r2:
+  bgp: False # Disable bgp at link level
+
+- r1:
+    bgp: False # Disable bgp at interface level
+  r2:


### PR DESCRIPTION
Revisiting https://github.com/ipspace/netlab/issues/446, data-model only changes with no impact on templates

* Allow user to specify ```bgp: False``` at vrf, interface or link levels
* Includes ```vrf.bgp: False``` to disable bgp within any vrfs by default (unless overridden)

This PR is for bgp only, something similar could be implemented for the other routing protocols (when approved)

Adds a 'cleanup' hook for removing bgp: False flags, could also be done generically ( i.e. run code that removes any attributes set to 'False'). Alternatively, bgp module could iterate internally over nodes in module_post_transform, and cleanup afterwards (without adding a hook)

As to why this is needed: Even a simple topology with 2 leaves currently gets ebgp sessions on customer facing vxlan vlans

If you prefer ```bgp.disable: True``` instead, that's also possible

