### PR TITLE
Refactor link transformation and interface addressing code

### DIFF
--- a/docs/addressing.md
+++ b/docs/addressing.md
@@ -207,22 +207,23 @@ The topology results in the following Ansible inventory data for R1 (please note
 
 ```
 ---
+af:
+  ipv4: true
 box: cisco/csr1000v
-links:
+device: csr
+id: 1
+interfaces:
 - ifindex: 2
   ifname: GigabitEthernet2
   ipv4: true
   linkindex: 1
   name: Unnumbered link between R1 and R2
   neighbors:
-    r2:
-      ifname: GigabitEthernet2
-      ipv4: true
+  - ifname: GigabitEthernet2
+    ipv4: true
+    node: r2
   pool: core
-  remote_id: 2
-  remote_ifindex: 2
   type: p2p
-  unnumbered: true
 - bridge: X_2
   ifindex: 3
   ifname: GigabitEthernet3
@@ -230,9 +231,9 @@ links:
   linkindex: 2
   name: LAN link between R1 and R2
   neighbors:
-    r2:
-      ifname: GigabitEthernet3
-      ipv4: 172.16.0.2/24
+  - ifname: GigabitEthernet3
+    ipv4: 172.16.0.2/24
+    node: r2
   type: lan
 loopback:
   ipv4: 10.0.0.1/32
@@ -240,4 +241,5 @@ mgmt:
   ifname: GigabitEthernet1
   ipv4: 192.168.121.101
   mac: 08-4F-A9-00-00-01
+name: r1
 ```

--- a/docs/example/addr-builtin.txt
+++ b/docs/example/addr-builtin.txt
@@ -34,6 +34,12 @@ vrf_loopback:
 * **router_id** address pool is used to allocate BGP and OSPFv3 router IDs in IPv6-only networks.
 * **vrf_loopback** address pool is used for optional VRF loopback interfaces.
 
+[^STUB]: Links with a single non-host node attached to them or links that have **type: stub** attribute.
+
+[^LAN]: Links with more than two non-host nodes attached to them or links that have **type: lan** attribute.
+
+[^P2P]: Links with exactly two non-host nodes and no hosts attached to them
+
 ### Loopback Addresses
 
 Let's start with the simplest possible process: assigning IP addresses to loopback interfaces. We'll use the following lab topology to make it a bit more interesting:
@@ -135,7 +141,9 @@ nodes:
 
 ### Stub Links
 
-Stub links[^STUB] get their IP prefixes from the **lan** address pool[^POOL]. To get an IP address for a node on a stub link, *netlab* combines link prefix with node ID.
+Stub links[^STUB] get their IP prefixes from the **lan** address pool[^POOL]. To get an IP address for a node on a stub link, *netlab* combines link prefix with node ID (see also: [lan links](addressing-tutorial-lan-links)).
+
+[^POOL]: You can also specify the pool to use with **pool** link attribute; we'll cover that a bit later.
 
 Imagine the simplest possible lab topology: one device and one link:
 
@@ -207,7 +215,9 @@ You could argue that a network device should always have a .1 IP address on a st
 
 ### Point-to-Point Links
 
-Point to point links get their prefixes from the **p2p** pool -- unless you changed default settings, you'll get /30 IPv4 prefix from 10.1.0.0/16 address space on every P2P link.
+Point to point links get their prefixes from the **p2p** pool -- unless you changed default settings, you'll get /30 IPv4 prefix from 10.1.0.0/16 address space on every P2P link[^P31].
+
+[^P31]: You can also use /31 IPv4 prefixes to number P2P links.
 
 IP address assignment on a point-to-point link does not use node identifiers. Nodes attached to a P2P link are sorted alphabetically, then the .1 address is assigned to the first node and .2 address to the second node. The same process is used for IPv6 addresses even though you get a /64 prefix assigned to every P2P link. You know the reason: it was easier to do consistent address allocation across address families.
 
@@ -219,7 +229,7 @@ links:
 - r1-r2
 ```
 
-Here's the resulting link data structure. It contains the **interfaces** (as expected), but also **left** and **right** nodes in case you want to look at the link from that perspective:
+Here's the resulting link data structure:
 
 ```
 links:
@@ -228,23 +238,15 @@ links:
     node: r1
   - ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: eth1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: eth1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 ```
 
-The interface data structure in individual nodes has more attributes: it contains a list of **neighbors**, as well as the remote node ID and interface index (that might come useful in configuration templates).
+The interface data structure in individual nodes has more attributes: it contains a list of **neighbors** (that might come useful in configuration templates or when generating EBGP sessions).
 
 ```
 nodes:
@@ -262,14 +264,17 @@ nodes:
           - ifname: eth1
             ipv4: 10.1.0.2/30
             node: r2
-        remote_id: 2
-        remote_ifindex: 1
         type: p2p
 ```
 
+(addressing-tutorial-lan-links)=
 ### LAN Links
 
-Multi-access (LAN) links are exactly like [stub links](#stub-links), but they have more nodes attached to them. Prefixes are allocated from the **lan** pool; node IP addresses are calculated from link prefix and node ID.
+Multi-access (LAN) links are exactly like [stub links](#stub-links), but they have more non-host nodes attached to them. Prefixes are allocated from the **lan** pool or the pool specified in the **pool** attribute.
+
+On LAN links with large-enough prefix to accommodate the highest **id** of all nodes attached to a link, *netlab* combines link prefix and node **id** to get the interface IP address.
+
+If the LAN prefix is not large enough (example: /29 prefix in a large lab), *netlab* allocates sequential IP addresses to interfaces attached to the link (based on their position in the link data structure).
 
 The simplest possible lab topology to illustrate how LAN links work contains three nodes and a single link:
 
@@ -323,12 +328,41 @@ nodes:
         type: lan
 ```
 
-If you read the [loopback interfaces](#loopback-addresses) and [stub links](#stub-links) sections, you know you can change node IDs. If you skipped those sections, you might want to read them now.
+If you read the [loopback interfaces](#loopback-addresses) and [stub links](#stub-links) sections, you know you can change node IDs[^RTN]. Let's change the node IDs in our lab and use a small static prefix on the LAN link to see how sequential address allocation works:
 
-[^STUB]: Links with a single node attached to them or links that have **type: stub** attribute.
+```
+nodes:
+  r1:
+    id: 42
+  r2:
+    id: 17
+  r3:
+    id: 1
+links:
+- r1:
+  r2:
+  r3:
+  prefix.ipv4: 10.42.0.0/27
+```
 
-[^LAN]: Links with more than two nodes attached to them or links that have **type: lan** attribute.
+Here's the interface data structure on R1 created from the above topology. As you can see, *netlab* allocated sequential IP address to R1 and its neighbors (R2 and R3):
 
-[^P2P]: Links with exactly two nodes attached to them
+```
+interfaces:
+- bridge: X_1
+  ifindex: 1
+  ifname: GigabitEthernet0/1
+  ipv4: 10.42.0.1/27
+  linkindex: 1
+  name: r1 -> [r2,r3]
+  neighbors:
+  - ifname: GigabitEthernet0/1
+    ipv4: 10.42.0.2/27
+    node: r2
+  - ifname: GigabitEthernet0/1
+    ipv4: 10.42.0.3/27
+    node: r3
+  type: lan
+```
 
-[^POOL]: You can also specify the pool to use with **pool** link attribute; we'll cover that a bit later.
+[^RTN]: If you skipped those sections, you might want to read them now.

--- a/docs/example/addr-complex.txt
+++ b/docs/example/addr-complex.txt
@@ -2,6 +2,8 @@
 
 In the [IPv6 section](#ipv6-support) we described how to [enable IPv6 on an interface](#link-local-addresses) without assigning a static address to it. *netlab* provides similar functionality for IPv4 -- when setting **ipv4** attribute to *True*, the device configuration modules try to configure unnumbered IPv4 Ethernet interfaces[^UNNUM].
 
+[^UNNUM]: Some network operating systems do not support unnumbered IPv4 Ethernet interfaces. In some other cases, device configuration templates don't provide that functionality. *netlab* tries to warn you about those exceptions.
+
 Now that you've seen that you can set **ipv4** or **ipv6** attribute to *True* you might wonder what happens if you set it to *False*. Should you do that, the affected interface (or link) gets no IPv4/IPv6 address.
 
 Now let's see how you can use these features in real-life scenarios.
@@ -60,7 +62,9 @@ It makes more sense to use link **prefix** when you're testing device behavior o
 
 ### Devices Without IP Addresses
 
-Several ways of building layer-2 only networks have been described in this document ([address pools](#layer-2-only-links-using-l2only-address-pool), [static prefixes](#static-link-prefixes)), but what if you want to connect a segment of IP hosts to a bridge (with no IP address)? Remove the IP addresses from the bridge interface with **ipv4: False** and/or **ipv6: False**.
+Several ways of building layer-2 only networks have been described in this document ([address pools](#layer-2-only-links-using-l2only-address-pool), [static prefixes](#static-link-prefixes)), but what if you want to connect a segment of IP hosts to a bridge (with no IP address)? Remove the IP addresses from the bridge interface with **ipv4: False** and/or **ipv6: False**[^VLAN].
+
+[^VLAN]: You should probably use the VLAN configuration module and set **vlan.mode** to **bridge**, but if you want to test technologies not yet supported by *netlab* like bridging over SRv6, you might have to use unaddressed interfaces.
 
 Imagine a network with four hosts and a bridge connecting two parts of the same subnet. You could describe the network with the following lab topology:
 
@@ -81,9 +85,7 @@ links:
 ```
 
 **Notes:**
-* The bridge B connects two parts of the same subnet. Such a topology is not yet supported by *netlab* IP address pools unless you use [VLAN configuration module](../module/vlan.md); you have to use the same static **prefix** on both links.
+* The bridge B connects two parts of the same subnet. Such a topology is not supported by *netlab* IP address pools unless you use [VLAN configuration module](../module/vlan.md); you have to use the same static **prefix** on both links.
 * Hosts will get IP addresses assigned from the link prefix based on their node ID (h1: 10.42.42.1/24 through h4: 10.42.42.4/24)
 * Bridge B would get the same IP address (10.42.42.5/24) assigned to both interface. Most network operating systems wouldn't agree with such an approach.
 * To make the topology work, remove the IPv4 address from bridge interfaces with **ipv4: False** interface attribute.
-
-[^UNNUM]: Some network operating systems do not support unnumbered IPv4 Ethernet interfaces. In some other cases, device configuration templates don't provide that functionality. *netlab* tries to warn you about those exceptions.

--- a/docs/example/addr-custom-pools.txt
+++ b/docs/example/addr-custom-pools.txt
@@ -83,20 +83,12 @@ links:
     node: r1
   - ipv4: 172.16.0.2/24
     node: r2
-  left:
-    ifname: eth1
-    ipv4: 172.16.0.1/24
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   pool: lan
   prefix:
     ipv4: 172.16.0.0/24
-  right:
-    ifname: eth1
-    ipv4: 172.16.0.2/24
-    node: r2
   type: p2p
 ```
 
@@ -118,44 +110,41 @@ The resulting link data structure contains no IP addresses:
 
 ```
 links:
-  - interfaces:
-      - node: r1
-      - node: r2
-    left:
-      ifname: eth1
-      node: r1
-    linkindex: 1
-    name: r1 - r2
-    node_count: 2
-    pool: l2only
-    right:
-      ifname: eth1
-      node: r2
-    type: p2p
+- interfaces:
+  - ifindex: 1
+    ifname: GigabitEthernet0/1
+    node: r1
+  - ifindex: 1
+    ifname: GigabitEthernet0/1
+    node: r2
+  linkindex: 1
+  node_count: 2
+  pool: l2only
+  type: p2p
 ```
 
 Similarly, the node data for R1 (what you'd find in Ansible inventory **host_vars** for R1) has no IP addresses apart from loopback and management ones:
 
 ```
-box: none
-device: none
+af:
+  ipv4: true
+box: cisco/iosv
+device: iosv
 id: 1
 interfaces:
-  - ifindex: 1
-    ifname: eth1
-    linkindex: 1
-    name: r1 -> r2
-    neighbors:
-      - ifname: eth1
-        node: r2
-    pool: l2only
-    remote_id: 2
-    remote_ifindex: 1
-    type: p2p
+- ifindex: 1
+  ifname: GigabitEthernet0/1
+  linkindex: 1
+  name: r1 -> r2
+  neighbors:
+  - ifname: GigabitEthernet0/1
+    node: r2
+  pool: l2only
+  type: p2p
 loopback:
   ipv4: 10.0.0.1/32
 mgmt:
-  ifname: eth0
+  ifname: GigabitEthernet0/0
   ipv4: 192.168.121.101
   mac: 08-4F-A9-00-00-01
 name: r1

--- a/docs/example/addr-static.txt
+++ b/docs/example/addr-static.txt
@@ -107,17 +107,21 @@ Regardless of what prefix gets assigned to the link, R1 will always get the firs
 
 ```
 links:
-  - bridge: X_1
-    interfaces:
-      - ipv4: 172.16.0.1/24
-        node: r1
-    linkindex: 1
-    node_count: 1
-    prefix:
-      ipv4: 172.16.0.0/24
-    type: stub
+- bridge: X_1
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.1/24
+    node: r1
+  linkindex: 1
+  node_count: 1
+  prefix:
+    ipv4: 172.16.0.0/24
+  type: stub
 nodes:
   r1:
+    af:
+      ipv4: true
     id: 42
     interfaces:
     - bridge: X_1
@@ -125,6 +129,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.0.1/24
       linkindex: 1
+      name: r1 -> stub
       neighbors: []
       type: stub
     loopback:

--- a/docs/example/addressing-tutorial.md
+++ b/docs/example/addressing-tutorial.md
@@ -2,7 +2,7 @@
 
 IP Address Management (IPAM) is one of the most interesting *netlab* features -- it allows you to create full-blown fully configured networking labs without spending a millisecond  on IP addressing scheme, assigning IP addresses to nodes and interfaces, or configuring them on network devices.
 
-This document starts with an easy walk through simple addressing schemes, gets progressively more complex, and ends with crazy scenarios like stretched subnets (eventually, we're not there yet).
+This document starts with an easy walk through simple addressing schemes, gets progressively more complex, and ends with crazy scenarios like stretched subnets.
 
 ```eval_rst
 .. contents:: Table of Contents

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -368,7 +368,7 @@ def augment_p2p_link(link: Box, addr_pools: Box, ndict: dict, defaults: Box) -> 
     print(f'\nProcess P2P link {link}')
   pfx_list = augment_link_prefix(link,['p2p','lan'],addr_pools,f'links[{link.linkindex}]')
 
-  end_names = ['left','right']
+  end_names = ['a','b']
   link_nodes: typing.List[Box] = []
   interfaces: typing.List[Box] = []
 
@@ -419,8 +419,6 @@ def augment_p2p_link(link: Box, addr_pools: Box, ndict: dict, defaults: Box) -> 
     link.name = link_nodes[0].name + " - " + link_nodes[1].name
 
   for i in range(0,2):
-    link[end_names[i]] = { 'node': link_nodes[i]['name'],'ifname': interfaces[i].get('ifname') }
-
     remote = link_nodes[1-i].name
     interfaces[i]['neighbors'] = [{
         'node': remote,
@@ -429,8 +427,6 @@ def augment_p2p_link(link: Box, addr_pools: Box, ndict: dict, defaults: Box) -> 
     for af in ('ipv4','ipv6'):
       if af in interfaces[1-i]:
         interfaces[i]['neighbors'][0][af] = interfaces[1-i][af]
-      if af in interfaces[i]:
-        link[end_names[i]][af] = interfaces[i][af]
 
     # JvB: copy module specific link attributes like bgp.local_as
     mods_with_ifattr = Box({ m : True for m in ndict[remote].get('module',[]) if defaults[m].attributes.get('interface',None) })

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -12,7 +12,6 @@ from box import Box
 from .. import common
 from ..data import get_from_box
 from ..callback import Callback
-from ..augment.links import IFATTR
 from ..augment import devices
 
 # List of attributes we don't want propagated from defaults to global/node
@@ -578,7 +577,7 @@ def link_transform(method: str, topology: Box) -> None:
 
   for l in topology.get("links",[]):
     mod_list: typing.Dict = {}
-    for node_data in l.get(IFATTR,[]):
+    for node_data in l.get('interfaces',[]):
       mod_list.update({ m: None for m in topology.nodes[node_data.node].get("module",[]) })
     for m in mod_list.keys():
       if not mod_load.get(m):  # pragma: no cover (module should have been loaded already)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -10,7 +10,6 @@ import netaddr
 from . import _Module,_routing
 from .. import common
 from .. import data
-from ..augment.links import IFATTR
 from ..augment import devices
 
 def check_bgp_parameters(node: Box) -> None:
@@ -509,7 +508,7 @@ class BGP(_Module):
       return
 
     as_set = {}
-    for ifdata in link.get(IFATTR,[]):
+    for ifdata in link.get('interfaces',[]):
       n = ifdata.node
       if "bgp" in topology.nodes[n]:
         node_as = topology.nodes[n].bgp.get("as")

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -197,7 +197,7 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
 
     vlan_pool = [ vdata.pool ] if 'pool' in vdata else []
     vlan_pool.extend(['vlan','lan'])
-    pfx_list = links.augment_link_prefix(vdata,vlan_pool,topology.pools,f'{obj_path}.{vname}')
+    pfx_list = links.assign_link_prefix(vdata,vlan_pool,topology.pools,f'{obj_path}.{vname}')
     vdata.prefix = addressing.rebuild_prefix(pfx_list)
 
 """

--- a/netsim/outputs/graph.py
+++ b/netsim/outputs/graph.py
@@ -37,11 +37,11 @@ def edge_label(f : typing.TextIO, direction: str, data: Box) -> None:
     f.write(' %slabel="%s"' % (direction,addr))
 
 def edge_p2p(f : typing.TextIO, l: Box, labels: typing.Optional[bool] = False) -> None:
-  f.write(' "%s" -- "%s"' % (l.left.node, l.right.node))
+  f.write(f' "{l.interfaces[0].node}" -- "{l.interfaces[1].node}"')
   f.write(' [')
   if labels:
-    edge_label(f,'tail',l[l.left.node])
-    edge_label(f,'head',l[l.right.node])
+    edge_label(f,'tail',l.interfaces[0])
+    edge_label(f,'head',l.interfaces[1])
   f.write(' ]\n')
 
 def edge_node_net(f : typing.TextIO, l: Box, k: str, labels: typing.Optional[bool] = False) -> None:

--- a/netsim/outputs/graphite.py
+++ b/netsim/outputs/graphite.py
@@ -103,10 +103,10 @@ def links_items(topology: Box) -> list:
         if l.type == "p2p":
             r.append(
                 {
-                    "source": l.left.node,
-                    "source_endpoint": short_ifname(l.left.ifname),
-                    "target": l.right.node,
-                    "target_endpoint": short_ifname(l.right.ifname)
+                    "source": l.interfaces[0].node,
+                    "source_endpoint": short_ifname(l.interfaces[0].ifname),
+                    "target": l.interfaces[1].node,
+                    "target_endpoint": short_ifname(l.interfaces[1].ifname)
                 }
             )
         elif l.type == "lan" or l.type == "stub":

--- a/netsim/templates/provider/external/external.j2
+++ b/netsim/templates/provider/external/external.j2
@@ -8,7 +8,7 @@ PHYSICAL P2P LINKS:
 | Link Name       | Origin Device | Origin Port | Destination Device | Destination Port |
 |-----------------|---------------|-------------|--------------------|------------------|
 {% for l in links if l.type=='p2p' %}
-| {{ "%-15s" | format(l.name) }} | {{ "%-13s" | format(l.left.node) }} | {{ "%-11s" | format(l.left.ifname) }} | {{ "%-18s" | format(l.right.node) }} | {{ "%-16s" | format(l.right.ifname) }} |
+| {{ "%-15s" | format(l.name) }} | {{ "%-13s" | format(l.interfaces[0].node) }} | {{ "%-11s" | format(l.interfaces[0].ifname) }} | {{ "%-18s" | format(l.interfaces[1].node) }} | {{ "%-16s" | format(l.interfaces[1].ifname) }} |
 |-----------------|---------------|-------------|--------------------|------------------|
 {% endfor %}
 

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -59,22 +59,12 @@ links:
     ipv4: 172.31.0.2/24
     ipv6: 2001:db8:2::2/64
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.0.1/24
-    ipv6: 2001:db8:2::1/64
-    node: ce1
   linkindex: 1
   name: ce1 - pe1
   node_count: 2
   prefix:
     ipv4: 172.31.0.0/24
     ipv6: 2001:db8:2::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.0.2/24
-    ipv6: 2001:db8:2::2/64
-    node: pe1
   role: external
   type: p2p
 - interfaces:
@@ -86,22 +76,12 @@ links:
     ipv4: 172.31.1.2/24
     ipv6: 2001:db8:2:1::2/64
     node: pe2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.1.1/24
-    ipv6: 2001:db8:2:1::1/64
-    node: ce2
   linkindex: 2
   name: ce2 - pe2
   node_count: 2
   prefix:
     ipv4: 172.31.1.0/24
     ipv6: 2001:db8:2:1::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.1.2/24
-    ipv6: 2001:db8:2:1::2/64
-    node: pe2
   role: external
   type: p2p
 - interfaces:
@@ -111,19 +91,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: cr
   linkindex: 3
   name: cr - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.2/30
-    node: pe1
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -132,19 +104,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: pe2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.5/30
-    node: cr
   linkindex: 4
   name: cr - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: pe2
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -52,10 +52,12 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.0.1/24
     ipv6: 2001:db8:2::1/64
     node: ce1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.0.2/24
     ipv6: 2001:db8:2::2/64
     node: pe1
@@ -68,10 +70,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.1.1/24
     ipv6: 2001:db8:2:1::1/64
     node: ce2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.1.2/24
     ipv6: 2001:db8:2:1::2/64
     node: pe2
@@ -84,9 +88,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.2/30
     node: pe1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: cr
   linkindex: 3
@@ -96,9 +102,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: pe2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.5/30
     node: cr
   linkindex: 4

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -60,7 +60,6 @@ links:
     ipv6: 2001:db8:2::2/64
     node: pe1
   linkindex: 1
-  name: ce1 - pe1
   node_count: 2
   prefix:
     ipv4: 172.31.0.0/24
@@ -77,7 +76,6 @@ links:
     ipv6: 2001:db8:2:1::2/64
     node: pe2
   linkindex: 2
-  name: ce2 - pe2
   node_count: 2
   prefix:
     ipv4: 172.31.1.0/24
@@ -85,27 +83,25 @@ links:
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.1/30
-    node: cr
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: pe1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: cr
   linkindex: 3
-  name: cr - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.5/30
-    node: cr
-  - ifindex: 2
     ipv4: 10.1.0.6/30
     node: pe2
+  - ifindex: 2
+    ipv4: 10.1.0.5/30
+    node: cr
   linkindex: 4
-  name: cr - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -25,15 +25,19 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv6: 2001:db8:1::7/64
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv6: 2001:db8:1::15/64
     node: r2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv6: 2001:db8:1::800/64
     node: r3
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv6: 2001:db8:1::1/64
     node: r4
   linkindex: 1
@@ -44,9 +48,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv6: 2001:db8:2::1/64
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv6: 2001:db8:2::2/64
     node: r2
   linkindex: 2
@@ -58,12 +64,15 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv6: true
     node: r1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv6: 2001:db8:1:1::15/64
     node: r2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv6: 2001:db8:1:1::2a/64
     node: r3
   linkindex: 3
@@ -74,9 +83,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv6: 2001:db8:2:1::1/64
     node: r1
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     node: r2
   linkindex: 4
   name: Unaddressed node on a P2P link

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -49,19 +49,11 @@ links:
   - ifindex: 2
     ipv6: 2001:db8:2::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv6: 2001:db8:2::1/64
-    node: r1
   linkindex: 2
   name: Standard P2P link
   node_count: 2
   prefix:
     ipv6: 2001:db8:2::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv6: 2001:db8:2::2/64
-    node: r2
   type: p2p
 - bridge: input_3
   interfaces:
@@ -87,18 +79,11 @@ links:
   - ifindex: 4
     ipv6: false
     node: r2
-  left:
-    ifname: GigabitEthernet0/4
-    ipv6: 2001:db8:2:1::1/64
-    node: r1
   linkindex: 4
   name: Unaddressed node on a P2P link
   node_count: 2
   prefix:
     ipv6: 2001:db8:2:1::/64
-  right:
-    ifname: GigabitEthernet0/4
-    node: r2
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -77,7 +77,6 @@ links:
     ipv6: 2001:db8:2:1::1/64
     node: r1
   - ifindex: 4
-    ipv6: false
     node: r2
   linkindex: 4
   name: Unaddressed node on a P2P link

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -244,22 +244,12 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:43::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet15
-    ipv4: true
-    ipv6: 2001:db8:42:43::1/64
-    node: r1
   linkindex: 14
   name: Link with unnumbered static prefix
   node_count: 2
   prefix:
     ipv4: true
     ipv6: 2001:db8:42:43::/64
-  right:
-    ifname: GigabitEthernet15
-    ipv4: true
-    ipv6: 2001:db8:42:43::2/64
-    node: r2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -5,12 +5,15 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv6: 2001:db8:1::7/64
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv6: 2001:db8:1::15/64
     node: r2
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv6: 2001:db8:1::2a/64
     node: r3
   linkindex: 1
@@ -22,13 +25,16 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.42.42.18/32
     node: r1
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: true
     ipv6: 2001:db8:42:44::1/64
     node: r2
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: true
     node: r3
   linkindex: 2
@@ -41,12 +47,15 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: r1
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: r2
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: r3
   linkindex: 3
@@ -57,13 +66,16 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: 1.2.3.5/29
     node: r1
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: 1.2.3.4/29
     ipv6: 2001:db8:1:1::1/127
     node: r2
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: 1.2.3.5/29
     node: r3
   linkindex: 4
@@ -75,12 +87,15 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv6: 2001:db8:2::7/64
     node: r1
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv6: 2001:db8:2::15/64
     node: r2
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv6: 2001:db8:2::2a/64
     node: r3
   linkindex: 5
@@ -93,14 +108,17 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 7
+    ifname: GigabitEthernet7
     ipv4: 172.17.0.7/25
     ipv6: 2001:db8:3::7/64
     node: r1
   - ifindex: 7
+    ifname: GigabitEthernet7
     ipv4: 172.17.0.21/25
     ipv6: 2001:db8:3::15/64
     node: r2
   - ifindex: 7
+    ifname: GigabitEthernet7
     ipv4: 172.17.0.42/25
     ipv6: 2001:db8:3::2a/64
     node: r3
@@ -115,10 +133,13 @@ links:
 - bridge: input_7
   interfaces:
   - ifindex: 8
+    ifname: GigabitEthernet8
     node: r1
   - ifindex: 8
+    ifname: GigabitEthernet8
     node: r2
   - ifindex: 8
+    ifname: GigabitEthernet8
     node: r3
   linkindex: 7
   name: P2P L2only link
@@ -128,14 +149,17 @@ links:
 - bridge: input_8
   interfaces:
   - ifindex: 9
+    ifname: GigabitEthernet9
     ipv4: 172.17.0.131/25
     ipv6: 2001:db8:3:1::7/64
     node: r1
   - ifindex: 9
+    ifname: GigabitEthernet9
     ipv4: 172.17.0.130/25
     ipv6: 2001:db8:3:1::2a/64
     node: r2
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 172.17.0.129/25
     ipv6: 2001:db8:3:1::1/64
     node: r4
@@ -150,14 +174,17 @@ links:
 - bridge: input_9
   interfaces:
   - ifindex: 10
+    ifname: GigabitEthernet10
     ipv4: true
     ipv6: 2001:db8:3:2::7/64
     node: r1
   - ifindex: 10
+    ifname: GigabitEthernet10
     ipv4: 172.17.1.21/25
     ipv6: true
     node: r2
   - ifindex: 9
+    ifname: GigabitEthernet9
     ipv4: 172.17.1.42/25
     ipv6: 2001:db8:3:2::2a/64
     node: r3
@@ -172,11 +199,14 @@ links:
 - bridge: input_10
   interfaces:
   - ifindex: 11
+    ifname: GigabitEthernet11
     ipv4: 10.0.0.1/30
     node: r1
   - ifindex: 11
+    ifname: GigabitEthernet11
     node: r2
   - ifindex: 10
+    ifname: GigabitEthernet10
     node: r3
   linkindex: 10
   name: l2only link with a static IP address
@@ -186,11 +216,14 @@ links:
 - bridge: input_11
   interfaces:
   - ifindex: 12
+    ifname: GigabitEthernet12
     node: r1
   - ifindex: 12
+    ifname: GigabitEthernet12
     ipv4: 10.42.42.17/32
     node: r2
   - ifindex: 11
+    ifname: GigabitEthernet11
     node: r3
   linkindex: 11
   name: l2only LAN link with a host IP address
@@ -200,12 +233,15 @@ links:
 - bridge: input_12
   interfaces:
   - ifindex: 13
+    ifname: GigabitEthernet13
     ipv4: 172.42.42.7/24
     node: r1
   - ifindex: 13
+    ifname: GigabitEthernet13
     ipv4: 172.42.42.21/24
     node: r2
   - ifindex: 12
+    ifname: GigabitEthernet12
     ipv4: 172.42.42.42/24
     node: r3
   linkindex: 12
@@ -217,14 +253,17 @@ links:
 - bridge: input_13
   interfaces:
   - ifindex: 14
+    ifname: GigabitEthernet14
     ipv4: 172.42.32.7/22
     ipv6: 2001:db8:42:42::7/64
     node: r1
   - ifindex: 14
+    ifname: GigabitEthernet14
     ipv4: 172.42.32.21/22
     ipv6: 2001:db8:42:42::15/64
     node: r2
   - ifindex: 13
+    ifname: GigabitEthernet13
     ipv4: 172.42.32.42/22
     ipv6: 2001:db8:42:42::2a/64
     node: r3
@@ -237,10 +276,12 @@ links:
   type: lan
 - interfaces:
   - ifindex: 15
+    ifname: GigabitEthernet15
     ipv4: true
     ipv6: 2001:db8:42:43::1/64
     node: r1
   - ifindex: 15
+    ifname: GigabitEthernet15
     ipv4: true
     ipv6: 2001:db8:42:43::2/64
     node: r2

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 2
     ipv4: true
     node: r2
-  left:
-    ifname: GigabitEthernet2
-    ipv4: true
-    node: r1
   linkindex: 1
   name: Standard P2P link (IPv4-only unnumbered)
   node_count: 2
   prefix:
     ipv4: true
-  right:
-    ifname: GigabitEthernet2
-    ipv4: true
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -31,20 +23,11 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:44::1/64
     node: r2
-  left:
-    ifname: GigabitEthernet3
-    ipv4: 10.42.42.18/32
-    node: r1
   linkindex: 2
   name: IPv4-only unnumbered link with static IPv4 and IPv6 addresses
   node_count: 2
   prefix:
     ipv4: true
-  right:
-    ifname: GigabitEthernet3
-    ipv4: true
-    ipv6: 2001:db8:42:44::1/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 4
@@ -53,18 +36,10 @@ links:
   - ifindex: 4
     ipv4: true
     node: r2
-  left:
-    ifname: GigabitEthernet4
-    ipv4: true
-    node: r1
   linkindex: 3
   name: P2P unnumbered link (using unnumbered attribute)
   node_count: 2
   pool: unnumbered
-  right:
-    ifname: GigabitEthernet4
-    ipv4: true
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 5
@@ -73,20 +48,12 @@ links:
   - ifindex: 5
     ipv6: 2001:db8:2::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet5
-    ipv6: 2001:db8:2::1/64
-    node: r1
   linkindex: 4
   name: P2P v6only link
   node_count: 2
   pool: v6only
   prefix:
     ipv6: 2001:db8:2::/64
-  right:
-    ifname: GigabitEthernet5
-    ipv6: 2001:db8:2::2/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 6
@@ -97,11 +64,6 @@ links:
     ipv4: 172.17.0.2/29
     ipv6: 2001:db8:3::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet6
-    ipv4: 172.17.0.1/29
-    ipv6: 2001:db8:3::1/64
-    node: r1
   linkindex: 5
   name: P2P dual-stack link with non-standard prefix length
   node_count: 2
@@ -109,27 +71,16 @@ links:
   prefix:
     ipv4: 172.17.0.0/29
     ipv6: 2001:db8:3::/64
-  right:
-    ifname: GigabitEthernet6
-    ipv4: 172.17.0.2/29
-    ipv6: 2001:db8:3::2/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 7
     node: r1
   - ifindex: 7
     node: r2
-  left:
-    ifname: GigabitEthernet7
-    node: r1
   linkindex: 6
   name: P2P L2only link
   node_count: 2
   pool: l2only
-  right:
-    ifname: GigabitEthernet7
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 8
@@ -140,11 +91,6 @@ links:
     ipv4: 172.17.0.10/29
     ipv6: 2001:db8:3:1::2a/64
     node: r2
-  left:
-    ifname: GigabitEthernet8
-    ipv4: 172.17.0.11/29
-    ipv6: 2001:db8:3:1::7/64
-    node: r1
   linkindex: 7
   name: P2P link with custom node IDs
   node_count: 2
@@ -152,11 +98,6 @@ links:
   prefix:
     ipv4: 172.17.0.8/29
     ipv6: 2001:db8:3:1::/64
-  right:
-    ifname: GigabitEthernet8
-    ipv4: 172.17.0.10/29
-    ipv6: 2001:db8:3:1::2a/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 9
@@ -167,11 +108,6 @@ links:
     ipv4: 172.17.0.18/29
     ipv6: true
     node: r2
-  left:
-    ifname: GigabitEthernet9
-    ipv4: true
-    ipv6: 2001:db8:3:2::1/64
-    node: r1
   linkindex: 8
   name: P2P link with one unnumbered node
   node_count: 2
@@ -179,11 +115,6 @@ links:
   prefix:
     ipv4: 172.17.0.16/29
     ipv6: 2001:db8:3:2::/64
-  right:
-    ifname: GigabitEthernet9
-    ipv4: 172.17.0.18/29
-    ipv6: true
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 10
@@ -191,17 +122,10 @@ links:
     node: r1
   - ifindex: 10
     node: r2
-  left:
-    ifname: GigabitEthernet10
-    ipv4: 10.0.0.1/30
-    node: r1
   linkindex: 9
   name: P2P l2only link with a static IP address
   node_count: 2
   pool: l2only
-  right:
-    ifname: GigabitEthernet10
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 11
@@ -209,17 +133,10 @@ links:
   - ifindex: 11
     ipv4: 10.42.42.17/32
     node: r2
-  left:
-    ifname: GigabitEthernet11
-    node: r1
   linkindex: 10
   name: l2only P2P link
   node_count: 2
   prefix: false
-  right:
-    ifname: GigabitEthernet11
-    ipv4: 10.42.42.17/32
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 12
@@ -228,19 +145,11 @@ links:
   - ifindex: 12
     ipv4: 172.42.42.2/28
     node: r2
-  left:
-    ifname: GigabitEthernet12
-    ipv4: 172.42.42.1/28
-    node: r1
   linkindex: 11
   name: P2P link with static prefix
   node_count: 2
   prefix:
     ipv4: 172.42.42.0/28
-  right:
-    ifname: GigabitEthernet12
-    ipv4: 172.42.42.2/28
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 13
@@ -249,19 +158,11 @@ links:
   - ifindex: 13
     ipv4: 172.42.42.129/31
     node: r2
-  left:
-    ifname: GigabitEthernet13
-    ipv4: 172.42.42.128/31
-    node: r1
   linkindex: 12
   name: P2P link with /31 static prefix
   node_count: 2
   prefix:
     ipv4: 172.42.42.128/31
-  right:
-    ifname: GigabitEthernet13
-    ipv4: 172.42.42.129/31
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 14
@@ -272,22 +173,12 @@ links:
     ipv4: 172.42.42.18/28
     ipv6: 2001:db8:42:42::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet14
-    ipv4: 172.42.42.17/28
-    ipv6: 2001:db8:42:42::1/64
-    node: r1
   linkindex: 13
   name: P2P link with static dual-stack prefix
   node_count: 2
   prefix:
     ipv4: 172.42.42.16/28
     ipv6: 2001:db8:42:42::/64
-  right:
-    ifname: GigabitEthernet14
-    ipv4: 172.42.42.18/28
-    ipv6: 2001:db8:42:42::2/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 15
@@ -298,22 +189,12 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:43::2/64
     node: r2
-  left:
-    ifname: GigabitEthernet15
-    ipv4: true
-    ipv6: 2001:db8:42:43::1/64
-    node: r1
   linkindex: 14
   name: P2P link with unnumbered static prefix
   node_count: 2
   prefix:
     ipv4: true
     ipv6: 2001:db8:42:43::/64
-  right:
-    ifname: GigabitEthernet15
-    ipv4: true
-    ipv6: 2001:db8:42:43::2/64
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 16
@@ -323,20 +204,11 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:44::1/128
     node: r2
-  left:
-    ifname: GigabitEthernet16
-    ipv4: 10.42.42.18/32
-    node: r1
   linkindex: 15
   name: Host addresses on a P2P link (useless but should work)
   node_count: 2
   prefix:
     ipv4: true
-  right:
-    ifname: GigabitEthernet16
-    ipv4: true
-    ipv6: 2001:db8:42:44::1/128
-    node: r2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: true
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: true
     node: r2
   linkindex: 1
@@ -17,9 +19,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.42.42.18/32
     node: r1
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: true
     ipv6: 2001:db8:42:44::1/64
     node: r2
@@ -31,9 +35,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: r1
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: r2
   linkindex: 3
@@ -43,9 +49,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv6: 2001:db8:2::1/64
     node: r1
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv6: 2001:db8:2::2/64
     node: r2
   linkindex: 4
@@ -57,10 +65,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv4: 172.17.0.1/29
     ipv6: 2001:db8:3::1/64
     node: r1
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv4: 172.17.0.2/29
     ipv6: 2001:db8:3::2/64
     node: r2
@@ -74,8 +84,10 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
+    ifname: GigabitEthernet7
     node: r1
   - ifindex: 7
+    ifname: GigabitEthernet7
     node: r2
   linkindex: 6
   name: P2P L2only link
@@ -84,10 +96,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ifname: GigabitEthernet8
     ipv4: 172.17.0.11/29
     ipv6: 2001:db8:3:1::7/64
     node: r1
   - ifindex: 8
+    ifname: GigabitEthernet8
     ipv4: 172.17.0.10/29
     ipv6: 2001:db8:3:1::2a/64
     node: r2
@@ -101,10 +115,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 9
+    ifname: GigabitEthernet9
     ipv4: true
     ipv6: 2001:db8:3:2::1/64
     node: r1
   - ifindex: 9
+    ifname: GigabitEthernet9
     ipv4: 172.17.0.18/29
     ipv6: true
     node: r2
@@ -118,9 +134,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 10
+    ifname: GigabitEthernet10
     ipv4: 10.0.0.1/30
     node: r1
   - ifindex: 10
+    ifname: GigabitEthernet10
     node: r2
   linkindex: 9
   name: P2P l2only link with a static IP address
@@ -129,8 +147,10 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 11
+    ifname: GigabitEthernet11
     node: r1
   - ifindex: 11
+    ifname: GigabitEthernet11
     ipv4: 10.42.42.17/32
     node: r2
   linkindex: 10
@@ -140,9 +160,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 12
+    ifname: GigabitEthernet12
     ipv4: 172.42.42.1/28
     node: r1
   - ifindex: 12
+    ifname: GigabitEthernet12
     ipv4: 172.42.42.2/28
     node: r2
   linkindex: 11
@@ -153,9 +175,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 13
+    ifname: GigabitEthernet13
     ipv4: 172.42.42.128/31
     node: r1
   - ifindex: 13
+    ifname: GigabitEthernet13
     ipv4: 172.42.42.129/31
     node: r2
   linkindex: 12
@@ -166,10 +190,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 14
+    ifname: GigabitEthernet14
     ipv4: 172.42.42.17/28
     ipv6: 2001:db8:42:42::1/64
     node: r1
   - ifindex: 14
+    ifname: GigabitEthernet14
     ipv4: 172.42.42.18/28
     ipv6: 2001:db8:42:42::2/64
     node: r2
@@ -182,10 +208,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 15
+    ifname: GigabitEthernet15
     ipv4: true
     ipv6: 2001:db8:42:43::1/64
     node: r1
   - ifindex: 15
+    ifname: GigabitEthernet15
     ipv4: true
     ipv6: 2001:db8:42:43::2/64
     node: r2
@@ -198,9 +226,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 16
+    ifname: GigabitEthernet16
     ipv4: 10.42.42.18/32
     node: r1
   - ifindex: 16
+    ifname: GigabitEthernet16
     ipv4: true
     ipv6: 2001:db8:42:44::1/128
     node: r2

--- a/tests/topology/expected/addrs-no-pool.yml
+++ b/tests/topology/expected/addrs-no-pool.yml
@@ -9,7 +9,6 @@ links:
     ipv4: 10.2.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.2.0.0/30

--- a/tests/topology/expected/addrs-no-pool.yml
+++ b/tests/topology/expected/addrs-no-pool.yml
@@ -8,19 +8,11 @@ links:
   - ifindex: 1
     ipv4: 10.2.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.2.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.2.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.2.0.2/30
-    node: r2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/addrs-no-pool.yml
+++ b/tests/topology/expected/addrs-no-pool.yml
@@ -3,9 +3,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.2.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.2.0.2/30
     node: r2
   linkindex: 1

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -24,19 +24,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: l2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: l1
   linkindex: 1
   name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: l2
   type: p2p
 module:
 - ospf

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -19,9 +19,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: l1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -25,7 +25,6 @@ links:
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1
-  name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -49,19 +49,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: s1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: l1
   linkindex: 1
   name: l1 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: s1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -70,19 +62,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: s1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.5/30
-    node: l2
   linkindex: 2
   name: l2 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: s1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -91,19 +75,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.10/30
     node: s1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.9/30
-    node: l3
   linkindex: 3
   name: l3 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.10/30
-    node: s1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -112,19 +88,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.14/30
     node: l2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.13/30
-    node: a1
   linkindex: 4
   name: a1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.14/30
-    node: l2
   role: external
   type: p2p
 - interfaces:
@@ -134,19 +102,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.18/30
     node: l2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.17/30
-    node: a2
   linkindex: 5
   name: a2 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.18/30
-    node: l2
   role: external
   type: p2p
 - interfaces:
@@ -156,19 +116,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.22/30
     node: l3
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.21/30
-    node: a3
   linkindex: 6
   name: a3 - l3
   node_count: 2
   prefix:
     ipv4: 10.1.0.20/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.22/30
-    node: l3
   role: external
   type: p2p
 module:

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -44,80 +44,74 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    node: l1
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     node: s1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: l1
   linkindex: 1
-  name: l1 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.5/30
-    node: l2
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: s1
+  - ifindex: 1
+    ipv4: 10.1.0.5/30
+    node: l2
   linkindex: 2
-  name: l2 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.9/30
-    node: l3
   - ifindex: 3
     ipv4: 10.1.0.10/30
     node: s1
+  - ifindex: 1
+    ipv4: 10.1.0.9/30
+    node: l3
   linkindex: 3
-  name: l3 - s1
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.13/30
-    node: a1
   - ifindex: 2
     ipv4: 10.1.0.14/30
     node: l2
+  - ifindex: 1
+    ipv4: 10.1.0.13/30
+    node: a1
   linkindex: 4
-  name: a1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.17/30
-    node: a2
   - ifindex: 3
     ipv4: 10.1.0.18/30
     node: l2
+  - ifindex: 1
+    ipv4: 10.1.0.17/30
+    node: a2
   linkindex: 5
-  name: a2 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.21/30
-    node: a3
   - ifindex: 2
     ipv4: 10.1.0.22/30
     node: l3
+  - ifindex: 1
+    ipv4: 10.1.0.21/30
+    node: a3
   linkindex: 6
-  name: a3 - l3
   node_count: 2
   prefix:
     ipv4: 10.1.0.20/30

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -44,9 +44,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: s1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: l1
   linkindex: 1
@@ -56,9 +58,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: s1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.5/30
     node: l2
   linkindex: 2
@@ -68,9 +72,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.10/30
     node: s1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.9/30
     node: l3
   linkindex: 3
@@ -80,9 +86,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
     node: l2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.13/30
     node: a1
   linkindex: 4
@@ -93,9 +101,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.18/30
     node: l2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.17/30
     node: a2
   linkindex: 5
@@ -106,9 +116,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.22/30
     node: l3
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.21/30
     node: a3
   linkindex: 6

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -24,19 +24,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r3
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r3
   type: p2p
 - interfaces:
   - bgp:
@@ -47,19 +39,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: r3
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.5/30
-    node: r2
   linkindex: 2
   name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: r3
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -19,9 +19,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r3
   linkindex: 1
@@ -33,9 +35,11 @@ links:
   - bgp:
       local_as: 65002
     ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -25,7 +25,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r3
   linkindex: 1
-  name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -40,7 +39,6 @@ links:
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
-  name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -26,45 +26,41 @@ links:
 - interfaces:
   - ifindex: 1
     ipv4: true
-    node: l1
+    node: s1
   - ifindex: 1
     ipv4: true
-    node: s1
+    node: l1
   linkindex: 1
-  name: l1 - s1
   node_count: 2
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: true
-    node: l2
   - ifindex: 2
     ipv4: true
     node: s1
+  - ifindex: 1
+    ipv4: true
+    node: l2
   linkindex: 2
-  name: l2 - s1
   node_count: 2
   type: p2p
 - interfaces:
-  - ifindex: 2
-    ipv4: true
-    node: l1
   - ifindex: 1
     ipv4: true
     node: s2
+  - ifindex: 2
+    ipv4: true
+    node: l1
   linkindex: 3
-  name: l1 - s2
   node_count: 2
   type: p2p
 - interfaces:
   - ifindex: 2
     ipv4: true
-    node: l2
+    node: s2
   - ifindex: 2
     ipv4: true
-    node: s2
+    node: l2
   linkindex: 4
-  name: l2 - s2
   node_count: 2
   type: p2p
 module:

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -25,9 +25,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: true
     node: s1
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: true
     node: l1
   linkindex: 1
@@ -35,9 +37,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: true
     node: s1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     node: l2
   linkindex: 2
@@ -45,9 +49,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: true
     node: s2
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: true
     node: l1
   linkindex: 3
@@ -55,9 +61,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: true
     node: s2
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     node: l2
   linkindex: 4

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -30,17 +30,9 @@ links:
   - ifindex: 1
     ipv4: true
     node: s1
-  left:
-    ifname: Ethernet1/1
-    ipv4: true
-    node: l1
   linkindex: 1
   name: l1 - s1
   node_count: 2
-  right:
-    ifname: Ethernet1/1
-    ipv4: true
-    node: s1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -49,17 +41,9 @@ links:
   - ifindex: 2
     ipv4: true
     node: s1
-  left:
-    ifname: Ethernet1
-    ipv4: true
-    node: l2
   linkindex: 2
   name: l2 - s1
   node_count: 2
-  right:
-    ifname: Ethernet1/2
-    ipv4: true
-    node: s1
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -68,17 +52,9 @@ links:
   - ifindex: 1
     ipv4: true
     node: s2
-  left:
-    ifname: Ethernet1/2
-    ipv4: true
-    node: l1
   linkindex: 3
   name: l1 - s2
   node_count: 2
-  right:
-    ifname: Ethernet1/1
-    ipv4: true
-    node: s2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -87,17 +63,9 @@ links:
   - ifindex: 2
     ipv4: true
     node: s2
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    node: l2
   linkindex: 4
   name: l2 - s2
   node_count: 2
-  right:
-    ifname: Ethernet1/2
-    ipv4: true
-    node: s2
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -20,9 +20,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -35,9 +37,11 @@ links:
 - bgp: false
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.5/30
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: r2
   linkindex: 2
@@ -50,9 +54,11 @@ links:
 - interfaces:
   - bgp: false
     ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.9/30
     node: r1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.10/30
     node: r2
   linkindex: 3

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -25,19 +25,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: Regular EBGP
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r2
   role: external
   type: p2p
 - bgp: false
@@ -48,19 +40,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.5/30
-    node: r1
   linkindex: 2
   name: No EBGP sesion
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: r2
   role: external
   type: p2p
 - interfaces:
@@ -71,19 +55,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.10/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.9/30
-    node: r1
   linkindex: 3
   name: No EBGP session on R1
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.10/30
-    node: r2
   role: external
   type: p2p
 module:

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -44,19 +44,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: rr1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: pe1
   linkindex: 1
   name: pe1 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: rr1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -65,19 +57,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: rr1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.5/30
-    node: pe2
   linkindex: 2
   name: pe2 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: rr1
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -86,19 +70,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.10/30
     node: rr2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.9/30
-    node: pe1
   linkindex: 3
   name: pe1 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.10/30
-    node: rr2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -107,19 +83,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.14/30
     node: rr2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.13/30
-    node: pe2
   linkindex: 4
   name: pe2 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.14/30
-    node: rr2
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -128,19 +96,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.18/30
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.17/30
-    node: e1
   linkindex: 5
   name: e1 - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.18/30
-    node: pe1
   role: external
   type: p2p
 - interfaces:
@@ -150,19 +110,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.22/30
     node: pe2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.21/30
-    node: e2
   linkindex: 6
   name: e2 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.20/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.22/30
-    node: pe2
   role: external
   type: p2p
 module:

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -39,79 +39,73 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    node: pe1
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     node: rr1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: pe1
   linkindex: 1
-  name: pe1 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.5/30
-    node: pe2
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: rr1
+  - ifindex: 1
+    ipv4: 10.1.0.5/30
+    node: pe2
   linkindex: 2
-  name: pe2 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
 - interfaces:
-  - ifindex: 2
-    ipv4: 10.1.0.9/30
-    node: pe1
   - ifindex: 1
     ipv4: 10.1.0.10/30
     node: rr2
+  - ifindex: 2
+    ipv4: 10.1.0.9/30
+    node: pe1
   linkindex: 3
-  name: pe1 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.13/30
-    node: pe2
-  - ifindex: 2
     ipv4: 10.1.0.14/30
     node: rr2
+  - ifindex: 2
+    ipv4: 10.1.0.13/30
+    node: pe2
   linkindex: 4
-  name: pe2 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.17/30
-    node: e1
   - ifindex: 3
     ipv4: 10.1.0.18/30
     node: pe1
+  - ifindex: 1
+    ipv4: 10.1.0.17/30
+    node: e1
   linkindex: 5
-  name: e1 - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.21/30
-    node: e2
   - ifindex: 3
     ipv4: 10.1.0.22/30
     node: pe2
+  - ifindex: 1
+    ipv4: 10.1.0.21/30
+    node: e2
   linkindex: 6
-  name: e2 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.20/30

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -39,9 +39,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: rr1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: pe1
   linkindex: 1
@@ -51,9 +53,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: rr1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.5/30
     node: pe2
   linkindex: 2
@@ -63,9 +67,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.10/30
     node: rr2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.9/30
     node: pe1
   linkindex: 3
@@ -75,9 +81,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
     node: rr2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.13/30
     node: pe2
   linkindex: 4
@@ -87,9 +95,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.18/30
     node: pe1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.17/30
     node: e1
   linkindex: 5
@@ -100,9 +110,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.22/30
     node: pe2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.21/30
     node: e2
   linkindex: 6

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -28,15 +28,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: r1
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: x1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    ipv6: 2001:db8:1::1/64
+    node: r1
   linkindex: 1
-  name: r1 - x1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -53,7 +52,6 @@ links:
     ipv6: 2001:db8:1:1::2/64
     node: r2
   linkindex: 2
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -35,22 +35,12 @@ links:
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: x1
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: r1
   linkindex: 1
   name: r1 - x1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: x1
   role: external
   type: p2p
 - interfaces:
@@ -62,22 +52,12 @@ links:
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: r2
-  left:
-    ifname: Ethernet2
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: r1
   linkindex: 2
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: r2
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -28,10 +28,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: x1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: r1
@@ -44,10 +46,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: r2

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -37,7 +37,6 @@ links:
     ipv6: true
     node: x1
   linkindex: 1
-  name: test - x1
   node_count: 2
   role: external
   type: p2p
@@ -50,7 +49,6 @@ links:
     ipv4: true
     node: x1
   linkindex: 2
-  name: test - x1
   node_count: 2
   prefix:
     ipv4: true
@@ -66,7 +64,6 @@ links:
     ipv6: true
     node: x2
   linkindex: 3
-  name: test - x2
   node_count: 2
   prefix:
     ipv4: true
@@ -81,7 +78,6 @@ links:
     ipv6: true
     node: x3
   linkindex: 4
-  name: test - x3
   node_count: 2
   prefix:
     ipv6: true
@@ -97,7 +93,6 @@ links:
     ipv6: true
     node: x4
   linkindex: 5
-  name: test - x4
   node_count: 2
   prefix:
     ipv4: 172.31.1.0/24
@@ -114,7 +109,6 @@ links:
     ipv6: 2001:db8:1::2/64
     node: x4
   linkindex: 6
-  name: test - x4
   node_count: 2
   prefix:
     ipv4: true

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -36,19 +36,9 @@ links:
     ipv4: true
     ipv6: true
     node: x1
-  left:
-    ifname: swp1
-    ipv4: true
-    ipv6: true
-    node: test
   linkindex: 1
   name: test - x1
   node_count: 2
-  right:
-    ifname: swp1
-    ipv4: true
-    ipv6: true
-    node: x1
   role: external
   type: p2p
   unnumbered: true
@@ -59,19 +49,11 @@ links:
   - ifindex: 2
     ipv4: true
     node: x1
-  left:
-    ifname: swp2
-    ipv4: true
-    node: test
   linkindex: 2
   name: test - x1
   node_count: 2
   prefix:
     ipv4: true
-  right:
-    ifname: swp2
-    ipv4: true
-    node: x1
   role: external
   type: p2p
 - interfaces:
@@ -83,22 +65,12 @@ links:
     ipv4: true
     ipv6: true
     node: x2
-  left:
-    ifname: swp3
-    ipv4: true
-    ipv6: true
-    node: test
   linkindex: 3
   name: test - x2
   node_count: 2
   prefix:
     ipv4: true
     ipv6: true
-  right:
-    ifname: swp1
-    ipv4: true
-    ipv6: true
-    node: x2
   role: external
   type: p2p
 - interfaces:
@@ -108,19 +80,11 @@ links:
   - ifindex: 1
     ipv6: true
     node: x3
-  left:
-    ifname: swp4
-    ipv6: true
-    node: test
   linkindex: 4
   name: test - x3
   node_count: 2
   prefix:
     ipv6: true
-  right:
-    ifname: swp1
-    ipv6: true
-    node: x3
   role: external
   type: p2p
 - interfaces:
@@ -132,22 +96,12 @@ links:
     ipv4: 172.31.1.2/24
     ipv6: true
     node: x4
-  left:
-    ifname: swp5
-    ipv4: 172.31.1.1/24
-    ipv6: true
-    node: test
   linkindex: 5
   name: test - x4
   node_count: 2
   prefix:
     ipv4: 172.31.1.0/24
     ipv6: true
-  right:
-    ifname: swp1
-    ipv4: 172.31.1.2/24
-    ipv6: true
-    node: x4
   role: external
   type: p2p
 - interfaces:
@@ -159,22 +113,12 @@ links:
     ipv4: true
     ipv6: 2001:db8:1::2/64
     node: x4
-  left:
-    ifname: swp6
-    ipv4: true
-    ipv6: 2001:db8:1::1/64
-    node: test
   linkindex: 6
   name: test - x4
   node_count: 2
   prefix:
     ipv4: true
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: swp2
-    ipv4: true
-    ipv6: 2001:db8:1::2/64
-    node: x4
   role: external
   type: p2p
 module:

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -29,10 +29,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: swp1
     ipv4: true
     ipv6: true
     node: test
   - ifindex: 1
+    ifname: swp1
     ipv4: true
     ipv6: true
     node: x1
@@ -43,9 +45,11 @@ links:
   unnumbered: true
 - interfaces:
   - ifindex: 2
+    ifname: swp2
     ipv4: true
     node: test
   - ifindex: 2
+    ifname: swp2
     ipv4: true
     node: x1
   linkindex: 2
@@ -56,10 +60,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: swp3
     ipv4: true
     ipv6: true
     node: test
   - ifindex: 1
+    ifname: swp1
     ipv4: true
     ipv6: true
     node: x2
@@ -72,9 +78,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
+    ifname: swp4
     ipv6: true
     node: test
   - ifindex: 1
+    ifname: swp1
     ipv6: true
     node: x3
   linkindex: 4
@@ -85,10 +93,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
+    ifname: swp5
     ipv4: 172.31.1.1/24
     ipv6: true
     node: test
   - ifindex: 1
+    ifname: swp1
     ipv4: 172.31.1.2/24
     ipv6: true
     node: x4
@@ -101,10 +111,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ifname: swp6
     ipv4: true
     ipv6: 2001:db8:1::1/64
     node: test
   - ifindex: 2
+    ifname: swp2
     ipv4: true
     ipv6: 2001:db8:1::2/64
     node: x4

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -41,7 +41,6 @@ links:
     ipv6: true
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   role: external
   type: p2p
@@ -53,7 +52,6 @@ links:
     ipv4: 10.10.10.2/24
     node: r3
   linkindex: 2
-  name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.10.10.0/24

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -33,10 +33,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: swp1
     ipv4: true
     ipv6: true
     node: r1
   - ifindex: 1
+    ifname: swp1
     ipv4: true
     ipv6: true
     node: r2
@@ -46,9 +48,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: swp2
     ipv4: 10.10.10.1/24
     node: r2
   - ifindex: 1
+    ifname: swp1
     ipv4: 10.10.10.2/24
     node: r3
   linkindex: 2

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -40,19 +40,9 @@ links:
     ipv4: true
     ipv6: true
     node: r2
-  left:
-    ifname: swp1
-    ipv4: true
-    ipv6: true
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
-  right:
-    ifname: swp1
-    ipv4: true
-    ipv6: true
-    node: r2
   role: external
   type: p2p
 - interfaces:
@@ -62,19 +52,11 @@ links:
   - ifindex: 1
     ipv4: 10.10.10.2/24
     node: r3
-  left:
-    ifname: swp2
-    ipv4: 10.10.10.1/24
-    node: r2
   linkindex: 2
   name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.10.10.0/24
-  right:
-    ifname: swp1
-    ipv4: 10.10.10.2/24
-    node: r3
   role: external
   type: p2p
 module:

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -34,16 +34,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r2
   role: external
   type: p2p
   vlan:
@@ -63,16 +57,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet2
-    node: r2
   linkindex: 2
   name: r2 - r3
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r3
   role: external
   type: p2p
   vlan:
@@ -98,19 +86,11 @@ links:
       access: vrf-leak
       mode: route
     vrf: blue
-  left:
-    ifname: Ethernet3
-    ipv4: 10.1.0.1/30
-    node: r2
   linkindex: 3
   name: r2 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet4
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
   vlan:
     mode: route

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -23,12 +23,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     node: r1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r2
     vlan:
       trunk:
@@ -45,12 +47,14 @@ links:
       red: {}
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: r2
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r3
     vlan:
       trunk:
@@ -69,6 +73,7 @@ links:
   - bgp:
       local_as: 65001
     ifindex: 3
+    ifname: Ethernet3
     ipv4: 10.1.0.1/30
     node: r2
     vlan:
@@ -78,6 +83,7 @@ links:
   - bgp:
       local_as: 65002
     ifindex: 4
+    ifname: Ethernet4
     ipv4: 10.1.0.2/30
     node: r2
     vlan:

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -35,7 +35,6 @@ links:
         blue: {}
         red: {}
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix: {}
   role: external
@@ -58,7 +57,6 @@ links:
         blue: {}
         red: {}
   linkindex: 2
-  name: r2 - r3
   node_count: 2
   prefix: {}
   role: external
@@ -87,7 +85,6 @@ links:
       mode: route
     vrf: blue
   linkindex: 3
-  name: r2 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -134,7 +131,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.3.1/24
-      name: r1 -> [r2]
+      name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.3.2/24
@@ -153,7 +150,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 172.16.4.1/24
-      name: r1 -> [r2]
+      name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.4.2/24
@@ -320,7 +317,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 172.16.3.2/24
-      name: r2 -> [r1]
+      name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.3.1/24
@@ -339,7 +336,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 172.16.4.2/24
-      name: r2 -> [r1]
+      name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.4.1/24
@@ -358,7 +355,7 @@ nodes:
       ifindex: 7
       ifname: Ethernet2.1
       ipv4: 172.16.5.2/24
-      name: r2 -> [r3]
+      name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.5.3/24
@@ -377,7 +374,7 @@ nodes:
       ifindex: 8
       ifname: Ethernet2.2
       ipv4: 172.16.6.2/24
-      name: r2 -> [r3]
+      name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.6.3/24
@@ -525,7 +522,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.5.3/24
-      name: r3 -> [r2]
+      name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
         ipv4: 172.16.5.2/24
@@ -544,7 +541,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 172.16.6.3/24
-      name: r3 -> [r2]
+      name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
         ipv4: 172.16.6.2/24

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -27,10 +27,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: rr1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: pe1
@@ -42,10 +44,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: rr1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: pe2
@@ -57,10 +61,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: rr2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
     node: pe1
@@ -72,10 +78,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: rr2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.13/30
     ipv6: 2001:db8:1:3::1/64
     node: pe2
@@ -87,9 +95,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.31.0.2/30
     node: pe1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.0.1/30
     node: e1
   linkindex: 5
@@ -100,9 +110,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.31.0.6/30
     node: pe2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.31.0.5/30
     node: e2
   linkindex: 6
@@ -116,6 +128,7 @@ links:
   - bgp:
       advertise: true
     ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.0.5/24
     node: e1
   linkindex: 7
@@ -126,6 +139,7 @@ links:
 - bridge: input_8
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.6/24
     node: e2
   linkindex: 8
@@ -135,10 +149,12 @@ links:
   type: stub
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.17/30
     ipv6: 2001:db8:1:4::1/64
     node: e2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: nar

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -34,22 +34,12 @@ links:
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: rr1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: pe1
   linkindex: 1
   name: pe1 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: rr1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -60,22 +50,12 @@ links:
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: rr1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: pe2
   linkindex: 2
   name: pe2 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: rr1
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -86,22 +66,12 @@ links:
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: rr2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: pe1
   linkindex: 3
   name: pe1 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: rr2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -112,22 +82,12 @@ links:
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: rr2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: pe2
   linkindex: 4
   name: pe2 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.14/30
-    ipv6: 2001:db8:1:3::2/64
-    node: rr2
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -136,19 +96,11 @@ links:
   - ifindex: 3
     ipv4: 172.31.0.2/30
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.0.1/30
-    node: e1
   linkindex: 5
   name: e1 - pe1
   node_count: 2
   prefix:
     ipv4: 172.31.0.0/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 172.31.0.2/30
-    node: pe1
   role: external
   type: p2p
 - interfaces:
@@ -158,19 +110,11 @@ links:
   - ifindex: 3
     ipv4: 172.31.0.6/30
     node: pe2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 172.31.0.5/30
-    node: e2
   linkindex: 6
   name: e2 - pe2
   node_count: 2
   prefix:
     ipv4: 172.31.0.4/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 172.31.0.6/30
-    node: pe2
   role: external
   type: p2p
 - bridge: input_7
@@ -204,22 +148,12 @@ links:
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: nar
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.17/30
-    ipv6: 2001:db8:1:4::1/64
-    node: e2
   linkindex: 9
   name: e2 - nar
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
     ipv6: 2001:db8:1:4::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.18/30
-    ipv6: 2001:db8:1:4::2/64
-    node: nar
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -27,47 +27,44 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: pe1
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: rr1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    ipv6: 2001:db8:1::1/64
+    node: pe1
   linkindex: 1
-  name: pe1 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: pe2
   - ifindex: 2
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: rr1
+  - ifindex: 1
+    ipv4: 10.1.0.5/30
+    ipv6: 2001:db8:1:1::1/64
+    node: pe2
   linkindex: 2
-  name: pe2 - rr1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
   type: p2p
 - interfaces:
-  - ifindex: 2
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: pe1
   - ifindex: 1
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: rr2
+  - ifindex: 2
+    ipv4: 10.1.0.9/30
+    ipv6: 2001:db8:1:2::1/64
+    node: pe1
   linkindex: 3
-  name: pe1 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
@@ -75,43 +72,40 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: pe2
-  - ifindex: 2
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: rr2
+  - ifindex: 2
+    ipv4: 10.1.0.13/30
+    ipv6: 2001:db8:1:3::1/64
+    node: pe2
   linkindex: 4
-  name: pe2 - rr2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 172.31.0.1/30
-    node: e1
   - ifindex: 3
     ipv4: 172.31.0.2/30
     node: pe1
+  - ifindex: 1
+    ipv4: 172.31.0.1/30
+    node: e1
   linkindex: 5
-  name: e1 - pe1
   node_count: 2
   prefix:
     ipv4: 172.31.0.0/30
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 172.31.0.5/30
-    node: e2
   - ifindex: 3
     ipv4: 172.31.0.6/30
     node: pe2
+  - ifindex: 1
+    ipv4: 172.31.0.5/30
+    node: e2
   linkindex: 6
-  name: e2 - pe2
   node_count: 2
   prefix:
     ipv4: 172.31.0.4/30
@@ -149,7 +143,6 @@ links:
     ipv6: 2001:db8:1:4::2/64
     node: nar
   linkindex: 9
-  name: e2 - nar
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
@@ -206,6 +199,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 172.16.0.5/24
       linkindex: 7
+      name: e1 -> stub
       neighbors: []
       ospf:
         area: 0.0.0.0
@@ -274,6 +268,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 172.16.1.6/24
       linkindex: 8
+      name: e2 -> stub
       neighbors: []
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/device-global-attr.yml
+++ b/tests/topology/expected/device-global-attr.yml
@@ -12,19 +12,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: l2
-  left:
-    ifname: ethernet-1/1
-    ipv4: 10.1.0.1/30
-    node: l1
   linkindex: 1
   name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    node: l2
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/device-global-attr.yml
+++ b/tests/topology/expected/device-global-attr.yml
@@ -7,9 +7,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: ethernet-1/1
     ipv4: 10.1.0.1/30
     node: l1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1

--- a/tests/topology/expected/device-global-attr.yml
+++ b/tests/topology/expected/device-global-attr.yml
@@ -13,7 +13,6 @@ links:
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1
-  name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -22,9 +22,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: ethernet-1/1
     ipv4: 10.1.0.1/30
     node: l1
   - ifindex: 1
+    ifname: 1/1/c1
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -28,7 +28,6 @@ links:
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1
-  name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -27,19 +27,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: l2
-  left:
-    ifname: ethernet-1/1
-    ipv4: 10.1.0.1/30
-    node: l1
   linkindex: 1
   name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: 1/1/c1
-    ipv4: 10.1.0.2/30
-    node: l2
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -56,7 +56,7 @@ nodes:
       ipv4: 172.16.0.2/24
       linkindex: 1
       mtu: 1500
-      name: h1 -> [rtr]
+      name: h1 -> rtr
       neighbors:
       - ifname: swp1
         ipv4: 172.16.0.1/24
@@ -88,7 +88,7 @@ nodes:
       ipv4: 172.16.1.3/24
       linkindex: 2
       mtu: 1500
-      name: h2 -> [rtr]
+      name: h2 -> rtr
       neighbors:
       - ifname: swp2
         ipv4: 172.16.1.1/24
@@ -118,7 +118,7 @@ nodes:
       ipv4: 172.16.0.1/24
       linkindex: 1
       mtu: 1500
-      name: rtr -> [h1]
+      name: rtr -> h1
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.2/24
@@ -135,7 +135,7 @@ nodes:
       ipv4: 172.16.1.1/24
       linkindex: 2
       mtu: 1500
-      name: rtr -> [h2]
+      name: rtr -> h2
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.3/24

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -7,9 +7,11 @@ links:
     ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.2/24
     node: h1
   - ifindex: 1
+    ifname: swp1
     ipv4: 172.16.0.1/24
     node: rtr
   linkindex: 1
@@ -23,9 +25,11 @@ links:
     ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.3/24
     node: h2
   - ifindex: 2
+    ifname: swp2
     ipv4: 172.16.1.1/24
     node: rtr
   linkindex: 2

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -31,14 +31,13 @@ links:
     ipv6: 2001:db8:1::/64
   type: lan
 - interfaces:
-  - ifindex: 3
-    ipv4: 10.1.0.1/30
-    node: c_csr
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_ios
+  - ifindex: 3
+    ipv4: 10.1.0.1/30
+    node: c_csr
   linkindex: 2
-  name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -100,7 +99,7 @@ nodes:
       ipv4: 10.2.0.68/26
       ipv6: 2001:db8:1:1::4/64
       linkindex: 3
-      name: a_eos -> [c_nxos]
+      name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
         ipv4: 10.2.0.67/26
@@ -257,7 +256,7 @@ nodes:
       ipv4: 10.2.0.67/26
       ipv6: 2001:db8:1:1::3/64
       linkindex: 3
-      name: c_nxos -> [a_eos]
+      name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2
         ipv4: 10.2.0.68/26

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -37,19 +37,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_ios
-  left:
-    ifname: GigabitEthernet3
-    ipv4: 10.1.0.1/30
-    node: c_csr
   linkindex: 2
   name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.2/30
-    node: c_ios
   type: p2p
 - bridge: c-to-a
   interfaces:

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -5,22 +5,27 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.2.0.1/26
     ipv6: 2001:db8:1::1/64
     node: c_ios
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.2.0.2/26
     ipv6: 2001:db8:1::2/64
     node: c_csr
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 10.2.0.3/26
     ipv6: 2001:db8:1::3/64
     node: c_nxos
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.2.0.4/26
     ipv6: 2001:db8:1::4/64
     node: a_eos
   - ifindex: 0
+    ifname: ge-0/0/0
     ipv4: 10.2.0.5/26
     ipv6: 2001:db8:1::5/64
     node: j_vsrx
@@ -32,9 +37,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.2/30
     node: c_ios
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.1.0.1/30
     node: c_csr
   linkindex: 2
@@ -45,10 +52,12 @@ links:
 - bridge: c-to-a
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.2.0.68/26
     ipv6: 2001:db8:1:1::4/64
     node: a_eos
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: 10.2.0.67/26
     ipv6: 2001:db8:1:1::3/64
     node: c_nxos

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -11,19 +11,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: c_nxos
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: c_ios
   linkindex: 1
   name: c_ios - c_nxos
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1/1
-    ipv4: 10.1.0.2/30
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -32,19 +24,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.6/30
     node: c_ios
-  left:
-    ifname: GigabitEthernet2
-    ipv4: 10.1.0.5/30
-    node: c_csr
   linkindex: 2
   name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: c_ios
   type: p2p
 - bridge: input_3
   interfaces:

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -6,26 +6,24 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    node: c_ios
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     node: c_nxos
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    node: c_ios
   linkindex: 1
-  name: c_ios - c_nxos
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.5/30
-    node: c_csr
-  - ifindex: 2
     ipv4: 10.1.0.6/30
     node: c_ios
+  - ifindex: 2
+    ipv4: 10.1.0.5/30
+    node: c_csr
   linkindex: 2
-  name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -155,6 +153,7 @@ nodes:
       ifname: GigabitEthernet4
       ipv4: 172.16.1.2/24
       linkindex: 5
+      name: c_csr -> stub
       neighbors: []
       type: stub
     - bridge: input_7
@@ -247,6 +246,7 @@ nodes:
       ifname: GigabitEthernet0/4
       ipv4: 172.16.2.3/24
       linkindex: 6
+      name: c_ios -> stub
       neighbors: []
       type: stub
     - bridge: input_7
@@ -326,6 +326,7 @@ nodes:
       ifname: Ethernet1/3
       ipv4: 172.16.0.1/24
       linkindex: 4
+      name: c_nxos -> stub
       neighbors: []
       type: stub
     - bridge: input_7

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -6,9 +6,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 10.1.0.2/30
     node: c_nxos
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: c_ios
   linkindex: 1
@@ -18,9 +20,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: c_ios
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.1.0.5/30
     node: c_csr
   linkindex: 2
@@ -31,14 +35,17 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: 172.31.0.1/24
     ipv6: 2008:db8:1::1/64
     node: c_nxos
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.31.0.3/24
     ipv6: 2008:db8:1::3/64
     node: c_ios
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 172.31.0.2/24
     ipv6: 2008:db8:1::2/64
     node: c_csr
@@ -52,6 +59,7 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 3
+    ifname: Ethernet1/3
     ipv4: 172.16.0.1/24
     node: c_nxos
   linkindex: 4
@@ -62,6 +70,7 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: 172.16.1.2/24
     node: c_csr
   linkindex: 5
@@ -72,6 +81,7 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 172.16.2.3/24
     node: c_ios
   linkindex: 6
@@ -82,12 +92,15 @@ links:
 - bridge: input_7
   interfaces:
   - ifindex: 4
+    ifname: Ethernet1/4
     ipv4: 172.16.3.1/24
     node: c_nxos
   - ifindex: 5
+    ifname: GigabitEthernet0/5
     ipv4: 172.16.3.3/24
     node: c_ios
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: 172.16.3.2/24
     node: c_csr
   linkindex: 7

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -23,10 +23,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 10.1.0.1/30
     node: r1
     vrf: hub
   - ifindex: 1
+    ifname: eth1
     ipv4: 10.1.0.2/30
     node: r2
     vrf: spoke

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -31,7 +31,6 @@ links:
     node: r2
     vrf: spoke
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -30,19 +30,11 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
     vrf: spoke
-  left:
-    ifname: eth1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: eth1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -10,7 +10,6 @@ links:
     ipv4: 10.1.0.2/30
     node: e2
   linkindex: 1
-  name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -23,7 +22,6 @@ links:
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
   linkindex: 2
-  name: e1 - pe1
   node_count: 2
   prefix:
     ipv6: 2001:db8:cafe:1::/64
@@ -52,7 +50,6 @@ links:
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
   linkindex: 4
-  name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24
@@ -134,7 +131,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 192.168.22.2/24
       linkindex: 3
-      name: e2 -> [pe1]
+      name: e2 -> pe1
       neighbors:
       - ifname: GigabitEthernet3
         ipv4: 192.168.22.3/24
@@ -185,7 +182,7 @@ nodes:
       ifname: GigabitEthernet3
       ipv4: 192.168.22.3/24
       linkindex: 3
-      name: pe1 -> [e2]
+      name: pe1 -> e2
       neighbors:
       - ifname: GigabitEthernet0/2
         ipv4: 192.168.22.2/24

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: e2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: e1
   linkindex: 1
   name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: e2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -30,19 +22,11 @@ links:
   - ifindex: 2
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
-  left:
-    ifname: GigabitEthernet0/2
-    ipv6: 2001:db8:cafe:1::1/64
-    node: e1
   linkindex: 2
   name: e1 - pe1
   node_count: 2
   prefix:
     ipv6: 2001:db8:cafe:1::/64
-  right:
-    ifname: GigabitEthernet2
-    ipv6: 2001:db8:cafe:1::2/64
-    node: pe1
   type: p2p
 - bridge: input_3
   interfaces:
@@ -67,22 +51,12 @@ links:
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 192.168.23.1/24
-    ipv6: 2001:db8:cafe:2::1/64
-    node: e1
   linkindex: 4
   name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24
     ipv6: 2001:db8:cafe:2::/64
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 192.168.23.2/24
-    ipv6: 2001:db8:cafe:2::2/64
-    node: e2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: e1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: e2
   linkindex: 1
@@ -16,9 +18,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv6: 2001:db8:cafe:1::1/64
     node: e1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
   linkindex: 2
@@ -29,9 +33,11 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 192.168.22.2/24
     node: e2
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 192.168.22.3/24
     node: pe1
   linkindex: 3
@@ -42,10 +48,12 @@ links:
 - dmz: 100000
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 192.168.23.1/24
     ipv6: 2001:db8:cafe:2::1/64
     node: e1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2

--- a/tests/topology/expected/extra-attr-missing.yml
+++ b/tests/topology/expected/extra-attr-missing.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/extra-attr-missing.yml
+++ b/tests/topology/expected/extra-attr-missing.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1

--- a/tests/topology/expected/extra-attr-missing.yml
+++ b/tests/topology/expected/extra-attr-missing.yml
@@ -10,7 +10,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/extra-module-attr-link.yml
+++ b/tests/topology/expected/extra-module-attr-link.yml
@@ -7,9 +7,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.1.0.1/30
     node: l1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1

--- a/tests/topology/expected/extra-module-attr-link.yml
+++ b/tests/topology/expected/extra-module-attr-link.yml
@@ -12,19 +12,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: l2
-  left:
-    ifname: GigabitEthernet2
-    ipv4: 10.1.0.1/30
-    node: l1
   linkindex: 1
   name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet2
-    ipv4: 10.1.0.2/30
-    node: l2
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/extra-module-attr-link.yml
+++ b/tests/topology/expected/extra-module-attr-link.yml
@@ -13,7 +13,6 @@ links:
     ipv4: 10.1.0.2/30
     node: l2
   linkindex: 1
-  name: l1 - l2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -33,16 +33,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r2
   type: p2p
   vlan:
     trunk:
@@ -61,16 +55,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet2
-    node: r1
   linkindex: 2
   name: r1 - r3
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r3
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -34,7 +34,6 @@ links:
         blue: {}
         red: {}
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix: {}
   type: p2p
@@ -56,7 +55,6 @@ links:
         blue: {}
         red: {}
   linkindex: 2
-  name: r1 - r3
   node_count: 2
   prefix: {}
   type: p2p

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -22,12 +22,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     node: r1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r2
     vlan:
       trunk:
@@ -43,12 +45,14 @@ links:
       red: {}
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: r1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r3
     vlan:
       trunk:

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -25,19 +25,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
   vrf: red
 module:

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -26,7 +26,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -20,9 +20,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1

--- a/tests/topology/expected/id.yml
+++ b/tests/topology/expected/id.yml
@@ -11,7 +11,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -24,20 +23,18 @@ links:
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
-  name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.9/30
-    node: r1
-  - ifindex: 2
     ipv4: 10.1.0.10/30
     node: r3
+  - ifindex: 2
+    ipv4: 10.1.0.9/30
+    node: r1
   linkindex: 3
-  name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30

--- a/tests/topology/expected/id.yml
+++ b/tests/topology/expected/id.yml
@@ -5,9 +5,11 @@ links:
 - bridge: b1
   interfaces:
   - ifindex: 1
+    ifname: swp1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: swp1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -17,9 +19,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: swp2
     ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 1
+    ifname: swp1
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
@@ -29,9 +33,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: swp2
     ipv4: 10.1.0.10/30
     node: r3
   - ifindex: 2
+    ifname: swp2
     ipv4: 10.1.0.9/30
     node: r1
   linkindex: 3

--- a/tests/topology/expected/id.yml
+++ b/tests/topology/expected/id.yml
@@ -10,19 +10,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: swp1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: swp1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -31,19 +23,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.6/30
     node: r3
-  left:
-    ifname: swp2
-    ipv4: 10.1.0.5/30
-    node: r2
   linkindex: 2
   name: r2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: swp1
-    ipv4: 10.1.0.6/30
-    node: r3
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -52,19 +36,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.10/30
     node: r3
-  left:
-    ifname: swp2
-    ipv4: 10.1.0.9/30
-    node: r1
   linkindex: 3
   name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: swp2
-    ipv4: 10.1.0.10/30
-    node: r3
   type: p2p
 module:
 - ospf

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -17,7 +17,6 @@ links:
     ipv6: true
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   type: p2p
 - interfaces:
@@ -30,7 +29,6 @@ links:
     ipv6: true
     node: r3
   linkindex: 2
-  name: r1 - r3
   node_count: 2
   type: p2p
 - interfaces:
@@ -43,7 +41,6 @@ links:
     ipv6: true
     node: r4
   linkindex: 3
-  name: r3 - r4
   node_count: 2
   type: p2p
 - interfaces:
@@ -56,7 +53,6 @@ links:
     ipv6: true
     node: r5
   linkindex: 4
-  name: r4 - r5
   node_count: 2
   type: p2p
 - bridge: input_5
@@ -369,6 +365,7 @@ nodes:
       isis:
         passive: true
       linkindex: 5
+      name: r5 -> stub
       neighbors: []
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -16,19 +16,9 @@ links:
     ipv4: true
     ipv6: true
     node: r2
-  left:
-    ifname: Ethernet1
-    ipv4: true
-    ipv6: true
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
-  right:
-    ifname: Ethernet1
-    ipv4: true
-    ipv6: true
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -39,19 +29,9 @@ links:
     ipv4: true
     ipv6: true
     node: r3
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    ipv6: true
-    node: r1
   linkindex: 2
   name: r1 - r3
   node_count: 2
-  right:
-    ifname: Ethernet1
-    ipv4: true
-    ipv6: true
-    node: r3
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -62,19 +42,9 @@ links:
     ipv4: true
     ipv6: true
     node: r4
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    ipv6: true
-    node: r3
   linkindex: 3
   name: r3 - r4
   node_count: 2
-  right:
-    ifname: Ethernet1
-    ipv4: true
-    ipv6: true
-    node: r4
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -85,19 +55,9 @@ links:
     ipv4: true
     ipv6: true
     node: r5
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    ipv6: true
-    node: r4
   linkindex: 4
   name: r4 - r5
   node_count: 2
-  right:
-    ifname: Ethernet1
-    ipv4: true
-    ipv6: true
-    node: r5
   type: p2p
 - bridge: input_5
   interfaces:

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -9,10 +9,12 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     ipv6: true
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     ipv6: true
     node: r2
@@ -21,10 +23,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     ipv6: true
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     ipv6: true
     node: r3
@@ -33,10 +37,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     ipv6: true
     node: r3
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     ipv6: true
     node: r4
@@ -45,10 +51,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     ipv6: true
     node: r4
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: true
     ipv6: true
     node: r5
@@ -58,6 +66,7 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv6: 2001:db8:1::5/64
     node: r5
   linkindex: 5

--- a/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
+++ b/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
@@ -9,9 +9,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -23,9 +25,11 @@ links:
 - eigrp: false
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.5/30
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     node: r2
   isis: false
@@ -39,11 +43,13 @@ links:
 - interfaces:
   - eigrp: false
     ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.9/30
     isis: false
     node: r1
     ospf: false
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.10/30
     node: r2
   linkindex: 3

--- a/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
+++ b/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
@@ -14,19 +14,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: Regular IGP
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 - eigrp: false
   interfaces:
@@ -37,20 +29,12 @@ links:
     ipv4: 10.1.0.6/30
     node: r2
   isis: false
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.5/30
-    node: r1
   linkindex: 2
   name: IGP disabled
   node_count: 2
   ospf: false
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    node: r2
   type: p2p
 - interfaces:
   - eigrp: false
@@ -62,19 +46,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.10/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.9/30
-    node: r1
   linkindex: 3
   name: IGP disabled on a R1 interface
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.10/30
-    node: r2
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -31,13 +31,13 @@ links:
 - bfd: false
   interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
-  - ifindex: 2
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
+  - ifindex: 2
+    ipv4: 10.1.0.1/30
+    ipv6: 2001:db8:1::1/64
+    node: srlinux_r2
   linkindex: 2
   name: Link with BFD disabled
   node_count: 2
@@ -47,13 +47,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
-  - ifindex: 3
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: sros_r1
+  - ifindex: 3
+    ipv4: 10.1.0.5/30
+    ipv6: 2001:db8:1:1::1/64
+    node: srlinux_r2
   isis:
     bfd: false
   linkindex: 3
@@ -65,13 +65,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
-  - ifindex: 4
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: sros_r1
+  - ifindex: 4
+    ipv4: 10.1.0.9/30
+    ipv6: 2001:db8:1:2::1/64
+    node: srlinux_r2
   isis:
     bfd:
       ipv4: true
@@ -85,13 +85,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: srlinux_r2
-  - ifindex: 5
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: sros_r1
+  - ifindex: 5
+    ipv4: 10.1.0.13/30
+    ipv6: 2001:db8:1:3::1/64
+    node: srlinux_r2
   isis:
     bfd:
       ipv4: false
@@ -105,13 +105,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ipv4: 10.42.42.2/24
+    node: sros_r1
+  - ifindex: 6
     ipv4: 10.42.42.1/24
     isis:
       bfd: true
     node: srlinux_r2
-  - ifindex: 6
-    ipv4: 10.42.42.2/24
-    node: sros_r1
   linkindex: 6
   name: IPv4-only link with BFD
   node_count: 2
@@ -120,11 +120,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
-    ipv6: 2001:db8:42:1::1/64
-    node: srlinux_r2
-  - ifindex: 7
     ipv6: 2001:db8:42:1::2/64
     node: sros_r1
+  - ifindex: 7
+    ipv6: 2001:db8:42:1::1/64
+    node: srlinux_r2
   linkindex: 7
   name: IPv6-only link with BFD
   node_count: 2
@@ -133,14 +133,14 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ipv4: 10.42.43.2/24
+    node: sros_r1
+  - ifindex: 8
     ipv4: 10.42.43.1/24
     isis:
       bfd:
         ipv6: true
     node: srlinux_r2
-  - ifindex: 8
-    ipv4: 10.42.43.2/24
-    node: sros_r1
   isis:
     bfd:
       ipv6: true
@@ -160,7 +160,6 @@ links:
     ipv6: 2001:db8:1:4::2/64
     node: n5
   linkindex: 9
-  name: n4 - n5
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -38,22 +38,12 @@ links:
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
-  left:
-    ifname: ethernet-1/2
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
   linkindex: 2
   name: Link with BFD disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: 1/1/c2
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -66,22 +56,12 @@ links:
     node: sros_r1
   isis:
     bfd: false
-  left:
-    ifname: ethernet-1/3
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
   linkindex: 3
   name: Link with ISIS BFD disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
-  right:
-    ifname: 1/1/c3
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 4
@@ -96,22 +76,12 @@ links:
     bfd:
       ipv4: true
       ipv6: false
-  left:
-    ifname: ethernet-1/4
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
   linkindex: 4
   name: Link with IPv4-only BFD
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
-  right:
-    ifname: 1/1/c4
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 5
@@ -126,22 +96,12 @@ links:
     bfd:
       ipv4: false
       ipv6: true
-  left:
-    ifname: ethernet-1/5
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: srlinux_r2
   linkindex: 5
   name: Link with IPv6-only BFD
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
-  right:
-    ifname: 1/1/c5
-    ipv4: 10.1.0.14/30
-    ipv6: 2001:db8:1:3::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 6
@@ -152,19 +112,11 @@ links:
   - ifindex: 6
     ipv4: 10.42.42.2/24
     node: sros_r1
-  left:
-    ifname: ethernet-1/6
-    ipv4: 10.42.42.1/24
-    node: srlinux_r2
   linkindex: 6
   name: IPv4-only link with BFD
   node_count: 2
   prefix:
     ipv4: 10.42.42.0/24
-  right:
-    ifname: 1/1/c6
-    ipv4: 10.42.42.2/24
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 7
@@ -173,19 +125,11 @@ links:
   - ifindex: 7
     ipv6: 2001:db8:42:1::2/64
     node: sros_r1
-  left:
-    ifname: ethernet-1/7
-    ipv6: 2001:db8:42:1::1/64
-    node: srlinux_r2
   linkindex: 7
   name: IPv6-only link with BFD
   node_count: 2
   prefix:
     ipv6: 2001:db8:42:1::/64
-  right:
-    ifname: 1/1/c7
-    ipv6: 2001:db8:42:1::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 8
@@ -200,19 +144,11 @@ links:
   isis:
     bfd:
       ipv6: true
-  left:
-    ifname: ethernet-1/8
-    ipv4: 10.42.43.1/24
-    node: srlinux_r2
   linkindex: 8
   name: IPv4-only link with IPv6-only BFD
   node_count: 2
   prefix:
     ipv4: 10.42.43.0/24
-  right:
-    ifname: 1/1/c8
-    ipv4: 10.42.43.2/24
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -223,22 +159,12 @@ links:
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: n5
-  left:
-    ifname: 1/1/c1
-    ipv4: 10.1.0.17/30
-    ipv6: 2001:db8:1:4::1/64
-    node: n4
   linkindex: 9
   name: n4 - n5
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
     ipv6: 2001:db8:1:4::/64
-  right:
-    ifname: 1/1/c1
-    ipv4: 10.1.0.18/30
-    ipv6: 2001:db8:1:4::2/64
-    node: n5
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -14,12 +14,15 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: 1/1/c1
     ipv4: 172.16.0.1/24
     node: sros_r1
   - ifindex: 1
+    ifname: ethernet-1/1
     ipv4: 172.16.0.2/24
     node: srlinux_r2
   - ifindex: 1
+    ifname: ethernet-1/1
     ipv4: 172.16.0.6/24
     node: n6
   linkindex: 1
@@ -31,10 +34,12 @@ links:
 - bfd: false
   interfaces:
   - ifindex: 2
+    ifname: 1/1/c2
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
   - ifindex: 2
+    ifname: ethernet-1/2
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: srlinux_r2
@@ -47,10 +52,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: 1/1/c3
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: sros_r1
   - ifindex: 3
+    ifname: ethernet-1/3
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: srlinux_r2
@@ -65,10 +72,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
+    ifname: 1/1/c4
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: sros_r1
   - ifindex: 4
+    ifname: ethernet-1/4
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
     node: srlinux_r2
@@ -85,10 +94,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
+    ifname: 1/1/c5
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: sros_r1
   - ifindex: 5
+    ifname: ethernet-1/5
     ipv4: 10.1.0.13/30
     ipv6: 2001:db8:1:3::1/64
     node: srlinux_r2
@@ -105,9 +116,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ifname: 1/1/c6
     ipv4: 10.42.42.2/24
     node: sros_r1
   - ifindex: 6
+    ifname: ethernet-1/6
     ipv4: 10.42.42.1/24
     isis:
       bfd: true
@@ -120,9 +133,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
+    ifname: 1/1/c7
     ipv6: 2001:db8:42:1::2/64
     node: sros_r1
   - ifindex: 7
+    ifname: ethernet-1/7
     ipv6: 2001:db8:42:1::1/64
     node: srlinux_r2
   linkindex: 7
@@ -133,9 +148,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ifname: 1/1/c8
     ipv4: 10.42.43.2/24
     node: sros_r1
   - ifindex: 8
+    ifname: ethernet-1/8
     ipv4: 10.42.43.1/24
     isis:
       bfd:
@@ -152,10 +169,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: 1/1/c1
     ipv4: 10.1.0.17/30
     ipv6: 2001:db8:1:4::1/64
     node: n4
   - ifindex: 1
+    ifname: 1/1/c1
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: n5

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -8,21 +8,25 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 172.16.0.1/24
     isis:
       metric: 10
     node: c_nxos
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 172.16.0.2/24
     isis:
       metric: 20
     node: c_csr
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     isis:
       metric: 30
     node: a_eos
   - ifindex: 0
+    ifname: ge-0/0/0
     ipv4: 172.16.0.4/24
     isis:
       metric: 50
@@ -35,6 +39,7 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: 172.16.1.1/24
     node: c_nxos
   linkindex: 2
@@ -45,6 +50,7 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 172.16.2.2/24
     node: c_csr
   linkindex: 3
@@ -55,6 +61,7 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.3.3/24
     node: a_eos
   linkindex: 4
@@ -65,6 +72,7 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 1
+    ifname: ge-0/0/1
     ipv4: 172.16.4.4/24
     node: j_vsrx
   linkindex: 5
@@ -75,18 +83,22 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 3
+    ifname: Ethernet1/3
     ipv4: 172.31.0.1/24
     ipv6: 2008:db8:1::1/64
     node: c_nxos
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: 172.31.0.2/24
     ipv6: 2008:db8:1::2/64
     node: c_csr
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 172.31.0.3/24
     ipv6: 2008:db8:1::3/64
     node: a_eos
   - ifindex: 2
+    ifname: ge-0/0/2
     ipv4: 172.31.0.4/24
     ipv6: 2008:db8:1::4/64
     node: j_vsrx
@@ -102,15 +114,19 @@ links:
 - bridge: input_7
   interfaces:
   - ifindex: 4
+    ifname: Ethernet1/4
     ipv4: 172.16.5.1/24
     node: c_nxos
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: 172.16.5.2/24
     node: c_csr
   - ifindex: 4
+    ifname: Ethernet4
     ipv4: 172.16.5.3/24
     node: a_eos
   - ifindex: 3
+    ifname: ge-0/0/3
     ipv4: 172.16.5.4/24
     node: j_vsrx
   linkindex: 7
@@ -121,9 +137,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 5
+    ifname: Ethernet1/5
     ipv4: true
     node: c_nxos
   - ifindex: 5
+    ifname: Ethernet5
     ipv4: true
     node: a_eos
   linkindex: 8
@@ -131,9 +149,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ifname: Ethernet1/6
     ipv4: true
     node: c_nxos
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv4: true
     node: c_csr
   linkindex: 9
@@ -141,9 +161,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
+    ifname: Ethernet1/7
     ipv6: true
     node: c_nxos
   - ifindex: 4
+    ifname: ge-0/0/4
     ipv6: true
     node: j_vsrx
   linkindex: 10
@@ -153,9 +175,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
+    ifname: Ethernet6
     ipv6: true
     node: a_eos
   - ifindex: 5
+    ifname: ge-0/0/5
     ipv6: true
     node: j_vsrx
   linkindex: 11
@@ -165,9 +189,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
+    ifname: Ethernet7
     ipv4: true
     node: a_eos
   - ifindex: 7
+    ifname: GigabitEthernet7
     ipv4: true
     node: c_csr
   linkindex: 12
@@ -175,9 +201,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ifname: GigabitEthernet8
     ipv6: true
     node: c_csr
   - ifindex: 6
+    ifname: ge-0/0/6
     ipv6: true
     node: j_vsrx
   linkindex: 13
@@ -187,8 +215,10 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ifname: Ethernet1/8
     node: c_nxos
   - ifindex: 8
+    ifname: Ethernet8
     node: a_eos
   linkindex: 14
   name: L2-only link to test removal of isis context

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -122,23 +122,21 @@ links:
 - interfaces:
   - ifindex: 5
     ipv4: true
-    node: a_eos
+    node: c_nxos
   - ifindex: 5
     ipv4: true
-    node: c_nxos
+    node: a_eos
   linkindex: 8
-  name: a_eos - c_nxos
   node_count: 2
   type: p2p
 - interfaces:
   - ifindex: 6
     ipv4: true
-    node: c_csr
+    node: c_nxos
   - ifindex: 6
     ipv4: true
-    node: c_nxos
+    node: c_csr
   linkindex: 9
-  name: c_csr - c_nxos
   node_count: 2
   type: p2p
 - interfaces:
@@ -149,7 +147,6 @@ links:
     ipv6: true
     node: j_vsrx
   linkindex: 10
-  name: c_nxos - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
@@ -162,7 +159,6 @@ links:
     ipv6: true
     node: j_vsrx
   linkindex: 11
-  name: a_eos - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
@@ -175,7 +171,6 @@ links:
     ipv4: true
     node: c_csr
   linkindex: 12
-  name: a_eos - c_csr
   node_count: 2
   type: p2p
 - interfaces:
@@ -186,16 +181,15 @@ links:
     ipv6: true
     node: j_vsrx
   linkindex: 13
-  name: c_csr - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
   type: p2p
 - interfaces:
   - ifindex: 8
-    node: a_eos
-  - ifindex: 8
     node: c_nxos
+  - ifindex: 8
+    node: a_eos
   linkindex: 14
   name: L2-only link to test removal of isis context
   node_count: 2
@@ -241,6 +235,7 @@ nodes:
       isis:
         passive: true
       linkindex: 4
+      name: a_eos -> stub
       neighbors: []
       type: stub
     - bridge: input_6
@@ -383,6 +378,7 @@ nodes:
       isis:
         passive: true
       linkindex: 3
+      name: c_csr -> stub
       neighbors: []
       type: stub
     - bridge: input_6
@@ -518,6 +514,7 @@ nodes:
       isis:
         passive: true
       linkindex: 2
+      name: c_nxos -> stub
       neighbors: []
       type: stub
     - bridge: input_6
@@ -661,6 +658,7 @@ nodes:
       isis:
         passive: true
       linkindex: 5
+      name: j_vsrx -> stub
       neighbors: []
       type: stub
     - bridge: input_6

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -126,17 +126,9 @@ links:
   - ifindex: 5
     ipv4: true
     node: c_nxos
-  left:
-    ifname: Ethernet5
-    ipv4: true
-    node: a_eos
   linkindex: 8
   name: a_eos - c_nxos
   node_count: 2
-  right:
-    ifname: Ethernet1/5
-    ipv4: true
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 6
@@ -145,17 +137,9 @@ links:
   - ifindex: 6
     ipv4: true
     node: c_nxos
-  left:
-    ifname: GigabitEthernet6
-    ipv4: true
-    node: c_csr
   linkindex: 9
   name: c_csr - c_nxos
   node_count: 2
-  right:
-    ifname: Ethernet1/6
-    ipv4: true
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 7
@@ -164,19 +148,11 @@ links:
   - ifindex: 4
     ipv6: true
     node: j_vsrx
-  left:
-    ifname: Ethernet1/7
-    ipv6: true
-    node: c_nxos
   linkindex: 10
   name: c_nxos - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
-  right:
-    ifname: ge-0/0/4
-    ipv6: true
-    node: j_vsrx
   type: p2p
 - interfaces:
   - ifindex: 6
@@ -185,19 +161,11 @@ links:
   - ifindex: 5
     ipv6: true
     node: j_vsrx
-  left:
-    ifname: Ethernet6
-    ipv6: true
-    node: a_eos
   linkindex: 11
   name: a_eos - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
-  right:
-    ifname: ge-0/0/5
-    ipv6: true
-    node: j_vsrx
   type: p2p
 - interfaces:
   - ifindex: 7
@@ -206,17 +174,9 @@ links:
   - ifindex: 7
     ipv4: true
     node: c_csr
-  left:
-    ifname: Ethernet7
-    ipv4: true
-    node: a_eos
   linkindex: 12
   name: a_eos - c_csr
   node_count: 2
-  right:
-    ifname: GigabitEthernet7
-    ipv4: true
-    node: c_csr
   type: p2p
 - interfaces:
   - ifindex: 8
@@ -225,36 +185,22 @@ links:
   - ifindex: 6
     ipv6: true
     node: j_vsrx
-  left:
-    ifname: GigabitEthernet8
-    ipv6: true
-    node: c_csr
   linkindex: 13
   name: c_csr - j_vsrx
   node_count: 2
   prefix:
     ipv6: true
-  right:
-    ifname: ge-0/0/6
-    ipv6: true
-    node: j_vsrx
   type: p2p
 - interfaces:
   - ifindex: 8
     node: a_eos
   - ifindex: 8
     node: c_nxos
-  left:
-    ifname: Ethernet8
-    node: a_eos
   linkindex: 14
   name: L2-only link to test removal of isis context
   node_count: 2
   prefix:
     ipv4: false
-  right:
-    ifname: Ethernet1/8
-    node: c_nxos
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/link-attr.yml
+++ b/tests/topology/expected/link-attr.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: e1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: e2
   linkindex: 1
@@ -16,9 +18,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv6: 2001:db8:cafe:1::1/64
     node: e1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
   linkindex: 2
@@ -29,9 +33,11 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 192.168.22.2/24
     node: e2
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 192.168.22.3/24
     node: pe1
   linkindex: 3
@@ -42,10 +48,12 @@ links:
 - dmz: 100000
   interfaces:
   - ifindex: 10
+    ifname: GigabitEthernet0/10
     ipv4: 192.168.23.1/24
     ipv6: 2001:db8:cafe:2::1/64
     node: e1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2

--- a/tests/topology/expected/link-attr.yml
+++ b/tests/topology/expected/link-attr.yml
@@ -10,7 +10,6 @@ links:
     ipv4: 10.1.0.2/30
     node: e2
   linkindex: 1
-  name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -23,7 +22,6 @@ links:
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
   linkindex: 2
-  name: e1 - pe1
   node_count: 2
   prefix:
     ipv6: 2001:db8:cafe:1::/64
@@ -52,7 +50,6 @@ links:
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
   linkindex: 4
-  name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24
@@ -134,7 +131,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 192.168.22.2/24
       linkindex: 3
-      name: e2 -> [pe1]
+      name: e2 -> pe1
       neighbors:
       - ifname: GigabitEthernet3
         ipv4: 192.168.22.3/24
@@ -185,7 +182,7 @@ nodes:
       ifname: GigabitEthernet3
       ipv4: 192.168.22.3/24
       linkindex: 3
-      name: pe1 -> [e2]
+      name: pe1 -> e2
       neighbors:
       - ifname: GigabitEthernet0/2
         ipv4: 192.168.22.2/24

--- a/tests/topology/expected/link-attr.yml
+++ b/tests/topology/expected/link-attr.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: e2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: e1
   linkindex: 1
   name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: e2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -30,19 +22,11 @@ links:
   - ifindex: 2
     ipv6: 2001:db8:cafe:1::2/64
     node: pe1
-  left:
-    ifname: GigabitEthernet0/2
-    ipv6: 2001:db8:cafe:1::1/64
-    node: e1
   linkindex: 2
   name: e1 - pe1
   node_count: 2
   prefix:
     ipv6: 2001:db8:cafe:1::/64
-  right:
-    ifname: GigabitEthernet2
-    ipv6: 2001:db8:cafe:1::2/64
-    node: pe1
   type: p2p
 - bridge: input_3
   interfaces:
@@ -67,22 +51,12 @@ links:
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
-  left:
-    ifname: GigabitEthernet0/10
-    ipv4: 192.168.23.1/24
-    ipv6: 2001:db8:cafe:2::1/64
-    node: e1
   linkindex: 4
   name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24
     ipv6: 2001:db8:cafe:2::/64
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 192.168.23.2/24
-    ipv6: 2001:db8:cafe:2::2/64
-    node: e2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/link-bw.yml
+++ b/tests/topology/expected/link-bw.yml
@@ -13,7 +13,6 @@ links:
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
   linkindex: 1
-  name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24

--- a/tests/topology/expected/link-bw.yml
+++ b/tests/topology/expected/link-bw.yml
@@ -12,22 +12,12 @@ links:
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 192.168.23.1/24
-    ipv6: 2001:db8:cafe:2::1/64
-    node: e1
   linkindex: 1
   name: e1 - e2
   node_count: 2
   prefix:
     ipv4: 192.168.23.0/24
     ipv6: 2001:db8:cafe:2::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 192.168.23.2/24
-    ipv6: 2001:db8:cafe:2::2/64
-    node: e2
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/link-bw.yml
+++ b/tests/topology/expected/link-bw.yml
@@ -5,10 +5,12 @@ links:
 - bandwidth: 100000
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 192.168.23.1/24
     ipv6: 2001:db8:cafe:2::1/64
     node: e1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 192.168.23.2/24
     ipv6: 2001:db8:cafe:2::2/64
     node: e2

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 - bridge: input_2
   interfaces:
@@ -64,19 +56,11 @@ links:
   - ifindex: 4
     ipv4: 10.1.0.6/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/4
-    ipv4: 10.1.0.5/30
-    node: r1
   linkindex: 4
   name: P2P link
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet0/4
-    ipv4: 10.1.0.6/30
-    node: r2
   type: p2p
 - bridge: input_5
   interfaces:
@@ -102,19 +86,11 @@ links:
   - ifindex: 6
     ipv4: 10.1.0.10/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/6
-    ipv4: 10.1.0.9/30
-    node: r1
   linkindex: 6
   name: LAN link with simple interfaces
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: GigabitEthernet0/6
-    ipv4: 10.1.0.10/30
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 7
@@ -125,19 +101,11 @@ links:
   - ifindex: 7
     ipv4: 10.1.0.14/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/7
-    ipv4: 10.1.0.13/30
-    node: r1
   linkindex: 7
   name: LAN link with complex interfaces
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
-  right:
-    ifname: GigabitEthernet0/7
-    ipv4: 10.1.0.14/30
-    node: r2
   type: p2p
 - interfaces:
   - ifindex: 8
@@ -146,19 +114,11 @@ links:
   - ifindex: 9
     ipv4: 10.1.0.18/30
     node: r1
-  left:
-    ifname: GigabitEthernet0/8
-    ipv4: 10.1.0.17/30
-    node: r1
   linkindex: 8
   name: Looped P2P link to same node
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
-  right:
-    ifname: GigabitEthernet0/9
-    ipv4: 10.1.0.18/30
-    node: r1
   type: p2p
 - bridge: input_9
   interfaces:

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -10,7 +10,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -17,12 +19,15 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.0.2/24
     node: r2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.3/24
     node: r3
   linkindex: 2
@@ -33,12 +38,15 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.16.1.1/24
     node: r1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.16.1.2/24
     node: r2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.3/24
     node: r3
   linkindex: 3
@@ -48,11 +56,13 @@ links:
   type: lan
 - interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 10.1.0.5/30
     node: r1
     ospf:
       cost: 3
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 10.1.0.6/30
     node: r2
   linkindex: 4
@@ -64,12 +74,15 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 5
+    ifname: GigabitEthernet0/5
     ipv4: 172.16.2.1/24
     node: r1
   - ifindex: 5
+    ifname: GigabitEthernet0/5
     ipv4: 172.16.2.2/24
     node: r2
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 172.16.2.3/24
     node: r3
   linkindex: 5
@@ -80,9 +93,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 6
+    ifname: GigabitEthernet0/6
     ipv4: 10.1.0.9/30
     node: r1
   - ifindex: 6
+    ifname: GigabitEthernet0/6
     ipv4: 10.1.0.10/30
     node: r2
   linkindex: 6
@@ -93,11 +108,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 7
+    ifname: GigabitEthernet0/7
     ipv4: 10.1.0.13/30
     node: r1
     ospf:
       cost: 3
   - ifindex: 7
+    ifname: GigabitEthernet0/7
     ipv4: 10.1.0.14/30
     node: r2
   linkindex: 7
@@ -108,9 +125,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 8
+    ifname: GigabitEthernet0/8
     ipv4: 10.1.0.17/30
     node: r1
   - ifindex: 9
+    ifname: GigabitEthernet0/9
     ipv4: 10.1.0.18/30
     node: r1
   linkindex: 8
@@ -122,21 +141,27 @@ links:
 - bridge: input_9
   interfaces:
   - ifindex: 10
+    ifname: GigabitEthernet0/10
     ipv4: 172.16.3.1/24
     node: r1
   - ifindex: 11
+    ifname: GigabitEthernet0/11
     ipv4: 172.16.3.1/24
     node: r1
   - ifindex: 12
+    ifname: GigabitEthernet0/12
     ipv4: 172.16.3.1/24
     node: r1
   - ifindex: 8
+    ifname: GigabitEthernet0/8
     ipv4: 172.16.3.2/24
     node: r2
   - ifindex: 9
+    ifname: GigabitEthernet0/9
     ipv4: 172.16.3.2/24
     node: r2
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 172.16.3.3/24
     node: r3
   linkindex: 9

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -4,9 +4,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -17,12 +19,15 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.2/24
     node: r2
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: r3
   linkindex: 2
@@ -32,8 +37,10 @@ links:
   type: lan
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     node: r1
   - ifindex: 3
+    ifname: Ethernet3
     node: r2
   linkindex: 3
   node_count: 2
@@ -42,10 +49,13 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 4
+    ifname: Ethernet4
     node: r1
   - ifindex: 4
+    ifname: Ethernet4
     node: r2
   - ifindex: 2
+    ifname: Ethernet2
     node: r3
   linkindex: 4
   node_count: 3

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -9,19 +9,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 - bridge: input_2
   interfaces:
@@ -44,16 +36,10 @@ links:
     node: r1
   - ifindex: 3
     node: r2
-  left:
-    ifname: Ethernet3
-    node: r1
   linkindex: 3
   name: r1 - r2
   node_count: 2
   prefix: false
-  right:
-    ifname: Ethernet3
-    node: r2
   type: p2p
 - bridge: input_4
   interfaces:

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -10,7 +10,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -37,7 +36,6 @@ links:
   - ifindex: 3
     node: r2
   linkindex: 3
-  name: r1 - r2
   node_count: 2
   prefix: false
   type: p2p

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -18,9 +18,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -24,7 +24,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -23,19 +23,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r2
   type: p2p
 module:
 - ospf

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -18,9 +18,11 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     node: r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     node: r3
   linkindex: 1

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -24,7 +24,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r3
   linkindex: 1
-  name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -23,19 +23,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r3
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    node: r3
   type: p2p
 module:
 - ospf

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -22,9 +22,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.1.0.2/30
     node: e1
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 10.1.0.1/30
     node: c1
   linkindex: 1
@@ -34,9 +36,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.1.0.6/30
     node: e1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.5/30
     node: c2
   linkindex: 2
@@ -46,9 +50,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.10/30
     node: e2
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.1.0.9/30
     node: c1
   linkindex: 3
@@ -58,9 +64,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.14/30
     node: e2
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.13/30
     node: c2
   linkindex: 4

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -22,52 +22,48 @@ isis:
 links:
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.1/30
-    node: c1
-  - ifindex: 2
     ipv4: 10.1.0.2/30
     node: e1
+  - ifindex: 2
+    ipv4: 10.1.0.1/30
+    node: c1
   linkindex: 1
-  name: c1 - e1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.5/30
-    node: c2
   - ifindex: 3
     ipv4: 10.1.0.6/30
     node: e1
+  - ifindex: 1
+    ipv4: 10.1.0.5/30
+    node: c2
   linkindex: 2
-  name: c2 - e1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
 - interfaces:
-  - ifindex: 3
-    ipv4: 10.1.0.9/30
-    node: c1
   - ifindex: 1
     ipv4: 10.1.0.10/30
     node: e2
+  - ifindex: 3
+    ipv4: 10.1.0.9/30
+    node: c1
   linkindex: 3
-  name: c1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.13/30
-    node: c2
-  - ifindex: 2
     ipv4: 10.1.0.14/30
     node: e2
+  - ifindex: 2
+    ipv4: 10.1.0.13/30
+    node: c2
   linkindex: 4
-  name: c2 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -27,19 +27,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: e1
-  left:
-    ifname: GigabitEthernet2
-    ipv4: 10.1.0.1/30
-    node: c1
   linkindex: 1
   name: c1 - e1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet2
-    ipv4: 10.1.0.2/30
-    node: e1
   type: p2p
 - interfaces:
   - ifindex: 1
@@ -48,19 +40,11 @@ links:
   - ifindex: 3
     ipv4: 10.1.0.6/30
     node: e1
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.5/30
-    node: c2
   linkindex: 2
   name: c2 - e1
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: GigabitEthernet3
-    ipv4: 10.1.0.6/30
-    node: e1
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -69,19 +53,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.10/30
     node: e2
-  left:
-    ifname: GigabitEthernet3
-    ipv4: 10.1.0.9/30
-    node: c1
   linkindex: 3
   name: c1 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.10/30
-    node: e2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -90,19 +66,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.14/30
     node: e2
-  left:
-    ifname: Ethernet2
-    ipv4: 10.1.0.13/30
-    node: c2
   linkindex: 4
   name: c2 - e2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
-  right:
-    ifname: Ethernet2
-    ipv4: 10.1.0.14/30
-    node: e2
   type: p2p
 module:
 - isis

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -26,15 +26,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: ce1
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: pe1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    ipv6: 2001:db8:1::1/64
+    node: ce1
   linkindex: 1
-  name: ce1 - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -43,15 +42,14 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: ce2
-  - ifindex: 1
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: pe2
+  - ifindex: 1
+    ipv4: 10.1.0.5/30
+    ipv6: 2001:db8:1:1::1/64
+    node: ce2
   linkindex: 2
-  name: ce2 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -59,16 +57,15 @@ links:
   role: external
   type: p2p
 - interfaces:
-  - ifindex: 1
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: p
   - ifindex: 2
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: pe1
+  - ifindex: 1
+    ipv4: 10.1.0.9/30
+    ipv6: 2001:db8:1:2::1/64
+    node: p
   linkindex: 3
-  name: p - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
@@ -76,31 +73,29 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: p
-  - ifindex: 2
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: pe2
+  - ifindex: 2
+    ipv4: 10.1.0.13/30
+    ipv6: 2001:db8:1:3::1/64
+    node: p
   linkindex: 4
-  name: p - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
   type: p2p
 - interfaces:
-  - ifindex: 3
-    ipv4: 10.1.0.17/30
-    ipv6: 2001:db8:1:4::1/64
-    node: p
   - ifindex: 1
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: rr
+  - ifindex: 3
+    ipv4: 10.1.0.17/30
+    ipv6: 2001:db8:1:4::1/64
+    node: p
   linkindex: 5
-  name: p - rr
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -26,10 +26,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: pe1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: ce1
@@ -42,10 +44,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: pe2
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: ce2
@@ -58,10 +62,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: pe1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
     node: p
@@ -73,10 +79,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: pe2
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.13/30
     ipv6: 2001:db8:1:3::1/64
     node: p
@@ -88,10 +96,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: rr
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.17/30
     ipv6: 2001:db8:1:4::1/64
     node: p

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -33,22 +33,12 @@ links:
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: ce1
   linkindex: 1
   name: ce1 - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: pe1
   role: external
   type: p2p
 - interfaces:
@@ -60,22 +50,12 @@ links:
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: pe2
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: ce2
   linkindex: 2
   name: ce2 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: pe2
   role: external
   type: p2p
 - interfaces:
@@ -87,22 +67,12 @@ links:
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: pe1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: p
   linkindex: 3
   name: p - pe1
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: pe1
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -113,22 +83,12 @@ links:
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: pe2
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: p
   linkindex: 4
   name: p - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.14/30
-    ipv6: 2001:db8:1:3::2/64
-    node: pe2
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -139,22 +99,12 @@ links:
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: rr
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.17/30
-    ipv6: 2001:db8:1:4::1/64
-    node: p
   linkindex: 5
   name: p - rr
   node_count: 2
   prefix:
     ipv4: 10.1.0.16/30
     ipv6: 2001:db8:1:4::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.18/30
-    ipv6: 2001:db8:1:4::2/64
-    node: rr
   type: p2p
 module:
 - bgp

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -7,13 +7,13 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
-  - ifindex: 1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
+  - ifindex: 1
+    ipv4: 10.1.0.1/30
+    ipv6: 2001:db8:1::1/64
+    node: srlinux_r2
   linkindex: 1
   name: Regular link, BFD enabled
   node_count: 2
@@ -24,13 +24,13 @@ links:
 - bfd: false
   interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
-  - ifindex: 2
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: sros_r1
+  - ifindex: 2
+    ipv4: 10.1.0.5/30
+    ipv6: 2001:db8:1:1::1/64
+    node: srlinux_r2
   linkindex: 2
   name: Link with BFD disabled
   node_count: 2
@@ -40,13 +40,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
-  - ifindex: 3
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: sros_r1
+  - ifindex: 3
+    ipv4: 10.1.0.9/30
+    ipv6: 2001:db8:1:2::1/64
+    node: srlinux_r2
   linkindex: 3
   name: Link with OSPF BFD disabled
   node_count: 2
@@ -98,6 +98,7 @@ nodes:
       ifname: GigabitEthernet0/1
       ipv4: 172.16.0.4/24
       linkindex: 4
+      name: n4 -> stub
       neighbors: []
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -14,22 +14,12 @@ links:
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
-  left:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
   linkindex: 1
   name: Regular link, BFD enabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
-  right:
-    ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: sros_r1
   type: p2p
 - bfd: false
   interfaces:
@@ -41,22 +31,12 @@ links:
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: sros_r1
-  left:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
   linkindex: 2
   name: Link with BFD disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: sros_r1
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -67,11 +47,6 @@ links:
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: sros_r1
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
   linkindex: 3
   name: Link with OSPF BFD disabled
   node_count: 2
@@ -80,11 +55,6 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
-  right:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: sros_r1
   type: p2p
 - bridge: input_4
   interfaces:

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -7,10 +7,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: sros_r1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: srlinux_r2
@@ -24,10 +26,12 @@ links:
 - bfd: false
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: sros_r1
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: srlinux_r2
@@ -40,10 +44,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: sros_r1
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
     node: srlinux_r2
@@ -59,6 +65,7 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.4/24
     node: n4
   linkindex: 4

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -39,10 +39,6 @@ links:
   - ifindex: 2
     ipv4: true
     node: c_nxos
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    node: a_eos
   linkindex: 2
   name: a_eos - c_nxos
   node_count: 2
@@ -51,10 +47,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: Ethernet1/2
-    ipv4: true
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -65,10 +57,6 @@ links:
     node: c_nxos
     ospf:
       cost: 10
-  left:
-    ifname: GigabitEthernet3
-    ipv4: true
-    node: c_csr
   linkindex: 3
   name: c_csr - c_nxos
   node_count: 2
@@ -77,10 +65,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: Ethernet1/3
-    ipv4: true
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 4
@@ -89,10 +73,6 @@ links:
   - ifindex: 1
     ipv4: true
     node: j_vsrx
-  left:
-    ifname: Ethernet1/4
-    ipv4: true
-    node: c_nxos
   linkindex: 4
   name: c_nxos - j_vsrx
   node_count: 2
@@ -101,10 +81,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: ge-0/0/1
-    ipv4: true
-    node: j_vsrx
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -113,10 +89,6 @@ links:
   - ifindex: 2
     ipv4: true
     node: j_vsrx
-  left:
-    ifname: Ethernet3
-    ipv4: true
-    node: a_eos
   linkindex: 5
   name: a_eos - j_vsrx
   node_count: 2
@@ -125,10 +97,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: ge-0/0/2
-    ipv4: true
-    node: j_vsrx
   type: p2p
 - interfaces:
   - ifindex: 4
@@ -137,10 +105,6 @@ links:
   - ifindex: 4
     ipv4: true
     node: c_csr
-  left:
-    ifname: Ethernet4
-    ipv4: true
-    node: a_eos
   linkindex: 6
   name: a_eos - c_csr
   node_count: 2
@@ -149,10 +113,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: GigabitEthernet4
-    ipv4: true
-    node: c_csr
   type: p2p
 - interfaces:
   - ifindex: 5
@@ -161,10 +121,6 @@ links:
   - ifindex: 3
     ipv4: true
     node: j_vsrx
-  left:
-    ifname: GigabitEthernet5
-    ipv4: true
-    node: c_csr
   linkindex: 7
   name: c_csr - j_vsrx
   node_count: 2
@@ -173,10 +129,6 @@ links:
   pool: core
   prefix:
     ipv4: true
-  right:
-    ifname: ge-0/0/3
-    ipv4: true
-    node: j_vsrx
   type: p2p
 - bridge: input_8
   interfaces:

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -5,20 +5,24 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 172.19.0.1/24
     ipv6: 2001:db8:1::1/64
     node: c_nxos
     ospf:
       cost: 20
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.19.0.3/24
     ipv6: 2001:db8:1::3/64
     node: a_eos
   - ifindex: 0
+    ifname: ge-0/0/0
     ipv4: 172.19.0.4/24
     ipv6: 2001:db8:1::4/64
     node: j_vsrx
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 172.19.0.2/24
     ipv6: 2001:db8:1::2/64
     node: c_csr
@@ -34,9 +38,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: true
     node: c_nxos
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     node: a_eos
   linkindex: 2
@@ -49,11 +55,13 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet1/3
     ipv4: true
     node: c_nxos
     ospf:
       cost: 10
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: true
     node: c_csr
   linkindex: 3
@@ -66,9 +74,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
+    ifname: Ethernet1/4
     ipv4: true
     node: c_nxos
   - ifindex: 1
+    ifname: ge-0/0/1
     ipv4: true
     node: j_vsrx
   linkindex: 4
@@ -81,9 +91,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: true
     node: a_eos
   - ifindex: 2
+    ifname: ge-0/0/2
     ipv4: true
     node: j_vsrx
   linkindex: 5
@@ -96,9 +108,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
+    ifname: Ethernet4
     ipv4: true
     node: a_eos
   - ifindex: 4
+    ifname: GigabitEthernet4
     ipv4: true
     node: c_csr
   linkindex: 6
@@ -111,9 +125,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
+    ifname: GigabitEthernet5
     ipv4: true
     node: c_csr
   - ifindex: 3
+    ifname: ge-0/0/3
     ipv4: true
     node: j_vsrx
   linkindex: 7
@@ -127,6 +143,7 @@ links:
 - bridge: input_8
   interfaces:
   - ifindex: 5
+    ifname: Ethernet1/5
     ipv4: 172.19.1.1/24
     ipv6: 2001:db8:1:1::1/64
     mtu: 8192
@@ -141,6 +158,7 @@ links:
 - bridge: input_9
   interfaces:
   - ifindex: 5
+    ifname: Ethernet5
     ipv4: 172.19.2.3/24
     ipv6: 2001:db8:1:2::3/64
     node: a_eos
@@ -154,18 +172,22 @@ links:
 - bridge: input_10
   interfaces:
   - ifindex: 6
+    ifname: Ethernet1/6
     ipv4: 172.19.3.1/24
     ipv6: 2001:db8:1:3::1/64
     node: c_nxos
   - ifindex: 6
+    ifname: GigabitEthernet6
     ipv4: 172.19.3.2/24
     ipv6: 2001:db8:1:3::2/64
     node: c_csr
   - ifindex: 6
+    ifname: Ethernet6
     ipv4: 172.19.3.3/24
     ipv6: 2001:db8:1:3::3/64
     node: a_eos
   - ifindex: 4
+    ifname: ge-0/0/4
     ipv4: 172.19.3.4/24
     ipv6: 2001:db8:1:3::4/64
     node: j_vsrx

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -35,12 +35,11 @@ links:
 - interfaces:
   - ifindex: 2
     ipv4: true
-    node: a_eos
+    node: c_nxos
   - ifindex: 2
     ipv4: true
-    node: c_nxos
+    node: a_eos
   linkindex: 2
-  name: a_eos - c_nxos
   node_count: 2
   ospf:
     cost: 3
@@ -51,14 +50,13 @@ links:
 - interfaces:
   - ifindex: 3
     ipv4: true
-    node: c_csr
-  - ifindex: 3
-    ipv4: true
     node: c_nxos
     ospf:
       cost: 10
+  - ifindex: 3
+    ipv4: true
+    node: c_csr
   linkindex: 3
-  name: c_csr - c_nxos
   node_count: 2
   ospf:
     cost: 3
@@ -74,7 +72,6 @@ links:
     ipv4: true
     node: j_vsrx
   linkindex: 4
-  name: c_nxos - j_vsrx
   node_count: 2
   ospf:
     cost: 3
@@ -90,7 +87,6 @@ links:
     ipv4: true
     node: j_vsrx
   linkindex: 5
-  name: a_eos - j_vsrx
   node_count: 2
   ospf:
     cost: 3
@@ -106,7 +102,6 @@ links:
     ipv4: true
     node: c_csr
   linkindex: 6
-  name: a_eos - c_csr
   node_count: 2
   ospf:
     cost: 3
@@ -122,7 +117,6 @@ links:
     ipv4: true
     node: j_vsrx
   linkindex: 7
-  name: c_csr - j_vsrx
   node_count: 2
   ospf:
     cost: 3
@@ -274,6 +268,7 @@ nodes:
       ipv4: 172.19.2.3/24
       ipv6: 2001:db8:1:2::3/64
       linkindex: 9
+      name: a_eos -> stub
       neighbors: []
       ospf:
         area: 0.0.0.1
@@ -538,6 +533,7 @@ nodes:
       ipv6: 2001:db8:1:1::1/64
       linkindex: 8
       mtu: 8192
+      name: c_nxos -> stub
       neighbors: []
       ospf:
         area: 0.0.0.1

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -5,6 +5,7 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.1/24
     node: s1
     vlan:
@@ -13,6 +14,7 @@ links:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: ros
     vlan:

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -17,9 +17,11 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
+    ifname: Ethernet1
     node: s1
     vlan:
       access: red
@@ -31,9 +33,11 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.2/24
     node: h2
   - ifindex: 2
+    ifname: Ethernet2
     node: s1
     vlan:
       access: red

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -20,8 +20,6 @@ links:
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: red
@@ -36,8 +34,6 @@ links:
     ipv4: 172.16.0.2/24
     node: h2
   - ifindex: 2
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: red

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -17,16 +17,10 @@ links:
     vlan:
       trunk:
         vxlan: {}
-  left:
-    ifname: ethernet-1/1
-    node: host
   linkindex: 1
   name: host - leaf
   node_count: 2
   prefix: {}
-  right:
-    ifname: ethernet-1/1
-    node: leaf
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -11,11 +11,13 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: ethernet-1/1
     node: leaf
     vlan:
       trunk:
         vxlan: {}
   - ifindex: 1
+    ifname: ethernet-1/1
     node: host
   linkindex: 1
   node_count: 2

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -11,14 +11,13 @@ input:
 links:
 - interfaces:
   - ifindex: 1
-    node: host
-  - ifindex: 1
     node: leaf
     vlan:
       trunk:
         vxlan: {}
+  - ifindex: 1
+    node: host
   linkindex: 1
-  name: host - leaf
   node_count: 2
   prefix: {}
   type: p2p

--- a/tests/topology/expected/simple.yml
+++ b/tests/topology/expected/simple.yml
@@ -5,18 +5,23 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.1/24
     node: c_ios
   - ifindex: 2
+    ifname: GigabitEthernet2
     ipv4: 172.16.0.2/24
     node: c_csr
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 172.16.0.3/24
     node: c_nxos
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.4/24
     node: a_eos
   - ifindex: 0
+    ifname: ge-0/0/0
     ipv4: 172.16.0.5/24
     node: j_vsrx
   linkindex: 1
@@ -26,9 +31,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 10.1.0.2/30
     node: c_ios
   - ifindex: 3
+    ifname: GigabitEthernet3
     ipv4: 10.1.0.1/30
     node: c_csr
   linkindex: 2
@@ -39,9 +46,11 @@ links:
 - bridge: c-to-a
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.1.4/24
     node: a_eos
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: 172.16.1.3/24
     node: c_nxos
   linkindex: 3

--- a/tests/topology/expected/simple.yml
+++ b/tests/topology/expected/simple.yml
@@ -25,14 +25,13 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 - interfaces:
-  - ifindex: 3
-    ipv4: 10.1.0.1/30
-    node: c_csr
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_ios
+  - ifindex: 3
+    ipv4: 10.1.0.1/30
+    node: c_csr
   linkindex: 2
-  name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -84,7 +83,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.1.4/24
       linkindex: 3
-      name: a_eos -> [c_nxos]
+      name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
         ipv4: 172.16.1.3/24
@@ -218,7 +217,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: 172.16.1.3/24
       linkindex: 3
-      name: c_nxos -> [a_eos]
+      name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2
         ipv4: 172.16.1.4/24

--- a/tests/topology/expected/simple.yml
+++ b/tests/topology/expected/simple.yml
@@ -31,19 +31,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_ios
-  left:
-    ifname: GigabitEthernet3
-    ipv4: 10.1.0.1/30
-    node: c_csr
   linkindex: 2
   name: c_csr - c_ios
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.2/30
-    node: c_ios
   type: p2p
 - bridge: c-to-a
   interfaces:

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -5,18 +5,22 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 172.19.0.1/24
     ipv6: 2001:db8:1::1/64
     node: c_nxos
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.19.0.2/24
     ipv6: 2001:db8:1::2/64
     node: a_eos
   - ifindex: 0
+    ifname: ge-0/0/0
     ipv4: 172.19.0.3/24
     ipv6: 2001:db8:1::3/64
     node: j_vsrx
   - ifindex: 1
+    ifname: swp1
     ipv4: 172.19.0.4/24
     ipv6: 2001:db8:1::4/64
     node: n_cumulus
@@ -28,10 +32,12 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: true
     ipv6: true
     node: c_nxos
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: true
     ipv6: true
     node: a_eos
@@ -41,10 +47,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: true
     ipv6: true
     node: a_eos
   - ifindex: 2
+    ifname: swp2
     ipv4: true
     ipv6: true
     node: n_cumulus
@@ -54,10 +62,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet1/3
     ipv4: true
     ipv6: true
     node: c_nxos
   - ifindex: 1
+    ifname: ge-0/0/1
     ipv4: true
     ipv6: true
     node: j_vsrx

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -30,13 +30,12 @@ links:
   - ifindex: 2
     ipv4: true
     ipv6: true
-    node: a_eos
+    node: c_nxos
   - ifindex: 2
     ipv4: true
     ipv6: true
-    node: c_nxos
+    node: a_eos
   linkindex: 2
-  name: a_eos - c_nxos
   node_count: 2
   pool: core
   type: p2p
@@ -50,7 +49,6 @@ links:
     ipv6: true
     node: n_cumulus
   linkindex: 3
-  name: a_eos - n_cumulus
   node_count: 2
   pool: core
   type: p2p
@@ -64,7 +62,6 @@ links:
     ipv6: true
     node: j_vsrx
   linkindex: 4
-  name: c_nxos - j_vsrx
   node_count: 2
   role: core
   type: p2p

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -35,20 +35,10 @@ links:
     ipv4: true
     ipv6: true
     node: c_nxos
-  left:
-    ifname: Ethernet2
-    ipv4: true
-    ipv6: true
-    node: a_eos
   linkindex: 2
   name: a_eos - c_nxos
   node_count: 2
   pool: core
-  right:
-    ifname: Ethernet1/2
-    ipv4: true
-    ipv6: true
-    node: c_nxos
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -59,20 +49,10 @@ links:
     ipv4: true
     ipv6: true
     node: n_cumulus
-  left:
-    ifname: Ethernet3
-    ipv4: true
-    ipv6: true
-    node: a_eos
   linkindex: 3
   name: a_eos - n_cumulus
   node_count: 2
   pool: core
-  right:
-    ifname: swp2
-    ipv4: true
-    ipv6: true
-    node: n_cumulus
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -83,19 +63,9 @@ links:
     ipv4: true
     ipv6: true
     node: j_vsrx
-  left:
-    ifname: Ethernet1/3
-    ipv4: true
-    ipv6: true
-    node: c_nxos
   linkindex: 4
   name: c_nxos - j_vsrx
   node_count: 2
-  right:
-    ifname: ge-0/0/1
-    ipv4: true
-    ipv6: true
-    node: j_vsrx
   role: core
   type: p2p
 name: input

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -5,12 +5,15 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1/1
     ipv4: 172.16.0.1/24
     node: c_nxos
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: a_eos
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: a_eos_2
   linkindex: 1
@@ -20,9 +23,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet1/2
     ipv4: 10.1.0.2/30
     node: c_nxos
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.1/30
     node: a_eos
   linkindex: 2

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -20,13 +20,12 @@ links:
   type: lan
 - interfaces:
   - ifindex: 2
-    ipv4: 10.1.0.1/30
-    node: a_eos
-  - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_nxos
+  - ifindex: 2
+    ipv4: 10.1.0.1/30
+    node: a_eos
   linkindex: 2
-  name: a_eos - c_nxos
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -25,19 +25,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.2/30
     node: c_nxos
-  left:
-    ifname: Ethernet2
-    ipv4: 10.1.0.1/30
-    node: a_eos
   linkindex: 2
   name: a_eos - c_nxos
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1/2
-    ipv4: 10.1.0.2/30
-    node: c_nxos
   type: p2p
 name: input
 nodes:

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -84,7 +84,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.1/24
       linkindex: 1
-      name: r1 -> [s1]
+      name: r1 -> s1
       neighbors:
       - ifname: Ethernet1
         ipv4: 172.16.0.2/24
@@ -130,7 +130,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 2
-      name: r2 -> [s1]
+      name: r2 -> s1
       neighbors:
       - ifname: Ethernet2
         ipv4: 172.16.0.2/24

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -21,9 +21,11 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
@@ -36,9 +38,11 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: r2
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.2/24
     node: s1
     vlan:

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -7,9 +7,11 @@ links:
     ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
@@ -22,9 +24,11 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.2/24
     node: s1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.1.3/24
     node: s2
     vlan:
@@ -39,11 +43,13 @@ links:
     ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.3/24
     node: s2
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.4/24
     node: h2
   linkindex: 3

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -69,7 +69,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.0.1/24
       linkindex: 1
-      name: h1 -> [s1]
+      name: h1 -> s1
       neighbors:
       - ifname: GigabitEthernet0/1
         ipv4: 172.16.0.2/24
@@ -95,7 +95,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.1.4/24
       linkindex: 3
-      name: h2 -> [s2]
+      name: h2 -> s2
       neighbors:
       - ifname: GigabitEthernet0/2
         ipv4: 172.16.1.3/24
@@ -127,7 +127,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 172.16.1.2/24
       linkindex: 2
-      name: s1 -> [s2]
+      name: s1 -> s2
       neighbors:
       - ifname: GigabitEthernet0/1
         ipv4: 172.16.1.3/24

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -7,9 +7,11 @@ links:
     ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
@@ -22,11 +24,13 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: s2
     vlan:
@@ -45,11 +49,13 @@ links:
     ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.3/24
     node: s2
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.4/24
     node: h2
   linkindex: 3

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -47,8 +47,6 @@ links:
     ipv4: 172.16.0.2/24
     node: h1
   - ifindex: 2
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: red
@@ -63,8 +61,6 @@ links:
     ipv4: 172.16.1.3/24
     node: h2
   - ifindex: 3
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: blue
@@ -79,8 +75,6 @@ links:
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
-    ipv4: false
-    ipv6: false
     node: s2
     vlan:
       access: red
@@ -95,8 +89,6 @@ links:
     ipv4: 172.16.1.1/24
     node: r1
   - ifindex: 3
-    ipv4: false
-    ipv6: false
     node: s2
     vlan:
       access: blue

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -21,12 +21,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     node: s1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: s2
     vlan:
       trunk:
@@ -43,9 +45,11 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.2/24
     node: h1
   - ifindex: 2
+    ifname: Ethernet2
     node: s1
     vlan:
       access: red
@@ -57,9 +61,11 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.3/24
     node: h2
   - ifindex: 3
+    ifname: Ethernet3
     node: s1
     vlan:
       access: blue
@@ -71,9 +77,11 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
+    ifname: Ethernet2
     node: s2
     vlan:
       access: red
@@ -85,9 +93,11 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.1/24
     node: r1
   - ifindex: 3
+    ifname: Ethernet3
     node: s2
     vlan:
       access: blue

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -32,16 +32,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: s1
   linkindex: 1
   name: s1 - s2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: s2
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -33,7 +33,6 @@ links:
         blue: {}
         red: {}
   linkindex: 1
-  name: s1 - s2
   node_count: 2
   prefix: {}
   type: p2p

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -58,8 +58,6 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 3
-    ipv4: false
-    ipv6: false
     node: s2
     vlan:
       access: blue

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -77,7 +77,6 @@ links:
     ipv4: 10.1.0.2/30
     node: s2
   linkindex: 5
-  name: s1 - s2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -149,7 +148,7 @@ nodes:
       ifname: eth2
       ipv4: 172.16.1.4/24
       linkindex: 4
-      name: h2 -> [s2]
+      name: h2 -> s2
       neighbors:
       - ifname: GigabitEthernet0/3
         node: s2

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -7,9 +7,11 @@ links:
     ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
@@ -22,11 +24,13 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.3/24
     node: s2
     vlan:
@@ -43,11 +47,13 @@ links:
     ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.0.3/24
     node: s2
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.4/24
     node: h2
   linkindex: 3
@@ -58,10 +64,12 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     node: s2
     vlan:
       access: blue
   - ifindex: 2
+    ifname: eth2
     ipv4: 172.16.1.4/24
     node: h2
   linkindex: 4
@@ -71,9 +79,11 @@ links:
   type: lan
 - interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     ipv4: 10.1.0.1/30
     node: s1
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 10.1.0.2/30
     node: s2
   linkindex: 5

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -78,19 +78,11 @@ links:
   - ifindex: 4
     ipv4: 10.1.0.2/30
     node: s2
-  left:
-    ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.1/30
-    node: s1
   linkindex: 5
   name: s1 - s2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: GigabitEthernet0/4
-    ipv4: 10.1.0.2/30
-    node: s2
   type: p2p
 module:
 - vlan

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -7,6 +7,7 @@ links:
     ipv4: 172.16.3.1/24
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.3.1/24
     node: r1
     vlan:
@@ -17,6 +18,7 @@ links:
         pxeboot: {}
         red: {}
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.3.2/24
     node: r2
     vlan:
@@ -27,6 +29,7 @@ links:
         pxeboot: {}
         red: {}
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.3.3/24
     node: h1
   linkindex: 1

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -5,12 +5,14 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.1/24
     node: r1
     vlan:
       access: red
       mode: route
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
@@ -27,11 +29,13 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: r2
     vlan:

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -77,7 +77,6 @@ links:
         green: {}
         red: {}
   linkindex: 4
-  name: s1 - s2
   node_count: 2
   prefix: {}
   type: p2p
@@ -87,6 +86,13 @@ links:
       green: {}
       red: {}
 - interfaces:
+  - ifindex: 3
+    node: s1
+    vlan:
+      trunk:
+        blue: {}
+        green: {}
+        red: {}
   - ifindex: 1
     node: r1
     vlan:
@@ -95,15 +101,7 @@ links:
         blue: {}
         green: {}
         red: {}
-  - ifindex: 3
-    node: s1
-    vlan:
-      trunk:
-        blue: {}
-        green: {}
-        red: {}
   linkindex: 5
-  name: r1 - s1
   node_count: 2
   prefix: {}
   type: p2p
@@ -113,13 +111,6 @@ links:
       green: {}
       red: {}
 - interfaces:
-  - ifindex: 1
-    node: r2
-    vlan:
-      trunk:
-        blue: {}
-        green: {}
-        red: {}
   - ifindex: 4
     node: s2
     vlan:
@@ -128,8 +119,14 @@ links:
         blue: {}
         green: {}
         red: {}
+  - ifindex: 1
+    node: r2
+    vlan:
+      trunk:
+        blue: {}
+        green: {}
+        red: {}
   linkindex: 6
-  name: r2 - s2
   node_count: 2
   prefix: {}
   type: p2p

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -45,8 +45,6 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
-    ipv4: false
-    ipv6: false
     node: s2
     vlan:
       access: green

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -78,16 +78,10 @@ links:
         blue: {}
         green: {}
         red: {}
-  left:
-    ifname: Ethernet2
-    node: s1
   linkindex: 4
   name: s1 - s2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet3
-    node: s2
   type: p2p
   vlan:
     trunk:
@@ -110,16 +104,10 @@ links:
         blue: {}
         green: {}
         red: {}
-  left:
-    ifname: eth1
-    node: r1
   linkindex: 5
   name: r1 - s1
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet3
-    node: s1
   type: p2p
   vlan:
     trunk:
@@ -142,16 +130,10 @@ links:
         blue: {}
         green: {}
         red: {}
-  left:
-    ifname: eth1
-    node: r2
   linkindex: 6
   name: r2 - s2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet4
-    node: s2
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -13,11 +13,13 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.5/24
     node: h1
   linkindex: 1
@@ -29,11 +31,13 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.1.4/24
     node: s2
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.6/24
     node: h2
   linkindex: 2
@@ -45,11 +49,13 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: s2
     vlan:
       access: green
       mode: bridge
   - ifindex: 1
+    ifname: eth1
     ipv4: true
     ipv6: true
     node: h3
@@ -62,6 +68,7 @@ links:
   vrf: green
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: s1
     vlan:
       trunk:
@@ -69,6 +76,7 @@ links:
         green: {}
         red: {}
   - ifindex: 3
+    ifname: Ethernet3
     node: s2
     vlan:
       mode: bridge
@@ -87,6 +95,7 @@ links:
       red: {}
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     node: s1
     vlan:
       trunk:
@@ -94,6 +103,7 @@ links:
         green: {}
         red: {}
   - ifindex: 1
+    ifname: eth1
     node: r1
     vlan:
       mode: route
@@ -112,6 +122,7 @@ links:
       red: {}
 - interfaces:
   - ifindex: 4
+    ifname: Ethernet4
     node: s2
     vlan:
       mode: bridge
@@ -120,6 +131,7 @@ links:
         green: {}
         red: {}
   - ifindex: 1
+    ifname: eth1
     node: r2
     vlan:
       trunk:

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -62,7 +62,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.1.2/24
       linkindex: 1
-      name: h1 -> [r1]
+      name: h1 -> r1
       neighbors:
       - ifname: GigabitEthernet0/1
         ipv4: 172.16.1.1/24
@@ -89,7 +89,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.2.3/24
       linkindex: 2
-      name: h2 -> [r1]
+      name: h2 -> r1
       neighbors:
       - ifname: GigabitEthernet0/2
         ipv4: 172.16.2.1/24
@@ -116,7 +116,7 @@ nodes:
       ifname: GigabitEthernet0/1
       ipv4: 172.16.1.1/24
       linkindex: 1
-      name: r1 -> [h1]
+      name: r1 -> h1
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.2/24
@@ -132,7 +132,7 @@ nodes:
       ifname: GigabitEthernet0/2
       ipv4: 172.16.2.1/24
       linkindex: 2
-      name: r1 -> [h2]
+      name: r1 -> h2
       neighbors:
       - ifname: eth1
         ipv4: 172.16.2.3/24

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -7,12 +7,14 @@ links:
     ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.1.1/24
     node: r1
     vlan:
       access: red
       mode: route
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.2/24
     node: h1
   linkindex: 1
@@ -28,12 +30,14 @@ links:
     ipv4: 172.16.2.1/24
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.2.1/24
     node: r1
     vlan:
       access: red
       mode: route
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.2.3/24
     node: h2
   linkindex: 2

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -30,7 +30,6 @@ links:
         blue: {}
         red: {}
   linkindex: 1
-  name: s1 - s2
   node_count: 2
   prefix: {}
   type: p2p
@@ -39,20 +38,19 @@ links:
       blue: {}
       red: {}
 - interfaces:
-  - ifindex: 1
-    node: ros
-    vlan:
-      trunk:
-        blue: {}
-        red: {}
   - ifindex: 2
     node: s2
     vlan:
       trunk:
         blue: {}
         red: {}
+  - ifindex: 1
+    node: ros
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
   linkindex: 2
-  name: ros - s2
   node_count: 2
   prefix: {}
   type: p2p

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -18,12 +18,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     node: s1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: s2
     vlan:
       trunk:
@@ -39,12 +41,14 @@ links:
       red: {}
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: s2
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: ros
     vlan:
       trunk:
@@ -61,9 +65,11 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.3/24
     node: r1
   - ifindex: 2
+    ifname: Ethernet2
     node: s1
     vlan:
       access: red
@@ -75,9 +81,11 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.1.4/24
     node: r2
   - ifindex: 3
+    ifname: Ethernet3
     node: s1
     vlan:
       access: blue

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -66,8 +66,6 @@ links:
     ipv4: 172.16.0.3/24
     node: r1
   - ifindex: 2
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: red
@@ -82,8 +80,6 @@ links:
     ipv4: 172.16.1.4/24
     node: r2
   - ifindex: 3
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       access: blue

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -29,16 +29,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: s1
   linkindex: 1
   name: s1 - s2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: s2
   type: p2p
   vlan:
     trunk:
@@ -57,16 +51,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: ros
   linkindex: 2
   name: ros - s2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet2
-    node: s2
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -7,11 +7,13 @@ links:
     ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
+    ifname: GigabitEthernet0/1
     ipv4: 172.16.0.1/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.3/24
     node: h1
   linkindex: 1
@@ -26,11 +28,13 @@ links:
     ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 2
+    ifname: GigabitEthernet0/2
     ipv4: 172.16.1.1/24
     node: s1
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.4/24
     node: h2
   linkindex: 2
@@ -43,11 +47,13 @@ links:
     ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: s2
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.5/24
     node: h3
   linkindex: 3
@@ -62,11 +68,13 @@ links:
     ipv4: 172.16.1.2/24
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.1.2/24
     node: s2
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.6/24
     node: h4
   linkindex: 4
@@ -79,11 +87,13 @@ links:
     ipv4: 172.16.2.2/24
   interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 172.16.2.2/24
     node: s2
     vlan:
       access: green
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.2.7/24
     node: h5
   linkindex: 5
@@ -94,12 +104,14 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 3
+    ifname: GigabitEthernet0/3
     node: s1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 4
+    ifname: Ethernet4
     ipv4: 172.16.2.2/24
     node: s2
     vlan:
@@ -120,6 +132,7 @@ links:
 - bridge: input_7
   interfaces:
   - ifindex: 4
+    ifname: GigabitEthernet0/4
     ipv4: 172.16.2.1/24
     node: s1
     vlan:
@@ -129,6 +142,7 @@ links:
         green: {}
         red: {}
   - ifindex: 5
+    ifname: Ethernet5
     ipv4: 172.16.2.2/24
     node: s2
     vlan:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -94,8 +94,6 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 3
-    ipv4: false
-    ipv6: false
     node: s1
     vlan:
       trunk:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -32,16 +32,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet1
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r2
   type: p2p
   vlan:
     trunk:
@@ -60,16 +54,10 @@ links:
       trunk:
         blue: {}
         red: {}
-  left:
-    ifname: Ethernet2
-    node: r2
   linkindex: 2
   name: r2 - r3
   node_count: 2
   prefix: {}
-  right:
-    ifname: Ethernet1
-    node: r3
   type: p2p
   vlan:
     trunk:
@@ -173,19 +161,11 @@ links:
     vlan:
       access: red
       mode: route
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: h5
   linkindex: 7
   name: h5 - r1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet4
-    ipv4: 10.1.0.2/30
-    node: r1
   type: p2p
   vlan:
     mode: route

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -21,12 +21,14 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     node: r1
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r2
     vlan:
       trunk:
@@ -42,12 +44,14 @@ links:
       red: {}
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     node: r2
     vlan:
       trunk:
         blue: {}
         red: {}
   - ifindex: 1
+    ifname: Ethernet1
     node: r3
     vlan:
       trunk:
@@ -66,9 +70,11 @@ links:
     ipv4: 172.16.2.1/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.2.4/24
     node: h1
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.2.1/24
     node: r1
     vlan:
@@ -88,9 +94,11 @@ links:
     ipv4: 172.16.3.1/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.3.6/24
     node: h3
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 172.16.3.1/24
     node: r1
     vlan:
@@ -110,9 +118,11 @@ links:
     ipv4: 172.16.4.2/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.4.5/24
     node: h2
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 172.16.4.2/24
     node: r2
     vlan:
@@ -132,9 +142,11 @@ links:
     ipv4: 172.16.5.2/24
   interfaces:
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.5.7/24
     node: h4
   - ifindex: 4
+    ifname: Ethernet4
     ipv4: 172.16.5.2/24
     node: r2
     vlan:
@@ -151,9 +163,11 @@ links:
   vrf: blue
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     node: h5
   - ifindex: 4
+    ifname: Ethernet4
     ipv4: 10.1.0.2/30
     node: r1
     vlan:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -33,7 +33,6 @@ links:
         blue: {}
         red: {}
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix: {}
   type: p2p
@@ -55,7 +54,6 @@ links:
         blue: {}
         red: {}
   linkindex: 2
-  name: r2 - r3
   node_count: 2
   prefix: {}
   type: p2p
@@ -162,7 +160,6 @@ links:
       access: red
       mode: route
   linkindex: 7
-  name: h5 - r1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -190,7 +187,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.2.4/24
       linkindex: 3
-      name: h1 -> [r1]
+      name: h1 -> r1
       neighbors:
       - ifname: Ethernet2
         ipv4: 172.16.2.1/24
@@ -218,7 +215,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.4.5/24
       linkindex: 5
-      name: h2 -> [r2]
+      name: h2 -> r2
       neighbors:
       - ifname: Ethernet3
         ipv4: 172.16.4.2/24
@@ -246,7 +243,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.3.6/24
       linkindex: 4
-      name: h3 -> [r1]
+      name: h3 -> r1
       neighbors:
       - ifname: Ethernet3
         ipv4: 172.16.3.1/24
@@ -274,7 +271,7 @@ nodes:
       ifname: eth1
       ipv4: 172.16.5.7/24
       linkindex: 6
-      name: h4 -> [r2]
+      name: h4 -> r2
       neighbors:
       - ifname: Ethernet4
         ipv4: 172.16.5.2/24
@@ -337,7 +334,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.2.1/24
       linkindex: 3
-      name: r1 -> [h1]
+      name: r1 -> h1
       neighbors:
       - ifname: eth1
         ipv4: 172.16.2.4/24
@@ -354,7 +351,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.3.1/24
       linkindex: 4
-      name: r1 -> [h3]
+      name: r1 -> h3
       neighbors:
       - ifname: eth1
         ipv4: 172.16.3.6/24
@@ -383,7 +380,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 172.16.6.1/24
-      name: r1 -> [r2]
+      name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.6.2/24
@@ -401,7 +398,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 172.16.7.1/24
-      name: r1 -> [r2]
+      name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.7.2/24
@@ -468,7 +465,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.3.1/24
             linkindex: 4
-            name: r1 -> [h3]
+            name: r1 -> h3
             neighbors:
             - ifname: eth1
               ipv4: 172.16.3.6/24
@@ -486,7 +483,7 @@ nodes:
             ifindex: 5
             ifname: Ethernet1.1
             ipv4: 172.16.6.1/24
-            name: r1 -> [r2]
+            name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.1
               ipv4: 172.16.6.2/24
@@ -526,7 +523,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 172.16.2.1/24
             linkindex: 3
-            name: r1 -> [h1]
+            name: r1 -> h1
             neighbors:
             - ifname: eth1
               ipv4: 172.16.2.4/24
@@ -563,7 +560,7 @@ nodes:
             ifindex: 6
             ifname: Ethernet1.2
             ipv4: 172.16.7.1/24
-            name: r1 -> [r2]
+            name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.2
               ipv4: 172.16.7.2/24
@@ -617,7 +614,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.4.2/24
       linkindex: 5
-      name: r2 -> [h2]
+      name: r2 -> h2
       neighbors:
       - ifname: eth1
         ipv4: 172.16.4.5/24
@@ -634,7 +631,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 172.16.5.2/24
       linkindex: 6
-      name: r2 -> [h4]
+      name: r2 -> h4
       neighbors:
       - ifname: eth1
         ipv4: 172.16.5.7/24
@@ -648,7 +645,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 172.16.6.2/24
-      name: r2 -> [r1]
+      name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.6.1/24
@@ -666,7 +663,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 172.16.7.2/24
-      name: r2 -> [r1]
+      name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.7.1/24
@@ -684,7 +681,7 @@ nodes:
       ifindex: 7
       ifname: Ethernet2.1
       ipv4: 172.16.8.2/24
-      name: r2 -> [r3]
+      name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
         ipv4: 172.16.8.3/24
@@ -702,7 +699,7 @@ nodes:
       ifindex: 8
       ifname: Ethernet2.2
       ipv4: 172.16.9.2/24
-      name: r2 -> [r3]
+      name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
         ipv4: 172.16.9.3/24
@@ -769,7 +766,7 @@ nodes:
             ifname: Ethernet4
             ipv4: 172.16.5.2/24
             linkindex: 6
-            name: r2 -> [h4]
+            name: r2 -> h4
             neighbors:
             - ifname: eth1
               ipv4: 172.16.5.7/24
@@ -787,7 +784,7 @@ nodes:
             ifindex: 5
             ifname: Ethernet1.1
             ipv4: 172.16.6.2/24
-            name: r2 -> [r1]
+            name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.1
               ipv4: 172.16.6.1/24
@@ -809,7 +806,7 @@ nodes:
             ifindex: 7
             ifname: Ethernet2.1
             ipv4: 172.16.8.2/24
-            name: r2 -> [r3]
+            name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.1
               ipv4: 172.16.8.3/24
@@ -849,7 +846,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.4.2/24
             linkindex: 5
-            name: r2 -> [h2]
+            name: r2 -> h2
             neighbors:
             - ifname: eth1
               ipv4: 172.16.4.5/24
@@ -867,7 +864,7 @@ nodes:
             ifindex: 6
             ifname: Ethernet1.2
             ipv4: 172.16.7.2/24
-            name: r2 -> [r1]
+            name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.2
               ipv4: 172.16.7.1/24
@@ -889,7 +886,7 @@ nodes:
             ifindex: 8
             ifname: Ethernet2.2
             ipv4: 172.16.9.2/24
-            name: r2 -> [r3]
+            name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.2
               ipv4: 172.16.9.3/24
@@ -931,7 +928,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.8.3/24
-      name: r3 -> [r2]
+      name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
         ipv4: 172.16.8.2/24
@@ -949,7 +946,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 172.16.9.3/24
-      name: r3 -> [r2]
+      name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
         ipv4: 172.16.9.2/24
@@ -1013,7 +1010,7 @@ nodes:
             ifindex: 2
             ifname: Ethernet1.1
             ipv4: 172.16.8.3/24
-            name: r3 -> [r2]
+            name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.1
               ipv4: 172.16.8.2/24
@@ -1050,7 +1047,7 @@ nodes:
             ifindex: 3
             ifname: Ethernet1.2
             ipv4: 172.16.9.3/24
-            name: r3 -> [r2]
+            name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.2
               ipv4: 172.16.9.2/24

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -30,20 +30,12 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: pe2
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: pe1
   linkindex: 1
   name: pe1 - pe2
   node_count: 2
   ospf: false
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    node: pe2
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -53,19 +45,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.6/30
     node: r2
-  left:
-    ifname: Ethernet2
-    ipv4: 10.1.0.5/30
-    node: pe1
   linkindex: 2
   name: pe1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.6/30
-    node: r2
   role: external
   type: p2p
 - interfaces:
@@ -75,19 +59,11 @@ links:
   - ifindex: 2
     ipv4: 10.1.0.10/30
     node: pe2
-  left:
-    ifname: Ethernet3
-    ipv4: 10.1.0.9/30
-    node: pe1
   linkindex: 3
   name: pe1 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
-  right:
-    ifname: Ethernet2
-    ipv4: 10.1.0.10/30
-    node: pe2
   type: p2p
   vrf: blue
 - interfaces:
@@ -100,19 +76,11 @@ links:
     node: r3
     ospf:
       area: 0.0.0.1
-  left:
-    ifname: Ethernet3
-    ipv4: 10.1.0.13/30
-    node: pe2
   linkindex: 4
   name: pe2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.14/30
-    node: r3
   type: p2p
 - bridge: input_5
   interfaces:

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -25,9 +25,11 @@ isis:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     node: pe1
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: pe2
   linkindex: 1
@@ -38,10 +40,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.5/30
     node: pe1
     vrf: red
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.6/30
     node: r2
   linkindex: 2
@@ -52,9 +56,11 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 10.1.0.9/30
     node: pe1
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.10/30
     node: pe2
   linkindex: 3
@@ -65,10 +71,12 @@ links:
   vrf: blue
 - interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 10.1.0.13/30
     node: pe2
     vrf: blue
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.14/30
     node: r3
     ospf:
@@ -81,6 +89,7 @@ links:
 - bridge: input_5
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.4/24
     node: r3
     vrf: yellow
@@ -92,6 +101,7 @@ links:
 - bridge: input_6
   interfaces:
   - ifindex: 3
+    ifname: Ethernet3
     ipv4: 172.16.1.4/24
     node: r3
     vrf: brown

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -31,7 +31,6 @@ links:
     ipv4: 10.1.0.2/30
     node: pe2
   linkindex: 1
-  name: pe1 - pe2
   node_count: 2
   ospf: false
   prefix:
@@ -46,7 +45,6 @@ links:
     ipv4: 10.1.0.6/30
     node: r2
   linkindex: 2
-  name: pe1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -60,7 +58,6 @@ links:
     ipv4: 10.1.0.10/30
     node: pe2
   linkindex: 3
-  name: pe1 - pe2
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
@@ -77,7 +74,6 @@ links:
     ospf:
       area: 0.0.0.1
   linkindex: 4
-  name: pe2 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
@@ -539,6 +535,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.4/24
       linkindex: 5
+      name: r3 -> stub
       neighbors: []
       type: stub
       vrf: yellow
@@ -549,6 +546,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.1.4/24
       linkindex: 6
+      name: r3 -> stub
       neighbors: []
       type: stub
       vrf: brown
@@ -589,6 +587,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.1.4/24
             linkindex: 6
+            name: r3 -> stub
             neighbors: []
             ospf:
               area: 0.0.0.0

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -21,16 +21,10 @@ links:
           vrf: customer1
         route-leak-to-global-customer2:
           vrf: customer2
-  left:
-    ifname: ethernet-1/1
-    node: leaf1
   linkindex: 1
   name: leaf1 - leaf1
   node_count: 2
   prefix: {}
-  right:
-    ifname: ethernet-1/2
-    node: leaf1
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -4,6 +4,7 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: ethernet-1/1
     name: Global side
     node: leaf1
     vlan:
@@ -13,6 +14,7 @@ links:
         route-leak-to-global-customer2:
           vrf: global
   - ifindex: 2
+    ifname: ethernet-1/2
     name: Customer side
     node: leaf1
     vlan:

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -22,7 +22,6 @@ links:
         route-leak-to-global-customer2:
           vrf: customer2
   linkindex: 1
-  name: leaf1 - leaf1
   node_count: 2
   prefix: {}
   type: p2p
@@ -73,7 +72,7 @@ nodes:
       ifindex: 3
       ifname: ethernet-1/1.1000
       ipv4: 172.16.2.1/24
-      name: leaf1 -> [leaf1]
+      name: leaf1 -> leaf1
       neighbors:
       - ifname: ethernet-1/2.1000
         ipv4: 172.16.2.1/24
@@ -92,7 +91,7 @@ nodes:
       ifindex: 4
       ifname: ethernet-1/2.1000
       ipv4: 172.16.2.1/24
-      name: leaf1 -> [leaf1]
+      name: leaf1 -> leaf1
       neighbors:
       - ifname: ethernet-1/1.1000
         ipv4: 172.16.2.1/24
@@ -111,7 +110,7 @@ nodes:
       ifindex: 5
       ifname: ethernet-1/1.1001
       ipv4: 172.16.3.1/24
-      name: leaf1 -> [leaf1]
+      name: leaf1 -> leaf1
       neighbors:
       - ifname: ethernet-1/2.1001
         ipv4: 172.16.3.1/24
@@ -130,7 +129,7 @@ nodes:
       ifindex: 6
       ifname: ethernet-1/2.1001
       ipv4: 172.16.3.1/24
-      name: leaf1 -> [leaf1]
+      name: leaf1 -> leaf1
       neighbors:
       - ifname: ethernet-1/1.1001
         ipv4: 172.16.3.1/24

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -21,10 +21,12 @@ input:
 links:
 - interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.1/30
     node: r1
     vrf: red
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -35,10 +37,12 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 10.1.0.5/30
     node: r1
     vrf: blue
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
@@ -49,6 +53,7 @@ links:
 - bridge: input_3
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.0.3/24
     node: r3
     vrf: yellow
@@ -60,6 +65,7 @@ links:
 - bridge: input_4
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.1.2/24
     node: r2
     vrf: black

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -27,19 +27,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.2/30
     node: r2
-  left:
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: r1
   linkindex: 1
   name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.2/30
-    node: r2
   role: external
   type: p2p
 - interfaces:
@@ -50,19 +42,11 @@ links:
   - ifindex: 1
     ipv4: 10.1.0.6/30
     node: r3
-  left:
-    ifname: Ethernet2
-    ipv4: 10.1.0.5/30
-    node: r1
   linkindex: 2
   name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
-  right:
-    ifname: Ethernet1
-    ipv4: 10.1.0.6/30
-    node: r3
   type: p2p
 - bridge: input_3
   interfaces:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -28,7 +28,6 @@ links:
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
-  name: r1 - r2
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
@@ -43,7 +42,6 @@ links:
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
-  name: r1 - r3
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -279,6 +277,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.1.2/24
       linkindex: 4
+      name: r2 -> stub
       neighbors: []
       type: stub
       vrf: black
@@ -370,6 +369,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.3/24
       linkindex: 3
+      name: r3 -> stub
       neighbors: []
       type: stub
       vrf: yellow

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -18,11 +18,13 @@ links:
     ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.1/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.4/24
     node: h1
   linkindex: 1
@@ -35,11 +37,13 @@ links:
     ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 2
+    ifname: Ethernet2
     ipv4: 172.16.1.1/24
     node: s1
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.5/24
     node: h2
   linkindex: 2
@@ -52,11 +56,13 @@ links:
     ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
     node: s2
     vlan:
       access: red
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.0.6/24
     node: h3
   linkindex: 3
@@ -69,11 +75,13 @@ links:
     ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 1
+    ifname: Ethernet1
     ipv4: 172.16.1.3/24
     node: s3
     vlan:
       access: blue
   - ifindex: 1
+    ifname: eth1
     ipv4: 172.16.1.7/24
     node: h4
   linkindex: 4

--- a/tests/topology/input/addressing-lan.yml
+++ b/tests/topology/input/addressing-lan.yml
@@ -111,7 +111,7 @@ links:
 - name: l2only LAN link with a host IP address
   r1:
   r2:
-    ipv4: 10.42.42.17
+    ipv4: 10.42.42.17/32
   r3:
   prefix: False
 


### PR DESCRIPTION
* Remove 'left' and 'right' elements from P2P links
* Implement multiple IPAM policies and select them based on prefix/link size or link type
* Remove P2P link augmentation and refactor/cleanup LAN link augmentation

Anyone brave enough to review the new spaghetti mess?