### PR TITLE
Use foreign VRF name as evpn.transit_vni to implement complex topologies

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -89,6 +89,13 @@ The default value of VRF EVPN Instance identifier is the VLAN ID of the first VL
 IRB is configured whenever EVPN-enabled VLANs in a VRF contain IPv4 or IPv6 addresses:
 
 * Asymmetric IRB requires no extra parameters[^NS]
-* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter. This parameter could be set to an integer value or to *True* in which case the EVPN configuration module auto-assigns a VNI to the VRF. Note that the EVI value used in this case is currently based on the VRF ID (vrfidx)
+* Symmetric IRB needs a transit VNI that has to be set with the **evpn.transit_vni** parameter.
+* You can set the EVI value with **evpn.evi** parameter.
+
+The **evpn.transit_vni** parameter must specify a globally unique VNI value. It could be set to:
+
+* *True*: EVPN configuration module auto-assigns a unique VNI to the VRF.
+* An *integer value*: static VNI assignment, checked for uniqueness
+* Name of *another VRF*: the **evpn_transit_vni** value is copied from that VRF. Use this setting for complex topologies where VRFs with different connectivity requirements have to share the transit VXLAN segment.
 
 [^NS]: Asymmetric IRB is only supported on Nokia SR OS at the moment

--- a/netsim/data/__init__.py
+++ b/netsim/data/__init__.py
@@ -365,3 +365,10 @@ def validate_list_elements(data: list, values: list, path: str) -> bool:
     common.fatal(f'{path} should be a list')
     return False
   return all(item in values for item in data)
+
+"""
+is_true_int: work around the Python stupidity of bools being ints
+"""
+
+def is_true_int(data: typing.Any) -> bool:
+  return isinstance(data,int) and not isinstance(data,bool)

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -1,0 +1,232 @@
+bgp:
+  advertise_loopback: true
+  as: 65000
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+evpn:
+  session:
+  - ibgp
+  vlan_bundle_service: false
+groups:
+  as65000:
+    members:
+    - r1
+    - r2
+input:
+- topology/input/evpn-hub-spoke.yml
+- package:topology-defaults.yml
+links:
+- interfaces:
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: r1
+    vrf: hub
+  - ifindex: 1
+    ipv4: 10.1.0.2/30
+    node: r2
+    vrf: spoke
+  left:
+    ifname: eth1
+    ipv4: 10.1.0.1/30
+    node: r1
+  linkindex: 1
+  name: r1 - r2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  right:
+    ifname: eth1
+    ipv4: 10.1.0.2/30
+    node: r2
+  type: p2p
+module:
+- bgp
+- vrf
+- evpn
+name: input
+nodes:
+  r1:
+    af:
+      ipv4: true
+      vpnv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - activate:
+          ipv4: true
+        as: 65000
+        evpn: true
+        ipv4: 10.0.0.2
+        name: r2
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.1
+    box: frrouting/frr:v8.3.1
+    clab:
+      binds:
+        clab_files/r1/daemons: /etc/frr/daemons
+      config_templates:
+        daemons: /etc/frr/daemons
+      kind: linux
+    device: frr
+    evpn:
+      session:
+      - ibgp
+      vlan_bundle_service: false
+    hostname: clab-input-r1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.2/30
+        node: r2
+        vrf: spoke
+      type: p2p
+      vrf: hub
+    loopback:
+      ipv4: 10.0.0.1/32
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08-4F-A9-00-00-01
+    module:
+    - bgp
+    - vrf
+    - evpn
+    mtu: 1500
+    name: r1
+    vrf:
+      as: 65000
+    vrfs:
+      hub:
+        af:
+          ipv4: true
+        evpn:
+          transit_vni: 200000
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:2'
+        rd: '65000:1'
+        vrfidx: 100
+  r2:
+    af:
+      ipv4: true
+      vpnv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - activate:
+          ipv4: true
+        as: 65000
+        evpn: true
+        ipv4: 10.0.0.1
+        name: r1
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.2
+    box: frrouting/frr:v8.3.1
+    clab:
+      binds:
+        clab_files/r2/daemons: /etc/frr/daemons
+      config_templates:
+        daemons: /etc/frr/daemons
+      kind: linux
+    device: frr
+    evpn:
+      session:
+      - ibgp
+      vlan_bundle_service: false
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.1/30
+        node: r1
+        vrf: hub
+      type: p2p
+      vrf: spoke
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - bgp
+    - vrf
+    - evpn
+    mtu: 1500
+    name: r2
+    vrf:
+      as: 65000
+    vrfs:
+      spoke:
+        af:
+          ipv4: true
+        evpn:
+          transit_vni: 200000
+        export:
+        - '65000:2'
+        id: 2
+        import:
+        - '65000:1'
+        rd: '65000:2'
+        vrfidx: 100
+provider: clab
+vrf:
+  as: 65000
+vrfs:
+  hub:
+    evpn:
+      transit_vni: 200000
+    export:
+    - '65000:1'
+    id: 1
+    import:
+    - '65000:2'
+    rd: '65000:1'
+  spoke:
+    evpn:
+      transit_vni: 200000
+    export:
+    - '65000:2'
+    id: 2
+    import:
+    - '65000:1'
+    rd: '65000:2'

--- a/tests/topology/input/evpn-hub-spoke.yml
+++ b/tests/topology/input/evpn-hub-spoke.yml
@@ -1,0 +1,27 @@
+defaults.device: frr
+provider: clab
+
+vrfs:
+ hub:
+  evpn.transit_vni: spoke
+  import: [spoke]
+  export: [hub]
+
+ spoke:
+  evpn.transit_vni: True
+  import: [hub]
+  export: [spoke]
+
+module: [vrf,bgp,evpn] # Note: no vlan module included
+
+bgp.as: 65000
+
+nodes:
+  r1:
+  r2:
+
+links:
+- r1:
+   vrf: hub
+  r2:
+   vrf: spoke


### PR DESCRIPTION
This is an alternate solution to #502. Instead of turning off uniqueness checks, allow a VRF evpn.transit_vni to refer to another VRF.