### PR TITLE
Fix ISIS template (broken after vlan updates, interface naming logic)

### DIFF
--- a/netsim/ansible/templates/isis/srlinux.j2
+++ b/netsim/ansible/templates/isis/srlinux.j2
@@ -16,18 +16,16 @@ updates:
      - interface-name: system0.0
        passive: True
        ipv4-unicast:
-        admin-state: {{ 'enable' if loopback.ipv4|default('')|ipv4 and 'ipv4' in isis.af else 'disable' }}
+        admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
        ipv6-unicast:
-        admin-state: {{ 'enable' if loopback.ipv6|default('')|ipv6 and 'ipv6' in isis.af else 'disable' }}
+        admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
 
-{%   for l in interfaces|default([]) %}
+{%   for l in interfaces if (l.vlan is not defined or l.vlan.mode|default('irb')!='bridge') and l.subif_index is not defined %}
+{%    set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
 {%    if "isis" not in l %}
-     # IS-IS not configured on external interface {{ l.ifname }}
-     - interface-name: {{ l.ifname }}.0
-       admin-state: disable
-       _annotate_admin-state: "Disabled on external interface"
+     # IS-IS not configured on external interface {{ ifname }}
 {%    else %}
-     - interface-name: {{ l.ifname }}.0
+     - interface-name: {{ ifname }}
        circuit-type: {{ l.isis.network_type|default("broadcast") }}
        passive: {{ l.isis.passive }}
 {%     if 'ipv4' in l and 'ipv4' in isis.af %}


### PR DESCRIPTION
Copy interface naming logic from ospf