### PR TITLE
Initial implementation of anycast gateway

### DIFF
--- a/docs/dev/config/gateway.md
+++ b/docs/dev/config/gateway.md
@@ -1,0 +1,49 @@
+# First-Hop Gateway Configuration Templates
+
+This document describes First-Hop Gateway configuration module implementation details.
+
+## Theory of Operation
+
+The configuration module:
+
+* Combines global parameters with link-level parameters
+* Sets up `_reserved` list of reserved node IDs for every link
+* Sets a `_stub` flag for routing modules to ignore this link
+* Removes IP addresses from node interfaces if the nodes use **gateway** module, if the **gateway.protocol** is set to *anycast* and if the **gateway.anycast.unicast** is set to *False.*
+
+Interactions with other modules:
+
+* The interface address allocation routines avoid the reserved IDs when assigning IP addresses to individual nodes.
+* Link processing code will set **gateway.ipv4** to the IP address corresponding to **gateway.id** on links with **gateway** dictionary. The **gateway** dictionary is then copied to interfaces of attached hosts to serve as the target for static routes configured on the hosts.
+* Common routing protocol code removes routing protocols from links with "ignore this link" flag.
+
+## Anycast Configuration Template Boilerplate
+
+Use node **gateway.anycast.mac** parameter to set the shared virtual router MAC address.
+
+When configuring anycast gateway on an interface, use the following interface parameters:
+
+* **gateway.protocol** must be set to **anycast**.
+* **gateway.ipv4** must be set to a valid IPv4 address (string)
+* **gateway.anycast.mac** could be set to a link-specific shared MAC address. Ignore this parameter if your platform cannot support link-specific virtual router MAC addresses.
+
+```
+{% for l in interfaces if bfd|default(False) or l.bfd|default(False) %}
+interface {{ l.ifname }}
+{%   set disable_bfd = l.bfd is defined and not l.bfd %}
+{%   if not disable_bfd %}
+{%     set link_bfd = l.bfd|default({}) %}
+ bfd interval {{ 
+   link_bfd.min_tx|default(bfd.min_tx)|default(500) }} min_rx {{ 
+   link_bfd.min_rx|default(bfd.min_rx)|default(500) }} multiplier {{
+   link_bfd.multiplier|default(bfd.multiplier)|default(3)
+   }}
+!
+{%   else %}
+ no bfd interval
+{%   endif %}
+{% endfor %}
+{% if bfd.min_echo_rx|default(0) %}
+bfd slow-timers {{ bfd.min_echo_rx }} 
+{% endif %}
+```

--- a/docs/dev/guidelines.md
+++ b/docs/dev/guidelines.md
@@ -34,6 +34,7 @@ The easiest way to get started is to [add support for a new platform for an exis
    config/bfd.md
    config/vlan.md
    config/vrf.md
+   config/gateway.md
 ```
 
 ```eval_rst

--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -10,6 +10,7 @@ The following configuration modules are included in **netlab** distribution:
    module/bgp.md
    module/eigrp.md
    module/evpn.md
+   module/gateway.md
    module/isis.md
    MPLS Configuration Module (LDP, BGP-LU, MPLS/VPN) <module/mpls.md>
    module/ospf.md

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -2,23 +2,14 @@
 
 First-hop Gateway configuration module implements mechanisms used to implement a shared router IPv4 address on a stub access network.
 
-The current implementation of the module supports statically configured anycast gateway IPv4 address.
+The module supports statically configured anycast gateway IPv4 address and VRRPv3 for IPv4 and IPv6.
 
 The module is supported on these platforms:
 
-| Operating system      | Anycast |
-| --------------------- | :-: |
-| Arista EOS            | ✅  |
-| Cumulus Linux         | ✅  |
-
-```{note}
-### Implementation Notes
-
-* The default *netlab* shared MAC address is 0200.cafe.00ff.
-* Vendors use different names for anycast gateways: VARP (Arista), VRR (Cumulus)
-* Arista EOS uses the same shared MAC address on all interfaces. Do not set link-level **gateway.anycast.mac** parameter in topologies using Arista EOS.
-* Arista vEOS cannot use VRRP MAC address as a shared MAC address (default recommended by Cumulus Linux)
-```
+| Operating system      | Anycast | VRRPv3 | VRRPv3<br>IPv6 |
+| --------------------- | :-: | :-: | :-: |
+| Arista EOS            | ✅  | ✅  | ✅  |
+| Cumulus Linux         | ✅  | ✅  | ✅  |
 
 ## Global Parameters
 
@@ -27,17 +18,44 @@ The module supports the following global parameters:
 * **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The only supported value is currently *anycast*
 * **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
 
-Anycast implementation of shared first-hop IP address supports these parameters:
+## Link Parameters
+
+Gateway configuration module is enabled on all links that have **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on per-link basis.
+
+## Anycast Gateway
+
+The *gateway* configuration module supports IPv4 anycast gateways -- MAC and IPv4 addresses shared between multiple nodes attached to the same segment.
+
+### Implementation Notes
+
+* The default *netlab* shared MAC address is 0200.cafe.00ff.
+* Vendors use different names for anycast gateways: VARP (Arista), VRR (Cumulus)
+* Arista EOS uses the same shared MAC address on all interfaces. Do not set link-level **gateway.anycast.mac** parameter in topologies using Arista EOS.
+* Arista vEOS cannot use VRRP MAC address as a shared MAC address (default recommended by Cumulus Linux)
+
+### Anycast Parameters
+
+Anycast implementation of shared first-hop IPv4 address supports these parameters that can be specified globally or on individual links or interfaces.
 
 * **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses together with anycast IP address.
 * **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
 
 ```{tip}
-Many implementations require unique unicast IP addresses configured on the interfaces that have anycast IP address. Set **‌gateway.anycast.unicast** to *‌False* only when absolutely necessary.
+Many implementations require unique unicast IP addresses configured on the interfaces that have anycast IP address. Set **gateway.anycast.unicast** to *False* only when absolutely necessary.
 ```
 
-## Link Parameters
+## Virtual Router Redundancy Protocol (VRRP)
 
-Gateway configuration module is enabled on all links that have **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on per-link basis[^MAC].
+*netlab* supports a single VRRPv3 instance per subnet. The VRRPv3 instance can provide shared IPv4 and IPv6 addresses. More complex topologies like multiple VRRPv3 instances could be deployed with a judicious application of interface parameters[^VNS].
 
-[^MAC]: Some platforms don't support per-link *virtual router MAC address*, so it might not be a good idea to set **gateway.anycast.mac** parameter on individual links.
+[^VNS]: These topologies are not supported and will not be integrated into *netlab* core. If you want to have an easier way of configuring the in a lab topology, please feel free to create a plugin.
+
+### VRRP Parameters
+
+*netlab* supports these VRRP parameters that can be specified globally or on individual links or interfaces.
+
+* **vrrp.group** (default: 1) -- VRRP group
+* **vrrp.priority** (interface parameter, integer)
+* **vrrp.preempt** (interface parameter, boolean)
+
+No other aspect of VRRP (VRRP version, timers...) is manageable through *netlab* parameters, if you want to configured them create a plugin to implement additional VRRP functionality.

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -18,8 +18,9 @@ The module is supported on these platforms:
 | Operating system      | Anycast | VRRPv3 | VRRPv3<br>IPv6 |
 | --------------------- | :-: | :-: | :-: |
 | Arista EOS            | ✅  | ✅  | ✅  |
-| Cisco CSR 1000v       | ✅  | ✅  | ✅  |
-| Cisco IOSv            | ✅  | ✅  | ✅  |
+| Cisco CSR 1000v       |  ❌  | ✅  | ✅  |
+| Cisco IOSv            |  ❌  | ✅  | ✅  |
+| Cisco Nexus OS        |  ❌  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  |
 
 ## Global Parameters

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -4,6 +4,15 @@ First-hop Gateway configuration module implements mechanisms used to implement a
 
 The module supports statically configured anycast gateway IPv4 address and VRRPv3 for IPv4 and IPv6.
 
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+```
+
+## Platform Support
+
 The module is supported on these platforms:
 
 | Operating system      | Anycast | VRRPv3 | VRRPv3<br>IPv6 |
@@ -40,17 +49,23 @@ The *gateway* configuration module supports IPv4 anycast gateways -- MAC and IPv
 Anycast implementation of shared first-hop IPv4 address supports these parameters that can be specified globally or on individual links or interfaces.
 
 * **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses together with anycast IP address.
-* **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
+* **gateway.anycast.mac** -- Static MAC address used for the anycast IPv4 address
 
 ```{tip}
-Many implementations require unique unicast IP addresses configured on the interfaces that have anycast IP address. Set **gateway.anycast.unicast** to *False* only when absolutely necessary.
+Many implementations require unique unicast IPv4 addresses configured on the interfaces that have anycast IPv4 address. Set **gateway.anycast.unicast** to *False* only when absolutely necessary.
 ```
 
 ## Virtual Router Redundancy Protocol (VRRP)
 
-*netlab* supports a single VRRPv3 instance per subnet. The VRRPv3 instance can provide shared IPv4 and IPv6 addresses. More complex topologies like multiple VRRPv3 instances could be deployed with a judicious application of interface parameters[^VNS].
+*netlab* supports a single VRRPv3 instance per subnet/interface. The VRRPv3 instance can provide shared IPv4 and IPv6 addresses.
 
-[^VNS]: These topologies are not supported and will not be integrated into *netlab* core. If you want to have an easier way of configuring the in a lab topology, please feel free to create a plugin.
+```{tip}
+More complex topologies like multiple VRRPv3 instances *on the same subnet* could be deployed with a judicious application of interface parameters[^VNS], but you won't be able to model multiple VRRPv3 instances *per interface*[^VDM].
+```
+
+[^VNS]: These topologies are not supported and will not be integrated into *netlab* core. If you want to have an easier way of configuring them in a lab topology, please feel free to create a plugin.
+
+[^VDM]: That would require a completely different data model. You'll have to use custom configuration templates if you want to implement something along those lines.
 
 ### VRRP Parameters
 

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -1,0 +1,30 @@
+# First-Hop Gateway Configuration Module
+
+First-hop Gateway configuration module implements mechanisms used to implement a shared router IPv4 address on a stub access network.
+
+The current implementation of the module supports statically configured anycast gateway IPv4 address.
+
+The module is supported on these platforms:
+
+| Operating system      | Anycast |
+| --------------------- | :-: |
+| Arista EOS            | ✅  |
+
+## Global Parameters
+
+The module supports the following global parameters: 
+
+* **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The only supported value is currently *anycast*
+* **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
+* **gateway.stub** (default: True) -- do not run routing protocols on links having shared first-hop addresses.
+
+Anycast implementation of shared first-hop IP address supports these parameters:
+
+* **gateway.anycast.unicast** (default: False) -- configure node-specific unicast IP addresses together with anycast IP address.
+* **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
+
+## Link Parameters
+
+Gateway configuration module is enabled on all links that have **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on per-link basis[^MAC].
+
+[^MAC]: Some platforms don't support per-link *virtual router MAC address*, so it might not be a good idea to set **gateway.anycast.mac** parameter on individual links.

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -10,18 +10,25 @@ The module is supported on these platforms:
 | --------------------- | :-: |
 | Arista EOS            | ✅  |
 
+```{note}
+* Arista's implementation of anycast gateway is called Virtual ARP
+```
+
 ## Global Parameters
 
 The module supports the following global parameters: 
 
 * **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The only supported value is currently *anycast*
 * **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
-* **gateway.stub** (default: True) -- do not run routing protocols on links having shared first-hop addresses.
 
 Anycast implementation of shared first-hop IP address supports these parameters:
 
-* **gateway.anycast.unicast** (default: False) -- configure node-specific unicast IP addresses together with anycast IP address.
+* **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses together with anycast IP address.
 * **gateway.anycast.mac** -- Static MAC address used for the anycast IP address
+
+```{tip}
+Many implementations require unique unicast IP addresses configured on the interfaces that have anycast IP address. Set **‌gateway.anycast.unicast** to *‌False* only when absolutely necessary.
+```
 
 ## Link Parameters
 

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -9,9 +9,15 @@ The module is supported on these platforms:
 | Operating system      | Anycast |
 | --------------------- | :-: |
 | Arista EOS            | ✅  |
+| Cumulus Linux         | ✅  |
 
 ```{note}
-* Arista's implementation of anycast gateway is called Virtual ARP
+### Implementation Notes
+
+* The default *netlab* shared MAC address is 0200.cafe.00ff.
+* Vendors use different names for anycast gateways: VARP (Arista), VRR (Cumulus)
+* Arista EOS uses the same shared MAC address on all interfaces. Do not set link-level **gateway.anycast.mac** parameter in topologies using Arista EOS.
+* Arista vEOS cannot use VRRP MAC address as a shared MAC address (default recommended by Cumulus Linux)
 ```
 
 ## Global Parameters

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -9,6 +9,8 @@ The module is supported on these platforms:
 | Operating system      | Anycast | VRRPv3 | VRRPv3<br>IPv6 |
 | --------------------- | :-: | :-: | :-: |
 | Arista EOS            | ✅  | ✅  | ✅  |
+| Cisco CSR 1000v       | ✅  | ✅  | ✅  |
+| Cisco IOSv            | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  |
 
 ## Global Parameters

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -190,23 +190,26 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 
 [^NSM]: Use **[netlab show module-support](netlab/show.md)** command to display the current system settings
 
-| Operating system      | OSPF | IS-IS | EIGRP | BGP | BFD | EVPN |
-| --------------------- | :--: | :---: | :---: | :-: | :-: | :--: |
-| Arista EOS            | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |
-| Cisco IOS             | ✅   |  ✅   |  ✅   | ✅  | ✅  |  ❌  |
-| Cisco IOS XE          | ✅   |  ✅   |  ✅   | ✅  | ✅  |  ❌  |
-| Cisco Nexus OS        | ✅   |  ✅   |  ✅   | ✅  | ✅  |  ❌  |
-| Cumulus Linux         | ✅   |   ❌   |   ❌   | ✅  |  ❌  | ✅  |
-| Cumulus Linux 5.0 (NVUE)        | ✅   |   ❌   |   ❌   | ✅  |  ❌  |  ❌  |
-| Dell OS10             | ✅   |   ❌   |   ❌   | ✅  | ✅  | ✅  |
-| Fortinet FortiOS      | [❗](caveats.html#fortinet-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |  ❌  |
-| FRR 7.5.0             | ✅   |  ✅   |   ❌   | ✅  |  ❌  | ✅  |
-| Juniper vSRX 3.0      | ✅   |  ✅   |   ❌   | ✅  | ✅  |  ❌  |
-| Mikrotik RouterOS 6   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |
-| Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |
-| Nokia SR Linux        | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |
-| Nokia SR OS           | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |
-| VyOS                  | ✅   |   ✅   |   ❌   | ✅  | ✅  | ✅  |
+| Operating system      | OSPF | IS-IS | EIGRP | BGP | BFD | EVPN | FHRP |
+| --------------------- | :--: | :---: | :---: | :-: | :-: | :--: | :--: |
+| Arista EOS            | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  | ✅  |
+| Cisco IOS             | ✅   |  ✅   |  ✅   | ✅  | ✅  |  ❌  | ✅  |
+| Cisco IOS XE          | ✅   |  ✅   |  ✅   | ✅  | ✅  |  ❌  | ✅  |
+| Cisco Nexus OS        | ✅   |  ✅   |  ✅   | ✅  | ✅  | ✅  | ✅  |
+| Cumulus Linux         | ✅   |   ❌   |   ❌   | ✅  |  ❌  | ✅  | ✅  |
+| Cumulus Linux 5.0 (NVUE)        | ✅   |   ❌   |   ❌   | ✅  |  ❌  |  ❌  |  ❌  |
+| Dell OS10             | ✅   |   ❌   |   ❌   | ✅  | ✅  | ✅  |  ❌  |
+| Fortinet FortiOS      | [❗](caveats.html#fortinet-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |  ❌  |  ❌  |
+| FRR 7.5.0             | ✅   |  ✅   |   ❌   | ✅  |  ❌  | ✅  |  ❌  |
+| Juniper vSRX 3.0      | ✅   |  ✅   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
+| Mikrotik RouterOS 6   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
+| Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
+| Nokia SR Linux        | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |  ❌  |
+| Nokia SR OS           | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |  ❌  |
+| VyOS                  | ✅   |  ✅   |   ❌   | ✅  | ✅  | ✅  |  ❌  |
+
+**Notes:**
+* FRHP = First-Hop Redundancy Protocol (anycast gateway or VRRP)
 
 (platform-dataplane-support)=
 The following data plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:

--- a/netsim/ansible/templates/gateway/cumulus.j2
+++ b/netsim/ansible/templates/gateway/cumulus.j2
@@ -21,6 +21,12 @@ interface {{ intf.ifname }}
 {%   for af in 'ipv4','ipv6' if af in intf.gateway %}
   vrrp {{ intf.gateway.vrrp.group }} {{ af|replace('ipv4','ip') }} {{ intf.gateway[af]|ipaddr('address') }}
 {%   endfor %}
+{%     if 'priority' in intf.gateway.vrrp %}
+  vrrp {{ intf.gateway.vrrp.group }} priority {{ intf.gateway.vrrp.priority }}
+{%     endif %}
+{%     if intf.gateway.vrrp.preempt|default(False) %}
+  vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     endif %}
 {% endfor %}
 do write
 CONFIG

--- a/netsim/ansible/templates/gateway/cumulus.j2
+++ b/netsim/ansible/templates/gateway/cumulus.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+set -e # Exit immediately when any command fails
+#
+cat >/etc/network/interfaces.d/80-gateway.intf <<CONFIG
+{% for intf in interfaces if 'gateway' in intf %}
+auto {{ intf.ifname }}
+iface {{ intf.ifname }}
+{%   if intf.gateway.protocol == 'anycast' %}
+    address-virtual {{ intf.gateway.anycast.mac|hwaddr('linux') }} {{ intf.gateway.ipv4 }}
+{%   endif %}
+{% endfor %}
+CONFIG
+ifreload -a

--- a/netsim/ansible/templates/gateway/cumulus.j2
+++ b/netsim/ansible/templates/gateway/cumulus.j2
@@ -9,6 +9,21 @@ iface {{ intf.ifname }}
 {%   if intf.gateway.protocol == 'anycast' %}
     address-virtual {{ intf.gateway.anycast.mac|hwaddr('linux') }} {{ intf.gateway.ipv4 }}
 {%   endif %}
+{%   if intf.gateway.protocol == 'vrrp' %}
+    vrrp {{ intf.gateway.vrrp.group }}{% for af in 'ipv4','ipv6' if af in intf.gateway %} {{ intf.gateway[af] }}{% endfor +%}
+{%   endif %}
 {% endfor %}
 CONFIG
 ifreload -a
+cat >/tmp/vrrp_config <<CONFIG
+{% for intf in interfaces if intf.gateway.protocol|default('') == 'vrrp' %}
+interface {{ intf.ifname }}
+{%   for af in 'ipv4','ipv6' if af in intf.gateway %}
+  vrrp {{ intf.gateway.vrrp.group }} {{ af|replace('ipv4','ip') }} {{ intf.gateway[af]|ipaddr('address') }}
+{%   endfor %}
+{% endfor %}
+do write
+CONFIG
+if [ -s /tmp/vrrp_config ]; then
+  vtysh -f /tmp/vrrp_config
+fi

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -1,0 +1,9 @@
+{% if gateway.anycast.mac is defined %}
+ip virtual-router mac-address {{ gateway.anycast.mac }}
+{% endif %}
+{% for intf in interfaces if intf.gateway.protocol is defined %}
+interface {{ intf.ifname }}
+{%   if intf.gateway.protocol == 'anycast' %}
+  ip virtual-router address {{ intf.gateway.ipv4 }}
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -1,7 +1,12 @@
+{% for intf in interfaces if intf.gateway.protocol is defined %}
+{%   if loop.first %}
+no ip icmp redirect
+!
 {% if gateway.anycast.mac is defined %}
 ip virtual-router mac-address {{ gateway.anycast.mac }}
+!
 {% endif %}
-{% for intf in interfaces if intf.gateway.protocol is defined %}
+{%   endif %}
 interface {{ intf.ifname }}
 {%   if intf.gateway.protocol == 'anycast' %}
   ip virtual-router address {{ intf.gateway.ipv4 }}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -12,11 +12,15 @@ interface {{ intf.ifname }}
   ip virtual-router address {{ intf.gateway.ipv4 }}
 {%   endif %}
 {%   if intf.gateway.protocol == 'vrrp' %}
-{%     if intf.gateway.ipv6 is defined %}
   vrrp {{ intf.gateway.vrrp.group }} ipv4 version 3
-{%     endif %}
 {%     for af in 'ipv4','ipv6' if af in intf.gateway %}
   vrrp {{ intf.gateway.vrrp.group }} {{ af }} {{ intf.gateway[af]|ipaddr('address') }}
 {%     endfor %}
+{%     if 'priority' in intf.gateway.vrrp %}
+  vrrp {{ intf.gateway.vrrp.group }} priority-level {{ intf.gateway.vrrp.priority }}
+{%     endif %}
+{%     if intf.gateway.vrrp.preempt|default(False) %}
+  vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     endif %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -2,10 +2,10 @@
 {%   if loop.first %}
 no ip icmp redirect
 !
-{% if gateway.anycast.mac is defined %}
+{%     if gateway.anycast.mac is defined %}
 ip virtual-router mac-address {{ gateway.anycast.mac }}
 !
-{% endif %}
+{%     endif %}
 {%   endif %}
 interface {{ intf.ifname }}
 {%   if intf.gateway.protocol == 'anycast' and 'ipv4' in intf.gateway %}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -8,7 +8,15 @@ ip virtual-router mac-address {{ gateway.anycast.mac }}
 {% endif %}
 {%   endif %}
 interface {{ intf.ifname }}
-{%   if intf.gateway.protocol == 'anycast' %}
+{%   if intf.gateway.protocol == 'anycast' and 'ipv4' in intf.gateway %}
   ip virtual-router address {{ intf.gateway.ipv4 }}
+{%   endif %}
+{%   if intf.gateway.protocol == 'vrrp' %}
+{%     if intf.gateway.ipv6 is defined %}
+  vrrp {{ intf.gateway.vrrp.group }} ipv4 version 3
+{%     endif %}
+{%     for af in 'ipv4','ipv6' if af in intf.gateway %}
+  vrrp {{ intf.gateway.vrrp.group }} {{ af }} {{ intf.gateway[af]|ipaddr('address') }}
+{%     endfor %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/gateway/ios.j2
+++ b/netsim/ansible/templates/gateway/ios.j2
@@ -1,0 +1,21 @@
+fhrp version vrrp v3
+!
+{% for intf in interfaces if intf.gateway.protocol is defined %}
+interface {{ intf.ifname }}
+{%   if intf.gateway.protocol == 'vrrp' %}
+{%     for af in 'ipv4','ipv6' if af in intf.gateway %}
+  vrrp {{ intf.gateway.vrrp.group }} address-family {{ af }}
+{%     if af == 'ipv4' %}
+    address {{ intf.gateway[af]|ipaddr('address') }}
+{%     else %}
+    address {{ intf.gateway[af] }}
+{%     endif %}
+{%     if 'priority' in intf.gateway.vrrp %}
+    priority {{ intf.gateway.vrrp.priority }}
+{%     endif %}
+{%     if intf.gateway.vrrp.preempt|default(False) %}
+    preempt
+{%     endif %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/gateway/nxos.j2
+++ b/netsim/ansible/templates/gateway/nxos.j2
@@ -1,22 +1,23 @@
-fhrp version vrrp v3
-!
 {% for intf in interfaces if intf.gateway.protocol is defined %}
+{%   if loop.first %}
+feature vrrpv3
+!
+{%   endif %}
+!
 interface {{ intf.ifname }}
 {%   if intf.gateway.protocol == 'vrrp' %}
 {%     for af in 'ipv4','ipv6' if af in intf.gateway %}
-  vrrp {{ intf.gateway.vrrp.group }} address-family {{ af }}
-{%     if af == 'ipv4' %}
-    address {{ intf.gateway[af]|ipaddr('address') }}
-{%     else %}
+  vrrpv3 {{ intf.gateway.vrrp.group }} address-family {{ af }}
+{%       if af == 'ipv6' %}
     address {{ 'fe80::200:5eff:fe00:02%02d' % ( intf.gateway.vrrp.group ) }} primary
-    address {{ intf.gateway[af] }}
-{%     endif %}
+{%       endif %}
+    address {{ intf.gateway[af]|ipaddr('address') }}
+{%     endfor %}
 {%     if 'priority' in intf.gateway.vrrp %}
     priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
     preempt
 {%     endif %}
-{%     endfor %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -62,7 +62,7 @@ service lldpd restart
 #
 # Enable FRR modules
 #
-{% set modlist = {'bgp':'bgpd','ospf':['ospfd','ospf6d'],'isis':'isisd','vrf':'bgpd'} %}
+{% set modlist = {'bgp':'bgpd','ospf':['ospfd','ospf6d'],'isis':'isisd','vrf':'bgpd','gateway':'vrrpd'} %}
 {% for m in module|default([]) if modlist[m] is defined %}
 {%   for frr_m in [modlist[m]]|flatten %}
 echo "{{ frr_m }}=yes" >>/etc/frr/daemons

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -1,5 +1,7 @@
 hostname {{ inventory_hostname.replace("_","-") }}
 !
+logging monitor debugging
+!
 lldp run
 {% if af.ipv4|default(False) %}
 ip routing

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -60,6 +60,7 @@ def transform_data(topology: Box) -> None:
     common.exit_on_error()
     augment.plugin.execute('pre_link_transform',topology)
     modules.pre_link_transform(topology)
+    common.exit_on_error()
     augment.links.transform(topology.links,topology.defaults,topology.nodes,topology.pools)
     common.exit_on_error()
     augment.plugin.execute('post_link_transform',topology)

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -12,7 +12,18 @@ from box import Box
 from .. import common
 from .. import addressing
 from . import devices
-from ..data.validate import validate_attributes
+from ..data.validate import validate_attributes,must_be_int
+from ..modules._dataplane import extend_id_set,is_id_used,set_id_counter,get_next_id
+
+"""
+Reserve a node ID, for example for gateway ID, return True if successful, False if duplicate
+"""
+def reserve_id(n_id: int) -> bool:
+  if is_id_used('node_id',n_id):
+    return False
+
+  extend_id_set('node_id',set([n_id]))
+  return True
 
 """
 Node data structure is a dictionary. Convert lists of dictionaries (now obsolete)
@@ -203,19 +214,6 @@ def augment_node_system_data(topology: Box) -> None:
               common.IncorrectValue,
               'nodes')
 
-'''
-get_next_id: given a list of static IDs and the last ID, get the next device ID
-'''
-def get_next_id(id_list: list, id: int) -> int:
-  while id < 254:
-    id = id + 1
-    if not id in id_list:
-      return id
-
-  common.fatal(
-    'Cannot get the next device ID. The lab topology is probably too big')  # pragma: no cover (I'm not going to write a test case for this one)
-  return -1                                                                 # pragma: no cover (making mypy happy)
-
 """
 augment_node_device_data: copy attributes that happen to be node attributes from device defaults into node data
 """
@@ -242,23 +240,20 @@ Main node transformation code
 * set management IP and MAC addresses
 '''
 def transform(topology: Box, defaults: Box, pools: Box) -> None:
-  id = 0
-  id_list = []
-
   for name,n in topology.nodes.items():
-    if 'id' in n:
-      if isinstance(n.id,int) and n.id > 0 and n.id <= 250:
-        id_list.append(n.id)
-      else:
-        common.error('Device ID must be an integer between 1 and 250')
+    if not must_be_int(n,'id',f'nodes.{name}',module='nodes',min_value=1,max_value=250):
+      continue
+    if not reserve_id(n.id):
+      common.error(
+        f'Duplicate static node ID {n.id} on node {n.name}',
+        common.IncorrectValue,
+        'nodes')
 
   common.exit_on_error()
-
-
+  set_id_counter('node_id',1,250)
   for name,n in topology.nodes.items():
     if not 'id' in n:
-      id = get_next_id(id_list,id)
-      n.id = id
+      n.id = get_next_id('node_id')
 
     if not n.name: # pragma: no cover (name should have been checked way before)
       common.fatal(f"Internal error: node does not have a name {n}",'nodes')

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -35,7 +35,6 @@ def create_node_dict(nodes: Box) -> Box:
     node_dict = nodes
   else:
     node_dict = Box({},default_box=True,box_dots=True)
-    node_id = 0
     for n in nodes or []:
       if isinstance(n,dict):
         if not 'name' in n:
@@ -43,8 +42,6 @@ def create_node_dict(nodes: Box) -> Box:
           continue
       elif isinstance(n,str):
         n = Box({ 'name': n },default_box=True,box_dots=True)
-      node_id = node_id + 1
-      n.id = node_id
       node_dict[n.name] = n
 
   for name in list(node_dict.keys()):

--- a/netsim/common.py
+++ b/netsim/common.py
@@ -70,9 +70,13 @@ def exit_on_error() -> None:
     fatal('Cannot proceed beyond this point due to errors, exiting')
 
 def extra_data_printout(s : str) -> str:
-  return textwrap.TextWrapper(
-    initial_indent="... ",
-    subsequent_indent="      ").fill(s)
+  lines = []
+  for line in s.split('\n'):
+    lines.append(textwrap.TextWrapper(
+      initial_indent="... ",
+      subsequent_indent="      ").fill(line))
+
+  return "\n".join(lines)
 
 #
 # File functions
@@ -134,13 +138,19 @@ def print_verbose(t: typing.Any) -> None:
   if VERBOSE:
     print(t)
 
-def print_structured_dict(d: Box, prefix: str = '') -> None:
+def format_structured_dict(d: Box, prefix: str = '') -> str:
+  lines = []
   for k,v in d.items():
     if v and (isinstance(v,dict) or isinstance(v,list)):
-      print(f'{prefix}{k}:')
-      print(f'{prefix}  {v}')
+      lines.append(f'{prefix}{k}:')
+      lines.append(f'{prefix}  {v}')
     else:
-      print(f'{prefix}{k}: {v}')
+      lines.append(f'{prefix}{k}: {v}')
+
+  return "\n".join(lines)
+
+def print_structured_dict(d: Box, prefix: str = '') -> None:
+  print(format_structured_dict(d,prefix))
 
 #
 # Sets common flags based on parsed arguments.

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -455,6 +455,9 @@ def validate_attributes(
     if not modules is None and k in modules:            # For module attributes, perform recursive check
       if data[k] is False and validate_module_can_be_false(attributes,attr_list):
         continue                                        # Some objects accept 'attribute: false' syntax (example: links)
+      if data[k] is True:
+        if set(attr_list) & set(topology.defaults[k].attributes.can_be_true):
+          continue
       fixed_data = validate_attributes(
         data=data[k],
         topology=topology,

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -362,11 +362,8 @@ def validate_module_can_be_false(
   if not 'can_be_false' in attributes:
     return False
 
-  for a in attr_list:                                   # Can at least one attribute category be false?
-    if a in attributes.can_be_false:
-      return True                                       # OK, we can accept False value
-
-  return False                                          # No such category found, reject the idea of accepting False values
+  intersect = set(attr_list) & set(attributes.can_be_false)
+  return bool(intersect)
 
 """
 validate_attributes -- validate object attributes

--- a/netsim/modules/_dataplane.py
+++ b/netsim/modules/_dataplane.py
@@ -74,6 +74,9 @@ def set_id_counter(name: str, start: int, max_value: int = 4096) -> int:
 	idvar = global_vars.get(f'{name}_id')
 	idvar.next = start
 	idvar.max = max_value
+	if not idvar.value:
+		idvar.value = set()
+
 	return start
 
 def get_next_id(name: str) -> int:

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -1,0 +1,59 @@
+#
+# First-hop gateway transformation module
+#
+from box import Box
+
+from . import _Module,get_effective_module_attribute
+from .. import common
+from .. import data
+from ..augment.nodes import reserve_id
+from ..data.validate import validate_attributes
+
+class FHRP(_Module):
+
+  def module_init(self, topology: Box) -> None:
+    gw = data.get_global_parameter(topology,'gateway')
+    if not gw or gw is None:
+      common.error(
+        f'Global/default gateway parameters are missing. We need at least a gateway ID',
+        common.IncorrectType,
+        'gateway')
+      return
+
+    if not data.is_true_int(gw.id):
+      common.error(
+        f'Global/default gateway.id parameter is missing or not integer',
+        common.IncorrectType,
+        'gateway')
+      return
+
+    if gw.id > 0:
+      reserve_id(gw.id)
+
+  def link_pre_link_transform(self, link: Box, topology: Box) -> None:
+    if not 'gateway' in link:
+      return
+
+    global_gateway = data.get_global_parameter(topology,'gateway')
+    if not global_gateway:                      # pragma: no cover
+      return                                    # We know (from init) that we have global parameters. This is just to keep mypy happy
+
+    if link.gateway is True:                    # We just want to do FHRP on the link ==> take global parameters
+      link.gateway = global_gateway
+    elif link.gateway is False:                 # We DEFINITELY don't want FHRP on this link ==> remove it and move on
+      link.pop('gateway',None)
+    else:                                       # Otherwise merge global defaults with links settings (because we usually don't do that)
+      link.gateway = global_gateway + link.gateway
+
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+    for intf in node.interfaces:                                      # Time to clean up interface addresses
+      if not intf.get('gateway',False):                               # This interface not using FHRP or FHRP is disabled
+        continue
+
+      if intf.gateway.protocol != 'anycast':                          # Leave non-anycast FHRP implementations alone, they need node IP addresses
+        continue
+
+      if data.get_from_box(intf,'gateway.anycast.unicast'):           # Do we use unicast IP addresses together with anycast ones?
+        continue
+
+      intf.pop('ipv4',None)                                           # No unicast with anycast ==> pop the address

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -1,24 +1,102 @@
 #
 # First-hop gateway transformation module
 #
+import typing
 from box import Box
 
 from . import _Module,get_effective_module_attribute
 from .. import common
 from .. import data
 from ..augment.nodes import reserve_id
-from ..data.validate import validate_attributes
+from ..augment import devices
+from ..data.validate import validate_attributes,must_be_string
+
+def check_gw_protocol(gw: Box, path: str, topology: Box) -> typing.Any:
+  return must_be_string(
+      parent=gw,
+      key='protocol',
+      path=path,
+      module='gateway',
+      valid_values=topology.defaults.gateway.attributes.protocols
+    )
+
+#
+# Check whether a node supports all FHRP protocols configured on it
+#
+
+def check_protocol_support(node: Box, topology: Box) -> bool:
+  features = devices.get_device_features(node,topology.defaults)
+  proto_list = []
+  OK = True
+
+  for intf in node.interfaces:                                        # Iterate over interfaces
+    if not 'gateway' in intf:                                         # ... and skip interfaces without FHRP
+      continue
+    gw_proto = intf.gateway.protocol                                  # We're asuming someone else did a sanity check on this value
+    if gw_proto in proto_list:                                        # Already checked?
+      continue
+
+    proto_list.append(gw_proto)
+    if not gw_proto in features.gateway.protocol:
+      OK = False
+      common.error(
+        f'Node {node.name} ({node.device}) does not support gateway protocol {gw_proto}',
+        common.IncorrectValue,
+        'gateway')
+
+  return OK
+
+#
+# Remove unicast IPv4 addresses from interfaces that use 'anycast' gateway protocol
+# and have 'gateway.anycast.unicast' set to False
+#
+def cleanup_unicast_ip(node: Box) -> None:
+  for intf in node.interfaces:
+    if not intf.get('gateway',False):                               # This interface not using FHRP or FHRP is disabled
+      continue
+
+    if intf.gateway.protocol != 'anycast':                          # Leave non-anycast FHRP implementations alone, they need node IP addresses
+      continue
+
+    if data.get_from_box(intf,'gateway.anycast.unicast') is False:  # Are we forbidden to use unicast IP addresses together with anycast ones?
+      intf.pop('ipv4',None)                                         # No unicast with anycast ==> pop the address
+
+#
+# Default settings copied onto individual links have parameters for every known FHRP protocol.
+# We don't need those parameters on every interface -- this function cleans up unusud gateway protocol
+# parameters from interfaces and returns a list of active protocols so we know what to clean on the
+# node level.
+
+def cleanup_protocol_parameters(node: Box,topology: Box) -> list:
+  active_proto: list = []
+
+  proto_list = topology.defaults.gateway.attributes.protocols         # List of known FHRP protocols
+  for intf in node.interfaces:                                        # Iterate over interfaces
+    if not 'gateway' in intf:                                         # ... and skip interfaces without FHRP
+      continue
+
+    gw_proto = intf.gateway.protocol                                  # We're asuming someone else did a sanity check on this value
+    if not gw_proto in active_proto:                                  # Add the current protocol to the list of active protocols
+      active_proto.append(gw_proto)
+
+    for k in list(intf.gateway):                                      # Now iterate over all keywords in interface gateway settings
+      if k != gw_proto and k in proto_list:                           # ... found FHRP protocol that is NOT the active protocol
+        intf.gateway.pop(k,None)                                      # ... useless, pop it
+
+  return active_proto
 
 class FHRP(_Module):
 
   def module_init(self, topology: Box) -> None:
-    gw = data.get_global_parameter(topology,'gateway')
+    gw = data.get_global_settings(topology,'gateway')
     if not gw or gw is None:
       common.error(
         f'Global/default gateway parameters are missing. We need at least a gateway ID',
         common.IncorrectType,
         'gateway')
       return
+
+    check_gw_protocol(gw,'topology.gateway',topology)
 
     if not data.is_true_int(gw.id):
       common.error(
@@ -34,7 +112,7 @@ class FHRP(_Module):
     if not 'gateway' in link:
       return
 
-    global_gateway = data.get_global_parameter(topology,'gateway')
+    global_gateway = data.get_global_settings(topology,'gateway')
     if not global_gateway:                      # pragma: no cover
       return                                    # We know (from init) that we have global parameters. This is just to keep mypy happy
 
@@ -42,7 +120,9 @@ class FHRP(_Module):
       link.gateway = global_gateway
     elif link.gateway is False:                 # We DEFINITELY don't want FHRP on this link ==> remove it and move on
       link.pop('gateway',None)
+      return
     else:                                       # Otherwise merge global defaults with links settings (because we usually don't do that)
+      check_gw_protocol(link.gateway,f'links[{link.linkindex}]',topology)
       link.gateway = global_gateway + link.gateway
 
     for k in ('id','protocol'):
@@ -70,14 +150,12 @@ class FHRP(_Module):
           'gateway')
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
-    for intf in node.interfaces:                                      # Time to clean up interface addresses
-      if not intf.get('gateway',False):                               # This interface not using FHRP or FHRP is disabled
-        continue
+    if not check_protocol_support(node,topology):
+      return
 
-      if intf.gateway.protocol != 'anycast':                          # Leave non-anycast FHRP implementations alone, they need node IP addresses
-        continue
-
-      if data.get_from_box(intf,'gateway.anycast.unicast'):           # Do we use unicast IP addresses together with anycast ones?
-        continue
-
-      intf.pop('ipv4',None)                                           # No unicast with anycast ==> pop the address
+    cleanup_unicast_ip(node)
+    active_proto = cleanup_protocol_parameters(node,topology)         # Cleanup interface parameters and get a list of active protocols
+    if 'gateway' in node:
+      for k in list(node.gateway):                                    # Iterate over node-level gateway parameters
+        if not k in active_proto:                                     # Not a parameter for a FHRP active on this node?
+          node.gateway.pop(k,None)                                    # ... zap it!

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -45,6 +45,30 @@ class FHRP(_Module):
     else:                                       # Otherwise merge global defaults with links settings (because we usually don't do that)
       link.gateway = global_gateway + link.gateway
 
+    for k in ('id','protocol'):
+      if not k in link.gateway or not link.gateway[k]:
+        common.error(
+          f'Gateway attribute {k} is missing in links[{link.linkindex}]\n' + \
+          common.extra_data_printout(common.format_structured_dict(link)),
+          common.MissingValue,
+          'gateway')
+        return
+
+    if not data.is_true_int(link.gateway.id):
+      common.error(
+        f'Gateway.id parameter in links[{link.linkindex}] must be an integer\n' + \
+          common.extra_data_printout(common.format_structured_dict(link)),
+        common.IncorrectType,
+        'gateway')
+      return
+
+    if link.gateway.id == -1:
+        common.error(
+          f'Cannot use -1 as the gateway ID in links[{link.linkindex}] -- that would be the broadcast address\n' + \
+          common.extra_data_printout(common.format_structured_dict(link)),
+          common.IncorrectValue,
+          'gateway')
+
   def node_post_transform(self, node: Box, topology: Box) -> None:
     for intf in node.interfaces:                                      # Time to clean up interface addresses
       if not intf.get('gateway',False):                               # This interface not using FHRP or FHRP is disabled

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -645,7 +645,8 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
   # VLAN attributes not copied into VLAN interface: we take the global defaults and remove
   # mode attribute from that list as it's needed to set interface VLAN mode
   #
-  svi_skipattr = [ k for k in list(topology.defaults.vlan.attributes.vlan_no_propagate or []) if k != "mode" ]
+  svi_skipattr = [ k for k in list(topology.defaults.vlan.attributes.vlan_no_propagate or []) if k != "mode" ] + \
+                  list(topology.defaults.vlan.attributes.vlan_svi_no_propagate)
 
   iflist_len = len(node.interfaces)
   for ifidx in range(0,iflist_len):

--- a/netsim/quirks/iosv.py
+++ b/netsim/quirks/iosv.py
@@ -1,0 +1,33 @@
+#
+# Arista EOS quirks
+#
+from box import Box
+
+from . import _Quirks
+from .. import common
+from ..data import get_from_box
+from ..augment import devices
+
+# Cisco IOSv does not support VRRP on BVI interfaces. Go figure...
+#
+def check_vrrp_bvi(node: Box, topology: Box) -> None:
+  for intf in node.interfaces:
+    if get_from_box(intf,'gateway.protocol') != 'vrrp':                 # No VRRP, move on
+      continue
+
+    if get_from_box(intf,'type') != 'svi':                              # Not a BVI interface, move on
+      continue
+
+    common.error(
+      f'Cisco IOSv cannot run VRRP on BVI interfaces.',
+      common.IncorrectType,
+      'quirks')
+    return
+
+class EOS(_Quirks):
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    mods = node.get('module',[])
+    if 'gateway' in mods:
+      check_vrrp_bvi(node,topology)

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -214,7 +214,7 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
     link: [ ldp ]
 
 gateway:
-  supported_on: [ eos, cumulus ]
+  supported_on: [ eos, cumulus, iosv, csr ]
   transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
   id: -2
@@ -411,6 +411,8 @@ devices:
         native_routed: True
       vrf:
         loopback_interface_name: Loopback{vrfidx}
+      gateway:
+        protocol: [ vrrp ]
     external:
       image: none
     graphite.icon: router
@@ -454,6 +456,8 @@ devices:
         6pe: True
       vrf:
         loopback_interface_name: Loopback{vrfidx}
+      gateway:
+        protocol: [ vrrp ]
     libvirt:
       image: cisco/csr1000v
       create:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -214,7 +214,7 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
     link: [ ldp ]
 
 gateway:
-  supported_on: [ eos, cumulus, iosv, csr ]
+  supported_on: [ eos, cumulus, iosv, csr, nxos ]
   transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
   id: -2
@@ -501,6 +501,8 @@ devices:
         native_routed: True
       evpn:
         irb: True
+      gateway:
+        protocol: [ vrrp ]
     libvirt:
       create_template: nxos.xml.j2
       image: cisco/nexus9300v

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -232,7 +232,7 @@ gateway:
     anycast: [ unicast, mac ]
     protocols: [ anycast, vrrp ]
     vrrp: [ group ]
-    link: [ id, ipv4, protocol, stub, anycast ]
+    link: [ id, ipv4, protocol, stub, anycast, vrrp ]
 
 #
 # Network automation defaults

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -210,6 +210,18 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
     node: [ ldp, bgp, vpn, 6pe ]
     link: [ ldp ]
 
+gateway:
+  supported_on: [ eos ]
+  transform_after: [ vlan,vrf ]
+  config_after: [ vlan,vrf ]
+  id: -1
+  no_propagate: [ id, stub ]
+  attributes:
+    global: [ id, protocol, stub, anycast ]
+    node: [ protocol, anycast ]
+    anycast: [ unicast, mac ]
+    link: [ id, ipv4, protocol, stub, anycast ]
+
 #
 # Network automation defaults
 #

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -29,7 +29,7 @@ attributes:
   global: [ addressing,defaults,groups,links,module,name,nodes,plugin,provider ]
   internal: [ input,includes,pools,Provider,Plugin,message ]
   can_be_false: [ link,interface ]
-  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,gateway,vlan_name ]
+  link: [ bandwidth,bridge,name,prefix,role,pool,type,unnumbered,interfaces,mtu,vlan_name ]
   link_internal: [ linkindex,parentindex ]
   link_no_propagate: [ prefix,interfaces,gateway ]
   link_module_no_propagate: [ vlan ]                  # Do not propagate VLAN attributes to node interfaces -- see #575
@@ -177,6 +177,9 @@ vlan: # VLAN support
     # Do not propagate these attributes into links or SVI interfaces
     vlan_no_propagate: [ id, vni, mode, prefix, evpn ]
     #
+    # Do not copy these VLAN attributes into SVI interfaces
+    vlan_svi_no_propagate: [ gateway ]
+    #
     # Do not copy these attributes into SVI interfaces
     phy_ifattr: [ bridge, ifindex, parentindex, ifname, linkindex, type, vlan, mtu, _selfloop_ifindex ]
     #
@@ -212,13 +215,18 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
 
 gateway:
   supported_on: [ eos ]
-  transform_after: [ vlan,vrf ]
+  transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
   id: -1
+  protocol: anycast
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: True
   no_propagate: [ id, stub ]
   attributes:
     global: [ id, protocol, stub, anycast ]
     node: [ protocol, anycast ]
+    can_be_true: [ link ]
     anycast: [ unicast, mac ]
     link: [ id, ipv4, protocol, stub, anycast ]
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -214,7 +214,7 @@ mpls: # LDP, BGP LU, L3VPN and 6PE support
     link: [ ldp ]
 
 gateway:
-  supported_on: [ eos ]
+  supported_on: [ eos, cumulus ]
   transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
   id: -1

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -217,17 +217,21 @@ gateway:
   supported_on: [ eos, cumulus ]
   transform_after: [ vlan, vrf, ospf, isis, eigrp ]
   config_after: [ vlan,vrf ]
-  id: -1
+  id: -2
   protocol: anycast
   anycast:
     mac: 0200.cafe.00ff
     unicast: True
-  no_propagate: [ id, stub ]
+  vrrp:
+    group: 1
+  no_propagate: [ id, protocol ]
   attributes:
-    global: [ id, protocol, stub, anycast ]
-    node: [ protocol, anycast ]
+    global: [ id, protocol, stub, anycast, vrrp ]
+    node: [ protocol, anycast, vrrp ]
     can_be_true: [ link ]
     anycast: [ unicast, mac ]
+    protocols: [ anycast, vrrp ]
+    vrrp: [ group ]
     link: [ id, ipv4, protocol, stub, anycast ]
 
 #
@@ -544,6 +548,8 @@ devices:
         loopback_interface_name: Loopback{vrfidx}
       evpn:
         irb: True
+      gateway:
+        protocol: [ anycast, vrrp ]
     clab:
       interface:
         name: et%d
@@ -746,6 +752,8 @@ devices:
         loopback_interface_name: "lo{vrfidx}"
       evpn:
         irb: True
+      gateway:
+        protocol: [ anycast, vrrp ]
     clab:
       mtu: 1500
       node:

--- a/tests/errors/anycast-params.yml
+++ b/tests/errors/anycast-params.yml
@@ -1,0 +1,17 @@
+---
+defaults.device: eos
+
+module: [ gateway ]
+
+nodes: [ r1, r2 ]
+
+links:
+- r1:
+  r2:
+  gateway.protocol: False
+- r1:
+  r2:
+  gateway.id: wrong
+- r1:
+  r2:
+  gateway.id: -1

--- a/tests/errors/anycast-prefix.yml
+++ b/tests/errors/anycast-prefix.yml
@@ -1,0 +1,17 @@
+---
+defaults.device: eos
+
+module: [ gateway ]
+
+nodes: [ r1, r2, r3, r4 ]
+
+links:
+- r1:
+  r2:
+  gateway.id: 1
+- r1:
+  r2:
+  r3:
+  r4:
+  prefix: 192.168.0.8/29
+  gateway.id: -4

--- a/tests/errors/gateway-global-params.yml
+++ b/tests/errors/gateway-global-params.yml
@@ -1,0 +1,7 @@
+defaults.device: eos
+
+module: [ gateway ]
+nodes: [ r1 ]
+
+gateway.protocol: False
+gateway.id: wrong

--- a/tests/errors/gateway-params.yml
+++ b/tests/errors/gateway-params.yml
@@ -1,0 +1,12 @@
+defaults.device: eos
+
+module: [ gateway ]
+nodes: [ r1 ]
+
+links:
+- r1:
+  gateway: True
+- r1:
+  gateway: False
+- r1:
+  gateway.protocol: False

--- a/tests/integration/gateway/anycast/lan-subnet.yml
+++ b/tests/integration/gateway/anycast/lan-subnet.yml
@@ -1,0 +1,34 @@
+#
+# Anycast gateway on a physical interface
+#
+
+message: |
+  This is the simplest anycast gateway test case. The switches have only anycast
+  IP address configured on the shared LAN. Static routes on hosts point to the
+  shared anycast IP address.
+
+  The switches are running OSPF over another interface to allow pings from hosts
+  to loopback switch addresses.
+
+  All four nodes should be able to ping each other.
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,ospf ]
+    members: [ s1,s2 ]
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+
+nodes: [ s1,s2,h1,h2 ]
+
+links:
+- s1:
+  s2:
+  h1:
+  h2:
+  gateway: True
+- s1:
+  s2:

--- a/tests/integration/gateway/anycast/lan-subnet.yml
+++ b/tests/integration/gateway/anycast/lan-subnet.yml
@@ -3,26 +3,26 @@
 #
 
 message: |
-  This is the simplest anycast gateway test case. The switches have only anycast
-  IP address configured on the shared LAN. Static routes on hosts point to the
-  shared anycast IP address.
+  This is the simplest anycast gateway test case -- the switches have anycast
+  IP address configured on the shared LAN. Two LANs are used in the topology
+  to explore the impact of shared MAC addresses on multiple LANs.
 
-  The switches are running OSPF over another interface to allow pings from hosts
-  to loopback switch addresses.
+  Static routes on hosts point to the shared anycast IP address. The switches
+  are running OSPF with a third switch to enable network-wide connectivity.
 
-  All four nodes should be able to ping each other.
+  All hosts should be able to ping the loopback addresses of all switches.
 
 gateway.id: 1
 
 groups:
   switches:
     module: [ gateway,ospf ]
-    members: [ s1,s2 ]
+    members: [ s1,s2,s3 ]
   hosts:
-    members: [ h1, h2 ]
+    members: [ h1, h2, h3, h4 ]
     device: linux
 
-nodes: [ s1,s2,h1,h2 ]
+nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
 
 links:
 - s1:
@@ -32,3 +32,10 @@ links:
   gateway: True
 - s1:
   s2:
+  h3:
+  h4:
+  gateway: True
+- s1:
+  s3:
+- s2:
+  s3:

--- a/tests/integration/gateway/anycast/vlan.yml
+++ b/tests/integration/gateway/anycast/vlan.yml
@@ -1,33 +1,52 @@
 #
-# Anycast gateway test case
+# Anycast gateway on a physical interface
 #
+
+message: |
+  This test case replaces a multi-access LAN with a VLAN -- the switches have anycast
+  IP address configured on the shared LAN. Two LANs are used in the topology to explore
+  the impact of shared MAC addresses on multiple LANs.
+
+  Static routes on hosts point to the shared anycast IP address. The switches
+  are running OSPF with a third switch to enable network-wide connectivity.
+
+  All hosts should be able to ping the loopback addresses of all switches.
 
 gateway.id: 1
 
 groups:
   switches:
-    module: [ gateway,vlan ]
-    members: [ r1, r2, r3 ]
-    device: eos
+    module: [ gateway,ospf,vlan ]
+    members: [ s1,s2,s3 ]
   hosts:
     members: [ h1, h2, h3, h4 ]
     device: linux
 
-nodes: [ r1,r2,r3,h1,h2,h3,h4 ]
-
 vlans:
   red:
-    gateway.anycast.unicast: True
+    gateway: True
+  blue:
+    gateway: True
+
+nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
 
 links:
-- r1:
-  r2:
+- s1:
   h1:
+  vlan.access: red
+- s2:
   h2:
-  gateway: True
-- r1:
+  vlan.access: red
+- s1:
   h3:
   vlan.access: red
-- r2:
+- s2:
   h4:
   vlan.access: red
+- s1:
+  s2:
+  vlan.trunk: [ red, blue ]
+- s1:
+  s3:
+- s2:
+  s3:

--- a/tests/integration/gateway/anycast/vlan.yml
+++ b/tests/integration/gateway/anycast/vlan.yml
@@ -39,10 +39,10 @@ links:
   vlan.access: red
 - s1:
   h3:
-  vlan.access: red
+  vlan.access: blue
 - s2:
   h4:
-  vlan.access: red
+  vlan.access: blue
 - s1:
   s2:
   vlan.trunk: [ red, blue ]

--- a/tests/integration/gateway/anycast/vlan.yml
+++ b/tests/integration/gateway/anycast/vlan.yml
@@ -1,0 +1,33 @@
+#
+# Anycast gateway test case
+#
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,vlan ]
+    members: [ r1, r2, r3 ]
+    device: eos
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+nodes: [ r1,r2,r3,h1,h2,h3,h4 ]
+
+vlans:
+  red:
+    gateway.anycast.unicast: True
+
+links:
+- r1:
+  r2:
+  h1:
+  h2:
+  gateway: True
+- r1:
+  h3:
+  vlan.access: red
+- r2:
+  h4:
+  vlan.access: red

--- a/tests/integration/gateway/vrrp/lan-subnet.yml
+++ b/tests/integration/gateway/vrrp/lan-subnet.yml
@@ -27,6 +27,8 @@ nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
 
 links:
 - s1:
+    gateway.vrrp.priority: 250
+    gateway.vrrp.preempt: True
   s2:
   h1:
   h2:

--- a/tests/integration/gateway/vrrp/lan-subnet.yml
+++ b/tests/integration/gateway/vrrp/lan-subnet.yml
@@ -1,0 +1,64 @@
+#
+# VRRP on a physical interface
+#
+
+message: |
+  This is the simplest VRRP test case -- the switches have VRRP configured on
+  the shared LAN. Two LANs are used in the topology to explore the impact of
+  using the same VRRP group on multiple LANs.
+
+  Static routes on hosts point to the shared anycast IP address. The switches
+  are running OSPF with a third switch to enable network-wide connectivity.
+
+  All hosts should be able to ping the loopback addresses of all switches.
+
+gateway.id: 1
+gateway.protocol: vrrp
+
+groups:
+  switches:
+    module: [ gateway,ospf ]
+    members: [ s1,s2,s3 ]
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
+
+links:
+- s1:
+  s2:
+  h1:
+  h2:
+  gateway: True
+- s1:
+  s2:
+  h3:
+  h4:
+  gateway: True
+  prefix:
+    ipv4: 192.168.42.0/24
+    ipv6: "2001:db8:abba:cafe::/64"
+- s1:
+  s3:
+- s2:
+  s3:
+
+#
+# The following "line noise" defines a Jinja2 template that you can use to
+# find the relevant data structures when creating your template.
+#
+# Display gateway-related node- and interface data structures with
+# with 'netlab create _file_ -o format:vrrp'
+#
+defaults.outputs.format:
+  vrrp: |
+    {% for n,n_d in nodes.items() if 'gateway' in n_d.module %}
+
+    {{ n }}:
+        {{ n_d.gateway }}
+    {%   for intf in n_d.interfaces if 'gateway' in intf %}
+      {{ intf.ifname }} {{ intf.name }}:
+        {{ intf.gateway }}
+    {%   endfor %}
+    {% endfor %}

--- a/tests/integration/gateway/vrrp/vlan.yml
+++ b/tests/integration/gateway/vrrp/vlan.yml
@@ -1,0 +1,71 @@
+#
+# Anycast gateway on a physical interface
+#
+
+message: |
+  This test case replaces a multi-access LAN with a VLAN -- the switches have VRRP
+  configured on the shared VLAN.
+
+  Static routes on hosts point to the shared anycast IP address. The switches
+  are running OSPF with a third switch to enable network-wide connectivity.
+
+  All hosts should be able to ping the loopback addresses of all switches.
+
+gateway.id: 1
+gateway.protocol: vrrp
+
+groups:
+  switches:
+    module: [ gateway,ospf,vlan ]
+    members: [ s1,s2,s3 ]
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+vlans:
+  red:
+    gateway: True
+  blue:
+    gateway: True
+
+nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
+
+links:
+- s1:
+  h1:
+  vlan.access: red
+- s2:
+  h2:
+  vlan.access: red
+- s1:
+  h3:
+  vlan.access: red
+- s2:
+  h4:
+  vlan.access: red
+- s1:
+  s2:
+  vlan.trunk: [ red, blue ]
+- s1:
+  s3:
+- s2:
+  s3:
+
+#
+# The following "line noise" defines a Jinja2 template that you can use to
+# find the relevant data structures when creating your template.
+#
+# Display gateway-related node- and interface data structures with
+# with 'netlab create _file_ -o format:vrrp'
+#
+defaults.outputs.format:
+  vrrp: |
+    {% for n,n_d in nodes.items() if 'gateway' in n_d.module %}
+
+    {{ n }}:
+        {{ n_d.gateway }}
+    {%   for intf in n_d.interfaces if 'gateway' in intf %}
+      {{ intf.ifname }} {{ intf.name }}:
+        {{ intf.gateway }}
+    {%   endfor %}
+    {% endfor %}

--- a/tests/integration/gateway/vrrp/vlan.yml
+++ b/tests/integration/gateway/vrrp/vlan.yml
@@ -32,6 +32,8 @@ nodes: [ s1,s2,s3,h1,h2,h3,h4 ]
 
 links:
 - s1:
+    gateway.vrrp.priority: 250
+    gateway.vrrp.preempt: True
   h1:
   vlan.access: red
 - s2:

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -3,7 +3,8 @@ gateway:
     mac: 0200.cafe.00ff
     unicast: true
   id: 1
-  protocol: anycast
+  vrrp:
+    group: 1
 groups:
   hosts:
     device: linux
@@ -33,6 +34,8 @@ links:
     id: -2
     ipv4: 172.16.1.254/24
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
@@ -63,6 +66,8 @@ links:
     id: 1
     ipv4: 172.16.0.1/24
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -90,6 +95,8 @@ links:
     id: 1
     ipv4: 172.16.0.1/24
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -117,6 +124,8 @@ links:
     id: -3
     ipv4: 10.42.42.13/28
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 3
     ifname: Ethernet3
@@ -140,6 +149,8 @@ links:
     id: 1
     ipv4: 10.42.42.1/29
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 4
     ifname: Ethernet4
@@ -164,6 +175,8 @@ links:
     ipv4: 172.31.31.1/24
     ipv6: 2001:db8:cafe:1::1/64
     protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - ifindex: 5
     ifname: Ethernet5
@@ -203,6 +216,8 @@ nodes:
         id: -2
         ipv4: 172.16.1.254/24
         protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.4/24
@@ -240,6 +255,8 @@ nodes:
         id: -2
         ipv4: 172.16.1.254/24
         protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.5/24
@@ -277,6 +294,8 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.6/24
@@ -315,6 +334,8 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.13/24
@@ -390,7 +411,6 @@ nodes:
       anycast:
         mac: 0200.cafe.00ff
         unicast: true
-      protocol: anycast
     id: 2
     interfaces:
     - bridge: input_1
@@ -493,7 +513,6 @@ nodes:
       anycast:
         mac: 0200.cafe.00ff
         unicast: true
-      protocol: anycast
     id: 3
     interfaces:
     - bridge: input_1

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -120,16 +120,66 @@ links:
   interfaces:
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 10.42.42.3/28
+    ipv4: 10.42.42.1/28
     node: r2
   - ifindex: 2
     ifname: eth2
-    ipv4: 10.42.42.13/28
+    ipv4: 10.42.42.2/28
     node: h4
   linkindex: 4
   node_count: 2
   prefix:
     ipv4: 10.42.42.0/28
+  role: stub
+  type: lan
+- bridge: input_5
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 10.42.42.1/29
+    protocol: anycast
+  interfaces:
+  - ifindex: 4
+    ifname: Ethernet4
+    ipv4: 10.42.42.2/29
+    node: r2
+  - ifindex: 3
+    ifname: eth3
+    ipv4: 10.42.42.3/29
+    node: h4
+  linkindex: 5
+  node_count: 2
+  prefix:
+    ipv4: 10.42.42.0/29
+  role: stub
+  type: lan
+- bridge: input_6
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 172.31.31.1/24
+    ipv6: 2001:db8:cafe:1::1/64
+    protocol: anycast
+  interfaces:
+  - ifindex: 5
+    ifname: Ethernet5
+    ipv4: 172.31.31.3/24
+    ipv6: 2001:db8:cafe:1::3/64
+    node: r2
+  - ifindex: 4
+    ifname: eth4
+    ipv4: 172.31.31.13/24
+    ipv6: 2001:db8:cafe:1::d/64
+    node: h4
+  linkindex: 6
+  node_count: 2
+  prefix:
+    ipv4: 172.31.31.0/24
+    ipv6: 2001:db8:cafe:1::/64
   role: stub
   type: lan
 module:
@@ -252,6 +302,7 @@ nodes:
   h4:
     af:
       ipv4: true
+      ipv6: true
     box: generic/ubuntu2004
     device: linux
     id: 13
@@ -282,15 +333,45 @@ nodes:
       type: lan
     - bridge: input_4
       gateway:
-        ipv4: 10.42.42.3/28
+        ipv4: 10.42.42.1/28
       ifindex: 2
       ifname: eth2
-      ipv4: 10.42.42.13/28
+      ipv4: 10.42.42.2/28
       linkindex: 4
       name: h4 -> r2
       neighbors:
       - ifname: Ethernet3
-        ipv4: 10.42.42.3/28
+        ipv4: 10.42.42.1/28
+        node: r2
+      role: stub
+      type: lan
+    - bridge: input_5
+      gateway:
+        ipv4: 10.42.42.2/29
+      ifindex: 3
+      ifname: eth3
+      ipv4: 10.42.42.3/29
+      linkindex: 5
+      name: h4 -> r2
+      neighbors:
+      - ifname: Ethernet4
+        ipv4: 10.42.42.2/29
+        node: r2
+      role: stub
+      type: lan
+    - bridge: input_6
+      gateway:
+        ipv4: 172.31.31.3/24
+      ifindex: 4
+      ifname: eth4
+      ipv4: 172.31.31.13/24
+      ipv6: 2001:db8:cafe:1::d/64
+      linkindex: 6
+      name: h4 -> r2
+      neighbors:
+      - ifname: Ethernet5
+        ipv4: 172.31.31.3/24
+        ipv6: 2001:db8:cafe:1::3/64
         node: r2
       role: stub
       type: lan
@@ -405,6 +486,7 @@ nodes:
   r2:
     af:
       ipv4: true
+      ipv6: true
     box: arista/veos
     device: eos
     gateway:
@@ -458,12 +540,61 @@ nodes:
         protocol: anycast
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 10.42.42.3/28
+      ipv4: 10.42.42.1/28
       linkindex: 4
       name: r2 -> h4
       neighbors:
       - ifname: eth2
-        ipv4: 10.42.42.13/28
+        ipv4: 10.42.42.2/28
+        node: h4
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: true
+      role: stub
+      type: lan
+    - bridge: input_5
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 10.42.42.1/29
+        protocol: anycast
+      ifindex: 4
+      ifname: Ethernet4
+      ipv4: 10.42.42.2/29
+      linkindex: 5
+      name: r2 -> h4
+      neighbors:
+      - ifname: eth3
+        ipv4: 10.42.42.3/29
+        node: h4
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: true
+      role: stub
+      type: lan
+    - bridge: input_6
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.31.31.1/24
+        ipv6: 2001:db8:cafe:1::1/64
+        protocol: anycast
+      ifindex: 5
+      ifname: Ethernet5
+      ipv4: 172.31.31.3/24
+      ipv6: 2001:db8:cafe:1::3/64
+      linkindex: 6
+      name: r2 -> h4
+      neighbors:
+      - ifname: eth4
+        ipv4: 172.31.31.13/24
+        ipv6: 2001:db8:cafe:1::d/64
         node: h4
       ospf:
         area: 0.0.0.0
@@ -479,7 +610,7 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 4
+      ifindex: 6
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h3,r1,h4]
@@ -514,6 +645,7 @@ nodes:
     ospf:
       af:
         ipv4: true
+        ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
     vlan:

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -30,8 +30,8 @@ links:
     anycast:
       mac: 0200.cafe.00ff
       unicast: false
-    id: 1
-    ipv4: 172.16.1.1/24
+    id: -2
+    ipv4: 172.16.1.254/24
     protocol: anycast
   interfaces:
   - ifindex: 1
@@ -99,7 +99,7 @@ links:
       access: red
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.7/24
+    ipv4: 172.16.0.13/24
     node: h4
   linkindex: 3
   node_count: 2
@@ -109,6 +109,29 @@ links:
   type: lan
   vlan:
     access: red
+- bridge: input_4
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: -3
+    ipv4: 10.42.42.13/28
+    protocol: anycast
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    ipv4: 10.42.42.3/28
+    node: r2
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 10.42.42.13/28
+    node: h4
+  linkindex: 4
+  node_count: 2
+  prefix:
+    ipv4: 10.42.42.0/28
+  role: stub
+  type: lan
 module:
 - vlan
 - ospf
@@ -127,8 +150,8 @@ nodes:
         anycast:
           mac: 0200.cafe.00ff
           unicast: false
-        id: 1
-        ipv4: 172.16.1.1/24
+        id: -2
+        ipv4: 172.16.1.254/24
         protocol: anycast
       ifindex: 1
       ifname: eth1
@@ -164,8 +187,8 @@ nodes:
         anycast:
           mac: 0200.cafe.00ff
           unicast: false
-        id: 1
-        ipv4: 172.16.1.1/24
+        id: -2
+        ipv4: 172.16.1.254/24
         protocol: anycast
       ifindex: 1
       ifname: eth1
@@ -214,7 +237,7 @@ nodes:
         ipv4: 172.16.0.2/24
         node: r1
       - ifname: eth1
-        ipv4: 172.16.0.7/24
+        ipv4: 172.16.0.13/24
         node: h4
       - ifname: Vlan1000
         ipv4: 172.16.0.3/24
@@ -231,7 +254,7 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 7
+    id: 13
     interfaces:
     - bridge: input_3
       gateway:
@@ -243,7 +266,7 @@ nodes:
         protocol: anycast
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.7/24
+      ipv4: 172.16.0.13/24
       linkindex: 3
       name: h4 -> [h3,r1,r2]
       neighbors:
@@ -257,10 +280,24 @@ nodes:
         ipv4: 172.16.0.3/24
         node: r2
       type: lan
+    - bridge: input_4
+      gateway:
+        ipv4: 10.42.42.3/28
+      ifindex: 2
+      ifname: eth2
+      ipv4: 10.42.42.13/28
+      linkindex: 4
+      name: h4 -> r2
+      neighbors:
+      - ifname: Ethernet3
+        ipv4: 10.42.42.3/28
+        node: r2
+      role: stub
+      type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.107
-      mac: 08-4F-A9-00-00-07
+      ipv4: 192.168.121.113
+      mac: 08-4F-A9-00-00-0D
     name: h4
     role: host
   r1:
@@ -280,8 +317,8 @@ nodes:
         anycast:
           mac: 0200.cafe.00ff
           unicast: false
-        id: 1
-        ipv4: 172.16.1.1/24
+        id: -2
+        ipv4: 172.16.1.254/24
         protocol: anycast
       ifindex: 1
       ifname: Ethernet1
@@ -326,7 +363,7 @@ nodes:
         ipv4: 172.16.0.6/24
         node: h3
       - ifname: eth1
-        ipv4: 172.16.0.7/24
+        ipv4: 172.16.0.13/24
         node: h4
       - ifname: Vlan1000
         ipv4: 172.16.0.3/24
@@ -382,8 +419,8 @@ nodes:
         anycast:
           mac: 0200.cafe.00ff
           unicast: false
-        id: 1
-        ipv4: 172.16.1.1/24
+        id: -2
+        ipv4: 172.16.1.254/24
         protocol: anycast
       ifindex: 1
       ifname: Ethernet1
@@ -411,6 +448,29 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+    - bridge: input_4
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -3
+        ipv4: 10.42.42.13/28
+        protocol: anycast
+      ifindex: 3
+      ifname: Ethernet3
+      ipv4: 10.42.42.3/28
+      linkindex: 4
+      name: r2 -> h4
+      neighbors:
+      - ifname: eth2
+        ipv4: 10.42.42.13/28
+        node: h4
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: true
+      role: stub
+      type: lan
     - bridge_group: 1
       gateway:
         anycast:
@@ -419,7 +479,7 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 3
+      ifindex: 4
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h3,r1,h4]
@@ -431,7 +491,7 @@ nodes:
         ipv4: 172.16.0.2/24
         node: r1
       - ifname: eth1
-        ipv4: 172.16.0.7/24
+        ipv4: 172.16.0.13/24
         node: h4
       ospf:
         area: 0.0.0.0
@@ -472,7 +532,7 @@ nodes:
           ipv4: 172.16.0.2/24
           node: r1
         - ifname: eth1
-          ipv4: 172.16.0.7/24
+          ipv4: 172.16.0.13/24
           node: h4
         - ifname: Vlan1000
           ipv4: 172.16.0.3/24
@@ -496,7 +556,7 @@ vlans:
       ipv4: 172.16.0.2/24
       node: r1
     - ifname: eth1
-      ipv4: 172.16.0.7/24
+      ipv4: 172.16.0.13/24
       node: h4
     - ifname: Vlan1000
       ipv4: 172.16.0.3/24

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -1,0 +1,506 @@
+gateway:
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: true
+  id: 1
+  protocol: anycast
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+  switches:
+    device: eos
+    members:
+    - r1
+    - r2
+    module:
+    - gateway
+    - vlan
+    - ospf
+input:
+- topology/input/anycast-gateway.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: false
+    id: 1
+    ipv4: 172.16.1.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.2/24
+    node: r1
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.3/24
+    node: r2
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.4/24
+    node: h1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.5/24
+    node: h2
+  linkindex: 1
+  node_count: 4
+  prefix:
+    ipv4: 172.16.1.0/24
+  type: lan
+- bridge: input_2
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 172.16.0.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.2/24
+    node: r1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.6/24
+    node: h3
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_3
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv4: 172.16.0.1/24
+    protocol: anycast
+  interfaces:
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.3/24
+    node: r2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.7/24
+    node: h4
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+module:
+- vlan
+- ospf
+- gateway
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 4
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.4/24
+      linkindex: 1
+      name: h1 -> [r1,r2,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08-4F-A9-00-00-04
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 5
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.5/24
+      linkindex: 1
+      name: h2 -> [r1,r2,h1]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08-4F-A9-00-00-05
+    name: h2
+    role: host
+  h3:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 6
+    interfaces:
+    - bridge: input_2
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.6/24
+      linkindex: 2
+      name: h3 -> [r1,h4,r2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.106
+      mac: 08-4F-A9-00-00-06
+    name: h3
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 7
+    interfaces:
+    - bridge: input_3
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.7/24
+      linkindex: 3
+      name: h4 -> [h3,r1,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.107
+      mac: 08-4F-A9-00-00-07
+    name: h4
+    role: host
+  r1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      protocol: anycast
+    id: 2
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: r1 -> [r2,h1,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.3/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: lan
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h3,h4,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: r2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - vlan
+    - ospf
+    - gateway
+    name: r1
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.2
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway: true
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  r2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      protocol: anycast
+    id: 3
+    interfaces:
+    - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: false
+        id: 1
+        ipv4: 172.16.1.1/24
+        protocol: anycast
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: r2 -> [r1,h1,h2]
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: lan
+    - bridge: input_3
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 3
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        protocol: anycast
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      name: VLAN red (1000) -> [h3,r1,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.6/24
+        node: h3
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r1
+      - ifname: eth1
+        ipv4: 172.16.0.7/24
+        node: h4
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - vlan
+    - ospf
+    - gateway
+    name: r2
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.3
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway: true
+        id: 1000
+        mode: irb
+        neighbors:
+        - ifname: eth1
+          ipv4: 172.16.0.6/24
+          node: h3
+        - ifname: Vlan1000
+          ipv4: 172.16.0.2/24
+          node: r1
+        - ifname: eth1
+          ipv4: 172.16.0.7/24
+          node: h4
+        - ifname: Vlan1000
+          ipv4: 172.16.0.3/24
+          node: r2
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+ospf:
+  area: 0.0.0.0
+provider: libvirt
+vlans:
+  red:
+    gateway: true
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.6/24
+      node: h3
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: r1
+    - ifname: eth1
+      ipv4: 172.16.0.7/24
+      node: h4
+    - ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      node: r2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -55,3 +55,19 @@ links:
     ipv4: "172.31.31.0/24"
     ipv6: "2001:db8:cafe:1::/64"
   gateway: True
+
+#
+# Use these formats to display a summary of transformed topology when debugging the test case
+#
+# Display anycast information with 'netlab create _file_ -o format:anycast'
+#
+defaults.outputs.format:
+  anycast: |
+    {% for n,n_d in nodes.items() if 'gateway' in n_d.module %}
+    {{ n }}:
+        {{ n_d.gateway }}
+    {%   for intf in n_d.interfaces if 'gateway' in intf %}
+      {{ intf.ifname }} {{ intf.name }}:
+        {{ intf.gateway }}
+    {%   endfor %}
+    {% endfor %}

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -39,8 +39,13 @@ links:
 - r2:
   h4:
   vlan.access: red
-- r2:
+- r2:                                 # Force sequential allocation through low last-in-subnet IP
   h4:
   prefix:
     ipv4: "10.42.42.0/28"
   gateway.id: -3
+- r2:                                 # Force sequential allocation through low prefix size -- verify gateway IP is skipped
+  h4:
+  prefix:
+    ipv4: "10.42.42.0/29"
+  gateway: True

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -13,21 +13,34 @@ groups:
     members: [ h1, h2, h3, h4 ]
     device: linux
 
-nodes: [ r1, r2, h1, h2, h3, h4 ]
+nodes:
+  r1:
+  r2:
+  h1:
+  h2:
+  h3:
+  h4:
+    id: 13
 
 vlans:
-  red:
-    gateway: True
+  red:                        # Test anycast in a VLAN
+    gateway: True             # ... also verify that the VLAN data is not overwriting gateway data on SVI interface
 
 links:
 - r1:
   r2:
   h1:
   h2:
-  gateway.anycast.unicast: False
+  gateway.anycast.unicast: False      # Test removal of unicast IP addresses
+  gateway.id: -2                      # And a negative offset
 - r1:
   h3:
   vlan.access: red
 - r2:
   h4:
   vlan.access: red
+- r2:
+  h4:
+  prefix:
+    ipv4: "10.42.42.0/28"
+  gateway.id: -3

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -1,0 +1,33 @@
+#
+# Anycast gateway test case
+#
+
+gateway.id: 1
+
+groups:
+  switches:
+    module: [ gateway,vlan,ospf ]
+    members: [ r1, r2 ]
+    device: eos
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+
+nodes: [ r1, r2, h1, h2, h3, h4 ]
+
+vlans:
+  red:
+    gateway: True
+
+links:
+- r1:
+  r2:
+  h1:
+  h2:
+  gateway.anycast.unicast: False
+- r1:
+  h3:
+  vlan.access: red
+- r2:
+  h4:
+  vlan.access: red

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -49,3 +49,9 @@ links:
   prefix:
     ipv4: "10.42.42.0/29"
   gateway: True
+- r2:
+  h4:
+  prefix:
+    ipv4: "172.31.31.0/24"
+    ipv6: "2001:db8:cafe:1::/64"
+  gateway: True


### PR DESCRIPTION
The initial implementation of the **gateway** module supports anycast gateways, optionally without unicast IP addresses, and VRRPv3 for IPv4 and IPv6