### PR TITLE
update links

### DIFF
--- a/docs/dev/device-box.md
+++ b/docs/dev/device-box.md
@@ -6,7 +6,7 @@ Here's what you have to do:
 
 * Choose a short name for the new device type (examples: *ios*, *eos*, *cumulus*...)
 * Select one or more virtualization providers you want to work with.
-* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/vagrant/). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
+* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
 * Document the process in a blog post or GitHub gist.
 * Add new device type to *netlab* settings in `netsim/topology-defaults.yml`
 * Update [Supported Platforms](../platforms.md) and box building documentation ([libvirt](../labs/libvirt.md#building-your-own-boxes), [VirtualBox](../labs/virtualbox.md#creating-vagrant-boxes))

--- a/docs/dev/device-platform.md
+++ b/docs/dev/device-platform.md
@@ -4,7 +4,7 @@ If you want to run a network device on a virtualization provider that is not yet
 
 Here's what you have to do:
 
-* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/vagrant/). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
+* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
 * Document the process in a blog post or GitHub gist.
 * Modify the *netlab* settings in `netsim/topology-defaults.yml`
 * Update [Supported Platforms](../platforms.md) and box building documentation ([libvirt](../labs/libvirt.md#building-your-own-boxes), [VirtualBox](../labs/virtualbox.md#creating-vagrant-boxes))

--- a/docs/labs/virtualbox.md
+++ b/docs/labs/virtualbox.md
@@ -56,7 +56,7 @@ Vagrant relies on *boxes* (prepackaged VM images). The following Vagrant boxes a
 | Cumulus VX 5.0 (NVUE)            | CumulusCommunity/cumulus-vx:5.0.1|
 | Generic Linux          | generic/ubuntu2004 |
 
-You'll have to download Arista vEOS and Nexus 9300v images from the vendor web site (requires registration) and install them with **vagrant box add _filename_ \-\-name _boxname_** command. You'll find build recipes for other network devices on [codingpackets.com](https://codingpackets.com/blog/tag/vagrant/).
+You'll have to download Arista vEOS and Nexus 9300v images from the vendor web site (requires registration) and install them with **vagrant box add _filename_ \-\-name _boxname_** command. You'll find build recipes for other network devices on [codingpackets.com](https://codingpackets.com/blog/tag/#vagrant).
 
 You have to use the following box names when installing or building the Vagrant boxes:
 


### PR DESCRIPTION
I updated codingpackets.com and moved the tags around a bit.

I updated the links in the docs to reflect the new location. 

from: `https://codingpackets.com/blog/tag/vagrant` 

to: `https://codingpackets.com/blog/tag/#vagrant`