### PR TITLE
Critical: sros - put 'routes' under bgp-evpn context

### DIFF
--- a/netsim/ansible/templates/vxlan/sros.j2
+++ b/netsim/ansible/templates/vxlan/sros.j2
@@ -6,12 +6,6 @@
    customer: '1'
    admin-state: enable
    service-id: {{ vni if type=='l3' else (vrf[4:]|int + 10000) }} # transit VNI for l3, should not overlap
-
-{% if type=='l3' %}
-   routes:
-     ip-prefix:
-      advertise: True # Symmetric IRB using RT5 prefixes
-{% endif %}
    vxlan:
     instance:
     - vxlan-instance: 1
@@ -19,11 +13,20 @@
    bgp:
    - bgp-instance: 1
      # route-distinguisher: {{ rd }} # Don't configure this, use auto RD
+{% if type=='l2' %}
      route-target:
       export: "target:{{ rts.export[0] }}"
       import: "target:{{ rts.import[0] }}"
+{% endif %}      
    bgp-evpn:
     evi: {{ evi }}
+{% if type=='l3' %}
+    routes:
+     ip-prefix:
+      advertise: True # Symmetric IRB using RT5 prefixes
+     mac-ip:
+      advertise: False
+{% endif %}
     vxlan:
     - vxlan-instance: 1
       bgp-instance: 1


### PR DESCRIPTION
YANG model mismatch