### PR TITLE
Initial anycast gateway implementation

### DIFF
--- a/docs/dev/config/gateway.md
+++ b/docs/dev/config/gateway.md
@@ -1,0 +1,49 @@
+# First-Hop Gateway Configuration Templates
+
+This document describes First-Hop Gateway configuration module implementation details.
+
+## Theory of Operation
+
+The configuration module:
+
+* Combines global parameters with link-level parameters
+* Sets up `_reserved` list of reserved node IDs for every link
+* Sets a `_stub` flag for routing modules to ignore this link
+* Removes IP addresses from node interfaces if the nodes use **gateway** module, if the **gateway.protocol** is set to *anycast* and if the **gateway.anycast.unicast** is set to *False.*
+
+Interactions with other modules:
+
+* The interface address allocation routines avoid the reserved IDs when assigning IP addresses to individual nodes.
+* Link processing code will set **gateway.ipv4** to the IP address corresponding to **gateway.id** on links with **gateway** dictionary. The **gateway** dictionary is then copied to interfaces of attached hosts to serve as the target for static routes configured on the hosts.
+* Common routing protocol code removes routing protocols from links with "ignore this link" flag.
+
+## Anycast Configuration Template Boilerplate
+
+Use node **gateway.anycast.mac** parameter to set the shared virtual router MAC address.
+
+When configuring anycast gateway on an interface, use the following interface parameters:
+
+* **gateway.protocol** must be set to **anycast**.
+* **gateway.ipv4** must be set to a valid IPv4 address (string)
+* **gateway.anycast.mac** could be set to a link-specific shared MAC address. Ignore this parameter if your platform cannot support link-specific virtual router MAC addresses.
+
+```
+{% for l in interfaces if bfd|default(False) or l.bfd|default(False) %}
+interface {{ l.ifname }}
+{%   set disable_bfd = l.bfd is defined and not l.bfd %}
+{%   if not disable_bfd %}
+{%     set link_bfd = l.bfd|default({}) %}
+ bfd interval {{ 
+   link_bfd.min_tx|default(bfd.min_tx)|default(500) }} min_rx {{ 
+   link_bfd.min_rx|default(bfd.min_rx)|default(500) }} multiplier {{
+   link_bfd.multiplier|default(bfd.multiplier)|default(3)
+   }}
+!
+{%   else %}
+ no bfd interval
+{%   endif %}
+{% endfor %}
+{% if bfd.min_echo_rx|default(0) %}
+bfd slow-timers {{ bfd.min_echo_rx }} 
+{% endif %}
+```

--- a/docs/dev/guidelines.md
+++ b/docs/dev/guidelines.md
@@ -34,6 +34,7 @@ The easiest way to get started is to [add support for a new platform for an exis
    config/bfd.md
    config/vlan.md
    config/vrf.md
+   config/gateway.md
 ```
 
 ```eval_rst

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -10,6 +10,7 @@ The following configuration modules are included in **netlab** distribution:
    module/bgp.md
    module/eigrp.md
    module/evpn.md
+   module/gateway.md
    module/isis.md
    MPLS Configuration Module (LDP, BGP-LU, MPLS/VPN) <module/mpls.md>
    module/ospf.md

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -1,0 +1,30 @@
+# First-Hop Gateway Configuration Module
+
+First-hop Gateway configuration module implements mechanisms used to implement a shared router IPv4 address on a stub access network.
+
+The current implementation of the module supports statically configured anycast gateway IPv4 address.
+
+The module is supported on these platforms:
+
+| Operating system      | Anycast |
+| --------------------- | :-: |
+| Arista EOS            | ✅  |
+
+## Global Parameters
+
+The module supports the following global parameters: 
+
+* **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The only supported value is currently *anycast*
+* **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
+* **gateway.stub** (default: True) -- do not run routing protocols on links having shared first-hop addresses.
+
+Anycast implementation of shared first-hop IP address supports these parameters:
+
+* **gateway.anycast.unicast** (default: False) -- configure node-specific unicast IP addresses together with anycast IP address.
+* **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
+
+## Link Parameters
+
+Gateway configuration module is enabled on all links that have **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on per-link basis[^MAC].
+
+[^MAC]: Some platforms don't support per-link *virtual router MAC address*, so it might not be a good idea to set **gateway.anycast.mac** parameter on individual links.

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -10,18 +10,25 @@ The module is supported on these platforms:
 | --------------------- | :-: |
 | Arista EOS            | ✅  |
 
+```{note}
+* Arista's implementation of anycast gateway is called Virtual ARP
+```
+
 ## Global Parameters
 
 The module supports the following global parameters: 
 
 * **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The only supported value is currently *anycast*
 * **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
-* **gateway.stub** (default: True) -- do not run routing protocols on links having shared first-hop addresses.
 
 Anycast implementation of shared first-hop IP address supports these parameters:
 
-* **gateway.anycast.unicast** (default: False) -- configure node-specific unicast IP addresses together with anycast IP address.
+* **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses together with anycast IP address.
 * **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
+
+```{tip}
+Many implementations require unique unicast IP addresses configured on the interfaces that have anycast IP address. Set **‌gateway.anycast.unicast** to *‌False* only when absolutely necessary.
+```
 
 ## Link Parameters
 

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -1,0 +1,9 @@
+{% if gateway.anycast.mac is defined %}
+ip virtual-router mac-address {{ gateway.anycast.mac }}
+{% endif %}
+{% for intf in interfaces if intf.gateway.protocol is defined %}
+interface {{ intf.ifname }}
+{%   if intf.gateway.protocol == 'anycast' %}
+  ip virtual-router address {{ intf.gateway.ipv4 }}
+{%   endif %}
+{% endfor %}

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -12,7 +12,18 @@ from box import Box
 from .. import common
 from .. import addressing
 from . import devices
-from ..data.validate import validate_attributes
+from ..data.validate import validate_attributes,must_be_int
+from ..modules._dataplane import extend_id_set,is_id_used,set_id_counter,get_next_id
+
+"""
+Reserve a node ID, for example for gateway ID, return True if successful, False if duplicate
+"""
+def reserve_id(n_id: int) -> bool:
+  if is_id_used('node_id',n_id):
+    return False
+
+  extend_id_set('node_id',set([n_id]))
+  return True
 
 """
 Node data structure is a dictionary. Convert lists of dictionaries (now obsolete)
@@ -203,19 +214,6 @@ def augment_node_system_data(topology: Box) -> None:
               common.IncorrectValue,
               'nodes')
 
-'''
-get_next_id: given a list of static IDs and the last ID, get the next device ID
-'''
-def get_next_id(id_list: list, id: int) -> int:
-  while id < 254:
-    id = id + 1
-    if not id in id_list:
-      return id
-
-  common.fatal(
-    'Cannot get the next device ID. The lab topology is probably too big')  # pragma: no cover (I'm not going to write a test case for this one)
-  return -1                                                                 # pragma: no cover (making mypy happy)
-
 """
 augment_node_device_data: copy attributes that happen to be node attributes from device defaults into node data
 """
@@ -242,23 +240,20 @@ Main node transformation code
 * set management IP and MAC addresses
 '''
 def transform(topology: Box, defaults: Box, pools: Box) -> None:
-  id = 0
-  id_list = []
-
   for name,n in topology.nodes.items():
-    if 'id' in n:
-      if isinstance(n.id,int) and n.id > 0 and n.id <= 250:
-        id_list.append(n.id)
-      else:
-        common.error('Device ID must be an integer between 1 and 250')
+    if not must_be_int(n,'id',f'nodes.{name}',module='nodes',min_value=1,max_value=250):
+      continue
+    if not reserve_id(n.id):
+      common.error(
+        f'Duplicate static node ID {n.id} on node {n.name}',
+        common.IncorrectValue,
+        'nodes')
 
   common.exit_on_error()
-
-
+  set_id_counter('node_id',1,250)
   for name,n in topology.nodes.items():
     if not 'id' in n:
-      id = get_next_id(id_list,id)
-      n.id = id
+      n.id = get_next_id('node_id')
 
     if not n.name: # pragma: no cover (name should have been checked way before)
       common.fatal(f"Internal error: node does not have a name {n}",'nodes')

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -35,7 +35,6 @@ def create_node_dict(nodes: Box) -> Box:
     node_dict = nodes
   else:
     node_dict = Box({},default_box=True,box_dots=True)
-    node_id = 0
     for n in nodes or []:
       if isinstance(n,dict):
         if not 'name' in n:
@@ -43,8 +42,6 @@ def create_node_dict(nodes: Box) -> Box:
           continue
       elif isinstance(n,str):
         n = Box({ 'name': n },default_box=True,box_dots=True)
-      node_id = node_id + 1
-      n.id = node_id
       node_dict[n.name] = n
 
   for name in list(node_dict.keys()):

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -455,6 +455,9 @@ def validate_attributes(
     if not modules is None and k in modules:            # For module attributes, perform recursive check
       if data[k] is False and validate_module_can_be_false(attributes,attr_list):
         continue                                        # Some objects accept 'attribute: false' syntax (example: links)
+      if data[k] is True:
+        if set(attr_list) & set(topology.defaults[k].attributes.can_be_true):
+          continue
       fixed_data = validate_attributes(
         data=data[k],
         topology=topology,

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -362,11 +362,8 @@ def validate_module_can_be_false(
   if not 'can_be_false' in attributes:
     return False
 
-  for a in attr_list:                                   # Can at least one attribute category be false?
-    if a in attributes.can_be_false:
-      return True                                       # OK, we can accept False value
-
-  return False                                          # No such category found, reject the idea of accepting False values
+  intersect = set(attr_list) & set(attributes.can_be_false)
+  return bool(intersect)
 
 """
 validate_attributes -- validate object attributes

--- a/netsim/modules/_dataplane.py
+++ b/netsim/modules/_dataplane.py
@@ -74,6 +74,9 @@ def set_id_counter(name: str, start: int, max_value: int = 4096) -> int:
 	idvar = global_vars.get(f'{name}_id')
 	idvar.next = start
 	idvar.max = max_value
+	if not idvar.value:
+		idvar.value = set()
+
 	return start
 
 def get_next_id(name: str) -> int:

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -1,0 +1,59 @@
+#
+# First-hop gateway transformation module
+#
+from box import Box
+
+from . import _Module,get_effective_module_attribute
+from .. import common
+from .. import data
+from ..augment.nodes import reserve_id
+from ..data.validate import validate_attributes
+
+class FHRP(_Module):
+
+  def module_init(self, topology: Box) -> None:
+    gw = data.get_global_parameter(topology,'gateway')
+    if not gw or gw is None:
+      common.error(
+        f'Global/default gateway parameters are missing. We need at least a gateway ID',
+        common.IncorrectType,
+        'gateway')
+      return
+
+    if not data.is_true_int(gw.id):
+      common.error(
+        f'Global/default gateway.id parameter is missing or not integer',
+        common.IncorrectType,
+        'gateway')
+      return
+
+    if gw.id > 0:
+      reserve_id(gw.id)
+
+  def link_pre_link_transform(self, link: Box, topology: Box) -> None:
+    if not 'gateway' in link:
+      return
+
+    global_gateway = data.get_global_parameter(topology,'gateway')
+    if not global_gateway:                      # pragma: no cover
+      return                                    # We know (from init) that we have global parameters. This is just to keep mypy happy
+
+    if link.gateway is True:                    # We just want to do FHRP on the link ==> take global parameters
+      link.gateway = global_gateway
+    elif link.gateway is False:                 # We DEFINITELY don't want FHRP on this link ==> remove it and move on
+      link.pop('gateway',None)
+    else:                                       # Otherwise merge global defaults with links settings (because we usually don't do that)
+      link.gateway = global_gateway + link.gateway
+
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+    for intf in node.interfaces:                                      # Time to clean up interface addresses
+      if not intf.get('gateway',False):                               # This interface not using FHRP or FHRP is disabled
+        continue
+
+      if intf.gateway.protocol != 'anycast':                          # Leave non-anycast FHRP implementations alone, they need node IP addresses
+        continue
+
+      if data.get_from_box(intf,'gateway.anycast.unicast'):           # Do we use unicast IP addresses together with anycast ones?
+        continue
+
+      intf.pop('ipv4',None)                                           # No unicast with anycast ==> pop the address

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -645,7 +645,8 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
   # VLAN attributes not copied into VLAN interface: we take the global defaults and remove
   # mode attribute from that list as it's needed to set interface VLAN mode
   #
-  svi_skipattr = [ k for k in list(topology.defaults.vlan.attributes.vlan_no_propagate or []) if k != "mode" ]
+  svi_skipattr = [ k for k in list(topology.defaults.vlan.attributes.vlan_no_propagate or []) if k != "mode" ] + \
+                  list(topology.defaults.vlan.attributes.vlan_svi_no_propagate)
 
   iflist_len = len(node.interfaces)
   for ifidx in range(0,iflist_len):

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -210,6 +210,18 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
     node: [ ldp, bgp, vpn, 6pe ]
     link: [ ldp ]
 
+gateway:
+  supported_on: [ eos ]
+  transform_after: [ vlan,vrf ]
+  config_after: [ vlan,vrf ]
+  id: -1
+  no_propagate: [ id, stub ]
+  attributes:
+    global: [ id, protocol, stub, anycast ]
+    node: [ protocol, anycast ]
+    anycast: [ unicast, mac ]
+    link: [ id, ipv4, protocol, stub, anycast ]
+
 #
 # Network automation defaults
 #

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -29,7 +29,7 @@ attributes:
   global: [ addressing,defaults,groups,links,module,name,nodes,plugin,provider ]
   internal: [ input,includes,pools,Provider,Plugin,message ]
   can_be_false: [ link,interface ]
-  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
+  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,vlan_name ]
   link_internal: [ linkindex,parentindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
   link_module_no_propagate: [ vlan ]                  # Do not propagate VLAN attributes to node interfaces -- see #575
@@ -177,6 +177,9 @@ vlan: # VLAN support
     # Do not propagate these attributes into links or SVI interfaces
     vlan_no_propagate: [ id, vni, mode, prefix, evpn ]
     #
+    # Do not copy these VLAN attributes into SVI interfaces
+    vlan_svi_no_propagate: [ gateway ]
+    #
     # Do not copy these attributes into SVI interfaces
     phy_ifattr: [ bridge, ifindex, parentindex, ifname, linkindex, type, vlan, mtu, _selfloop_ifindex ]
     #
@@ -212,13 +215,18 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
 
 gateway:
   supported_on: [ eos ]
-  transform_after: [ vlan,vrf ]
+  transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
   id: -1
+  protocol: anycast
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: True
   no_propagate: [ id, stub ]
   attributes:
     global: [ id, protocol, stub, anycast ]
     node: [ protocol, anycast ]
+    can_be_true: [ link ]
     anycast: [ unicast, mac ]
     link: [ id, ipv4, protocol, stub, anycast ]
 

--- a/tests/integration/gateway/anycast/lan-subnet.yml
+++ b/tests/integration/gateway/anycast/lan-subnet.yml
@@ -1,0 +1,34 @@
+#
+# Anycast gateway on a physical interface
+#
+
+message: |
+  This is the simplest anycast gateway test case. The switches have only anycast
+  IP address configured on the shared LAN. Static routes on hosts point to the
+  shared anycast IP address.
+
+  The switches are running OSPF over another interface to allow pings from hosts
+  to loopback switch addresses.
+
+  All four nodes should be able to ping each other.
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,ospf ]
+    members: [ s1,s2 ]
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+
+nodes: [ s1,s2,h1,h2 ]
+
+links:
+- s1:
+  s2:
+  h1:
+  h2:
+  gateway: True
+- s1:
+  s2:

--- a/tests/integration/gateway/anycast/vlan.yml
+++ b/tests/integration/gateway/anycast/vlan.yml
@@ -1,0 +1,33 @@
+#
+# Anycast gateway test case
+#
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,vlan ]
+    members: [ r1, r2, r3 ]
+    device: eos
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+nodes: [ r1,r2,r3,h1,h2,h3,h4 ]
+
+vlans:
+  red:
+    gateway.anycast.unicast: True
+
+links:
+- r1:
+  r2:
+  h1:
+  h2:
+  gateway: True
+- r1:
+  h3:
+  vlan.access: red
+- r2:
+  h4:
+  vlan.access: red

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -1,0 +1,506 @@
+gateway:
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: true
+  id: 1
+  protocol: anycast
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+  switches:
+    device: eos
+    members:
+    - r1
+    - r2
+    module:
+    - gateway
+    - vlan
+    - ospf
+input:
+- topology/input/anycast-gateway.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: false
+    id: 1
+    ipv4: 172.16.1.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.2/24
+    node: r1
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.3/24
+    node: r2
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.4/24
+    node: h1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.5/24
+    node: h2
+  linkindex: 1
+  node_count: 4
+  prefix:
+    ipv4: 172.16.1.0/24
+  type: lan
+- bridge: input_2
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 172.16.0.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.2/24
+    node: r1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.6/24
+    node: h3
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_3
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 172.16.0.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.3/24
+    node: r2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.7/24
+    node: h4
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+module:
+- vlan
+- ospf
+- gateway
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 4
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.4/24
+      linkindex: 1
+      name: h1 -> [r1,r2,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08-4F-A9-00-00-04
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 5
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.5/24
+      linkindex: 1
+      name: h2 -> [r1,r2,h1]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08-4F-A9-00-00-05
+    name: h2
+    role: host
+  h3:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 6
+    interfaces:
+    - bridge: input_2
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.6/24
+      linkindex: 2
+      name: h3 -> [r1,h4,r2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.106
+      mac: 08-4F-A9-00-00-06
+    name: h3
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 7
+    interfaces:
+    - bridge: input_3
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.7/24
+      linkindex: 3
+      name: h4 -> [h3,r1,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.107
+      mac: 08-4F-A9-00-00-07
+    name: h4
+    role: host
+  r1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      protocol: anycast
+    id: 2
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: r1 -> [r2,h1,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: lan
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h3,h4,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - vlan
+    - ospf
+    - gateway
+    name: r1
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.2
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway: true
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  r2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      protocol: anycast
+    id: 3
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: r2 -> [r1,h1,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: lan
+    - bridge: input_3
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 3
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      name: VLAN red (1000) -> [h3,r1,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - vlan
+    - ospf
+    - gateway
+    name: r2
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.3
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway: true
+        id: 1000
+        mode: irb
+        neighbors:
+        - ifname: eth1
+          ipv4: 172.16.0.6/24
+          node: h3
+        - ifname: Vlan1000
+          ipv4: 172.16.0.2/24
+          node: r1
+        - ifname: eth1
+          ipv4: 172.16.0.7/24
+          node: h4
+        - ifname: Vlan1000
+          ipv4: 172.16.0.3/24
+          node: r2
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+ospf:
+  area: 0.0.0.0
+provider: libvirt
+vlans:
+  red:
+    gateway: true
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.6/24
+      node: h3
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: r1
+    - ifname: eth1
+      ipv4: 172.16.0.7/24
+      node: h4
+    - ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      node: r2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -1,0 +1,33 @@
+#
+# Anycast gateway test case
+#
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,vlan,ospf ]
+    members: [ r1, r2 ]
+    device: eos
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+nodes: [ r1, r2, h1, h2, h3, h4 ]
+
+vlans:
+  red:
+    gateway: True
+
+links:
+- r1:
+  r2:
+  h1:
+  h2:
+  gateway.anycast.unicast: False
+- r1:
+  h3:
+  vlan.access: red
+- r2:
+  h4:
+  vlan.access: red


### PR DESCRIPTION
The initial implementation of the **gateway** module supports anycast gateways with optional unicast IP addresses. The implementation has been kept as simple as possible, I'm still aware of a few quirks that have to be fixed, but that will have to wait for another day.

Known quirks:
* Static interface IDs could clash with gateway.id
* When gateway.id == -N, a high-enough node ID could clash with it when using id_based allocation. The allocation should switch to 'sequential' in that case
* Sequential address allocation should skip gateway.id (for example when gateway.id == 1)