### PR TITLE
srlinux/sros: Cleanup address families enabled for BGP sessions:

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -18,7 +18,7 @@
 
 - path: routing-policy/policy[name={{name}}]
   val:
-   default-action: 
+   default-action:
     reject: { }
    statement:
 {% if is_import %}
@@ -28,7 +28,7 @@
       bgp:
        community-set: "C{{ c|replace(':','_') }}"
      action:
-{{    accept() }}       
+{{    accept() }}
 {%  endfor %}
 {% else %}
    - sequence-id: 5
@@ -100,23 +100,27 @@
 {% endfor %}
 {% endfor %}
 
-{% macro bgp_peer_group(name,type,neighbor,transport_ip) %}
-- path: network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
-  val:
-   admin-state: enable
+{% macro bgp_families(neighbor,ipv4=True,ipv6=True) %}
 {% set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
    ipv4-unicast:
-    admin-state: {{ 'enable' if activate.ipv4|default(False) else 'disable' }}
+    admin-state: {{ 'enable' if activate.ipv4|default(False) and ipv4 else 'disable' }}
 {% if neighbor.ipv4_rfc8950|default(False) %}
     advertise-ipv6-next-hops: True
     receive-ipv6-next-hops: True
 {% endif %}
    ipv6-unicast:
-    admin-state: {{ 'enable' if activate.ipv6|default(False) else 'disable' }}
+    admin-state: {{ 'enable' if activate.ipv6|default(False) and ipv6 else 'disable' }}
 {% if 'evpn' in neighbor and neighbor.evpn %}
    evpn:
     admin-state: enable # Must have at least 1 address family enabled
 {% endif %}
+{% endmacro %}
+
+{% macro bgp_peer_group(name,type,neighbor,transport_ip) %}
+- path: network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
+  val:
+   admin-state: enable
+{{ bgp_families(neighbor) }}
    timers:
     connect-retry: 10
     _annotate_connect-retry: "Reduce default 120s to 10s"
@@ -161,6 +165,7 @@
    - peer-address: "{{ n[af] }}"
      description: {{ n.name }}
      peer-group: {{ peer_group }}
+  {{ bgp_families(n,ipv4=(af=='ipv4' or 'ipv4' not in n),ipv6=(af=='ipv6')) | indent(2) }}
 {% if 'ebgp' in n.type %}
      peer-as: {{ n.as }}
 {% elif vrf_bgp.rr|default(False) and n.rr|default(False) %}

--- a/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
@@ -17,17 +17,21 @@
     # family: cannot disable this
     # ipv4: False # Enabled by default, disable globally and set per group
 
+{% macro bgp_families(neighbor,ipv4=True,ipv6=True) %}
+   family:
+{% set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
+    ipv4: {{ activate.ipv4|default(False) and ipv4 }}
+    ipv6: {{ activate.ipv6|default(False) and ipv6 }}
+{%  if 'evpn' in neighbor and neighbor.evpn %}
+    evpn: True # Must have at least 1 address family enabled
+{%  endif %}
+{% endmacro %}
+
 {% macro bgp_peer_group(name,type,neighbor,transport_ip) %}
 - path: configure/{{ path }}/bgp/group[group-name={{name}}]
   val:
    admin-state: enable
-   family:
-{% set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
-    ipv4: {{ activate.ipv4|default(False) }}
-    ipv6: {{ activate.ipv6|default(False) }}
-{% if 'evpn' in neighbor and neighbor.evpn %}
-    evpn: True # Must have at least 1 address family enabled
-{% endif %}
+{{ bgp_families(neighbor) }}
    import:
     policy: ["accept_all"]
    export:
@@ -71,6 +75,8 @@
      description: "{{ n.name }}"
      peer-as: {{ n.as }}
      group: "{{ peer_group }}"
+  {{ bgp_families(n,ipv4=(af=='ipv4' or 'ipv4' not in n),ipv6=(af=='ipv6')) | indent(2) }}
+
 {%    if n.local_as is defined %}
      local-as:
       as-number: {{ n.local_as }}


### PR DESCRIPTION
1. If both ipv4 and ipv6 peering addresses are given, activate ipv4 for v4 and ipv6 for v6 (not both for both)
2. If only ipv6 is given, allow ipv4 to be activated too (if enabled by Netlab flag)

The data model only provides
```
activate:
  ipv4: True/False
  ipv6: True/False
```

and does not specify which one(s) apply to which peering session