### PR TITLE
sros: Add policy to set next-hop-self for eBGP routes only

### DIFF
--- a/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
@@ -35,7 +35,7 @@
    import:
     policy: ["accept_all"]
    export:
-    policy: ["accept_all"]
+    policy: [ "{{ 'next-hop-self-ebgp-routes-only' if 'ibgp' in type and bgp.next_hop_self|default(False) else 'accept_all' }}" ]
 
 {% if bgp.community[ type ]|default([])|length < 2 %}
    send-communities:
@@ -47,14 +47,11 @@
 {%   endif %}
 {%  endfor %}
 {% endif %}
-
 {% if transport_ip %}
    local-address: "{{ transport_ip }}"
 {%  if bgp.rr|default('')|bool %}
    cluster:
     cluster-id: "{{ bgp.rr_cluster_id|default(False) or vrf_bgp.router_id|default(bgp.router_id) }}"
-{%  elif bgp.next_hop_self|default(false) %}
-   next-hop-self: True
 {%  endif %}
 {% endif %}
 {% endmacro %}

--- a/netsim/ansible/templates/bgp/sros.j2
+++ b/netsim/ansible/templates/bgp/sros.j2
@@ -7,4 +7,18 @@ updates:
    default-action:
     action-type: accept
 
+{% if bgp.next_hop_self|default(False) %}
+- path: configure/policy-options/policy-statement[name=next-hop-self-ebgp-routes-only]
+  val:
+   entry:
+   - entry-id: 10
+     from:
+      path-type: ebgp
+     action:
+      action-type: accept
+      next-hop: self
+   default-action:
+    action-type: accept
+{% endif %}
+
 {{ bgp_config(bgp,None) }}

--- a/netsim/ansible/templates/evpn/sros.j2
+++ b/netsim/ansible/templates/evpn/sros.j2
@@ -9,7 +9,8 @@ updates:
       family:
        evpn: True
 {%  if bgp.rr|default(0) %}
-      next-hop-self: False
+      next-hop-unchanged:
+       evpn: True
 {%  endif %}
 
     rapid-withdrawal: True


### PR DESCRIPTION
Similar to EOS https://github.com/ipspace/netlab/issues/491, on SR OS ```next-hop-self``` affects all routes - including reflected ones

This PR adds a policy to enable next-hop-self on export, but only for EBGP routes.

Note: the 'next-hop-unchanged' config for evpn is probably not strictly needed when using the ebgp-only policy, but it shouldn't hurt