### PR TITLE
Validate groups and node_data with the new validation routines

### DIFF
--- a/docs/groups.md
+++ b/docs/groups.md
@@ -89,6 +89,98 @@ links: [ s1-s2, s2-s3 ]
 A **netlab config** command is executed by **netlab up** process for every template in every **config** parameter, regardless of whether it's specified on a group or a node. Excessive use of **config** parameters might thus result in slower lab deployment.
 ```
 
+## Setting Node Data in Groups
+
+Sometimes you'd like to set a node attribute for all members of a group. For example, in a BGP anycast scenario we should set **[bgp.advertise_loopback](module/bgp.md#advertised-bgp-prefixes)** to *false* on all anycast server -- they should advertise only the anycast prefix not individual loopback prefixes. 
+
+While it's perfectly OK to set the desired attribute(s) on individual nodes, it's much more convenient to set them in a group definition -- you can use any valid node attribute (including configuration module node attributes[^MNA]) in group definitions[^NDT].
+
+[^MNA]: If a group definition contains **module** attribute, you  cannot set attributes for modules not listed in the **module** attribute in the group definition.
+ 
+[^NDT]: Node attributes were stored in **node_data** group attribute prior to *netlab* release 1.4. Starting with release 1.4, you can continue using **node_data** dictionary or set node  attributes directly in group definitions.
+
+The node group attribute will be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute.
+
+Using this functionality, a BGP anycast topology file becomes much more concise than it would have been otherwise:
+
+```
+defaults:
+  device: iosv
+
+module: [ bgp, ospf ]
+
+bgp.as: 65000
+
+groups:
+  anycast:
+    members: [ a1, a2, a3 ]
+    bgp.as: 65001
+    bgp.advertise_loopback: false
+
+nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
+```
+
+### Using Group Node Data with VRFs and VLANs
+
+VRFs and VLANs mentioned in **vrfs** or **vlans** group attributes will be defined as global (topology-wide) VRFs/VLANs. The VLAN ID/VNI or VRF RT/RD values will be copied from **vlans**/**vrfs** into global **vlans**/**vrfs**. As every VLAN  needs a unique ID/VNI (likewise for VRF RT/RD), you cannot define different ID/VNI or RT/RD values for the same VLAN/VRF in different groups.
+
+Example:
+
+```
+module: [ vlan,ospf ]
+
+groups:
+  g1:
+    members: [ r1, r2 ]
+    vlans:
+      red:
+        ospf.cost: 10
+      blue:
+        ospf.cost: 20
+
+nodes: [r1, r2]
+
+links:
+- r1:
+  r2:
+  vlan.trunk: [ red, blue ]
+```
+
+The above topology will:
+
+* Create topology-wide *red* and *blue* VLANs.
+* Auto-assign VLAN ID and VNI to those VLANs.
+* Copy group **vlans** into R1 and R2 (setting OSPF cost for VLAN interfaces)
+* Merge the global **vlans** definitions into **nodes.r1.vlans** and **nodes.r2.vlans**, ensuring the VLANs on R1 and R2 have the correct VLAN ID/VNI.
+
+```{tip}
+As the group VLANs/VRFs are copied into all nodes in a group, you'll get all VLANs/VRFs (and VLAN interfaces) mentioned in group definition defined on all group members regardless of whether they actually use those VLANs/VRFs.
+```
+
+## Setting Device Type or List of Modules in Groups
+
+You can set node device type (**device** attribute[^DVTRANS]) or the list of configuration modules (**module** attribute[^MDTRANS]) in group definitions, but only on groups with static members.
+
+The following example uses this functionality to use Cumulus VX on routers advertising anycast IP address, and to use BGP as the only configuration module on those devices.
+
+```
+defaults:
+  device: iosv
+
+module: [ bgp, ospf ]
+bgp.as: 65000
+
+groups:
+  anycast:
+    members: [ a1, a2, a3 ]
+    module: [ bgp ]
+    device: cumulus
+    bgp.as: 65001
+    bgp.advertise_loopback: false
+
+nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
+```
+
 ## Group Variables
 
 Group definition could include group variables in the **vars** element. Group variables are a dictionary of name/value pairs:
@@ -110,7 +202,7 @@ groups:
 
 Group variables are stored in **group_vars** directory when **[netlab create](netlab/create.md)** creates an Ansible inventory from the topology file. They can be used as normal Ansible group variables, for example in a Jinja2 template specified in **netlab config** command.
 
-## Changing Group Variables for Predefined Groups
+### Changing Group Variables for Predefined Groups
 
 If you want to set one or more Ansible facts for all devices in your lab, use **vars** element in **all** group:
 
@@ -144,105 +236,6 @@ nodes: [ a,b,c ]
 
 groups.cumulus.vars.ansible_user: other
 ```
-
-## Setting Node Data in Groups
-
-Sometimes you'd like to set a node attribute for all members of a group. For example, in a BGP anycast scenario we should set **[bgp.advertise_loopback](module/bgp.md#advertised-bgp-prefixes)** to *false* on all anycast server -- they should advertise only the anycast prefix not individual loopback prefixes. 
-
-While it's perfectly OK to set the desired attribute on individual nodes, it's much more convenient to set it in a group definition with the **node_data** attribute.
-
-**node_data** group attribute contains a set of values that should be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute without affecting **bgp.as** attribute.
-
-Using **node_data** functionality, a BGP anycast topology file becomes much more concise than it would have been otherwise:
-
-```
-defaults:
-  device: iosv
-
-module: [ bgp, ospf ]
-
-bgp.as: 65000
-
-groups:
-  anycast:
-    members: [ a1, a2, a3 ]
-    node_data:
-      bgp.as: 65001
-      bgp.advertise_loopback: false
-
-nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
-```
-
-### Using Group Node Data with VRFs and VLANs
-
-VRFs and VLANs mentioned in **node_data.vrfs** or **node_data.vlans** will be defined as global (topology-wide) VRFs/VLANs. The VLAN ID/VNI or VRF RT/RD values will be copied from **node_data.vlans**/**node_data.vrfs** into global **vlans**/**vrfs**. As every VLAN  needs a unique ID/VNI (likewise for VRF RT/RD), you cannot define different ID/VNI or RT/RD values for the same VLAN/VRF in different groups.
-
-Example:
-
-```
-module: [ vlan,ospf ]
-
-groups:
-  g1:
-    members: [ r1, r2 ]
-    node_data:
-      vlans:
-        red:
-          ospf.cost: 10
-        blue:
-          ospf.cost: 20
-
-nodes: [r1, r2]
-
-links:
-- r1:
-  r2:
-  vlan.trunk: [ red, blue ]
-```
-
-The above topology will:
-
-* Create topology-wide *red* and *blue* VLANs.
-* Auto-assign VLAN ID and VNI to those VLANs.
-* Copy **node_data.vlans** into R1 and R2 (setting OSPF cost for VLAN interfaces)
-* Merge the global **vlans** definitions into **nodes.r1.vlans** and **nodes.r2.vlans**, ensuring the VLANs on R1 and R2 have the correct VLAN ID/VNI.
-
-```{tip}
-As the **node_data** is copied into all nodes in a group, you'll get all VLANs/VRFs mentioned in **node_data** defined on all group members regardless of whether they actually use those VLANs/VRFs.
-```
-
-## Setting Device Type or List of Modules in Groups
-
-Node device type (**device** attribute[^DVTRANS]) or the list of configuration modules (**module** attribute[^MDTRANS]) cannot be set within group **node_data**. Use **device** or **module** attribute at the group level to set them.
-
-The following example uses this functionality to use Cumulus VX on routers advertising anycast IP address, and to use BGP as the only configuration module on those devices.
-
-```
-defaults:
-  device: iosv
-
-module: [ bgp, ospf ]
-bgp.as: 65000
-
-groups:
-  anycast:
-    members: [ a1, a2, a3 ]
-    module: [ bgp ]
-    device: cumulus
-    node_data:
-      bgp.as: 65001
-      bgp.advertise_loopback: false
-
-nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
-```
-
-Notes:
-
-* You can use **device** or **module** attribute only on groups with static members.
-
-[^DVTRANS]: Device type must be set very early in the topology transformation process to check whether the selected device supports the configuration modules enabled for a node.
-
-[^MDTRANS]: Configuration modules have to be initialized before the **node_data** is copied into nodes to support automatic BGP groups. Modifying the list of node modules after the modules have been initialized would result in weird errors.
 
 ## Automatic BGP Groups
 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -101,6 +101,12 @@ While it's perfectly OK to set the desired attribute(s) on individual nodes, it'
 
 The node group attribute will be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute.
 
+```{warning}
+Due to a [circular dependency documented in Issue #611](https://github.com/ipspace/netlab/issues/611), the node data specified in groups overwrites the attributes specified in individual nodes.
+
+**Workaround**: Do not specify the same node attributes in groups and individual group members.
+```
+
 Using this functionality, a BGP anycast topology file becomes much more concise than it would have been otherwise:
 
 ```

--- a/docs/release/1.4.md
+++ b/docs/release/1.4.md
@@ -7,6 +7,9 @@
 * New address allocation algorithm for links with small IPv4 prefixes
 * Control allocation of VNI identifiers with **vxlan.vlans** attribute
 * Specify EVPN-enabled VLANs and VRFs with **evpn.vlans** and **evpn.vrfs** lists
+* VLAN interfaces are created for all VLANs listed in node **vlans** dictionary even when there's no physical interface using a particular VLAN.
+* VLANs and VRFs mentioned in group **vlans**/**vrfs** dictionaries are copied into all group members, resulting in VLAN interfaces and VRFs on all group members.
+* **node_data** is deprecated -- you can specify node attributes directly in group data.
 
 ## Breaking changes
 
@@ -23,3 +26,4 @@ Release 1.4 introduced behind-the-scenes functionality that might break existing
 * **ip** attribute within a **prefix** dictionary is no longer valid. Use **ipv4**.
 * The tests for unique VNI values are stricter and might break topologies that used duplicate VNI values in VLANs or VRFs.
 * Stricter checking of VLANs on VLAN trunks breaks nonsense topologies that had a non-VLAN node connected to a trunk with no native VLAN, or that had a single node using a particular VLAN on the trunk.
+* Group data is thoroughly checked, including node attributes. This might break topologies that used invalid node attributes or attributes for non-active modules in **node_data**.

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -28,7 +28,10 @@ def common_parse_args(debugging: bool = False) -> argparse.ArgumentParser:
   parser.add_argument('--raise_on_error', dest='raise_on_error', action='store_true',help=argparse.SUPPRESS)
   if debugging:
     parser.add_argument('--debug', dest='debug', action='store',nargs='*',
-                    choices=['all','addr','cli','links','libvirt','modules','plugin','template','vlan','vrf','quirks','validate','addressing'],
+                    choices=[
+                      'all','addr','cli','links','libvirt','modules','plugin','template',
+                      'vlan','vrf','quirks','validate','addressing','groups'
+                    ],
                     help=argparse.SUPPRESS)
 
   return parser

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -272,54 +272,7 @@ def adjust_modules(topology: Box) -> None:
 Validate module parameters and dependencies
 """
 def module_validate(topology: Box) -> None:
-  check_module_parameters(topology)
   check_module_dependencies(topology)
-
-"""
-check_module_parameters:
-
-Verify global, node, link, and node-on-link data for all modules
-that include _attributes_ element in default settings
-
-parse_module_attributes:
-
-Accept list or dict as module attributes. List format applies to
-all levels (global, node, link, node-on-link), dict format specifies
-lists for every level.
-
-Global attributes are used as default value for node attributes.
-Link attributes are used as default value for node-on-link attributes.
-"""
-
-def check_module_parameters(topology: Box) -> None:
-  mod_attr = Box({},default_box=True,box_dots=True)
-
-  for m in topology.get("module",[]):                      # Iterate over all active modules
-    mod_def = topology.defaults.get(m,{})                  # Get module defaults
-    if mod_def:                                            # Did we get something meaningful?
-      if "attributes" in topology.defaults.get(m,{}):      # ... and does it include "attributes"?
-        mod_attr[m] = parse_module_attributes(topology.defaults[m].attributes)
-#
-#        if topology.get(m,{}):                             # Now we can start: are there global module parameters in topology?
-#          for k in topology[m].keys():                     # Got them - iterate over them
-#            if not k in mod_attr[m]["global"]:             # Did we get a parameter that is not in global attributes? Jeez... barf
-#              common.error(
-#                "Invalid global %s attribute %s" % (m,k),
-#                common.IncorrectValue,
-#                'module')
-
-  for g in topology.get('groups',{}):                    # Inspect node_data in groups
-    if 'node_data' in topology.groups[g]:
-      for m in topology.get('module',[]):                # Iterate over global modules
-        if m in topology.groups[g].node_data:            # Does the group node_data contain module attributes?
-          for k in topology.groups[g].node_data[m]:      # Iterate over module-specific attributes in node_data
-            if not k in mod_attr[m].node:                # Is the attribute a valid node attribute for the module?
-              common.error(
-                f"node_data in group {g} contains invalid attribute {k} for module {m}",
-                common.IncorrectValue,
-                'groups')
-
-  return
 
 """
 Prepare module attribute dictionary

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -42,6 +42,7 @@ attributes:
   pool: [ ipv4, ipv6, start, prefix, allocation, mac, unnumbered ]
   pool_no_copy: [ start, prefix, mac ]
   prefix: [ ipv4, ipv6, allocation ]
+  group: [ members, vars, config, node_data, device, module ]
 
 # Built-in module defaults
 #

--- a/tests/errors/group-invalid-config.yml
+++ b/tests/errors/group-invalid-config.yml
@@ -8,6 +8,12 @@ nodes:
 groups:
   g1: 
     members: [ a,b ]
-    config:
+    bgp.as: 65000                       # Invalid module
+    foo: 13                             # Invalid node attribute
+    config:                             # Config must be dictionary
       x: 1
       y: 2
+  g2:
+    members: [ a ]
+    module: [ ospf ]
+    bgp.as: 65000                       # BGP module not used by G2

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -20,7 +20,7 @@ groups:
     - g1
     - g3
     node_data:
-      foo: bar
+      box: bar
   g3:
     device: iosv
     members:
@@ -30,7 +30,7 @@ groups:
     node_data:
       bgp:
         as: 65000
-      foo: baz
+      box: baz
 input:
 - topology/input/groups-hierarchy.yml
 - package:topology-defaults.yml
@@ -44,7 +44,6 @@ nodes:
     - g2a
     - a
     device: cumulus
-    foo: bar
     id: 1
     interfaces: []
     loopback:
@@ -59,7 +58,6 @@ nodes:
     config:
     - b
     device: cumulus
-    foo: bar
     id: 2
     interfaces: []
     loopback:
@@ -87,7 +85,6 @@ nodes:
     - g2a
     - g2b
     device: cumulus
-    foo: bar
     id: 4
     interfaces: []
     loopback:
@@ -117,7 +114,6 @@ nodes:
     - g3
     - e
     device: iosv
-    foo: baz
     id: 5
     interfaces: []
     loopback:
@@ -132,7 +128,6 @@ nodes:
   f:
     box: CumulusCommunity/cumulus-vx:4.4.0
     device: cumulus
-    foo: bar
     id: 6
     interfaces: []
     loopback:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -20,40 +20,84 @@ groups:
     - g1
     - g3
     node_data:
-      box: bar
+      ospf:
+        area: 42
   g3:
     device: iosv
     members:
     - e
     module:
     - bgp
+    - ospf
     node_data:
       bgp:
         as: 65000
-      box: baz
+      ospf:
+        area: 51
 input:
 - topology/input/groups-hierarchy.yml
 - package:topology-defaults.yml
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: swp1
+    ipv4: 10.1.0.1/30
+    node: a
+  - ifindex: 1
+    ifname: GigabitEthernet0/1
+    ipv4: 10.1.0.2/30
+    node: e
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
 module:
+- ospf
 - bgp
 name: input
 nodes:
   a:
+    af:
+      ipv4: true
     box: CumulusCommunity/cumulus-vx:4.4.0
     config:
     - g2a
     - a
     device: cumulus
     id: 1
-    interfaces: []
+    interfaces:
+    - ifindex: 1
+      ifname: swp1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      name: a -> e
+      neighbors:
+      - ifname: GigabitEthernet0/1
+        ipv4: 10.1.0.2/30
+        node: e
+      ospf:
+        area: 42
+        network_type: point-to-point
+        passive: false
+      type: p2p
     loopback:
       ipv4: 10.0.0.1/32
     mgmt:
       ifname: eth0
       ipv4: 192.168.121.101
       mac: 08-4F-A9-00-00-01
+    module:
+    - ospf
     name: a
+    ospf:
+      af:
+        ipv4: true
+      area: 42
+      router_id: 10.0.0.1
   b:
+    af:
+      ipv4: true
     box: CumulusCommunity/cumulus-vx:4.4.0
     config:
     - b
@@ -66,8 +110,11 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.102
       mac: 08-4F-A9-00-00-02
+    module: []
     name: b
   c:
+    af:
+      ipv4: true
     box: arista/veos
     device: eos
     id: 3
@@ -78,8 +125,11 @@ nodes:
       ifname: Management1
       ipv4: 192.168.121.103
       mac: 08-4F-A9-00-00-03
+    module: []
     name: c
   d:
+    af:
+      ipv4: true
     box: CumulusCommunity/cumulus-vx:4.4.0
     config:
     - g2a
@@ -93,8 +143,11 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.104
       mac: 08-4F-A9-00-00-04
+    module: []
     name: d
   e:
+    af:
+      ipv4: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -115,7 +168,21 @@ nodes:
     - e
     device: iosv
     id: 5
-    interfaces: []
+    interfaces:
+    - ifindex: 1
+      ifname: GigabitEthernet0/1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      name: e -> a
+      neighbors:
+      - ifname: swp1
+        ipv4: 10.1.0.1/30
+        node: a
+      ospf:
+        area: 42
+        network_type: point-to-point
+        passive: false
+      type: p2p
     loopback:
       ipv4: 10.0.0.5/32
     mgmt:
@@ -124,8 +191,16 @@ nodes:
       mac: 08-4F-A9-00-00-05
     module:
     - bgp
+    - ospf
     name: e
+    ospf:
+      af:
+        ipv4: true
+      area: 42
+      router_id: 10.0.0.5
   f:
+    af:
+      ipv4: true
     box: CumulusCommunity/cumulus-vx:4.4.0
     device: cumulus
     id: 6
@@ -136,5 +211,8 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.106
       mac: 08-4F-A9-00-00-06
+    module: []
     name: f
+ospf:
+  area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/input/bgp-autogroup.yml
+++ b/tests/topology/input/bgp-autogroup.yml
@@ -18,8 +18,7 @@ bgp:
 
 groups:
   as65101:
-    node_data:
-      bgp.advertise_loopback: false
+    bgp.advertise_loopback: false
 
 nodes: 
   [ l1, l2, l3, s1, a1, a2, a3 ]

--- a/tests/topology/input/group-data-vlan.yml
+++ b/tests/topology/input/group-data-vlan.yml
@@ -5,16 +5,16 @@ module: [ vlan,ospf ]
 groups:
   g1:
     members: [ r1, r2 ]
-    node_data:
-      vlans:
-        red:
-          ospf.cost: 10
-          id: 1001
-          vni: 1001
-        blue:
-          ospf.cost: 20
-        green:
-          ospf.cost: 30
+    vlans:
+      red:
+        ospf.cost: 10
+        id: 1001
+        vni: 1001
+      blue:
+        ospf.cost: 20
+      green:
+        ospf.cost: 30
+
 nodes:
   r1:
   r2:

--- a/tests/topology/input/group-data-vrf.yml
+++ b/tests/topology/input/group-data-vrf.yml
@@ -8,14 +8,14 @@ vrfs:
 groups:
   g1:
     members: [ r1, r2 ]
-    node_data:
-      vrf.loopback: True
-      vrfs:
-        red:
-          ospf.area: 1
-          rd: '65101:11'
-        blue:
-          ospf.area: 2
+    vrf.loopback: True
+    vrfs:
+      red:
+        ospf.area: 1
+        rd: '65101:11'
+      blue:
+        ospf.area: 2
+
 nodes:
   r1:
   r2:

--- a/tests/topology/input/groups-hierarchy.yml
+++ b/tests/topology/input/groups-hierarchy.yml
@@ -17,13 +17,11 @@ groups:
     device: cumulus
     members: [ d,f,g1,g3 ]
     config: [ g2a, g2b ]
-    node_data:
-      foo: bar
+    box: bar
   g3:
     members: [ e ]
     module: [ bgp ]
     config: [ g3 ]
     device: iosv
-    node_data:
-      foo: baz
-      bgp.as: 65000
+    box: baz
+    bgp.as: 65000

--- a/tests/topology/input/groups-hierarchy.yml
+++ b/tests/topology/input/groups-hierarchy.yml
@@ -11,17 +11,22 @@ nodes:
   f:
     config: [ '-' ]
 
+module: [ ospf ]
+
 groups:
   g1: [ a,b ]
   g2:
     device: cumulus
     members: [ d,f,g1,g3 ]
     config: [ g2a, g2b ]
-    box: bar
+    ospf.area: 42
   g3:
     members: [ e ]
-    module: [ bgp ]
+    module: [ bgp, ospf ]
     config: [ g3 ]
     device: iosv
-    box: baz
+    ospf.area: 51
     bgp.as: 65000
+
+links:
+- a-e


### PR DESCRIPTION
Also:
* Allow node attributes in group definitions (node_data is optional)
* Cleanup the remains of 'check_module_parameters' code (no longer needed, all validation is done elsewhere)

Note:
* 'node_data' is still used internally