### PR TITLE
Critical fix: srlinux RT5 announcement of host routes for symmetric IRB inter-subnet forwarding

### DIFF
--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -28,6 +28,7 @@
 - name: Generated gNMI config based on {{ config_template }}
   debug:
    msg: "SRL config: {{ lookup('file', tempfile_1.path ) }}"
+   verbosity: 1
 
 # - block:
 #   - name: Copy CLI configuration to SRL node {{ ansible_host }} using SCP
@@ -55,6 +56,8 @@
   # - debug: var=hostvars
 - name: Update SRL {{ netsim_action }} node configuration (gNMI SET template={{config_template}},CA={{ansible_root_certificates_file}})
   when: d!=[] or (u!=[] and u!="") or r!=[]
+  until: gnmi_set_result is success
+  retries: 2 # Add robustness, downside is that this hides error messages
   vars:
     ansible_port: "{{ srlinux_grpc_port }}" # Uses gNMI over TLS to this port
     ansible_connection: nokia.grpc.gnmi
@@ -78,7 +81,7 @@
   register: gnmi_set_result
   tags: [ print_action, always ]
 
-- debug: var=gnmi_set_result
+- debug: var=gnmi_set_result verbosity=1
 
 - local_action:
     module: file

--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -17,4 +17,7 @@ updates:
 {% endif %}
    evpn:
     rapid-update: True
+   route-advertisement:
+    rapid-withdrawal: True
+
 {% endfor %}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -22,8 +22,9 @@
     router-advertisement:
      router-role:
       admin-state: enable             # no ipv6 nd suppress-ra
-      # min-advertisement-interval: 5 # Leave at platform default 200..600
-      # max-advertisement-interval: 5
+      min-advertisement-interval: 4   # Leaving this at platform default 200..600 takes too long at startup
+      _annotate_min-advertisement-interval: "Reduced from platform default 200s"
+      max-advertisement-interval: 5
 {% endif %}
 {% endif %}
 {% endmacro %}

--- a/netsim/ansible/templates/vlan/srlinux.j2
+++ b/netsim/ansible/templates/vlan/srlinux.j2
@@ -8,7 +8,7 @@ updates:
 
 {# 1. Create the interface, configure tagging for vlan_members or trunk ports with native vlans #}
 - path: interface[name={{if_name}}]
-  val: # {{l}}
+  val:
 {% if l.vlan.trunk_id is defined %}
 {% set _desc = l.name|default("without a name") | replace('->','~')|regex_replace('[\\[\\]]','') %}
    description: "Trunk port {{ _desc }} native={{ l.vlan.native|default("not set") }}"

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -16,8 +16,9 @@
     bgp-vpn:
      bgp-instance:
      - id: 1
-       route-distinguisher:
-        rd: "{{ rd }}"
+       # route-distinguisher:
+       # rd: "{{ rd }}"
+       _annotate: "RD left as <auto> for EVPN services and ECMP to work as expected, not '{{ rd }}'"
        route-target:
         _annotate: "For compatibility with frr, override auto-derived RT based on EVI {{evi}} with VNI {{vni}}"
         import-rt: "target:{{ rts.import[0] }}"
@@ -42,5 +43,28 @@ updates:
 {% if vrfs is defined %}
 {% for vname,vdata in vrfs.items() if 'evpn' in vdata and 'transit_vni' in vdata.evpn %}
 {{ vxlan_interface(vname,vdata.vrfidx,'routed',vdata.evpn.transit_vni,vdata.vrfidx,vdata.rd,vdata) }}
+
+{# Enable RT5 host routes for all irb interfaces in these vrfs, to deal with silent hosts and avoid suboptimal routing #}
+{% for i in interfaces if i.vrf|default('')==vname and i.type=='svi' and i.vlan.mode|default('irb')=='irb' %}
+- path: /interface[name=irb0]/subinterface[index={{ i.ifname.split('.')[1] }}]
+  val:
+{% for ip,arpnd in [('ipv4','arp'),('ipv6','neighbor-discovery')] %}
+{%  if ip in i %}
+   {{ ip }}:
+     {{ arpnd }}:
+       learn-unsolicited: True
+       evpn:
+        advertise: # Type of ARP/ND entries to be advertised
+        - route-type: dynamic
+        # - route-type: static
+       host-route: # Creation of host routes in ip-vrf route table
+        populate:
+        - route-type: dynamic
+        # - route-type: static
+        # - route-type: evpn # not for entries learned through EVPN
+{%  endif %}
+{% endfor %}
+{% endfor %}
+
 {% endfor %}
 {% endif %}

--- a/tests/integration/evpn/vxlan-symmetric-irb-leaf-pairs.yml
+++ b/tests/integration/evpn/vxlan-symmetric-irb-leaf-pairs.yml
@@ -1,0 +1,56 @@
+message: |
+  The devices under test are pairs of layer-3 switches running VXLAN/EVPN with
+  symmetric IRB. 4 hosts are in two VLANs, all in one VRF.
+
+  All hosts should be able to ping each other, eventually (may take some time to learn and exchange all routes)
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  switches:
+    members: [ leaf1a,leaf1b,leaf2a,leaf2b,spine ]
+    module: [ vlan,vxlan,ospf,bgp,evpn,vrf ]
+
+bgp.as: 65000
+
+vrfs:
+  tenant:
+    evpn.transit_vni: True
+
+vlans:
+  red:
+    vrf: tenant
+  blue:
+    vrf: tenant
+
+nodes:
+  h1:
+  h2:
+  h3:
+  h4:
+  leaf1a:
+  leaf1b:
+  leaf2a:
+  leaf2b:
+  spine:
+    bgp.rr: True
+
+links:
+- h1:
+  leaf1a:
+    vlan.access: red
+- h2:
+  leaf1b:
+    vlan.access: red
+- h3:
+  leaf2a:
+    vlan.access: blue
+- h4:
+  leaf2b:
+    vlan.access: blue
+
+- leaf1a-spine
+- leaf1b-spine
+- leaf2a-spine
+- leaf2b-spine


### PR DESCRIPTION
As illustrated by the included integration test case, in inter-subnet forwarding scenarios we need to explicitly enable advertisement of RT5 prefixes for hosts. This causes ARP ND entries to be advertised using the l3 transit VNI for the vrf

Also includes some minor fixes/enhancements
* Add verbosity setting for debug messages
* Add retries:2 for increased robustness against GRPC connection failures (at the expense of missing error messages in case of invalid configurations)
* Set lower default RA intervals to avoid long waits during boot
* Enable EVPN fast withdrawal
* Leave RD as auto-generated (Netlab provided RD value for IP-VPN scenarios breaks ecmp forwarding for evpn)
* Remove debug info

Related to https://github.com/ipspace/netlab/discussions/490