### PR TITLE
srlinux: Don't configure next-hop-self when acting as RR

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -133,7 +133,6 @@
 {% if 'ibgp' in type %}
    import-policy: accept_all
    export-policy: accept_all
-   next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
    peer-as: {{ neighbor.as }}
    transport:
     local-address: {{ transport_ip }}
@@ -143,6 +142,8 @@
    route-reflector:
     cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
     client: True
+{%  else %}
+   next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
 {%  endif %}
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Need to leave next hops unchanged. On SR Linux, next-hop-self also affects reflected routes