### PR TITLE
Explicitly enable 'proxy_arp' attribute for vrfs

### DIFF
--- a/netsim/extra/proxy-arp/plugin.py
+++ b/netsim/extra/proxy-arp/plugin.py
@@ -4,9 +4,10 @@ from box import Box
 from netsim import api
 
 """
-Attribute 'proxy_arp' is enabled per VRF; not currently enforced
+Enable 'proxy_arp' attribute per VRF
 """
-# def init(topology: Box) -> None:
+def init(topology: Box) -> None:
+  topology.defaults.attributes.vrf.append('proxy_arp')
 
 """
 Add 'proxy_arp' flag and trigger custom config file for any interfaces that are


### PR DESCRIPTION
Now that attribute checks have become more strict, we need to play along