### PR TITLE
Update eos.vrf.j2

### DIFF
--- a/netsim/ansible/templates/initial/eos.vrf.j2
+++ b/netsim/ansible/templates/initial/eos.vrf.j2
@@ -1,6 +1,6 @@
 {% for vname,vdata in vrfs.items() %}
 vrf instance {{ vname }}
- rd {{ vdata.rd }}
+ rd {{ vdata.rd|string }}
 !
 {% if 'ipv4' in vdata.af|default({}) %}
 ip routing vrf {{ vname }}


### PR DESCRIPTION
For some reason jinja interprets the RD as possibly a sexagesimal number? TIL: https://en.wikipedia.org/wiki/Sexagesimal

The effect is when ansible reads the `host_vars` file value `rd: 65000:1` it interprets it as `3900001`.

```
TASK [eos_config: deploying initial from templates/initial/eos.j2] **************************************************************************************
fatal: [h1xgw1]: FAILED! => changed=false
  data: |-
    rd 3900001
    % Ambiguous command
    localhost(config-s-ansibl-vrf-blue)#
  msg: |-
    rd 3900001
    % Ambiguous command
    localhost(config-s-ansibl-vrf-blue)#
```