### PR TITLE
Default to new frr 8.4.0

### DIFF
--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -614,7 +614,7 @@ devices:
       ansible_python_interpreter: auto_silent
     clab:
       # image: frrouting/frr:v7.5.0
-      image: frrouting/frr:v8.3.1
+      image: frrouting/frr:v8.4.0
       mtu: 1500
       node:
         kind: linux

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -69,7 +69,7 @@ nodes:
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/r1/daemons: /etc/frr/daemons
@@ -151,7 +151,7 @@ nodes:
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/r2/daemons: /etc/frr/daemons

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -159,7 +159,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/h1/daemons: /etc/frr/daemons
@@ -203,7 +203,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/h2/daemons: /etc/frr/daemons
@@ -249,7 +249,7 @@ nodes:
     af:
       ipv4: true
       ipv6: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/h3/daemons: /etc/frr/daemons
@@ -299,7 +299,7 @@ nodes:
       ipv6: true
       vpnv4: true
       vpnv6: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/r1/daemons: /etc/frr/daemons
@@ -484,7 +484,7 @@ nodes:
       ipv6: true
       vpnv4: true
       vpnv6: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/r2/daemons: /etc/frr/daemons

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -176,7 +176,7 @@ nodes:
   r2:
     af:
       ipv4: true
-    box: frrouting/frr:v8.3.1
+    box: frrouting/frr:v8.4.0
     clab:
       binds:
         clab_files/r2/daemons: /etc/frr/daemons


### PR DESCRIPTION
Tested using ```netlab up -d frr -p clab tests/integration/evpn/vxlan-routing-ibgp-over-ebgp-unnumbered.yml```