### PR TITLE
Critical: Filter out the case of ipv4: True in pools

### DIFF
--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -52,7 +52,7 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
 {%   for name,pool in pools.items()|default({}) %}
 {%     for af,pfx in pool.items() if af == 'ipv4' and
-         name not in ['mgmt','router_id'] and
+         name not in ['mgmt','router_id'] and pfx is string and
          pfx|ipaddr('network') != ifdata.gateway.ipv4|ipaddr('network') %}
 set +e
 ip route del {{ pfx }} 2>/dev/null


### PR DESCRIPTION
None of the Linux hosts come up in my topology with unnumbered ipv4/ipv6