### PR TITLE
srlinux: fix static routes with ipv6 prefixes

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -226,9 +226,11 @@
      generate-icmp: True
 
 {% for pfx in vrf_bgp.originate|default([]) %}
-- path: network-instance[name={{vrf}}]/static-routes/route[prefix={{pfx}}]
+- path: network-instance[name={{vrf}}]/static-routes
   val:
-   next-hop-group: blackhole
+   route:
+   - prefix: "{{ pfx }}"
+     next-hop-group: blackhole
 {% endfor %}
 
 {% if 'sr' in module|default([]) %}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -220,12 +220,13 @@
 {#
   Add extra IPv4 prefixes using static blackhole routes
 #}
+{% for pfx in vrf_bgp.originate|default([]) %}
+{% if loop.first %}
 - path: network-instance[name={{vrf}}]/next-hop-groups/group[name=blackhole]
   val:
    blackhole:
      generate-icmp: True
-
-{% for pfx in vrf_bgp.originate|default([]) %}
+{% endif %}
 - path: network-instance[name={{vrf}}]/static-routes
   val:
    route:


### PR DESCRIPTION
Ansible doesn't like unquoted strings that contain ':' characters...