### PR TITLE
VyOS: support unnumbered OSPF

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -80,7 +80,7 @@ The following table documents the interface-level OSPF features:
 | Mikrotik RouterOS 7      |   ✅  |         ✅        |             ❌            |            ✅           |
 | Nokia SR Linux           |   ✅  |         ✅        |             ❌            |            ✅           |
 | Nokia SR OS              |   ✅  |         ✅        |             ✅            |            ✅           |
-| VyOS                     |   ✅  |         ✅        |             ❌            |            ✅           |
+| VyOS                     |   ✅  |         ✅        |             ✅            |            ✅           |
 
 Notes:
 * Arista EOS, Cisco Nexus OS, SR Linux and Dell OS10 support point-to-point and broadcast network types. Other network types will not be configured.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -187,7 +187,7 @@ The following interface addresses are supported on various platforms:
 | Mikrotik RouterOS 7   |          ✅          |          ✅          |             ❌              |
 | Nokia SR Linux        |          ✅          |          ✅          |             ❌              |
 | Nokia SR OS           |          ✅          |          ✅          |             ✅              |
-| VyOS                  |          ✅          |          ✅          |             ❌              |
+| VyOS                  |          ✅          |          ✅          |             ✅              |
 
 ## Supported Configuration Modules
 

--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -64,10 +64,20 @@ set interfaces {{ ns.iface_level }} {{ ns.ifname }} mtu {{ l.mtu }}
 {% endif %}
 
 {% if 'ipv4' in l %}
+{%   if l.ipv4 == True and 'ipv4' in loopback %}
+# Need to set the same address as loopback (dum0) to make it behave as unnumbered
+set interfaces {{ ns.iface_level }} {{ ns.ifname }} address {{ loopback.ipv4 }}
+{%   elif l.ipv4|ipv4 %}
 set interfaces {{ ns.iface_level }} {{ ns.ifname }} address {{ l.ipv4 }}
+{%   endif %}
 {% endif %}
+
 {% if 'ipv6' in l %}
+{%   if l.ipv6 == True %}
+set interfaces {{ ns.iface_level }} {{ ns.ifname }} ipv6
+{%   elif l.ipv6|ipv6 %}
 set interfaces {{ ns.iface_level }} {{ ns.ifname }} address {{ l.ipv6 }};
+{%   endif %}
 {% endif %}
 
 {% if l.vrf is defined %}

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -990,6 +990,8 @@ devices:
           unnumbered: True
         ipv6:
           lla: True
+      ospf:
+        unnumbered: True
       bgp:
         local_as: True
         vrf_local_as: True


### PR DESCRIPTION
Tested with both:

* tests/integration/ospf/ospfv2/unnumbered.yml
* tests/integration/ospf/ospfv3/unnumbered.yml