### PR TITLE
srlinux vlan bundle support

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -25,7 +25,7 @@ The following table describes per-platform support of individual VXLAN features:
 | Arista EOS         | ✅  | ✅  | ✅  |  ❌  | ✅  |
 | Cisco Nexus OS     | ✅  | ✅  |  ❌  |  ❌  | ✅  |
 | Cumulus Linux      | ✅  | ✅  |  ❌  |  ❌  | ✅  |
-| Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  | ✅  |
+| Nokia SR Linux     | ✅  | ✅  |  ✅  |  ✅  | ✅  |
 | Nokia SR OS        | ✅  | ✅  |  ❌  |  ✅  | ✅  |
 | FRR                | ✅  | ✅  |  ❌  |  ❌  | ✅  |
 | VyOS               | ✅  | ✅  |  ❌  |  ❌  | ✅  |
@@ -92,3 +92,7 @@ IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addr
 * Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. This parameter could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns a VNI to the VRF. Note that the EVI value used in this case is currently based on the VRF ID (vrfidx)
 
 [^NS]: Asymmetric IRB is only supported on Nokia SR OS at the moment
+
+### Asymmetric IRB - Prefix Routes Only (per VRF)
+
+**frr** and **cumulus** have a configuration option to support RT5 prefix routing in combination with asymmetric IRB mode. The **evpn.prefix_routes_only** flag can be used to enable this mode, per VRF instance.

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -92,7 +92,3 @@ IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addr
 * Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. This parameter could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns a VNI to the VRF. Note that the EVI value used in this case is currently based on the VRF ID (vrfidx)
 
 [^NS]: Asymmetric IRB is only supported on Nokia SR OS at the moment
-
-### Asymmetric IRB - Prefix Routes Only (per VRF)
-
-**frr** and **cumulus** have a configuration option to support RT5 prefix routing in combination with asymmetric IRB mode. The **evpn.prefix_routes_only** flag can be used to enable this mode, per VRF instance.

--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -27,7 +27,7 @@
 
 - name: Generated gNMI config based on {{ config_template }}
   debug:
-   msg: "SRL config: {{ lookup('file', tempfile_1.path ) }}"
+   msg: "{{ lookup('file', tempfile_1.path ) | from_yaml }}"
    verbosity: 1
 
 # - block:

--- a/netsim/ansible/templates/evpn/dellos10.j2
+++ b/netsim/ansible/templates/evpn/dellos10.j2
@@ -15,7 +15,7 @@ router bgp {{ bgp.as }}
 
 {% if vlans is defined %}
 evpn
-{%   for v in vlans.values() if v.evpn.evi is defined and v.vni is defined %}
+{%   for v in vlans.values() if v.evpn.evi is defined and v.evpn.rd is defined and v.vni is defined %}
 {%     set import_target = v.evpn.import|join(' ') -%}
 {%     set export_target = v.evpn.export|join(' ') -%}
   evi {{ v.evpn.evi }}

--- a/netsim/ansible/templates/evpn/eos.j2
+++ b/netsim/ansible/templates/evpn/eos.j2
@@ -6,7 +6,7 @@ router bgp {{ bgp.as }}
   neighbor {{ n.ipv4 }} activate
 {% endfor %}
 {% if vlans is defined %}
-{%   for v in vlans.values() if v.evpn.evi is defined %}
+{%   for v in vlans.values() if v.evpn.rd is defined %}
 !
  vlan {{ v.id }}
   rd {{ v.evpn.rd }}

--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -35,7 +35,7 @@ exit
 {% for vname,vdata in vrfs.items() if 'evpn' in vdata %}
 vrf {{ vname }}
 {% if vdata.evpn.transit_vni is defined %}
- vni {{ vdata.evpn.transit_vni }} {{ 'prefix-routes-only' if vdata.evpn.prefix_routes_only|default(False) else '' }}
+ vni {{ vdata.evpn.transit_vni }}
 {% endif %}
  exit-vrf
 

--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -7,7 +7,7 @@ router bgp {{ bgp.as }}
 {% endfor %}
 
 ! Configure explicit Route Targets and RD per L2 VNI; auto-derived differs
-{% for vlan in (vlans|default({})).values() if 'vni' in vlan and 'evpn' in vlan %}
+{% for vlan in (vlans|default({})).values() if 'vni' in vlan and 'evpn' in vlan and 'rd' in vlan.evpn %}
   vni {{ vlan.vni }}
    rd {{ vlan.evpn.rd }}
    route-target export {{ vlan.evpn.export[0] }}
@@ -35,7 +35,7 @@ exit
 {% for vname,vdata in vrfs.items() if 'evpn' in vdata %}
 vrf {{ vname }}
 {% if vdata.evpn.transit_vni is defined %}
- vni {{ vdata.evpn.transit_vni }}
+ vni {{ vdata.evpn.transit_vni }} {{ 'prefix-routes-only' if vdata.evpn.prefix_routes_only|default(False) else '' }}
 {% endif %}
  exit-vrf
 

--- a/netsim/ansible/templates/evpn/nxos.j2
+++ b/netsim/ansible/templates/evpn/nxos.j2
@@ -12,7 +12,7 @@ router bgp {{ bgp.as }}
 {% endfor %}
 {% if vlans is defined and 'vxlan' in module %}
 evpn
-{%   for v in vlans.values() if v.evpn.evi is defined %}
+{%   for v in vlans.values() if v.evpn.rd is defined %}
   vni {{ v.vni }} l2
     rd {{ v.evpn.rd }}
     route-target import {{ v.evpn.import|join(' ') }}

--- a/netsim/ansible/templates/evpn/vyos.j2
+++ b/netsim/ansible/templates/evpn/vyos.j2
@@ -26,7 +26,7 @@ set protocols bgp neighbor {{ n[af] }} address-family l2vpn-evpn route-reflector
 
 # Configure VNI params
 {% if vlans is defined %}
-{%   for v in vlans.values() if v.evpn.evi is defined and v.vni is defined %}
+{%   for v in vlans.values() if v.evpn.rd is defined and v.vni is defined %}
 set protocols bgp address-family l2vpn-evpn vni {{ v.vni }} rd {{ v.evpn.rd }}
 set protocols bgp address-family l2vpn-evpn vni {{ v.vni }} route-target import "{{ v.evpn.import|join(' ') }}"
 set protocols bgp address-family l2vpn-evpn vni {{ v.vni }} route-target export "{{ v.evpn.export|join(' ') }}"

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -1,4 +1,4 @@
-{% macro vxlan_interface(vrf,index,type,vni,evi,rd,rts) %}
+{% macro vxlan_interface(vrf,index,type,vni,evi,rd,rts,bundle=False) %}
 - path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{index}}]
   val:
    type: {{ type }}
@@ -29,13 +29,23 @@
        evi: {{ evi }}
        ecmp: 8
        vxlan-interface: vxlan0.{{ index }}
+{%     if bundle %}
+       routes:
+        bridge-table:
+         vlan-aware-bundle-eth-tag: {{ index }}
+{%     endif %}
 {% endmacro %}
 
 updates:
 {% if vlans is defined and vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}
+{%     if evpn.vlan_bundle_service|default(False) %}
+{%      set vrf = vrfs[vlan.vrf] %}
+{{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi,vrf.rd,vrf,bundle=True) }}
+{%     else %}
 {{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi,vlan.evpn.rd,vlan.evpn) }}
+{%     endif %}
 {%   endfor %}
 {% endif %}
 

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -40,7 +40,7 @@ updates:
 {% if vlans is defined and vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}
-{%     if evpn.vlan_bundle_service|default(False) %}
+{%     if vlan.vrf is defined and vlan.evpn is defined and vlan.evpn.rd is not defined %}
 {%      set vrf = vrfs[vlan.vrf] %}
 {{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi,vrf.rd,vrf,bundle=True) }}
 {%     else %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -762,6 +762,7 @@ devices:
         requires: [ evpn ] # vrf for l3 vxlan
       evpn:
         irb: True
+        asymmetrical_irb: True
       ospf:
         unnumbered: False
       isis:

--- a/tests/integration/evpn/vxlan-vlan-bundle.yml
+++ b/tests/integration/evpn/vxlan-vlan-bundle.yml
@@ -15,12 +15,15 @@ groups:
   switches:
     members: [ s1,s2 ]
     module: [ vlan,vxlan,ospf,bgp,evpn,vrf ]
-    device: eos
+    # device: eos
 
 bgp.as: 65000
 
+evpn.vlan_bundle_service: True
+
 vrfs:
   bundle:
+    evpn:
 
 vlans:
   red:


### PR DESCRIPTION
* Update srlinux evpn templates to support vlan aware bundle service
* Modify all templates to check evpn.rd and build individual vlans if defined, instead of evpn.evi
* Generate unique EVI per vlan, also in bundle (needed for srlinux, not used by other platforms)
* Update integration example to enable evpn and set vlan bundle service flag
* Enable asymmetric irb support (tested with integration/evpn/vxlan-asymmetric-irb.yml, though h4 lacks an svi interface)

evpn.rd is a better distinguisher than evpn.evi