### PR TITLE
Add support for anycast gateway IPs (v4/v6)

### DIFF
--- a/netsim/addressing.py
+++ b/netsim/addressing.py
@@ -81,6 +81,9 @@ def rebuild_prefix(pfx: typing.Union[dict,Box]) -> dict:
   for af in ('ipv4','ipv6'):
     if af in pfx:
       out_pfx[af] = str(pfx[af]) if not isinstance(pfx[af],bool) else pfx[af]
+    gw = 'anycast_gateway_' + af
+    if gw in pfx:
+      out_pfx[gw] = str(pfx[gw]) # Results in fairly verbose output, could strip
   return out_pfx
 
 def setup_pools(addr_pools: typing.Optional[Box] = None, defaults: typing.Optional[Box] = None) -> Box:
@@ -196,15 +199,23 @@ def create_pool_generators(addrs: typing.Optional[Box] = None) -> typing.Dict:
   gen: typing.Dict = {}
   for pool,pfx in addrs.items():
     gen[pool] = {}
-    for key,data in pfx.items():
+    for key,_data in pfx.items():
       if "_pfx" in key:
         af   = key.replace('_pfx','')
         plen = pfx['prefix'] if af == 'ipv4' else 64
-        gen[pool][af] = data.subnet(plen)
+        gen[pool][af] = _data.subnet(plen)
         if (af == 'ipv4' and plen == 32) or (pool == 'loopback'):
           next(gen[pool][af])
-      elif isinstance(data,bool):
-        gen[pool][key] = data
+      elif key=='anycast_gateway':
+        if 'prefix' in pfx and pfx['prefix']>=31:
+          common.error( "Anycast gateway requires at least a /30 prefix",
+                        common.IncorrectValue, 'addressing' )
+        if data.is_true_int(_data):
+          gen[pool]['anycast_gateway'] = _data
+        elif _data is True:
+          gen[pool]['anycast_gateway'] = -2  # default to last available address
+      elif isinstance(_data,bool):
+        gen[pool][key] = _data
   return gen
 
 def get_pool(pools: Box, pool_list: typing.List[str]) -> typing.Optional[str]:
@@ -227,7 +238,11 @@ def get_pool_prefix(pools: typing.Dict, p: str, n: typing.Optional[int] = None) 
   prefixes: typing.Dict = {}
   if pools[p].get('unnumbered'):
     return { 'unnumbered': True }
+  anycast_gw = None
   for af in list(pools[p]):
+    if af == 'anycast_gateway':
+      anycast_gw = pools[p]['anycast_gateway']
+      continue
     if not 'cache' in af:
       if isinstance(pools[p][af],bool):
         prefixes[af] = pools[p][af]
@@ -251,7 +266,10 @@ def get_pool_prefix(pools: typing.Dict, p: str, n: typing.Optional[int] = None) 
             (' (use --debug addr CLI argument to get more details)' if not common.debug_active('addr') else ''),
             common.MissingValue,
             'addressing')
-
+  if anycast_gw:
+    for af in ['ipv4','ipv6']:
+      if af in prefixes:
+        prefixes[ 'anycast_gateway_' + af ] = get_addr_mask(prefixes[af],anycast_gw)
   return prefixes
 
 def get(pools: Box, pool_list: typing.Optional[typing.List[str]] = None, n: typing.Optional[int] = None) -> typing.Dict:
@@ -285,10 +303,10 @@ def parse_prefix(prefix: typing.Union[str,dict]) -> typing.Dict:
     print(f"parse prefix: {prefix} type={type(prefix)}")
   if not prefix:
     return {}
-  supported_af = ['ip','ipv4','ipv6']
+  supported_af = ['ip','ipv4','ipv6','anycast_gateway_ipv4','anycast_gateway_ipv6']
   prefix_list: typing.Dict = {}
   if isinstance(prefix,dict):
-    for af,pfx in prefix.items():
+    for af,pfx in sorted(prefix.items(),reverse=True): # process anycast gw last
       if not af in supported_af:
         common.error( \
           'Unknown address family %s in prefix %s' % (af,prefix), \
@@ -302,8 +320,12 @@ def parse_prefix(prefix: typing.Union[str,dict]) -> typing.Dict:
           except Exception as ex:
             common.error(f'Cannot parse {af} prefix: {prefix}\n... {ex}',common.IncorrectValue,'addressing')
             return {}
-          if str(prefix_list[af]) != str(prefix_list[af].cidr):
-            common.error(f'{af} prefix contains host bits: {prefix}',common.IncorrectValue,'addressing')
+          if af[0:2]=="ip":
+            if str(prefix_list[af]) != str(prefix_list[af].cidr):
+              common.error(f'{af} prefix contains host bits: {prefix}',common.IncorrectValue,'addressing')
+          else:
+            ip_af = af[-4:] # Fix/set anycast_gateway_ip prefix length
+            prefix_list[af].prefixlen = prefix_list[ip_af].prefixlen
     return prefix_list
   else:
     return { 'ipv4' : netaddr.IPNetwork(prefix) }

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -66,6 +66,10 @@ interface {{ l.ifname }}
 {%   else %}
 ! Invalid IPv4 address {{ l.ipv4 }}
 {%   endif %}
+{%   if 'virtual_gateway_ipv4' in l %}
+! Note: Could also be provisioned without subnet, different ARP behavior
+ ip virtual-router address {{ l.virtual_gateway_ipv4 }}
+{%   endif %}
 {% endif %}
 {#
     Set interface IPv6 addresses
@@ -77,6 +81,9 @@ interface {{ l.ifname }}
  ipv6 address {{ l.ipv6 }}
 {%   else %}
 ! Invalid IPv6 address {{ l.ipv6 }}
+{%   endif %}
+{%   if 'virtual_gateway_ipv6' in l %}
+ ipv6 virtual-router address {{ l.virtual_gateway_ipv6 }}
 {%   endif %}
 {% endif %}
 {% if l.virtual_interface is not defined %}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -6,17 +6,27 @@
    ipv4:
     address:
     - ip-prefix: "{{ intf.ipv4 }}"
-{% if not is_system %}
+{%  if not is_system %}
       primary: [null]
-{% endif %}
+{%  endif %}
+{%  if 'anycast_gateway_ipv4' in intf %}
+    - ip-prefix: "{{ intf.anycast_gateway_ipv4 }}"
+      anycast-gw: True
+{%  endif %}
 {% endif %}
 {% if 'ipv6' in intf %}
    ipv6:
-{%   if intf.ipv6 is string %}
+{%  if intf.ipv6 is string or 'anycast_gateway_ipv6' in intf %}
     address:
+    - ip-prefix: "{{ intf.anycast_gateway_ipv6|default(intf.ipv6) }}"
+{%   if 'anycast_gateway_ipv6' in intf %}
+      anycast-gw: True
+{%    if intf.ipv6 is string %}
     - ip-prefix: "{{ intf.ipv6 }}"
+{%    endif %}
 {%   endif %}
-{% if ipv6_ra %}
+{%  endif %}
+{%  if ipv6_ra %}
     neighbor-discovery:
      learn-unsolicited: link-local
     router-advertisement:
@@ -25,7 +35,10 @@
       min-advertisement-interval: 4   # Leaving this at platform default 200..600 takes too long at startup
       _annotate_min-advertisement-interval: "Reduced from platform default 200s"
       max-advertisement-interval: 5
+{%  endif %}
 {% endif %}
+{% if 'anycast_gateway_ipv4' in intf or 'anycast_gateway_ipv6' in intf %}
+   anycast-gw: { }
 {% endif %}
 {% endmacro %}
 

--- a/netsim/ansible/templates/vlan/cumulus.j2
+++ b/netsim/ansible/templates/vlan/cumulus.j2
@@ -50,6 +50,9 @@ iface {{ ifdata.ifname }}
 {%   endif %}
 {%   if ifdata.type == "svi" %}
 {{     ipaddr(ifdata,loopback|default({})) }}
+{%     if 'virtual_gateway_ipv4' in ifdata or 'virtual_gateway_ipv6' in ifdata %}
+    address-virtual 00:00:5e:00:01:00 {{ ifdata.virtual_gateway_ipv4|default('') }} {{ ifdata.virtual_gateway_ipv6|default('') }}
+{%     endif %}
     vlan-id {{ ifdata.ifname|replace("vlan","") }}
     vlan-raw-device bridge
 {%   endif %}

--- a/netsim/ansible/templates/vxlan/srlinux.j2
+++ b/netsim/ansible/templates/vxlan/srlinux.j2
@@ -6,7 +6,7 @@
     vni: {{ vni }}
    egress:
     source-ip: use-system-ipv4-address
-    
+
 - path: network-instance[name={{vrf}}]
   val:
    type: {{ 'mac-vrf' if type=='bridged' else 'ip-vrf' }}
@@ -64,7 +64,7 @@ updates:
 {%  if ip in i %}
    {{ ip }}:
      {{ arpnd }}:
-       learn-unsolicited: True
+       learn-unsolicited: {{ True if ip=='ipv4' else 'both' }}
        evpn:
         advertise: # Type of ARP/ND entries to be advertised
         - route-type: dynamic

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -28,10 +28,11 @@ addressing:
 attributes:
   global: [ addressing,defaults,groups,links,module,name,nodes,plugin,provider ]
   internal: [ input,includes,pools,Provider,Plugin,message ]
-  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
+  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,gateway,vlan_name,anycast_gateway ]
   link_internal: [ linkindex,parentindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
   node: [ role,mtu,runtime,provider,id,loopback,cpu,memory ]  # not enforced yet
+  interface: [ anycast_gateway ]
 
 # Built-in module defaults
 #
@@ -47,7 +48,7 @@ bgp:
   transform_after: [ vlan ]
   next_hop_self: true
   attributes:
-    global: [ 
+    global: [
       af, as, next_hop_self, rr_cluster_id, rr_list, ebgp_role, as_list, sessions, activate,
       advertise_loopback, advertise_roles, community, replace_global_as ]
     node: [
@@ -750,6 +751,7 @@ devices:
           unnumbered: True
         ipv6:
           lla: True
+        anycast_gateway: True
       vlan:
         model: router
         svi_interface_name: "irb0.{vlan}"
@@ -948,7 +950,7 @@ devices:
     external:
       image: none
     graphite.icon: router
-  
+
   routeros7:
     interface_name: ether%d
     mgmt_if: ether1

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -445,6 +445,7 @@ devices:
           unnumbered: True
         ipv6:
           lla: True
+        anycast_gateway: True
       ospf:
         unnumbered: True
       isis:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -651,6 +651,7 @@ devices:
           unnumbered: True
         ipv6:
           lla: True
+        anycast_gateway: True
       ospf:
         unnumbered: True
       bgp:

--- a/tests/integration/evpn/vxlan-symmetric-irb-anycast.yml
+++ b/tests/integration/evpn/vxlan-symmetric-irb-anycast.yml
@@ -1,0 +1,69 @@
+message: |
+  The devices under test are layer-3 switches running VXLAN/EVPN with
+  symmetric IRB. Hosts are in three VLANs, all in one VRF - red/blue with anycast gateway
+
+  All hosts should be able to ping each other.
+
+addressing:
+  anycast-pool:
+    ipv4: 10.10.0.0/20
+    prefix: 24
+    anycast_gateway: 10  # .10 of every ipv4/ipv6 subnet
+
+  anycast-pool2:
+    ipv4: 10.20.0.0/20
+    prefix: 24
+    anycast_gateway: True  # Default: last of every ipv4/ipv6 subnet
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  switches:
+    members: [ s1,s2 ]
+    module: [ vlan,vxlan,ospf,bgp,evpn,vrf ]
+
+bgp.as: 65000
+
+vrfs:
+  tenant:
+    evpn.transit_vni: True
+
+vlans:
+  red:
+    vrf: tenant
+    pool: anycast-pool
+  blue:
+    vrf: tenant
+    prefix:
+      ipv4: 192.168.0.0/24
+      ipv6: 2001:1::/64
+      anycast_gateway_ipv4: 192.168.0.100/24  # ipv4 only, specified as address
+  green:
+    vrf: tenant        # Anycast gateway disabled on interface
+    pool: anycast-pool2
+
+nodes:
+  h1:
+  h2:
+  h3:
+  h4:
+  s1:
+  s2:
+
+links:
+- h1:
+  s1:
+    vlan.access: red
+- h2:
+  s2:
+    vlan.access: red
+- h3:
+  s1:
+    vlan.access: blue
+- h4:
+  s2:
+    vlan.access: green
+    anycast_gateway: False # Can only pick True/False to accept/ignore value from pool or vlan
+- s1:
+  s2:

--- a/tests/topology/expected/addressing-anycast-gateway.yml
+++ b/tests/topology/expected/addressing-anycast-gateway.yml
@@ -1,0 +1,611 @@
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+  switches:
+    members:
+    - s1
+    - s2
+    module:
+    - vlan
+    - vrf
+input:
+- topology/input/addressing-anycast-gateway.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  gateway:
+    ipv4: 10.10.0.10/24
+  interfaces:
+  - ifindex: 1
+    ipv4: 10.10.0.1/24
+    node: h1
+  - anycast_gateway_ipv4: 10.10.0.10/24
+    ifindex: 1
+    ipv4: 10.10.0.5/24
+    node: s1
+    vlan:
+      access: red
+  linkindex: 1
+  node_count: 2
+  prefix:
+    anycast_gateway_ipv4: 10.10.0.10/24
+    ipv4: 10.10.0.0/24
+  type: lan
+  vrf: tenant
+- bridge: input_2
+  gateway:
+    ipv4: 10.10.0.10/24
+  interfaces:
+  - ifindex: 1
+    ipv4: 10.10.0.2/24
+    node: h2
+  - anycast_gateway_ipv4: 10.10.0.10/24
+    ifindex: 1
+    ipv4: 10.10.0.6/24
+    node: s2
+    vlan:
+      access: red
+  linkindex: 2
+  node_count: 2
+  prefix:
+    anycast_gateway_ipv4: 10.10.0.10/24
+    ipv4: 10.10.0.0/24
+  type: lan
+  vrf: tenant
+- bridge: input_3
+  gateway:
+    ipv4: 192.168.0.100/24
+  interfaces:
+  - ifindex: 1
+    ipv4: 192.168.0.3/24
+    ipv6: 2001:1::3/64
+    node: h3
+  - anycast_gateway_ipv4: 192.168.0.100/24
+    ifindex: 2
+    ipv4: 192.168.0.5/24
+    ipv6: 2001:1::5/64
+    node: s1
+    vlan:
+      access: blue
+  linkindex: 3
+  node_count: 2
+  prefix:
+    anycast_gateway_ipv4: 192.168.0.100/24
+    ipv4: 192.168.0.0/24
+    ipv6: 2001:1::/64
+  type: lan
+  vrf: tenant
+- bridge: input_4
+  gateway:
+    ipv4: 10.20.0.6/24
+  interfaces:
+  - ifindex: 1
+    ipv4: 10.20.0.4/24
+    node: h4
+  - ifindex: 2
+    ipv4: 10.20.0.6/24
+    node: s2
+    vlan:
+      access: green
+  linkindex: 4
+  node_count: 2
+  prefix:
+    anycast_gateway_ipv4: 10.20.0.254/24
+    ipv4: 10.20.0.0/24
+  type: lan
+  vrf: tenant
+- interfaces:
+  - ifindex: 3
+    ipv4: 10.1.0.1/30
+    node: s1
+  - ifindex: 3
+    ipv4: 10.1.0.2/30
+    node: s2
+  left:
+    ifname: ethernet-1/3
+    ipv4: 10.1.0.1/30
+    node: s1
+  linkindex: 5
+  name: s1 - s2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  right:
+    ifname: ethernet-1/3
+    ipv4: 10.1.0.2/30
+    node: s2
+  type: p2p
+module:
+- vlan
+- vrf
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      kind: linux
+    device: linux
+    hostname: clab-input-h1
+    id: 1
+    interfaces:
+    - bridge: input_1
+      gateway:
+        ipv4: 10.10.0.10/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 10.10.0.1/24
+      linkindex: 1
+      mtu: 1500
+      name: h1 -> [s1,h2,s2]
+      neighbors:
+      - ifname: irb0.1000
+        ipv4: 10.10.0.5/24
+        node: s1
+      - ifname: eth1
+        ipv4: 10.10.0.2/24
+        node: h2
+      - ifname: irb0.1000
+        ipv4: 10.10.0.6/24
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08-4F-A9-00-00-01
+    mtu: 1500
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      kind: linux
+    device: linux
+    hostname: clab-input-h2
+    id: 2
+    interfaces:
+    - bridge: input_2
+      gateway:
+        ipv4: 10.10.0.10/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 10.10.0.2/24
+      linkindex: 2
+      mtu: 1500
+      name: h2 -> [h1,s1,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.10.0.1/24
+        node: h1
+      - ifname: irb0.1000
+        ipv4: 10.10.0.5/24
+        node: s1
+      - ifname: irb0.1000
+        ipv4: 10.10.0.6/24
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    mtu: 1500
+    name: h2
+    role: host
+  h3:
+    af:
+      ipv4: true
+      ipv6: true
+    box: python:3.9-alpine
+    clab:
+      kind: linux
+    device: linux
+    hostname: clab-input-h3
+    id: 3
+    interfaces:
+    - bridge: input_3
+      gateway:
+        ipv4: 192.168.0.100/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 192.168.0.3/24
+      ipv6: 2001:1::3/64
+      linkindex: 3
+      mtu: 1500
+      name: h3 -> [s1]
+      neighbors:
+      - ifname: irb0.1001
+        ipv4: 192.168.0.5/24
+        ipv6: 2001:1::5/64
+        node: s1
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    mtu: 1500
+    name: h3
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      kind: linux
+    device: linux
+    hostname: clab-input-h4
+    id: 4
+    interfaces:
+    - bridge: input_4
+      gateway:
+        ipv4: 10.20.0.6/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 10.20.0.4/24
+      linkindex: 4
+      mtu: 1500
+      name: h4 -> [s2]
+      neighbors:
+      - ifname: irb0.1002
+        ipv4: 10.20.0.6/24
+        node: s2
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08-4F-A9-00-00-04
+    mtu: 1500
+    name: h4
+    role: host
+  s1:
+    af:
+      ipv4: true
+      ipv6: true
+      vpnv4: true
+      vpnv6: true
+    box: ghcr.io/nokia/srlinux
+    clab:
+      kind: srl
+      type: ixrd2
+    device: srlinux
+    hostname: clab-input-s1
+    id: 5
+    interfaces:
+    - bridge: input_1
+      clab:
+        name: e1-1
+      ifindex: 1
+      ifname: ethernet-1/1
+      linkindex: 1
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_3
+      clab:
+        name: e1-2
+      ifindex: 2
+      ifname: ethernet-1/2
+      linkindex: 3
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - clab:
+        name: e1-3
+      ifindex: 3
+      ifname: ethernet-1/3
+      ipv4: 10.1.0.1/30
+      linkindex: 5
+      name: s1 -> s2
+      neighbors:
+      - ifname: ethernet-1/3
+        ipv4: 10.1.0.2/30
+        node: s2
+      type: p2p
+    - anycast_gateway_ipv4: 10.10.0.10/24
+      bridge_group: 1
+      ifindex: 4
+      ifname: irb0.1000
+      ipv4: 10.10.0.5/24
+      name: VLAN red (1000) -> [h1,h2,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.10.0.1/24
+        node: h1
+      - ifname: eth1
+        ipv4: 10.10.0.2/24
+        node: h2
+      - ifname: irb0.1000
+        ipv4: 10.10.0.6/24
+        node: s2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+      vrf: tenant
+    - anycast_gateway_ipv4: 192.168.0.100/24
+      bridge_group: 2
+      ifindex: 5
+      ifname: irb0.1001
+      ipv4: 192.168.0.5/24
+      ipv6: 2001:1::5/64
+      name: VLAN blue (1001) -> [h3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 192.168.0.3/24
+        ipv6: 2001:1::3/64
+        node: h3
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+      vrf: tenant
+    loopback:
+      ipv4: 10.0.0.5/32
+    mgmt:
+      ifname: mgmt0
+      ipv4: 192.168.121.105
+      mac: 08-4F-A9-00-00-05
+    module:
+    - vlan
+    - vrf
+    name: s1
+    vlan:
+      max_bridge_group: 2
+      mode: irb
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: irb
+        prefix:
+          anycast_gateway_ipv4: 192.168.0.100/24
+          ipv4: 192.168.0.0/24
+          ipv6: 2001:1::/64
+        vni: 101001
+        vrf: tenant
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        pool: anycast-pool
+        prefix:
+          anycast_gateway_ipv4: 10.10.0.10/24
+          ipv4: 10.10.0.0/24
+        vni: 101000
+        vrf: tenant
+    vrf:
+      as: 65000
+    vrfs:
+      tenant:
+        af:
+          ipv4: true
+          ipv6: true
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        rd: '65000:1'
+        vrfidx: 100
+  s2:
+    af:
+      ipv4: true
+      vpnv4: true
+    box: ghcr.io/nokia/srlinux
+    clab:
+      kind: srl
+      type: ixrd2
+    device: srlinux
+    hostname: clab-input-s2
+    id: 6
+    interfaces:
+    - bridge: input_2
+      clab:
+        name: e1-1
+      ifindex: 1
+      ifname: ethernet-1/1
+      linkindex: 2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      clab:
+        name: e1-2
+      ifindex: 2
+      ifname: ethernet-1/2
+      linkindex: 4
+      type: lan
+      vlan:
+        access: green
+        access_id: 1002
+    - clab:
+        name: e1-3
+      ifindex: 3
+      ifname: ethernet-1/3
+      ipv4: 10.1.0.2/30
+      linkindex: 5
+      name: s2 -> s1
+      neighbors:
+      - ifname: ethernet-1/3
+        ipv4: 10.1.0.1/30
+        node: s1
+      type: p2p
+    - anycast_gateway_ipv4: 10.10.0.10/24
+      bridge_group: 1
+      ifindex: 4
+      ifname: irb0.1000
+      ipv4: 10.10.0.6/24
+      name: VLAN red (1000) -> [h1,s1,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.10.0.1/24
+        node: h1
+      - ifname: irb0.1000
+        ipv4: 10.10.0.5/24
+        node: s1
+      - ifname: eth1
+        ipv4: 10.10.0.2/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+      vrf: tenant
+    - bridge_group: 2
+      ifindex: 5
+      ifname: irb0.1002
+      ipv4: 10.20.0.6/24
+      name: VLAN green (1002) -> [h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.20.0.4/24
+        node: h4
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+      vrf: tenant
+    loopback:
+      ipv4: 10.0.0.6/32
+    mgmt:
+      ifname: mgmt0
+      ipv4: 192.168.121.106
+      mac: 08-4F-A9-00-00-06
+    module:
+    - vlan
+    - vrf
+    name: s2
+    vlan:
+      max_bridge_group: 2
+      mode: irb
+    vlans:
+      green:
+        bridge_group: 2
+        id: 1002
+        mode: irb
+        pool: anycast-pool2
+        prefix:
+          anycast_gateway_ipv4: 10.20.0.254/24
+          ipv4: 10.20.0.0/24
+        vni: 101002
+        vrf: tenant
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        neighbors:
+        - ifname: eth1
+          ipv4: 10.10.0.1/24
+          node: h1
+        - ifname: irb0.1000
+          ipv4: 10.10.0.5/24
+          node: s1
+        - ifname: eth1
+          ipv4: 10.10.0.2/24
+          node: h2
+        - ifname: irb0.1000
+          ipv4: 10.10.0.6/24
+          node: s2
+        pool: anycast-pool
+        prefix:
+          anycast_gateway_ipv4: 10.10.0.10/24
+          ipv4: 10.10.0.0/24
+        vni: 101000
+        vrf: tenant
+    vrf:
+      as: 65000
+    vrfs:
+      tenant:
+        af:
+          ipv4: true
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        rd: '65000:1'
+        vrfidx: 100
+provider: clab
+vlan:
+  mode: irb
+vlans:
+  blue:
+    host_count: 1
+    id: 1001
+    neighbors:
+    - ifname: eth1
+      ipv4: 192.168.0.3/24
+      ipv6: 2001:1::3/64
+      node: h3
+    - ifname: irb0.1001
+      ipv4: 192.168.0.5/24
+      ipv6: 2001:1::5/64
+      node: s1
+    prefix:
+      anycast_gateway_ipv4: 192.168.0.100/24
+      ipv4: 192.168.0.0/24
+      ipv6: 2001:1::/64
+    vni: 101001
+    vrf: tenant
+  green:
+    host_count: 1
+    id: 1002
+    neighbors:
+    - ifname: eth1
+      ipv4: 10.20.0.4/24
+      node: h4
+    - ifname: irb0.1002
+      ipv4: 10.20.0.6/24
+      node: s2
+    pool: anycast-pool2
+    prefix:
+      anycast_gateway_ipv4: 10.20.0.254/24
+      ipv4: 10.20.0.0/24
+    vni: 101002
+    vrf: tenant
+  red:
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 10.10.0.1/24
+      node: h1
+    - ifname: irb0.1000
+      ipv4: 10.10.0.5/24
+      node: s1
+    - ifname: eth1
+      ipv4: 10.10.0.2/24
+      node: h2
+    - ifname: irb0.1000
+      ipv4: 10.10.0.6/24
+      node: s2
+    pool: anycast-pool
+    prefix:
+      anycast_gateway_ipv4: 10.10.0.10/24
+      ipv4: 10.10.0.0/24
+    vni: 101000
+    vrf: tenant
+vrf:
+  as: 65000
+vrfs:
+  tenant:
+    export:
+    - '65000:1'
+    id: 1
+    import:
+    - '65000:1'
+    rd: '65000:1'

--- a/tests/topology/input/addressing-anycast-gateway.yml
+++ b/tests/topology/input/addressing-anycast-gateway.yml
@@ -1,0 +1,66 @@
+#
+# Incomplete topology focused on the various ways to configure anycast gateways
+#
+defaults.device: srlinux
+provider: clab
+
+addressing:
+  anycast-pool:
+    ipv4: 10.10.0.0/20
+    prefix: 24
+    anycast_gateway: 10  # .10 of every ipv4/ipv6 subnet
+
+  anycast-pool2:
+    ipv4: 10.20.0.0/20
+    prefix: 24
+    anycast_gateway: True  # Default: last of every ipv4/ipv6 subnet
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  switches:
+    members: [ s1,s2 ]
+    module: [ vlan,vrf ] # subset of modules reqauired
+
+vrfs:
+  tenant:
+
+vlans:
+  red:
+    vrf: tenant
+    pool: anycast-pool
+  blue:
+    vrf: tenant
+    prefix:
+      ipv4: 192.168.0.0/24
+      ipv6: 2001:1::/64
+      anycast_gateway_ipv4: 192.168.0.100  # ipv4 only, specified as address
+  green:
+    vrf: tenant        # Anycast gateway disabled on interface
+    pool: anycast-pool2
+
+nodes:
+  h1:
+  h2:
+  h3:
+  h4:
+  s1:
+  s2:
+
+links:
+- h1:
+  s1:
+    vlan.access: red
+- h2:
+  s2:
+    vlan.access: red
+- h3:
+  s1:
+    vlan.access: blue
+- h4:
+  s2:
+    vlan.access: green
+    anycast_gateway: False # Can add True/False to accept/ignore value from pool or vlan
+- s1:
+  s2:


### PR DESCRIPTION
This PR adds an ```anycast_gateway``` attribute to address pools and ```anycast_gateway_ipv4/6``` to vlan prefixes, allowing the user to specify an address by index or IP. By default, 'True' picks the last available address in each subnet (to minimize chance at overlap with auto-assigned ips)

Use of an anycast_gateway associated with a pool or vlan can be overridden using 'anycast_gateway: False' at the interface

The anycast_gateway translates to an ipv4 and/or ipv6 address that is passed to templates for configuration of devices. The SR Linux templates have been updated to use these parameters. A device feature flag features.initial.anycast_gateway controls the appearance/support of these flags

For Linux hosts, the default gateway is set to the anycast_gateway address if available on the first non-host interface on the link

Notes:
* The resulting data model could be trimmed, leaving only anycast_gateway_ipv4/6 on node interfaces (and not in prefixes or vlans). A convention of using ```_anycast_gateway_ipvx``` internally could make sense
* Further data model changes could be made to provide better control over which IPs are primary/secondary etc., template assumes non-anycast IP as primary to support BGP sessions to that IP
* I added Cumulus and EOS for good measure, untested but it should be something simple like that

Fixes https://github.com/ipspace/netlab/issues/520