### PR TITLE
Add global evpn.enforce_unique_transit_vni flag (default: True)

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -88,7 +88,12 @@ The default value of VRF EVPN Instance identifier is the VLAN ID of the first VL
 
 IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addresses:
 
-* Asymmetric IRB requires no extra parameters[^NS]
+* Asymmetric IRB requires no extra parameters[^NS]; note that every vlan must be present on every node for this model to work (not done automatically)
 * Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. This parameter could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns a VNI to the VRF. Note that the EVI value used in this case is currently based on the VRF ID (vrfidx)
 
 [^NS]: Asymmetric IRB is only supported on Nokia SR OS at the moment
+
+### Advanced topologies with duplicate EVPN transit VNIs
+
+In some cases, users may want to implement advanced topologies that use the same **evpn.transit_vni** parameter for different VRFs.
+By default, the evpn module enforces globally unique transit VNIs; set **evpn.enforce_unique_transit_vni** to _False_ to skip this check.

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -87,7 +87,7 @@ def vrf_transit_vni(topology: Box) -> None:
     vni = data.get_from_box(vrf_data,'evpn.transit_vni')
     if not isinstance(vni,int) or isinstance(vni,bool):         # Note that isinstance(bool_var,int) is True
       continue
-    if vni in vni_list:
+    if vni in vni_list and data.get_from_box(topology,'evpn.enforce_unique_transit_vni',True):
       common.error(
         f'VRF {vrf_name} is using the same EVPN transit VNI as another VRF',
         common.IncorrectValue,

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -122,14 +122,15 @@ srv6:
 evpn: # Enables the EVPN address family towards BGP peers
   requires: [ bgp ]
   supported_on: [ sros, srlinux, frr, eos, vyos, dellos10, cumulus, nxos ]
-  no_propagate: [ start_transit_vni ]
+  no_propagate: [ start_transit_vni, enforce_unique_transit_vni ]
   transform_after: [ vlan, vxlan, vrf ]
   config_after: [ vlan, vxlan, vrf ]
   session: [ ibgp ]
   start_transit_vni: 200000
   vlan_bundle_service: False
+  enforce_unique_transit_vni: True  # Require that transit vnis are globally unique, error when not
   attributes:
-    global: [ session, start_transit_vni, vlan_bundle_service ]
+    global: [ session, start_transit_vni, vlan_bundle_service, enforce_unique_transit_vni ]
     node: [ session, vlan_bundle_service, start_transit_vlan ]
     vlans: [ evpn.evi ]
 


### PR DESCRIPTION
Default: True enforces globally unique evpn.transit_vni values, which is the more common and sane default.
Advanced users can set this flag to False to skip this sanity check