### PR TITLE
Fix precedence order of vlan.mode to match documentation

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -117,8 +117,8 @@ def interface_vlan_mode(intf: Box, node: Box, topology: Box) -> str:
 
   return get_from_box(intf,'vlan.mode') or \
          get_from_box(node,f'vlans.{vlan}.mode') or \
-         get_from_box(topology,f'vlans.{vlan}.mode') or \
          get_from_box(node,'vlan.mode') or \
+         get_from_box(topology,f'vlans.{vlan}.mode') or \
          get_from_box(topology,'vlan.mode') or 'irb'
 
 #


### PR DESCRIPTION
https://github.com/ipspace/netlab/blob/e3ce92d62e1462b976928ff10e51b60c8edbe8d4/netsim/modules/vlan.py#L118
```
return get_from_box(intf,'vlan.mode') or \                           # 1 + 2
         get_from_box(node,f'vlans.{vlan}.mode') or \                # 3
         get_from_box(topology,f'vlans.{vlan}.mode') or \            # 5
         get_from_box(node,'vlan.mode') or \                         # 4   <-- too late
         get_from_box(topology,'vlan.mode') or 'irb'                 # 6
```

According to the documentation:
https://github.com/ipspace/netlab/blob/dev/docs/module/vlan.md#vlan-forwarding-modes
```
The precedence of various vlan.mode parameters (from highest to lowest) is as follows:

1. Interface vlan.mode, potentially inherited from parent interface vlan.mode or from parent interface vlan.trunk dictionary.
2. Link vlan.mode, potentially inherited from parent link vlan.trunk dictionary
3. mode set in node vlans definition
4. Node vlan.mode setting
5. mode set in global vlans definition
6. Global vlan.mode setting
```