### PR TITLE
Change node.runtime to node.clab.runtime, add documentation

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -28,7 +28,7 @@ You can also use [vrnetlab](https://github.com/vrnetlab/vrnetlab) to build VM-in
 
 ## LAN bridges
 
-For multi-access network topologies, **[netlab up](../netlab/up.md)** command automatically creates additional standard Linux bridges. 
+For multi-access network topologies, **[netlab up](../netlab/up.md)** command automatically creates additional standard Linux bridges.
 
 You might want to use Open vSwitch bridges instead of standard Linux bridges (OVS interferes less with layer-2 protocols). After installing OVS, set **defaults.providers.clab.bridge_type** to **ovs-bridge**, for example:
 
@@ -51,4 +51,16 @@ links: [ s1-s2, s2-s3 ]
 
    ceos.md
 ..
+```
+
+## Container runtime support
+Containerlab supports [multiple container runtimes](https://containerlab.dev/cmd/deploy/#runtime) besides the default **docker**.
+The runtime to use can be configured globally or per node, for example:
+
+```
+provider: clab
+defaults.providers.clab.runtime: podman
+nodes:
+ s1:
+  clab.runtime: ignite
 ```

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -24,6 +24,7 @@ topology:
       type: {{ clab.type }}
 {%    endif %}
       image: {{ clab.image|default(n.box) }}
+      runtime: {{ clab.runtime|default(defaults.providers.clab.runtime) }}
 {%    if groups is defined %}
       group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor %}
 
@@ -40,9 +41,6 @@ topology:
 {% for f,m in clab.binds.items() %}
       - {{ f }}:{{ m }}
 {% endfor %}
-{% endif %}
-{% if 'runtime' in n %}
-      runtime: {{ n.runtime }}
 {% endif %}
 {% if 'startup-config' in clab %}
       startup-config: {{ clab['startup-config'] }}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -31,7 +31,7 @@ attributes:
   link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
   link_internal: [ linkindex,parentindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
-  node: [ role,mtu,runtime,provider,id,loopback,cpu,memory ]  # not enforced yet
+  node: [ role,mtu,clab.runtime,provider,id,loopback,cpu,memory ]  # not enforced yet
 
 # Built-in module defaults
 #
@@ -227,6 +227,7 @@ providers:
     probe: [ "containerlab version" ]
     cleanup: [ clab.yml,clab_files ]
     bridge_type: bridge # Use 'ovs-bridge' to create Openvswitch bridges
+    runtime: docker     # Default runtime, see Containerlab documentation
 
   external:
     config: external.txt

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -161,7 +161,6 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
-    runtime: docker
 ospf:
   area: 0.0.0.0
 provider: clab


### PR DESCRIPTION
Context: https://github.com/ipspace/netlab/issues/586

Configuration did support multiple runtimes, but feature was undocumented and directly under the node while being a Containerlab specific setting

* Move node.runtime -> node.clab.runtime
* Add defaults.providers.clab.runtime = docker, always set 'runtime' config in clab.yml
* Add documentation