### PR TITLE
Adds a plugin that enables proxy ARP on all interfaces in selected VRFs

### DIFF
--- a/netsim/extra/proxy-arp/plugin.py
+++ b/netsim/extra/proxy-arp/plugin.py
@@ -1,0 +1,30 @@
+import typing, netaddr
+from box import Box
+
+from netsim import api
+
+"""
+Attribute 'proxy_arp' is enabled per VRF; not currently enforced
+"""
+# def init(topology: Box) -> None:
+
+"""
+Add 'proxy_arp' flag and trigger custom config file for any interfaces that are
+part of a VRF with proxy ARP enabled
+"""
+def post_transform(topology: Box) -> None:
+
+  if not topology.get('vrfs',[]):
+    return
+
+  target_vrfs = [ v for v,d in topology.vrfs.items() if 'proxy_arp' in d ]
+
+  config_name = api.get_config_name(globals())
+
+  # Iterate over node[x].interfaces that are part of a VRF with proxy_arp enabled
+  for n, ndata in topology.nodes.items():
+    for i in ndata.interfaces:
+      if i.type in ['lan','p2p','svi'] and 'vrf' in i and i.vrf in target_vrfs \
+        and ('ipv4' in i or 'ipv6' in i):
+          i.proxy_arp = True
+          api.node_config(ndata,config_name)

--- a/netsim/extra/proxy-arp/srlinux.j2
+++ b/netsim/extra/proxy-arp/srlinux.j2
@@ -1,0 +1,24 @@
+#
+# See https://documentation.nokia.com/srlinux/22-6/SR_Linux_Book_Files/pdf/EVPN-VXLAN_Guide_22.6.pdf
+# section 7.7 Layer 3 proxy-ARP/ND
+
+updates:
+{% for l in interfaces if 'proxy_arp' in l %}
+{% set if_name_index = l.ifname.split('.') %}
+{% set if_name = if_name_index[0] if l.type!='stub' else "lo0" %}
+{% set if_index = if_name_index[1] if if_name_index|length > 1 else l.ifindex if l.type=='stub' else l.vlan.access_id|default(0) -%}
+- path: interface[name={{if_name}}]
+  val:
+   subinterface:
+   - index: {{ if_index }}
+{%   if 'ipv4' in l %}
+     ipv4:
+      arp:
+       proxy-arp: True
+{%   endif %}
+{%   if 'ipv6' in l %}
+     ipv6:
+      neighbor-discovery:
+       proxy-nd: True
+{%   endif %}
+{% endfor %}

--- a/netsim/extra/proxy-arp/sros.j2
+++ b/netsim/extra/proxy-arp/sros.j2
@@ -1,0 +1,17 @@
+#
+# See https://documentation.nokia.com/cgi-bin/dbaccessfilename.cgi/3HE17292AAABTQZZA01_V1_7450%20ESS%207750%20SR%207950%20XRS%20MD-CLI%20Advanced%20Configuration%20Guide%20for%20Releases%20up%20to%2021.5.R2.pdf
+# Proxy-ARP/ND MAC List for Dynamic Entries for a more advanced feature (L2 VPLS only)
+
+updates:
+{# Enable proxy ARP for all marked interfaces #}
+{% for l in interfaces if l.vrf is defined and 'proxy_arp' in l %}
+- path: configure/service/vprn[service-name={{ l.vrf }}]
+  val:
+   interface:
+   - interface-name: {{ l.ifname }}
+{%  for af in ('ipv4','ipv6') if af in l %}
+     {{ af }}:
+      neighbor-discovery:
+       remote-proxy-arp: True
+{%  endfor %}
+{% endfor %}

--- a/tests/integration/evpn/vxlan-symmetric-irb-proxy-arp.yml
+++ b/tests/integration/evpn/vxlan-symmetric-irb-proxy-arp.yml
@@ -1,0 +1,59 @@
+message: |
+  The devices under test are layer-3 switches running VXLAN/EVPN with
+  symmetric IRB, using eBGP. Hosts are in three VLANs, all in one VRF.
+  The *proxy-arp* plugin is enabled to add proxy ARP functionality
+
+  All hosts should be able to ping each other.
+
+plugin: [proxy-arp]
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+  switches:
+    members: [ s1,s2 ]
+    module: [ vlan,vxlan,ospf,bgp,evpn,vrf ]
+
+bgp.as: 65000
+
+vrfs:
+  tenant:
+    evpn.transit_vni: True
+    proxy_arp: True # Enable proxy ARP on all interfaces that are part of this vrf
+
+vlans:
+  red:
+    vrf: tenant
+  blue:
+    vrf: tenant
+  green:
+    vrf: tenant
+
+nodes:
+  h1:
+  h2:
+  h3:
+  h4:
+  s1:
+    # evpn.as: 65001
+    bgp.local_as: 65001
+  s2:
+    # evpn.as: 65002
+    bgp.local_as: 65002
+
+links:
+- h1:
+  s1:
+    vlan.access: red
+- h2:
+  s2:
+    vlan.access: red
+- h3:
+  s1:
+    vlan.access: blue
+- h4:
+  s2:
+    vlan.access: green
+- s1:
+  s2:


### PR DESCRIPTION
Users can set ```proxy_arp: True``` for each VRF where proxy ARP is required

Platforms supported: srlinux, sros