### PR TITLE
Add support for all EVPN bundle services

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -41,6 +41,13 @@ The following table describes per-platform support of individual EVPN/MPLS featu
 * Arista EOS requires anycast gateway for EVPN/MPLS symmetric IRB configuration.
 ```
 
+Devices supporting [EVPN VLAN bundle services](evpn-bundle-service) implement the following bundle service types (see RFC 7432 section 6 for more details):
+
+| Operating system   | VLAN<br>bundle | Port<br>service | VLAN-aware<br>bundle | Port-based<br>VLAN bundle |
+| ------------------ | :-: | :-: | :-: | :-: |
+| Arista EOS         |  ❌  |  ❌  | ✅  |  ❌  |
+| Nokia SR Linux     |  ❌  |  ❌  | ✅  |  ❌  |
+
 EVPN module supports three design paradigms:
 
 * IBGP with IGP
@@ -73,10 +80,10 @@ EVPN module supports these default/global/node parameters:
 * **evpn.vlans** (global or node parameter): A list of EVPN-enabled VLANs. Default value with VXLAN transport: all global VLANs with **vni** parameter. There is no default value with MPLS transport.
 * **evpn.session** (global or node parameter): A list of BGP session types on which the EVPN address family is enabled (default: `ibgp`)
 * **evpn.as** (global parameter): Autonomous system number to use for VLAN and VRF route targets. Default value: **bgp.as** (when set globally) or **vrf.as**.
-* **evpn.vlan_bundle_service** (global parameter): Use VLAN bundle service for VLANs within a VRF (default: `False`)
 * **evpn.start_transit_vni** (system default parameter) -- the first symmetric IRB transit VNI, range 4096..16777215
 * **evpn.start_transit_vlan** (device-dependent node parameter) -- the starting VLAN ID for VLANs used to map VXLAN transit VNIs
 
+(evpn-vlan-service)=
 ### VLAN-Based Service Parameters
 
 EVPN-related VLAN parameters are set on **vlans** dictionary. You can set the following parameters for every VLAN using VLAN-Based Service:
@@ -85,7 +92,7 @@ EVPN-related VLAN parameters are set on **vlans** dictionary. You can set the fo
 * **evpn.rd**: EVPN Instance route distinguisher (not checked at the moment). Default: **bgp.router_id**:**evpn.evi**
 * **evpn.import** and **evpn.export**: Import and export route targets (not checked at the moment).
 
-EVPN configuration module sets the following default EVI/RD/RT values for [VXLAN-enabled VLANs](vxlan.md#selecting-vxlan-enabled-vlans):
+EVPN configuration module sets the following default EVI/RD/RT values for EVPN-enabled VLANs that are not part of a bundle service:
 
 * **evpn.evi**: `vlan-id`
 * **evpn.rd**: `router-id:evi` (according to Section 7.9 of RFC 7432 as the **evpn.evi** is set to **vlan.id**)
@@ -93,13 +100,19 @@ EVPN configuration module sets the following default EVI/RD/RT values for [VXLAN
 
 [^EAS]: The AS number used in EVPN route targets is described in [](evpn-global-parameters).
 
-### VLAN-Aware Bundle Service
+(evpn-bundle-service)=
+### EVPN Bundle Services
 
-VLAN-Aware Bundle Service is disabled by default and has to be enabled by setting **evpn.vlan_bundle_service** parameter to _True_. Although that parameter is a global/node parameter, it might not be a good idea to use different settings on different nodes. 
+VLAN-Aware Bundle Service uses VRF configuration (and thus requires [VRF configuration module](vrf.md)). All EVPN-enabled VLANs belonging to a single VRF are configured as a bundle service, modeled as a single EVPN Instance.
 
-VLAN-Aware Bundle Service uses VRF configuration (and thus requires [VRF configuration module](vrf.md)). All VLANs belonging to a single VRF are configured as a VLAN bundle, modeled as a single EVPN Instance. [RD and RT values assigned by VRF module](vrf.md#rd-and-rt-values) are used to configure the VLAN bundle; you can set **evpn.evi** VRF parameter to set the EVPN Instance identifier.
+[RD and RT values assigned by VRF module](vrf.md#rd-and-rt-values) are used to configure the VLAN bundle; you can set **evpn.evi** VRF parameter to set the EVPN Instance identifier. The default value of VRF EVPN Instance identifier is the **vrf.id**.
 
-The default value of VRF EVPN Instance identifier is the **vrf.id**.
+The EVPN bundle service is enabled with **evpn.bundle** VRF parameter that can take one of the following values:
+
+* **vlan** -- VLAN bundle service (RFC 7432 section 6.2)
+* **port** -- Port-based service (RFC 7432 section 6.2.1)
+* **vlan_aware** -- VLAN-aware bundle service (RFC 7432 section 6.3)
+* **port_aware** -- Port-based VLAN-aware service (RFC 7432 section 6.3.1)
 
 ### Integrated Routing and Bridging
 

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -143,12 +143,12 @@ evpn: # Enables the EVPN address family towards BGP peers
   config_after: [ vlan, vxlan, vrf ]
   session: [ ibgp ]
   start_transit_vni: 200000
-  vlan_bundle_service: False
   attributes:
-    global: [ session, start_transit_vni, vlan_bundle_service, transport, vlans, vrfs, as ]
+    global: [ session, start_transit_vni, transport, vlans, vrfs, as ]
+    bundle: [ vlan_aware, vlan, port, port_vlan ]
     node: [ session, vlans, vrfs ]
     vlans: [ evi,rd,import,export ]
-    vrf: [ transit_vni ]
+    vrf: [ transit_vni, bundle ]
 
 vrf: # Basic VRF support
   supported_on: [ eos, iosv, csr, routeros, dellos10, vyos, cumulus_nvue, nxos, srlinux, frr, cumulus, sros, routeros7, none ]
@@ -578,6 +578,7 @@ devices:
       evpn:
         irb: True
         asymmetrical_irb: True
+        bundle: [ vlan_aware ]
       gateway:
         protocol: [ anycast, vrrp ]
     clab:
@@ -1136,3 +1137,6 @@ hints:
       All VLANs that are part of a VRF using asymmetric IRB have to be present on all nodes
       using that VRF. The easiest way to achieve that is to create a group with all
       participating nodes and list VLANs in the 'vlans' attribute of that group
+    node_bundle: |
+      evpn.bundle attribute can be used only in global VRF definition
+

--- a/tests/integration/evpn/vxlan-vlan-bundle.yml
+++ b/tests/integration/evpn/vxlan-vlan-bundle.yml
@@ -1,13 +1,13 @@
-#
-# The devices under test are VLAN-to-VXLAN bridges
-#
-# * h1 and h2 should be able to ping each other
-# * h3 and h4 should be able to ping each other
-# * h1 should not be able to reach h3
-#
-# Please note it might take a while for the lab to work due to
-# STP learning phase
-#
+message: |
+  The devices under test are VLAN-to-VXLAN bridges using EVPN VLAN-aware
+  bundle service.
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+  
+  It might take a while for the lab to work due to STP learning phase
+
 groups:
   hosts:
     members: [ h1, h2, h3, h4 ]
@@ -19,11 +19,9 @@ groups:
 
 bgp.as: 65000
 
-evpn.vlan_bundle_service: True
-
 vrfs:
   bundle:
-    evpn:
+    evpn.bundle: vlan_aware
 
 vlans:
   red:

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -411,12 +411,9 @@ nodes:
       blue:
         bridge_group: 3
         evpn:
-          evi: 1001
-          export:
-          - 65000:1001
-          import:
-          - 65000:1001
-          rd: 10.0.0.1:1001
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.1:1
         id: 1001
         mode: irb
         prefix:
@@ -435,12 +432,9 @@ nodes:
       red:
         bridge_group: 1
         evpn:
-          evi: 1000
-          export:
-          - 65000:1000
-          import:
-          - 65000:1000
-          rd: 10.0.0.1:1000
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.1:1
         id: 1000
         mode: irb
         prefix:
@@ -454,6 +448,16 @@ nodes:
       tenant:
         af:
           ipv4: true
+        evpn:
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.1:1
+          vlan_ids:
+          - 1000
+          - 1001
+          vlans:
+          - red
+          - blue
         export:
         - '65000:1'
         id: 1
@@ -676,12 +680,9 @@ nodes:
       blue:
         bridge_group: 1
         evpn:
-          evi: 1001
-          export:
-          - 65000:1001
-          import:
-          - 65000:1001
-          rd: 10.0.0.2:1001
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.2:1
         id: 1001
         mode: irb
         prefix:
@@ -700,12 +701,9 @@ nodes:
       red:
         bridge_group: 3
         evpn:
-          evi: 1000
-          export:
-          - 65000:1000
-          import:
-          - 65000:1000
-          rd: 10.0.0.2:1000
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.2:1
         id: 1000
         mode: irb
         prefix:
@@ -719,6 +717,16 @@ nodes:
       tenant:
         af:
           ipv4: true
+        evpn:
+          bundle: vlan_aware
+          evi: 1
+          rd: 10.0.0.2:1
+          vlan_ids:
+          - 1000
+          - 1001
+          vlans:
+          - red
+          - blue
         export:
         - '65000:1'
         id: 1
@@ -805,11 +813,8 @@ provider: libvirt
 vlans:
   blue:
     evpn:
-      evi: 1001
-      export:
-      - 65000:1001
-      import:
-      - 65000:1001
+      bundle: vlan_aware
+      evi: 1
     host_count: 1
     id: 1001
     neighbors:
@@ -857,11 +862,8 @@ vlans:
     vrf: tenant
   red:
     evpn:
-      evi: 1000
-      export:
-      - 65000:1000
-      import:
-      - 65000:1000
+      bundle: vlan_aware
+      evi: 1
     host_count: 1
     id: 1000
     neighbors:
@@ -883,6 +885,15 @@ vrf:
   as: 65000
 vrfs:
   tenant:
+    evpn:
+      bundle: vlan_aware
+      evi: 1
+      vlan_ids:
+      - 1000
+      - 1001
+      vlans:
+      - red
+      - blue
     export:
     - '65000:1'
     id: 1

--- a/tests/topology/input/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/input/evpn-asymmetric-irb-ospf.yml
@@ -12,6 +12,7 @@ bgp.as: 65000
 
 vrfs:
   tenant:
+    evpn.bundle: vlan_aware
 
 vlans:
   red:


### PR DESCRIPTION
* Add 'evpn.bundle' VRF parameter
* Validate 'evpn.bundle' value against evpn.attributes.bundle list
* Check 'evpn.bundle' value against device.features.evpn.bundle list
* Refactor VLAN bundle code in EVPN configuration module
* Fix EVPN VLAN bundle integration test case
* Add 'evpn.bundle' to EVPN asymmetric IRB test case
* Update the documentation

Implements #636