### PR TITLE
SR Linux bgp fixes

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -1,5 +1,5 @@
 {% macro bgp_policy(vrf,is_import,communities,vrf_context) %}
-{% set name = vrf + "_" + ('import' if is_import else 'export') %}
+{% set name = vrf + "_ebgp_" + ('import' if is_import else 'export') %}
 
 {% macro accept() %}
 {% if is_import or not communities %}
@@ -56,13 +56,13 @@
 {% macro bgp_config(vrf,_as,router_id,vrf_bgp,vrf_context) %}
 
 {% if 'import' in vrf_context %}
-{% set import_policy = vrf + "_import" %}
+{% set import_policy = vrf + "_ebgp_import" %}
 {{ bgp_policy(vrf,1,vrf_context.import,vrf_context) }}
 {% else %}
 {% set import_policy = "accept_all" %}
 {% endif -%}
 
-{% set export_policy = vrf + "_export" %}
+{% set export_policy = vrf + "_ebgp_export" %}
 {{ bgp_policy(vrf,0,vrf_context.export|default({}),vrf_context) }}
 
 - path: network-instance[name={{vrf}}]/protocols/bgp
@@ -73,6 +73,8 @@
    ebgp-default-policy:
     export-reject-all: False
     import-reject-all: False
+   import-policy: {{ import_policy }}  # Set eBGP policy globally, override for iBGP
+   export-policy: {{ export_policy }}
 
 {# Configure BGP address families globally #}
 {% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
@@ -105,25 +107,28 @@
 {% set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
    ipv4-unicast:
     admin-state: {{ 'enable' if activate.ipv4|default(False) else 'disable' }}
+{% if neighbor.ipv4_rfc8950|default(False) %}
+    advertise-ipv6-next-hops: True
+    receive-ipv6-next-hops: True
+{% endif %}
    ipv6-unicast:
     admin-state: {{ 'enable' if activate.ipv6|default(False) else 'disable' }}
 {% if 'evpn' in neighbor and neighbor.evpn %}
    evpn:
     admin-state: enable # Must have at least 1 address family enabled
 {% endif %}
-   import-policy: {{ import_policy if 'ebgp' in type else 'accept_all' }}
-   export-policy: {{ export_policy if 'ebgp' in type else 'accept_all' }}
    timers:
     connect-retry: 10
     _annotate_connect-retry: "Reduce default 120s to 10s"
     minimum-advertisement-interval: 1
-{% if vrf_bgp.community[ type ]|default([]) %}
-{% set list = vrf_bgp.community[ type ] %}
+{% set list = vrf_bgp.community[type]|default([]) %}
    send-community:
     standard: {{ 'standard' in list }}
-    large: {{ 'extended' in list }}
-{% endif %}
+    large: {{ 'standard' in list }}
+    _annotate_large: "Assuming 'standard' implies 'large' here"
 {% if 'ibgp' in type %}
+   import-policy: accept_all
+   export-policy: accept_all
    next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
    peer-as: {{ neighbor.as }}
    transport:
@@ -172,7 +177,11 @@
 {% endif %}
 
 {% elif n[af]==True and af=='ipv6' and n.type == 'ebgp' %}
-{# BGP unnumbered for IPv6 LLA, only supported for EBGP peers #}
+{# BGP unnumbered for IPv6 LLA, only supported for EBGP peers and not in combination with evpn #}
+{% if 'evpn' in n %}
+{{ raise_error | mandatory( 'EVPN not supported for BGP unnumbered peers' ) }}
+{% endif %}
+
 {% set peer_group = "ebgp-unnumbered" + (('-' + n.local_as|string()) if n.local_as is defined else '') %}
 {{ bgp_peer_group(peer_group,'ebgp',n,None) }}
 {% if n.local_as is defined %}
@@ -180,11 +189,8 @@
    - as-number: {{ n.local_as }}
      prepend-global-as: {{ not n.replace_global_as|default(True) }} # Don't include iBGP AS in eBGP advertisements
 {% endif %}
-{% if n.ipv4_rfc8950|default(False) %}
-   ipv4-unicast:
-     advertise-ipv6-next-hops: true
-     receive-ipv6-next-hops: true
 
+{% if n.ipv4_rfc8950|default(False) %}
 - path: network-instance[name={{vrf}}]/ip-forwarding
   val:
    receive-ipv4-check: false


### PR DESCRIPTION
* Put ebgp policy at top level of vrf, easier to replace with custom configs
* Warn against using evpn with bgp unnumbered peers (could be a device feature flag, but isn't currently)
* Fix 'large' communities to be implied by 'standard', allow user to disable all communities by using []