### PR TITLE
Avoid same subnet routes

### DIFF
--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -51,7 +51,9 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 #
 {% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
 {%   for name,pool in pools.items()|default({}) %}
-{%     for af,pfx in pool.items() if af == 'ipv4' and name != 'mgmt' and name != 'router_id' %}
+{%     for af,pfx in pool.items() if af == 'ipv4' and
+         name not in ['mgmt','router_id'] and
+         pfx|ipaddr('network') != ifdata.gateway.ipv4|ipaddr('network') %}
 set +e
 ip route del {{ pfx }} 2>/dev/null
 set -e


### PR DESCRIPTION
When users declare a 10.2.0.0/24 pool, the route add fails for obscure reasons (overlap with default vrf_loopback pool, even when not used)

In general, route add fails when the prefix subnet is the same as the host's own subnet