### PR TITLE
Add internal loopback interface to associate vlans and create interfaces

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -120,7 +120,7 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
     ifindex_offset = 1
 
   # Allow user to select a specific interface index per link
-  ifindex = ifdata.get('ifindex',None) or (len(node.interfaces) + ifindex_offset)
+  ifindex = ifdata.get('ifindex',None) or (len(node.interfaces)-1 + ifindex_offset)
 
   ifname_format = devices.get_device_attribute(node,'interface_name',defaults)
 
@@ -348,7 +348,7 @@ def augment_lan_link(link: Box, addr_pools: Box, ndict: dict, defaults: Box) -> 
         for af in ('ipv4','ipv6'):
           if af in remote_if['data']:
             ngh_data[af] = remote_if['data'][af]
-        
+
         # List enabled modules that have interface level attributes; copy those attributes too
         mods_with_ifattr = Box({ m : True for m in ndict[remote_if['node']].get('module',[]) if defaults[m].attributes.get('interface',None) })
         ifaddr_add_module(ngh_data,remote_if['data'],mods_with_ifattr)

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -45,7 +45,8 @@ def create_node_dict(nodes: Box) -> Box:
     else:
       ndata['name'] = name
 
-    ndata.interfaces = ndata.interfaces or []   # Make sure node.interfaces is always defined
+    ndata._loopback = ndata._loopback + { 'type': 'loopback', 'ifname': 'loopback', 'ifindex': 0 }  # Make sure each node has a defined loopback interface
+    ndata.interfaces = ndata.interfaces or [ndata._loopback]   # Make sure node.interfaces is always defined
     node_dict[name] = ndata
 
   common.exit_on_error()

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -148,7 +148,7 @@ def lab_commands() -> None:
     except Exception as ex:
       if 'dev' in __version__:
         print( f"Error importing .{cmd},{__name__}: {ex}" )
-  
+
   if mod:
     if hasattr(mod,'run'):
       mod.run(sys.argv[arg_start:])   # type: ignore

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -253,7 +253,7 @@ def adjust_modules(topology: Box) -> None:
   adjust_global_modules(topology)
   if not 'module' in topology:
     return
-    
+
   module_transform("init",topology)
   merge_node_module_params(topology)
   merge_global_module_params(topology)
@@ -477,6 +477,11 @@ Example: copy node-level OSPF area into interfaces that don't have explicit area
 
 def copy_node_data_into_interfaces(topology: Box) -> None:
   for n in topology.nodes.values():
+
+    # Remove internal loopback interface
+    n.interfaces.pop(0)
+    del n._loopback
+
     for m in n.get('module',[]):                                 # Iterate over node modules
       mod_attr = topology.defaults[m].attributes                 # ... get a pointer to module attributes to make code easier to read
       if not mod_attr.node_copy:                                 # Any copyable attributes for this module?

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -566,7 +566,6 @@ def create_node_vlan(node: Box, vlan: str, topology: Box) -> typing.Optional[Box
 """
 create_svi_interfaces: for every physical interface with access VLAN, create an SVI interface
 """
-
 def create_svi_interfaces(node: Box, topology: Box) -> dict:
   global phy_ifattr
   skip_ifattr = list(phy_ifattr)

--- a/tests/integration/evpn/vxlan-asymmetric-irb.yml
+++ b/tests/integration/evpn/vxlan-asymmetric-irb.yml
@@ -26,15 +26,20 @@ nodes:
   h3:
   h4:
   s1:
-    vlans:
-      red:
-      blue:
-      green:
+    # JvB instead of pulling in vlans like this...
+    # vlans:
+    #   red:
+    #   blue:
+    #   green:
+    _loopback:
+      vlan.access: green # Pull in missing vlans + create interface like this
   s2:
-    vlans:
-      red:
-      blue:
-      green:
+    # vlans:
+    #   red:
+    #   blue:
+    #   green:
+    _loopback:
+      vlan.access: blue
 
 links:
 - h1:


### PR DESCRIPTION
Not to be merged as-is, just to illustrate a point about creating vlan interfaces

By defining a virtual 'loopback' interface and associating vlans with that, the existing code that processes physical interfaces will create the associated vlan interfaces, as needed (depending on vlan.mode etc.)