### PR TITLE
(dev-1.4) Move check for duplicate L2 VNI to register_static_transit_vni

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -177,12 +177,6 @@ def vrf_transit_vni(topology: Box) -> None:
         f'VRF {vrf_name} is using the same EVPN transit VNI as another VRF',
         common.IncorrectValue,
         'evpn')
-      continue
-    elif _dataplane.is_id_used('vni',vni):
-      common.error(
-        f'VRF {vrf_name} is using an EVPN transit VNI that is also used as L2 VNI {vni}',
-        common.IncorrectValue,
-        'evpn')
       continue  
     vni_list.append( vni )                                      # Insert it to detect duplicates elsewhere
 

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -125,6 +125,12 @@ def register_static_transit_vni(topology: Box) -> None:
 
     transit_vni = data.get_from_box(vrf_data,'evpn.transit_vni')
     if data.is_true_int(transit_vni):
+      if transit_vni in vni_set:
+        common.error(
+          f'transit VNI {transit_vni} for VRF {vrf_name} is already used elsewhere',
+          common.IncorrectValue,
+          'evpn')
+        continue
       vni_set.add(transit_vni)
 
   for n in topology.nodes.values():


### PR DESCRIPTION
Due to register_static_transit_vni being called by module_pre_transform, the transit VNIs are already in the vni list. Any duplication should now be detected when the l2 vni is added (with a little help from my second commit)