### PR TITLE
Fix vlan mode precedence to match documentation

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -114,7 +114,6 @@ def interface_vlan_mode(intf: Box, node: Box, topology: Box) -> str:
   vlan = get_from_box(intf,'vlan.access') or get_from_box(intf,'vlan.native')
   if not vlan:
     return 'irb'
-
   return get_from_box(intf,'vlan.mode') or \
          get_from_box(node,f'vlans.{vlan}.mode') or \
          get_from_box(node,'vlan.mode') or \

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -117,8 +117,8 @@ def interface_vlan_mode(intf: Box, node: Box, topology: Box) -> str:
 
   return get_from_box(intf,'vlan.mode') or \
          get_from_box(node,f'vlans.{vlan}.mode') or \
-         get_from_box(topology,f'vlans.{vlan}.mode') or \
          get_from_box(node,'vlan.mode') or \
+         get_from_box(topology,f'vlans.{vlan}.mode') or \
          get_from_box(topology,'vlan.mode') or 'irb'
 
 #

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -47,7 +47,7 @@ bgp:
   transform_after: [ vlan ]
   next_hop_self: true
   attributes:
-    global: [ 
+    global: [
       af, as, next_hop_self, rr_cluster_id, rr_list, ebgp_role, as_list, sessions, activate,
       advertise_loopback, advertise_roles, community, replace_global_as ]
     node: [
@@ -149,7 +149,7 @@ vrf: # Basic VRF support
 
 vlan: # VLAN support
   supported_on: [ eos, iosv, vyos, dellos10, srlinux, none, routeros, nxos, frr, cumulus, sros, routeros7 ]
-  no_propagate: [ start_vlan_id, start_vni, auto_vni ]
+  no_propagate: [ start_vlan_id, start_vni, auto_vni, mode ]
   vlan_no_propagate: [ id, vni, mode, pool, prefix, evpn ]
   start_vlan_id: 1000
   start_vni: 100000
@@ -948,7 +948,7 @@ devices:
     external:
       image: none
     graphite.icon: router
-  
+
   routeros7:
     interface_name: ether%d
     mgmt_if: ether1

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -201,7 +201,6 @@ nodes:
     name: r1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -425,7 +424,6 @@ nodes:
     name: r2
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -592,7 +590,6 @@ nodes:
     name: r3
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -648,8 +645,6 @@ nodes:
         rd: '65000:1'
         vrfidx: 100
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     id: 1001

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -175,7 +175,6 @@ nodes:
       router_id: 10.0.0.1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -281,7 +280,6 @@ nodes:
       router_id: 10.0.0.2
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -385,7 +383,6 @@ nodes:
       router_id: 10.0.0.3
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -424,8 +421,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 0

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -186,7 +186,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -205,8 +204,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 0

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -15,13 +15,14 @@ input:
 - package:topology-defaults.yml
 links:
 - bridge: input_1
+  gateway:
+    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.3/24
     node: s1
     vlan:
       access: red
@@ -31,13 +32,14 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 - bridge: input_2
+  gateway:
+    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.2/24
     node: h2
   - ifindex: 2
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.3/24
     node: s1
     vlan:
       access: red
@@ -58,6 +60,8 @@ nodes:
     id: 1
     interfaces:
     - bridge: input_1
+      gateway:
+        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.1/24
@@ -85,6 +89,8 @@ nodes:
     id: 2
     interfaces:
     - bridge: input_2
+      gateway:
+        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -15,14 +15,13 @@ input:
 - package:topology-defaults.yml
 links:
 - bridge: input_1
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
-    ipv4: 172.16.0.3/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: red
@@ -32,14 +31,13 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 - bridge: input_2
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.2/24
     node: h2
   - ifindex: 2
-    ipv4: 172.16.0.3/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: red
@@ -60,8 +58,6 @@ nodes:
     id: 1
     interfaces:
     - bridge: input_1
-      gateway:
-        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.1/24
@@ -89,8 +85,6 @@ nodes:
     id: 2
     interfaces:
     - bridge: input_2
-      gateway:
-        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24
@@ -160,7 +154,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -170,8 +163,6 @@ nodes:
           ipv4: 172.16.0.0/24
         vni: 101000
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     id: 1001

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -119,7 +119,6 @@ nodes:
     name: leaf
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       vxlan:
         bridge_group: 1
@@ -131,8 +130,6 @@ nodes:
           ipv6: true
         vni: 101000
 provider: clab
-vlan:
-  mode: irb
 vlans:
   vxlan:
     host_count: 0

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -204,7 +204,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -225,5 +224,3 @@ nodes:
           ipv4: 172.16.0.0/24
         vni: 101000
 provider: clab
-vlan:
-  mode: irb

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -158,7 +158,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -225,7 +224,6 @@ nodes:
     name: s2
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       blue:
         bridge_group: 1

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -208,7 +208,6 @@ nodes:
       router_id: 10.0.0.2
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -290,7 +289,6 @@ nodes:
       router_id: 10.0.0.3
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -303,8 +301,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: clab
-vlan:
-  mode: irb
 vlans:
   red:
     host_count: 2

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -48,13 +48,14 @@ links:
       blue: {}
       red: {}
 - bridge: input_2
+  gateway:
+    ipv4: 172.16.0.4/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.2/24
     node: h1
   - ifindex: 2
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.4/24
     node: s1
     vlan:
       access: red
@@ -64,13 +65,14 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 - bridge: input_3
+  gateway:
+    ipv4: 172.16.1.4/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.1.3/24
     node: h2
   - ifindex: 3
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.1.4/24
     node: s1
     vlan:
       access: blue
@@ -85,8 +87,7 @@ links:
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.5/24
     node: s2
     vlan:
       access: red
@@ -101,8 +102,7 @@ links:
     ipv4: 172.16.1.1/24
     node: r1
   - ifindex: 3
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.1.5/24
     node: s2
     vlan:
       access: blue
@@ -124,7 +124,7 @@ nodes:
     interfaces:
     - bridge: input_2
       gateway:
-        ipv4: 172.16.0.1/24
+        ipv4: 172.16.0.4/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24
@@ -154,7 +154,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.1.1/24
+        ipv4: 172.16.1.4/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.3/24

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -48,14 +48,13 @@ links:
       blue: {}
       red: {}
 - bridge: input_2
-  gateway:
-    ipv4: 172.16.0.4/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.2/24
     node: h1
   - ifindex: 2
-    ipv4: 172.16.0.4/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: red
@@ -65,14 +64,13 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 - bridge: input_3
-  gateway:
-    ipv4: 172.16.1.4/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.1.3/24
     node: h2
   - ifindex: 3
-    ipv4: 172.16.1.4/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: blue
@@ -87,7 +85,8 @@ links:
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 2
-    ipv4: 172.16.0.5/24
+    ipv4: false
+    ipv6: false
     node: s2
     vlan:
       access: red
@@ -102,7 +101,8 @@ links:
     ipv4: 172.16.1.1/24
     node: r1
   - ifindex: 3
-    ipv4: 172.16.1.5/24
+    ipv4: false
+    ipv6: false
     node: s2
     vlan:
       access: blue
@@ -124,7 +124,7 @@ nodes:
     interfaces:
     - bridge: input_2
       gateway:
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24
@@ -154,7 +154,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.1.4/24
+        ipv4: 172.16.1.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.3/24
@@ -302,7 +302,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -401,7 +400,6 @@ nodes:
     name: s2
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -440,8 +438,6 @@ nodes:
           ipv4: 172.16.0.0/24
         vni: 101000
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 1

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -3,14 +3,13 @@ input:
 - package:topology-defaults.yml
 links:
 - bridge: input_1
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
-    ipv4: 172.16.0.2/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: red
@@ -22,12 +21,14 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
-    ipv4: 172.16.0.2/24
+    ipv4: false
+    ipv6: false
     node: s1
     vlan:
       access: red
   - ifindex: 1
-    ipv4: 172.16.0.3/24
+    ipv4: false
+    ipv6: false
     node: s2
     vlan:
       access: red
@@ -39,11 +40,10 @@ links:
   vlan:
     access: red
 - bridge: input_3
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 2
-    ipv4: 172.16.0.3/24
+    ipv4: false
+    ipv6: false
     node: s2
     vlan:
       access: red
@@ -104,8 +104,6 @@ nodes:
     id: 1
     interfaces:
     - bridge: input_1
-      gateway:
-        ipv4: 172.16.0.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.1/24
@@ -113,10 +111,8 @@ nodes:
       name: h1 -> [s1,s2,h2]
       neighbors:
       - ifname: BVI1
-        ipv4: 172.16.0.2/24
         node: s1
       - ifname: BVI1
-        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -136,8 +132,6 @@ nodes:
     id: 4
     interfaces:
     - bridge: input_3
-      gateway:
-        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
@@ -148,10 +142,8 @@ nodes:
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
-        ipv4: 172.16.0.2/24
         node: s1
       - ifname: BVI1
-        ipv4: 172.16.0.3/24
         node: s2
       type: lan
     - bridge: input_4
@@ -206,14 +198,12 @@ nodes:
     - bridge_group: 1
       ifindex: 4
       ifname: BVI1
-      ipv4: 172.16.0.2/24
       name: VLAN red (1001) -> [h1,s2,h2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
-        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -286,14 +276,12 @@ nodes:
     - bridge_group: 1
       ifindex: 5
       ifname: BVI1
-      ipv4: 172.16.0.3/24
       name: VLAN red (1001) -> [h1,s1,h2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
-        ipv4: 172.16.0.2/24
         node: s1
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -351,10 +339,8 @@ nodes:
           ipv4: 172.16.0.1/24
           node: h1
         - ifname: BVI1
-          ipv4: 172.16.0.2/24
           node: s1
         - ifname: BVI1
-          ipv4: 172.16.0.3/24
           node: s2
         - ifname: eth1
           ipv4: 172.16.0.4/24
@@ -375,10 +361,8 @@ vlans:
       ipv4: 172.16.0.1/24
       node: h1
     - ifname: BVI1
-      ipv4: 172.16.0.2/24
       node: s1
     - ifname: BVI1
-      ipv4: 172.16.0.3/24
       node: s2
     - ifname: eth1
       ipv4: 172.16.0.4/24

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -3,13 +3,14 @@ input:
 - package:topology-defaults.yml
 links:
 - bridge: input_1
+  gateway:
+    ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
     ipv4: 172.16.0.1/24
     node: h1
   - ifindex: 1
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
@@ -21,14 +22,12 @@ links:
 - bridge: input_2
   interfaces:
   - ifindex: 2
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.3/24
     node: s2
     vlan:
       access: red
@@ -40,10 +39,11 @@ links:
   vlan:
     access: red
 - bridge: input_3
+  gateway:
+    ipv4: 172.16.0.3/24
   interfaces:
   - ifindex: 2
-    ipv4: false
-    ipv6: false
+    ipv4: 172.16.0.3/24
     node: s2
     vlan:
       access: red
@@ -104,6 +104,8 @@ nodes:
     id: 1
     interfaces:
     - bridge: input_1
+      gateway:
+        ipv4: 172.16.0.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.1/24
@@ -111,8 +113,10 @@ nodes:
       name: h1 -> [s1,s2,h2]
       neighbors:
       - ifname: BVI1
+        ipv4: 172.16.0.2/24
         node: s1
       - ifname: BVI1
+        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -132,6 +136,8 @@ nodes:
     id: 4
     interfaces:
     - bridge: input_3
+      gateway:
+        ipv4: 172.16.0.3/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
@@ -142,8 +148,10 @@ nodes:
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
+        ipv4: 172.16.0.2/24
         node: s1
       - ifname: BVI1
+        ipv4: 172.16.0.3/24
         node: s2
       type: lan
     - bridge: input_4
@@ -198,12 +206,14 @@ nodes:
     - bridge_group: 1
       ifindex: 4
       ifname: BVI1
+      ipv4: 172.16.0.2/24
       name: VLAN red (1001) -> [h1,s2,h2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
+        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -223,7 +233,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 1
-      mode: bridge
     vlans:
       red:
         bridge_group: 1
@@ -276,12 +285,14 @@ nodes:
     - bridge_group: 1
       ifindex: 5
       ifname: BVI1
+      ipv4: 172.16.0.3/24
       name: VLAN red (1001) -> [h1,s1,h2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
         node: h1
       - ifname: BVI1
+        ipv4: 172.16.0.2/24
         node: s1
       - ifname: eth1
         ipv4: 172.16.0.4/24
@@ -314,7 +325,6 @@ nodes:
     name: s2
     vlan:
       max_bridge_group: 2
-      mode: bridge
     vlans:
       blue:
         bridge_group: 2
@@ -339,8 +349,10 @@ nodes:
           ipv4: 172.16.0.1/24
           node: h1
         - ifname: BVI1
+          ipv4: 172.16.0.2/24
           node: s1
         - ifname: BVI1
+          ipv4: 172.16.0.3/24
           node: s2
         - ifname: eth1
           ipv4: 172.16.0.4/24
@@ -361,8 +373,10 @@ vlans:
       ipv4: 172.16.0.1/24
       node: h1
     - ifname: BVI1
+      ipv4: 172.16.0.2/24
       node: s1
     - ifname: BVI1
+      ipv4: 172.16.0.3/24
       node: s2
     - ifname: eth1
       ipv4: 172.16.0.4/24

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -157,7 +157,6 @@ nodes:
     name: r1
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -261,7 +260,6 @@ nodes:
     name: r2
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -298,8 +296,6 @@ nodes:
           ipv4: 172.16.0.0/24
         vni: 101000
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 0

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -96,7 +96,6 @@ nodes:
       router_id: 10.0.0.1
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -151,7 +150,6 @@ nodes:
       router_id: 10.0.0.3
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -222,7 +220,6 @@ nodes:
       router_id: 10.0.0.2
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -236,8 +233,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   red:
     host_count: 0

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -417,7 +417,6 @@ nodes:
     name: r1
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -598,7 +597,6 @@ nodes:
     name: r2
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -803,7 +801,6 @@ nodes:
     name: s1
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -1048,7 +1045,6 @@ nodes:
     name: s2
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -1154,8 +1150,6 @@ nodes:
         rd: '65000:1'
         vrfidx: 100
 provider: clab
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 0

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -152,7 +152,6 @@ nodes:
     name: r1
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -162,8 +161,6 @@ nodes:
           ipv4: 172.16.0.0/24
         vni: 101000
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   red:
     id: 1000

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -495,7 +495,6 @@ nodes:
     name: s2
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -538,8 +537,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 0

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -481,7 +481,6 @@ nodes:
       router_id: 10.0.0.1
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -648,7 +647,6 @@ nodes:
       router_id: 10.0.0.2
     vlan:
       max_bridge_group: 3
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -710,8 +708,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 2

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -448,7 +448,6 @@ nodes:
     name: r1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -749,7 +748,6 @@ nodes:
     name: r2
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -996,7 +994,6 @@ nodes:
     name: r3
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -1094,8 +1091,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     id: 1001

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -163,7 +163,6 @@ nodes:
     name: leaf1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       route-leak-to-global-customer1:
         bridge_group: 1
@@ -213,8 +212,6 @@ nodes:
         rd: '65000:1'
         vrfidx: 100
 provider: clab
-vlan:
-  mode: irb
 vlans:
   route-leak-to-global-customer1:
     id: 1000

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -300,7 +300,6 @@ nodes:
       router_id: 10.0.0.1
     vlan:
       max_bridge_group: 2
-      mode: irb
     vlans:
       blue:
         bridge_group: 2
@@ -385,7 +384,6 @@ nodes:
       router_id: 10.0.0.2
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       red:
         bridge_group: 1
@@ -472,7 +470,6 @@ nodes:
       router_id: 10.0.0.3
     vlan:
       max_bridge_group: 1
-      mode: irb
     vlans:
       blue:
         bridge_group: 1
@@ -507,8 +504,6 @@ nodes:
 ospf:
   area: 0.0.0.0
 provider: libvirt
-vlan:
-  mode: irb
 vlans:
   blue:
     host_count: 2


### PR DESCRIPTION
Fix requires adding 'mode' to no_propagate list, else the global vlan.mode default 'irb' gets copied into every node.

None of the templates reference vlan.mode in the output data, so this should not affect generated device configurations