### PR TITLE
srlinux vlan bundle service take2

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -80,9 +80,9 @@ EVPN configuration module sets the following default EVI/RD/RT values for [VXLAN
 
 VLAN-Aware Bundle Service is disabled by default and has to be enabled by setting **evpn.vlan_bundle_service** parameter to _True_. Although that parameter is a global/node parameter, it might not be a good idea to use different settings on different nodes. 
 
-VLAN-Aware Bundle Service uses VRF configuration (and thus requires [VRF configuration module](vrf.md)). All VLANs belonging to a single VRF are configured as a VLAN bundle. [RD and RT values assigned by VRF module](vrf.md#rd-and-rt-values) are used to configure the VLAN bundle; you can set **evpn.evi** VRF parameter to set the EVPN Instance identifier.
+VLAN-Aware Bundle Service uses VRF configuration (and thus requires [VRF configuration module](vrf.md)). All VLANs belonging to a single VRF are configured as a VLAN bundle, modeled as a single EVPN Instance. [RD and RT values assigned by VRF module](vrf.md#rd-and-rt-values) are used to configure the VLAN bundle; you can set **evpn.evi** VRF parameter to set the EVPN Instance identifier
 
-The default value of VRF EVPN Instance identifier is the VLAN ID of the first VLAN in that VRF.
+The default value of VRF EVPN Instance identifier is the VLAN ID of the first VLAN referencing that VRF (typically lowest when auto-generated)
 
 ### Integrated Routing and Bridging
 

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -25,7 +25,7 @@ The following table describes per-platform support of individual VXLAN features:
 | Arista EOS         | ✅  | ✅  | ✅  |  ❌  | ✅  |
 | Cisco Nexus OS     | ✅  | ✅  |  ❌  |  ❌  | ✅  |
 | Cumulus Linux      | ✅  | ✅  |  ❌  |  ❌  | ✅  |
-| Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  | ✅  |
+| Nokia SR Linux     | ✅  | ✅  |  ✅  |  ✅  | ✅  |
 | Nokia SR OS        | ✅  | ✅  |  ❌  |  ✅  | ✅  |
 | FRR                | ✅  | ✅  |  ❌  |  ❌  | ✅  |
 | VyOS               | ✅  | ✅  |  ❌  |  ❌  | ✅  |

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -1,4 +1,4 @@
-{% macro vxlan_interface(vrf,index,type,vni,evi,rd,rts) %}
+{% macro vxlan_interface(vrf,index,type,vni,evi,rd,rts,bundle=False) %}
 - path: tunnel-interface[name=vxlan0]/vxlan-interface[index={{index}}]
   val:
    type: {{ type }}
@@ -29,13 +29,25 @@
        evi: {{ evi }}
        ecmp: 8
        vxlan-interface: vxlan0.{{ index }}
+{%     if bundle %}
+       routes:
+        bridge-table:
+         vlan-aware-bundle-eth-tag: {{ index }}
+{%     endif %}
 {% endmacro %}
 
 updates:
 {% if vlans is defined and vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}
+{%     if vlan.vrf is defined and vrfs[vlan.vrf].evpn.vlans is defined %}
+{%      set vrf = vrfs[vlan.vrf] %}
+{# Netlab models a bundle as 1 EVPN instance, SR Linux considers it as individual services with unique EVI/RD but common RT #}
+{# Use VLAN ID as EVI, and assign each an auto-generated RD #}
+{{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.id,vrf.rd,vrf,bundle=True) }}
+{%     else %}
 {{ vxlan_interface('vlan'+vlan.id|string,vlan.id,'bridged',vlan.vni,vlan.evpn.evi,vlan.evpn.rd,vlan.evpn) }}
+{%     endif %}
 {%   endfor %}
 {% endif %}
 

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -57,7 +57,7 @@ def vlan_aware_bundle_service(vlan: Box, vname: str, node: Box, topology: Box) -
     topology.vrfs[vrf_name].evpn = {}
   g_evpn = topology.vrfs[vrf_name].evpn
   if not 'evi' in g_evpn:                                           # If needed, set EVI attribute for the global VRF
-    g_evpn.evi = topology.vlans[vname].id                           # ... to VLAN ID
+    g_evpn.evi = topology.vlans[vname].id                           # ... to first VLAN ID encountered (lowest when auto-assigned)
 
   if node.vrfs[vrf_name].evpn is None:                              # Normalize to non-None
     node.vrfs[vrf_name].evpn = {}

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -53,10 +53,14 @@ def vlan_aware_bundle_service(vlan: Box, vname: str, node: Box, topology: Box) -
       'evpn')
     return
 
+  if topology.vrfs[vrf_name].evpn is None:                          # Provided by user -> can be None
+    topology.vrfs[vrf_name].evpn = {}
   g_evpn = topology.vrfs[vrf_name].evpn
   if not 'evi' in g_evpn:                                           # If needed, set EVI attribute for the global VRF
     g_evpn.evi = topology.vlans[vname].id                           # ... to VLAN ID
 
+  if node.vrfs[vrf_name].evpn is None:                              # Normalize to non-None
+    node.vrfs[vrf_name].evpn = {}
   evpn = node.vrfs[vrf_name].evpn                                   # Now set VRF EVPN parameters for node VRF
   evpn.evi = g_evpn.evi                                             # Copy EVI from global VRF
   for k in ('vlans','vlan_ids'):

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -762,6 +762,7 @@ devices:
         requires: [ evpn ] # vrf for l3 vxlan
       evpn:
         irb: True
+        asymmetrical_irb: True
       ospf:
         unnumbered: False
       isis:

--- a/tests/integration/evpn/vxlan-vlan-bundle.yml
+++ b/tests/integration/evpn/vxlan-vlan-bundle.yml
@@ -15,12 +15,15 @@ groups:
   switches:
     members: [ s1,s2 ]
     module: [ vlan,vxlan,ospf,bgp,evpn,vrf ]
-    device: eos
+    # device: eos
 
 bgp.as: 65000
 
+evpn.vlan_bundle_service: True
+
 vrfs:
   bundle:
+    evpn:
 
 vlans:
   red:


### PR DESCRIPTION
Supersedes https://github.com/ipspace/netlab/pull/503

SR Linux treats a VLAN bundle as a set of EVPN services, one per VNI. A unique RD is assigned per service, auto-generated based on the (locally assigned) EVI (== vlan ID) and the node's router ID.

The RD's assigned by Netlab may require further thought/testing, e.g. in case of multi-homed VLAN bundles with ECMP

Note the minor fixes in case user provided evpn: is ```None```