### PR TITLE
install ansible-pylibssh to fix connection issues with Cisco IOS and ASA

### DIFF
--- a/netsim/install/ansible.sh
+++ b/netsim/install/ansible.sh
@@ -55,8 +55,8 @@ $SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP jinja2 six bracket-expansion netad
 echo "Install Ansible Python dependencies"
 echo ".. pynacl lxml"
 $SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP pynacl lxml
-echo ".. paramiko netmiko"
-$SUDO pip3 install $REPLACE $FLAG_PIP paramiko netmiko
+echo ".. paramiko netmiko ansible-pylibssh"
+$SUDO pip3 install $REPLACE $FLAG_PIP paramiko netmiko ansible-pylibssh
 #
 echo "Install optional Python components"
 $SUDO pip3 install $REPLACE $FLAG_PIP textfsm ttp jmespath ntc-templates


### PR DESCRIPTION
After hours of debugging I figured out that paramiko causes authentication problems with Cisco IOSv and ASAv devices.
According to the IOS log, the username in the authentication request is empty.

Therefore I would recommend installing ansible-pylibssh which works fine with these devices.