### PR TITLE
Resolve circular dependency between groups and BGP module

### DIFF
--- a/docs/dev/transform.md
+++ b/docs/dev/transform.md
@@ -20,6 +20,10 @@ The data transformation has three major steps:
 	* Add group members based on nodes' **group** attribute
 	* Check recursive groups
 	* Copy group **device** and **module** attribute into nodes
+	* Copy group **node_data** into nodes
+	* Process **bgp.as_list** to get **bgp.as** node attributes
+	* Create BGP autogroups (groups based on BGP AS numbers)
+	* Copy **node_data** from BGP autogroups into nodes
 
 * Adjust the list of links -- transform [strings or lists of nodes](../example/link-definition.md) into link dictionaries (`netsim.augment.links.adjust_link_list`)
 * Initialize [plugin system](../plugins.md): load all plugins listed in the **plugin** top-level element (`netsim.augment.plugin.init`)
@@ -40,7 +44,6 @@ The data transformation has three major steps:
 * Execute **pre_transform** plugin hooks (`netsim.augment.plugin.execute`)
 * Execute [**pre_transform** module adjustments](#adjust-global-module-parameters) (`netsim.modules.adjust_modules`)
 * Execute **pre_transform** [node-](#node-level-module-hooks) and [link-level](#link-level-module-hooks) module hooks
-* Adjust node groups: copy group-level **node_data** settings into all member nodes (`netsim.augment.groups.adjust_groups`):
 * Validate top-level topology elements (`netsim.augment.topology.check_global_elements`)
 
 ## Node Data Transformation

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -99,13 +99,9 @@ While it's perfectly OK to set the desired attribute(s) on individual nodes, it'
  
 [^NDT]: Node attributes were stored in **node_data** group attribute prior to *netlab* release 1.4. Starting with release 1.4, you can continue using **node_data** dictionary or set node  attributes directly in group definitions.
 
-The node group attribute will be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute.
+The node group attribute will be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute[^NDGP].
 
-```{warning}
-Due to a [circular dependency documented in Issue #611](https://github.com/ipspace/netlab/issues/611), the node data specified in groups overwrites the attributes specified in individual nodes.
-
-**Workaround**: Do not specify the same node attributes in groups and individual group members.
-```
+[^NDGP]: In a topology with hierarchical groups, attributes from the innermost groups take precedence. Node attributes from groups with static members have have precedence over node attributes from BGP-generated groups
 
 Using this functionality, a BGP anycast topology file becomes much more concise than it would have been otherwise:
 

--- a/docs/release/1.4.md
+++ b/docs/release/1.4.md
@@ -27,3 +27,4 @@ Release 1.4 introduced behind-the-scenes functionality that might break existing
 * The tests for unique VNI values are stricter and might break topologies that used duplicate VNI values in VLANs or VRFs.
 * Stricter checking of VLANs on VLAN trunks breaks nonsense topologies that had a non-VLAN node connected to a trunk with no native VLAN, or that had a single node using a particular VLAN on the trunk.
 * Group data is thoroughly checked, including node attributes. This might break topologies that used invalid node attributes or attributes for non-active modules in **node_data**.
+* Group node attribute inheritance sometimes produced incorrect results in releases prior to 1.4, in particular when combined with BGP-based groups. Resolved circular dependency between groups and BGP module might result in slightly different (but correct) group membership and node data.

--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -5,11 +5,14 @@ top-level element. That dictionary is merged from global- and node-level paramet
 '''
 
 import typing
+import re
 
 from box import Box
 
 from .. import common
 from .. import data
+from .. import modules
+from ..modules import bgp
 from ..data.validate import must_be_dict,must_be_list,must_be_string,validate_attributes
 from . import nodes
 
@@ -64,9 +67,7 @@ def check_group_data_structure(topology: Box) -> None:
   Sanity checks on global group data
   '''
 
-  list_of_modules = [ m for m in topology.defaults.keys() \
-                          if isinstance(topology.defaults[m],dict) \
-                            and 'supported_on' in topology.defaults[m] ]
+  list_of_modules = modules.list_of_modules(topology)
   group_attr = topology.defaults.attributes.group
 
   for grp,gdata in topology.groups.items():
@@ -142,8 +143,7 @@ def add_node_level_groups(topology: Box) -> None:
     if not 'group' in n:
       continue
 
-    if isinstance(n.group,str):                           # Node group should be a list
-      n.group = [ n.group ]                               # Convert a string value into a single-element list
+    must_be_list(n,'group',f'nodes.{name}')
 
     for grpname in n.group:
       if not grpname in topology.groups:
@@ -222,38 +222,26 @@ def copy_group_device_module(topology: Box) -> None:
               print(f'... setting {attr} on {name} to {gdata[attr]}')
 
 '''
-Utility function: merge group value into node value. Deals with scalars and dicts
-'''
-def merge_node_data(ndata: Box, k: str, v: typing.Any, node_name: str, group_name: str) -> None:
-  if not k in ndata:
-    ndata[k] = v
-  if isinstance(ndata[k],dict):
-    if isinstance(v,dict):
-      ndata[k] = ndata[k] + v
-    else:
-      common.error(
-        f'Cannot merge non-dictionary node_data {k} from group {group_name} into node {node_name}',
-        common.IncorrectValue,
-        'groups')
-
-'''
 Copy node data from group into group members
 '''
-def copy_group_node_data(topology: Box) -> None:
+def copy_group_node_data(topology: Box,pfx: str) -> None:
   for grp in reverse_topsort(topology):
+    if not grp.startswith(pfx):                                       # Skip groups that don't match the current prefix (ex: BGP autogroups)
+      continue
     gdata = topology.groups[grp]
-    if not 'node_data' in gdata:
+    if not 'node_data' in gdata:                                      # No group data, skip
       continue
 
-    g_members = group_members(topology,grp)
+    g_members = group_members(topology,grp)                           # Get recursive list of members
     if common.debug_active('groups'):
       print(f'copy node data {grp}: {gdata.node_data}')
-    for name,ndata in topology.nodes.items():
-      if name in g_members:
-        if common.debug_active('groups'):
-          print(f'... merging node data with {name}')
-        for k,v in gdata.node_data.items():   # Have to go one level deeper, changing ndata value wouldn't work
-          merge_node_data(ndata,k,v,ndata.name,grp)
+    for name in g_members:                                            # Iterate over group members
+      if not name in topology.nodes:                                  # Member is not a node, skip it
+        continue
+
+      if common.debug_active('groups'):
+        print(f'... merging node data with {name}')
+      topology.nodes[name] = gdata.node_data + topology.nodes[name]
 
 '''
 Export node_data from groups to topology
@@ -298,6 +286,44 @@ def export_group_node_data(
             topology[key][obj_name][attr] = obj_data[attr]
 
 #
+# create_bgp_autogroups -- create BGP AS groups
+#
+
+def create_bgp_autogroups(topology: Box) -> None:
+  g_module = topology.get('module',[])                          # Global list of modules, could be invalid
+  if not isinstance(g_module,list):                             # Won't deal with incorrectly formatted 'module' attribute here
+    g_module = []                                               # ... just assume it's an empty list
+  g_bgpas = data.get_global_parameter(topology,'bgp.as')        # Try to get the global BGP AS
+  if not data.is_true_int(g_bgpas):                             # ... don't worry if it's not int, someone else will complain
+    g_bgpas = 0
+
+  for gname,gdata in topology.groups.items():                   # Sanity check: BGP autogroups should not have static members
+    if re.match('as\\d+$',gname):
+      if gdata.get('members',None):                             # Well, it's OK to have an empty list of members ;)
+        common.error(
+          f'BGP AS group {gname} should not have static members',
+          common.IncorrectValue,
+          'groups')
+
+  for n_name,n_data in topology.nodes.items():                  # Now iterate over nodes
+    n_module = n_data.get('module',g_module)                    # Get node or global module (global modules haven't been propagated yet)
+    if not isinstance(n_module,list):                           # Node list of modules is insane, someone else will complain
+      continue
+
+    if not 'bgp' in n_module:                                   # Looks like this node does not care about BGP
+      continue
+
+    n_bgpas = data.get_from_box(n_data,'bgp.as') or g_bgpas     # Get node-level or global BGP AS
+    if not n_bgpas:
+      continue
+
+    grpname = f"as{n_bgpas}"                                    # BGP auto-group name
+    if not 'members' in topology.groups[grpname]:               # Set members of a new group to an empty list
+      topology.groups[grpname].members = []                     # ... because we're using Box this also creates an empty group dict
+
+    topology.groups[grpname].members.append(n_name)             # ... and append the node to AS group
+
+#
 # init_groups:
 #
 # * Check and adjust group data structures
@@ -316,22 +342,11 @@ def init_groups(topology: Box) -> None:
   common.exit_on_error()
 
   copy_group_device_module(topology)
-
-#
-# adjust_groups:
-#
-# * Copy group data into nodes
-#
-# We have to split the group initialization code into two phases
-# due to BGP auto groups.
-#
-def adjust_groups(topology: Box) -> None:
-  copy_group_node_data(topology)
+  copy_group_node_data(topology,'')                 # Copy all group data into nodes (potentially setting bgp.as)
+  bgp.process_as_list(topology)
+  create_bgp_autogroups(topology)                   # Create AS-based groups
+  copy_group_node_data(topology,'as')               # And add group data from 'asxxxx' into nodes
   common.exit_on_error()
-
-  '''
-  Finally, remove 'groups' topology element if it's not needed
-  '''
   if not topology.groups:
     del topology['groups']
 

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -46,8 +46,6 @@ def transform_data(topology: Box) -> None:
   augment.plugin.execute('pre_transform',topology)
   modules.pre_transform(topology)
 
-  augment.groups.adjust_groups(topology)
-
   augment.plugin.execute('pre_node_transform',topology)
   modules.pre_node_transform(topology)
   augment.nodes.transform(topology,topology.defaults,topology.pools)

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -137,6 +137,7 @@ def must_be_dict(
       true_value: typing.Optional[dict] = None,         # Value to use to replace _true_, set _false_ to []
       context:    typing.Optional[typing.Any] = None,   # Additional context (use when verifying link values)
       module:     typing.Optional[str] = None,          # Module name to display in error messages
+      crash:      bool = False                          # Crash on error
                 ) -> typing.Optional[list]:
 
   value = get_from_box(parent,key)
@@ -145,6 +146,8 @@ def must_be_dict(
       set_dots(parent,key.split('.'),{})
       return parent[key]
     else:
+      if crash:
+        raise common.IncorrectValue()
       return None
 
   if isinstance(value,bool) and not true_value is None:
@@ -155,6 +158,10 @@ def must_be_dict(
     return parent[key]
 
   wrong_type_message(path=path, key=key, expected='a dictionary', value=value, context=context, module=module)
+
+  if crash:
+    raise common.IncorrectType()
+
   return None
 
 def must_be_string(

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -18,6 +18,20 @@ from ..augment import devices
 #
 no_propagate_list = ["attributes","extra_attributes","requires","supported_on","no_propagate","config_after","transform_after"]
 
+"""
+Return the authoritative list of all modules.
+
+A module is a top-level 'defaults' dictionary key if the value is a dictionary with 'supported_on' key
+"""
+def list_of_modules(topology: Box) -> list:
+  if not '_modlist' in topology.defaults._globals:
+    topology.defaults._globals._modlist = [ 
+      m for m in topology.defaults.keys() \
+        if isinstance(topology.defaults[m],dict) \
+          and 'supported_on' in topology.defaults[m] ]
+
+  return topology.defaults._globals._modlist
+
 class _Module(Callback):
 
   def __init__(self, data: Box) -> None:

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -25,7 +25,7 @@ A module is a top-level 'defaults' dictionary key if the value is a dictionary w
 """
 def list_of_modules(topology: Box) -> list:
   if not '_modlist' in topology.defaults._globals:
-    topology.defaults._globals._modlist = [ 
+    topology.defaults._globals._modlist = [
       m for m in topology.defaults.keys() \
         if isinstance(topology.defaults[m],dict) \
           and 'supported_on' in topology.defaults[m] ]

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -409,7 +409,7 @@ def process_as_list(topology: Box) -> None:
         common.IncorrectValue,
         'bgp')
       continue
-    
+
     must_be_list(as_data,'members',f'bgp.as_list.{asn}',create_empty=False,module='bgp',valid_values=node_list)
     must_be_list(as_data,'rr',f'bgp.as_list.{asn}',create_empty=False,module='bgp',valid_values=node_list)
     if not as_data.members:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -8,6 +8,9 @@ bgp:
     - extended
   next_hop_self: true
 groups:
+  as65000:
+    members:
+    - e
   g1:
     members:
     - a
@@ -179,7 +182,7 @@ nodes:
         ipv4: 10.1.0.1/30
         node: a
       ospf:
-        area: 42
+        area: 51
         network_type: point-to-point
         passive: false
       type: p2p
@@ -196,7 +199,7 @@ nodes:
     ospf:
       af:
         ipv4: true
-      area: 42
+      area: 51
       router_id: 10.0.0.5
   f:
     af:

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -14,6 +14,8 @@ groups:
     - a
     - b
     - c
+  as65001:
+    members:
     - d
     - e
     - f

--- a/tests/topology/input/groups-node-data.yml
+++ b/tests/topology/input/groups-node-data.yml
@@ -11,5 +11,4 @@ groups:
   g1: [ a,b,c ]
   g2:
     members: [ d,e,f ]
-    node_data:
-      bgp.as: 65001
+    bgp.as: 65001


### PR DESCRIPTION
* Process **bgp.as_list** as part of group initialization
* Create BGP auto-groups as part of group initialization
* Do a two-pass copy of group data into node data -- first for static group members, then for BGP auto-groups
* Simplify merging of group data into node data -- use Box merge and replace node data in topology.nodes

Also:
* Allow 'id' and 'vni' parameters in node 'vlans' as long as they match global values
  (needed for static id/vni values for vlans defined in groups)
* Introduce 'crash' parameter to validation routines to trigger an exception
  (needed when a validation error should result in a different action in the calling routine)
* Update 'breaking changes' and 'data transformation' documentation
* Add common 'list_of_module' function into 'modules'
  (will eventually fix references to the old way of generating modules)
