### PR TITLE
Add Cisco ASA quirk

### DIFF
--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -38,7 +38,7 @@ The following table describes per-platform support of individual IS-IS features:
 **Notes:**
 * On Arista EOS, IPv6 is enabled on all interfaces as soon as one interface has an IPv6 address. Arista EOS implementation of IS-IS refuses to work on interfaces with missing address families.
 * On VyOS, IPv6 is enabled on all interfaces as soon as one interface has an IPv6 address.
-* Cisco ASA does not support P2P IS-IS links. You could either add `isis.network_type: false` to point-to-point links connecting ASA to other devices or set `type: lan` on those links.
+* Cisco ASA does not support P2P IS-IS links. You could add `isis.network_type: false` to point-to-point links connecting ASA to other devices.
 
 ## Global Parameters
 

--- a/netsim/quirks/asav.py
+++ b/netsim/quirks/asav.py
@@ -9,16 +9,15 @@ from ..data import get_from_box
 
 def check_isis_p2p_interfaces(node: Box, topology: Box) -> None:
   for intf in node.interfaces:
-    for neighbor in intf['neighbors']:
-      remote_node = get_from_box(neighbor, 'node')
-      remote_interface_name = get_from_box(neighbor, 'ifname')
-      remote_interfaces = topology[f'nodes.{remote_node}.interfaces']
+    for neighbor in intf.neighbors:
+      remote_node = neighbor.node
+      remote_interfaces = topology.nodes[remote_node].interfaces
       for rintf in remote_interfaces:
-        if get_from_box(rintf, 'ifname') == remote_interface_name:
+        if rintf.ifname == neighbor.ifname:
           if get_from_box(rintf, 'isis.network_type') != None:
             common.error(
                 f'Cisco ASA does not support P2P IS-IS links.'
-                f'Problematic Interface: {remote_node} {remote_interface_name}',
+                f'Problematic Interface: {remote_node} {neighbor.ifname}',
                 common.IncorrectType,
                 'quirks',
             )

--- a/netsim/quirks/asav.py
+++ b/netsim/quirks/asav.py
@@ -9,10 +9,10 @@ from ..data import get_from_box
 
 def check_isis_p2p_interfaces(node: Box, topology: Box) -> None:
   for intf in node.interfaces:
-    for neighbor in get_from_box(intf, 'neighbors'):
+    for neighbor in intf['neighbors']:
       remote_node = get_from_box(neighbor, 'node')
       remote_interface_name = get_from_box(neighbor, 'ifname')
-      remote_interfaces = get_from_box(topology, f'nodes.{remote_node}.interfaces')
+      remote_interfaces = topology[f'nodes.{remote_node}.interfaces']
       for rintf in remote_interfaces:
         if get_from_box(rintf, 'ifname') == remote_interface_name:
           if get_from_box(rintf, 'isis.network_type') != None:
@@ -24,6 +24,8 @@ def check_isis_p2p_interfaces(node: Box, topology: Box) -> None:
             )
 
 class ASA(_Quirks):
+
+  @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     mods = node.get('module', [])
     if 'isis' in mods:

--- a/netsim/quirks/asav.py
+++ b/netsim/quirks/asav.py
@@ -1,0 +1,30 @@
+#
+# Cisco ASA quirks
+#
+from box import Box
+
+from . import _Quirks
+from .. import common
+from ..data import get_from_box
+
+def check_isis_p2p_interfaces(node: Box, topology: Box) -> None:
+  for intf in node.interfaces:
+    for neighbor in get_from_box(intf, 'neighbors'):
+      remote_node = get_from_box(neighbor, 'node')
+      remote_interface_name = get_from_box(neighbor, 'ifname')
+      remote_interfaces = get_from_box(topology, f'nodes.{remote_node}.interfaces')
+      for rintf in remote_interfaces:
+        if get_from_box(rintf, 'ifname') == remote_interface_name:
+          if get_from_box(rintf, 'isis.network_type') != None:
+            common.error(
+                f'Cisco ASA does not support P2P IS-IS links.'
+                f'Problematic Interface: {remote_node} {remote_interface_name}',
+                common.IncorrectType,
+                'quirks',
+            )
+
+class ASA(_Quirks):
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    mods = node.get('module', [])
+    if 'isis' in mods:
+      check_isis_p2p_interfaces(node, topology)


### PR DESCRIPTION
I have added a quirk as suggested in #635.

Furthermore while testing I have discovered that `type: lan` on those links has no impact on the generation of the `isis.network_type` Variable.
As far as I can see the code which adds the problematic attribute only looks for the number of neighbors but not for the link type: https://github.com/ipspace/netlab/blob/dev/netsim/modules/_routing.py#L77
Therefore I have removed the hint in the documentation.