### PR TITLE
Error on attempt to modify global vrf or vlan attributes through group node_data

### DIFF
--- a/docs/groups.md
+++ b/docs/groups.md
@@ -166,6 +166,8 @@ groups:
 nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
 ```
 
+Note that modifying attributes for global vlans or vrfs through node_data is currently not supported; an error is reported to the user instead.
+
 ## Setting Device Type or List of Modules in Groups
 
 Node device type (**device** attribute[^DVTRANS]) or the list of configuration modules (**module** attribute[^MDTRANS]) cannot be set within group **node_data**. Use **device** or **module** attribute at the group level to set them.

--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -203,6 +203,16 @@ def copy_group_node_data(topology: Box) -> None:
       for name,ndata in topology.nodes.items():
         if name in g_members:
           for k,v in gdata.node_data.items():   # Have to go one level deeper, changing ndata value wouldn't work
+
+            # Check for modification of vrf or vlan attributes via node_data, currently not working
+            if k in ['vrfs','vlans'] and v is not None:
+              for vname,vdata in v.items():
+                if vdata and vname in topology[k]:
+                  common.error(
+                    f'Modifying global {k} attributes via node_data from group {grp} into node {ndata.name} is currently not supported',
+                    common.IncorrectValue,
+                    'groups')
+
             if not k in ndata:
               ndata[k] = v
             if isinstance(ndata[k],dict):


### PR DESCRIPTION
Context: https://github.com/ipspace/netlab/issues/480

While waiting for this issue to be fixed, warn users about attempts to modify global vlans or vrfs through node_data in a group.
Due to the order of processing in various hooks, this currently does not work (and may result in obscure errors like https://github.com/ipspace/netlab/pull/474)