### PR TITLE
Handle dotted clab.binds by allowing file mappings to be specified as a list of strings too

### DIFF
--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -39,9 +39,15 @@ topology:
 {% endif %}
 {% if 'binds' in clab %}
       binds:
-{% for f,m in clab.binds.items() %}
+{%  if clab.binds.items is defined %}
+{%   for f,m in clab.binds.items() %}
       - {{ f }}:{{ m }}
-{% endfor %}
+{%   endfor %}
+{%  else %}
+{%   for m in clab.binds %}
+      - {{ m }}
+{%   endfor %}
+{%  endif %}
 {% endif %}
 {% if 'startup-config' in clab %}
       startup-config: {{ clab['startup-config'] }}


### PR DESCRIPTION
Example:
```yaml
clab.binds:
 - config.json:/etc/config.json
```

This is currently a problem because 'config.json' becomes ```config: { 'json': ... }```