### PR TITLE
Check full range of Python versions 3.8 through 3.11.0, in parallel (upgrade minimum Python version to 3.8)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 4
       matrix:
-        python-version: [ 3.9 ]
+        python-version: [3.8, 3.9, 3.10.0, 3.11.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ PyYAML >= 5.0.0
 netaddr >= 0.8.0
 python-box >= 5.4.1,<6.0
 importlib_resources
-typing-extensions
+typing-extensions>=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 with open("requirements.txt", "r") as fs:
   reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
-if sys.version_info < (3, 7):
-  raise RuntimeError("This package requires Python 3.7+")
+if sys.version_info < (3, 8):
+  raise RuntimeError("This package requires Python 3.8+")
 
 setup(
   name="networklab",
@@ -21,19 +21,22 @@ setup(
   author_email="ip@ipspace.net",
   description="CLI-based Virtual Networking Lab Abstraction Layer",
   long_description=long_description,
-  long_description_content_type='text/markdown',  
+  long_description_content_type='text/markdown',
   classifiers=[
     "Topic :: Utilities",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10.0",
+    "Programming Language :: Python :: 3.11.0",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
   ],
   url="https://github.com/ipspace/netlab",
   include_package_data=True,
   setup_requires=["wheel"],
-  python_requires='>=3.7',  # Due to e.g. 'capture_output' in subprocess.run
+  python_requires='>=3.8',  # Due to e.g. 'capture_output' in subprocess.run, and use of typing.Final
   install_requires=reqs,
   entry_points={
     "console_scripts": ["netlab=netsim.cli:lab_commands"]


### PR DESCRIPTION
Upgrade to minimum supported 3.8 version because 3.7 requires typing-extensions for typing.Final and refactoring of imports, could be supported if needed but to me a range of 4 supported Python versions is pretty good

(if anybody was using Python 3.7, Netlab wasn't working for them anyway - so merely documenting and verifying what was already the case)