### PR TITLE
Add a feature flag for advanced RR topologies with combined IBGP/EBGP peers

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -18,7 +18,7 @@
 
 - path: routing-policy/policy[name={{name}}]
   val:
-   default-action: 
+   default-action:
     reject: { }
    statement:
 {% if is_import %}
@@ -28,7 +28,7 @@
       bgp:
        community-set: "C{{ c|replace(':','_') }}"
      action:
-{{    accept() }}       
+{{    accept() }}
 {%  endfor %}
 {% else %}
    - sequence-id: 5
@@ -129,7 +129,6 @@
 {% if 'ibgp' in type %}
    import-policy: accept_all
    export-policy: accept_all
-   next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
    peer-as: {{ neighbor.as }}
    transport:
     local-address: {{ transport_ip }}
@@ -139,6 +138,8 @@
    route-reflector:
     cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
     client: True
+{%  else %}
+   next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
 {%  endif %}
 {% endif %}
 {% endmacro %}

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -65,7 +65,7 @@ def validate_bgp_sessions(node: Box, sessions: Box, attribute: str) -> bool:
           true_value=BGP_VALID_SESSION_TYPE,
           valid_values=BGP_VALID_SESSION_TYPE,
           module='bgp') is None:
-        OK = False        
+        OK = False
 
   return OK
 
@@ -75,8 +75,8 @@ find_bgp_rr: find route reflectors in the specified autonomous system
 Given an autonomous system and lab topology, return a list of node names that are route reflectors in that AS
 """
 def find_bgp_rr(bgp_as: int, topology: Box) -> typing.List[Box]:
-  return [ n 
-    for n in topology.nodes.values() 
+  return [ n
+    for n in topology.nodes.values()
       if 'bgp' in n and n.bgp["as"] == bgp_as and n.bgp.get("rr",None) ]
 
 """
@@ -202,6 +202,13 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
 
       if node_as == neighbor_real_as and node_local_as == neighbor_local_as:
         continue                                                      # Routers in the same AS + no local-as trickery => nothing to do here
+
+      if node.bgp.get("rr",None) and not features.bgp.rr_with_ebgp_peers:
+        common.error(
+          text=f'{node.name} (device {node.device}) does not support Route Reflection in combination with EBGP sessions',
+          category=common.IncorrectValue,
+          module='bgp')
+        continue
 
       extra_data = Box({})
       extra_data.ifindex = l.ifindex

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -47,7 +47,7 @@ bgp:
   transform_after: [ vlan ]
   next_hop_self: true
   attributes:
-    global: [ 
+    global: [
       af, as, next_hop_self, rr_cluster_id, rr_list, ebgp_role, as_list, sessions, activate,
       advertise_loopback, advertise_roles, community, replace_global_as ]
     node: [
@@ -438,6 +438,7 @@ devices:
         vrf_local_as: True
         local_as_ibgp: True
         activate_af: True
+        rr_with_ebgp_peers: True
       initial:
         system_mtu: True
         ipv4:
@@ -762,6 +763,7 @@ devices:
         activate_af: True
         ipv6_lla: True
         rfc8950: True
+        rr_with_ebgp_peers: False
       vxlan:
         requires: [ evpn ] # vrf for l3 vxlan
       evpn:
@@ -948,7 +950,7 @@ devices:
     external:
       image: none
     graphite.icon: router
-  
+
   routeros7:
     interface_name: ether%d
     mgmt_if: ether1


### PR DESCRIPTION
Context: https://github.com/ipspace/netlab/commit/be1c546aeb029960f231f3382ccf0768c918656a

On EOS this requires policy support to selectively set next-hop only for external routes
SR Linux (and possibly others) do not support such policies, or do not have them implemented in current templates

For SR Linux, do not set next-hop-self when operating as Route Reflector

TODO: Set flag for platforms that do correctly support this scenario