### PR TITLE
Initial support for Juniper vMX plus "specific" device types

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -118,3 +118,15 @@ Additionally, using always the latest build published on [Vagrant Hub](https://a
 Dell OS10 uses a concept of a so-called *Virtual Network* interface to try to handle transparently VLANs and VXLANs in the same way. However, it seems that right now it is **NOT** possible to activate OSPF on a *Virtual Network* (VLAN) SVI interface.
 
 Sadly, it's also **NOT** possible to use *VRRP* on a *Virtual Network* interface (but *anycast* gateway is supported). At the same time, *anycast* gateway is not supported on plain *ethernet* interfaces, so you need to use *VRRP* there.
+
+## Juniper vMX in Containerlab
+Juniper vMX runs in Containerlab with the *vrnetlab* extension. See https://containerlab.dev/manual/kinds/vr-vmx/ for further details.
+
+Additionally, the Juniper vMX image in *vrnetlab* uses the network `10.0.0.0/24` for its own internal network, which conflicts with the default network used by **netlab** for the loopback addressing. For this reason it's better to use a different subnet for the loopback addresses of your topologies with:
+```
+addressing:
+  loopback:
+    ipv4: 10.255.0.0/24
+  router_id:
+    ipv4: 10.255.0.0/24
+```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -15,6 +15,7 @@
 | Fortinet FortiOS [❗](caveats.html#fortinet-fortios) | fortios            |
 | FRR 7.5.0                                 | frr                |
 | Generic Linux host                        | linux              |
+| Juniper vMX                               | vmx                |
 | Juniper vSRX 3.0                          | vsrx               |
 | Mikrotik RouterOS 6 (CHR)                 | routeros           |
 | Mikrotik RouterOS 7 (CHR) [❗](caveats.html#mikrotik-routeros-7) | routeros7           |
@@ -73,6 +74,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Fortinet FortiOS                                   |          ✅           |              ❌               |            ❌             |
 | FRR 7.5.0                                          |          ❌           |              ❌               |   ✅[❗](caveats.html#frr)   |
 | Generic Linux (Ubuntu/Alpine)[❗](caveats.html#generic-linux) |          ✅           |              ✅               |            ✅             |
+| Juniper vMX                                        |          ❌           | ❌ |            ✅[❗](caveats.html#juniper-vmx-in-containerlab)             |
 | Juniper vSRX 3.0                                   |          ✅           | ✅ |            ❌             |
 | Mikrotik RouterOS 6                                |          ✅           |              ❌               |            ❌             |
 | Mikrotik RouterOS 7                                |          ✅           |              ❌               |            ❌             |
@@ -118,6 +120,7 @@ Ansible playbooks included with **netlab** can deploy and collect device configu
 | Fortinet FortiOS      |          ✅           |           ✅           |
 | FRR container         |          ✅           |           ❌           |
 | Generic Linux         |          ✅           |           ❌           |
+| Juniper vMX           |          ✅           |           ✅           |
 | Juniper vSRX 3.0      |          ✅           |           ✅           |
 | Mikrotik RouterOS 6   |          ✅           |           ✅           |
 | Mikrotik RouterOS 7   |          ✅           |           ✅           |
@@ -141,6 +144,7 @@ The following system-wide features are configured on supported network operating
 | Fortinet FortiOS      |    ✅     |     ❌      |             ✅             |             ✅              |             ✅              |
 | FRR 7.5.0             |    ✅     |     ✅      |             ❌             |             ✅              |             ✅              |
 | Generic Linux         |    ✅     |     ✅      |  ✅[❗](caveats.html#lldp)   |             ✅              |             ✅              |
+| Juniper vMX           |    ✅     |     ❌      |             ✅             |             ✅              |             ✅              |
 | Juniper vSRX 3.0      |    ✅     |     ❌      |             ✅             |             ✅              |             ✅              |
 | Mikrotik RouterOS 6   |    ✅     |     ✅      | ✅[❗](caveats.html#mikrotik-routeros-6) |             ✅              |             ✅              |
 | Mikrotik RouterOS 7   |    ✅     |     ✅      | ✅[❗](caveats.html#mikrotik-routeros-6) |             ✅              |             ✅              |
@@ -162,6 +166,7 @@ The following interface parameters are configured on supported network operating
 | Fortinet FortiOS      |            ✅              |            ✅            | ❌ |
 | FRR 7.5.0             |            ✅              |            ✅            | ✅ |
 | Generic Linux         |            ❌              |            ❌            | ✅ |
+| Juniper vMX           |            ✅              |            ✅            | ✅ |
 | Juniper vSRX 3.0      |            ✅              |            ✅            | ✅ |
 | Mikrotik RouterOS 6   |            ✅              |            ❌            | ✅ |
 | Mikrotik RouterOS 7   |            ✅              |            ❌            | ✅ |
@@ -183,6 +188,7 @@ The following interface addresses are supported on various platforms:
 | Fortinet FortiOS      |          ✅          |          ✅          |             ❌              |
 | FRR 7.5.0             |          ✅          |          ✅          |             ❌              |
 | Generic Linux         |          ✅          |          ✅          |             ❌              |
+| Juniper vMX           |          ✅          |          ✅          |             ✅              |
 | Juniper vSRX 3.0      |          ✅          |          ✅          |             ✅              |
 | Mikrotik RouterOS 6   |          ✅          |          ✅          |             ❌              |
 | Mikrotik RouterOS 7   |          ✅          |          ✅          |             ❌              |
@@ -209,6 +215,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Dell OS10             | [❗](caveats.html#dell-os10) |   ❌   |   ❌   | ✅  | ✅  | ✅  |  ❌  |
 | Fortinet FortiOS      | [❗](caveats.html#fortinet-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |  ❌  |  ❌  |
 | FRR 7.5.0             | ✅   |  ✅   |   ❌   | ✅  |  ❌  | ✅  |  ❌  |
+| Juniper vMX           | ✅   |  ✅   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
 | Juniper vSRX 3.0      | ✅   |  ✅   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
 | Mikrotik RouterOS 6   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
 | Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌   | ✅  | ✅  |  ❌  |  ❌  |
@@ -231,6 +238,7 @@ The following data plane [configuration modules](module-reference.md) are suppor
 | Cumulus Linux         |  ✅  | ✅  | ✅   |  ❌   |    ❌    |  ❌   |
 | Cumulus Linux 5.0 (NVUE) | ❌ |[❗](module/vrf.html#platform-support)|  ❌   | ❌  |   ❌    |  ❌   |
 | Dell OS10             |  ✅  | ✅  |  ✅   |   ❌  |    ❌    |  ❌   |
+| Juniper vMX           |   ❌  |  ❌  |  ❌   |  ❌   |    ✅   |  ❌   |
 | Juniper vSRX 3.0      |   ❌  |  ❌  |  ❌   |  ❌   |    ✅   |  ❌   |
 | Mikrotik RouterOS 6   |  ✅  | ✅  |  ❌   | ✅   |    ❌    |  ❌   |
 | Mikrotik RouterOS 7   |  ✅  | ✅  |  ❌   | ✅   |    ❌    |  ❌   |
@@ -255,6 +263,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Fortinet FortiOS      |          ✅          |   ❌    |    ❌     |         ❌          |        ❌         |    ❌    |
 | FRR 7.5.0             |          ✅          |   ✅    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Generic Linux         |          ✅          |   ❌    |    ❌     |         ❌          |        ❌         |    ❌    |
+| Juniper vMX           |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Juniper vSRX 3.0      |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Mikrotik RouterOS 6   |          ✅          |   ❌    |    ❌     |         ❌          |        ✅         |    ❌    |
 | Mikrotik RouterOS 7   |          ✅          |   ✅    |    ❌     |         ❌          |        ✅         |    ❌    |

--- a/netsim/ansible/collect-configs.ansible
+++ b/netsim/ansible/collect-configs.ansible
@@ -19,6 +19,7 @@
     name: Collect device configurations
     with_first_found:
     - "tasks/fetch-config/{{netlab_device_type}}.yml"
+    - "tasks/fetch-config/{{ansible_network_os}}.yml"
     - "missing.yml"
     args:
       apply:

--- a/netsim/ansible/config.ansible
+++ b/netsim/ansible/config.ansible
@@ -23,6 +23,8 @@
           files:
           - "{{ config + '/' + netlab_device_type + '.j2' }}"
           - "{{ config + '.' + netlab_device_type + '.j2' }}"
+          - "{{ config + '/' + ansible_network_os + '.j2' }}"
+          - "{{ config + '.' + ansible_network_os + '.j2' }}"
           - "{{ config }}"
           - "{{ config + '.j2' }}"
 
@@ -39,4 +41,7 @@
 
     tags: [ always ]
 
-  - include_tasks: "tasks/deploy-config/{{netlab_device_type}}.yml"
+  - include_tasks: "{{ item }}"
+    with_first_found:
+    - "tasks/deploy-config/{{netlab_device_type}}.yml"
+    - "tasks/deploy-config/{{ansible_network_os}}.yml"

--- a/netsim/ansible/create-config.ansible
+++ b/netsim/ansible/create-config.ansible
@@ -16,9 +16,19 @@
         state: directory
       run_once: true
 
+    - set_fact:
+        config_template: "{{ lookup('first_found',params,errors='ignore') }}"
+      vars:
+        params:
+          paths:
+          - "templates/initial/"
+          files:
+          - "{{netlab_device_type}}.j2"
+          - "{{ansible_network_os}}.j2"
+
     - name: Create initial configurations (IP addressing)
       template:
-        src: "templates/initial/{{ netlab_device_type }}.j2"
+        src: "{{ config_template }}"
         dest: "{{config_dir}}/{{inventory_hostname}}.initial.cfg"
     
     delegate_to: localhost
@@ -28,12 +38,9 @@
   tasks:
   - set_fact:
       modlist: "{{ modlist.split(',') if modlist is defined else netlab_module }}"
-  - template:
-      src: "templates/{{ item }}/{{ netlab_device_type }}.j2"
-      dest: "{{config_dir}}/{{inventory_hostname}}.{{item}}.cfg"
+  - include_tasks: "tasks/create-config.yml"
     loop: "{{ netlab_module|intersect(modlist) }}"
     when: item in module|default([])
-    delegate_to: localhost
 
 - name: Create custom deployment templates
   hosts: custom_configs

--- a/netsim/ansible/initial-config.ansible
+++ b/netsim/ansible/initial-config.ansible
@@ -19,21 +19,36 @@
     vars:
       config_module: initial
     with_first_found:
+    - "templates/{{ config_module }}/{{ device }}.j2"
     - "templates/{{ config_module }}/{{ netlab_device_type }}.j2"
     - "templates/missing.j2"
     tags: [ initial,test ]
+
+  - set_fact:
+      config_template: "{{ lookup('first_found',params,errors='ignore') }}"
+    tags: [ always ]
+    vars:
+      config_module: initial
+      params:
+        paths:
+        - "templates/"
+        files:
+        - "{{ config_module }}/{{device}}.j2"
+        - "{{ config_module }}/{{netlab_device_type}}.j2"
 
   - include_tasks: "{{ item }}"
     name: Deploy initial device configuration
     tags: [ initial ]
     with_first_found:
+    - "tasks/{{device}}/initial.yml"
+    - "tasks/deploy-config/{{device}}.yml"
     - "tasks/{{netlab_device_type}}/initial.yml"
     - "tasks/deploy-config/{{netlab_device_type}}.yml"
     - "missing.yml"
     args:
       apply:
         vars:
-          config_template: "templates/initial/{{netlab_device_type}}.j2"
+          config_template: "{{ config_template }}"
           netsim_action: initial
         tags: [ always ]
 

--- a/netsim/ansible/initial-config.ansible
+++ b/netsim/ansible/initial-config.ansible
@@ -12,15 +12,15 @@
   - name: Find initial configuration template
     debug:
       msg: |
-        Config for {{ inventory_hostname }} (type {{ netlab_device_type }})
+        Config for {{ inventory_hostname }} (type {{ netlab_device_type|default(ansible_network_os) }})
         ===================================
         {{ lookup('template',item) }}
       verbosity: 1
     vars:
       config_module: initial
     with_first_found:
-    - "templates/{{ config_module }}/{{ device }}.j2"
     - "templates/{{ config_module }}/{{ netlab_device_type }}.j2"
+    - "templates/{{ config_module }}/{{ ansible_network_os }}.j2"
     - "templates/missing.j2"
     tags: [ initial,test ]
 
@@ -33,17 +33,17 @@
         paths:
         - "templates/"
         files:
-        - "{{ config_module }}/{{device}}.j2"
         - "{{ config_module }}/{{netlab_device_type}}.j2"
+        - "{{ config_module }}/{{ansible_network_os}}.j2"
 
   - include_tasks: "{{ item }}"
     name: Deploy initial device configuration
     tags: [ initial ]
     with_first_found:
-    - "tasks/{{device}}/initial.yml"
-    - "tasks/deploy-config/{{device}}.yml"
     - "tasks/{{netlab_device_type}}/initial.yml"
     - "tasks/deploy-config/{{netlab_device_type}}.yml"
+    - "tasks/{{ansible_network_os}}/initial.yml"
+    - "tasks/deploy-config/{{ansible_network_os}}.yml"
     - "missing.yml"
     args:
       apply:

--- a/netsim/ansible/tasks/create-config.yml
+++ b/netsim/ansible/tasks/create-config.yml
@@ -1,0 +1,14 @@
+- delegate_to: localhost
+  block:
+  - set_fact:
+      config_template: "{{ lookup('first_found',params,errors='ignore') }}"
+    vars:
+      params:
+        paths:
+        - "../templates/{{ item }}/"
+        files:
+        - "{{netlab_device_type}}.j2"
+        - "{{ansible_network_os}}.j2"
+  - template:
+      src: "{{ config_template }}"
+      dest: "{{config_dir}}/{{inventory_hostname}}.{{item}}.cfg"

--- a/netsim/ansible/tasks/create-custom-config.yml
+++ b/netsim/ansible/tasks/create-custom-config.yml
@@ -10,6 +10,8 @@
       - "{{ lookup('env','PWD') }}"
       - "../../extra"
       files:
+      - "{{ custom_config + '/' + device + '.j2' }}"
+      - "{{ custom_config + '.' + device + '.j2' }}"
       - "{{ custom_config + '/' + netlab_device_type + '.j2' }}"
       - "{{ custom_config + '.' + netlab_device_type + '.j2' }}"
       - "{{ custom_config }}"

--- a/netsim/ansible/tasks/create-custom-config.yml
+++ b/netsim/ansible/tasks/create-custom-config.yml
@@ -10,10 +10,10 @@
       - "{{ lookup('env','PWD') }}"
       - "../../extra"
       files:
-      - "{{ custom_config + '/' + device + '.j2' }}"
-      - "{{ custom_config + '.' + device + '.j2' }}"
       - "{{ custom_config + '/' + netlab_device_type + '.j2' }}"
       - "{{ custom_config + '.' + netlab_device_type + '.j2' }}"
+      - "{{ custom_config + '/' + ansible_network_os + '.j2' }}"
+      - "{{ custom_config + '.' + ansible_network_os + '.j2' }}"
       - "{{ custom_config }}"
       - "{{ custom_config + '.j2' }}"
 

--- a/netsim/ansible/tasks/deploy-custom-config.yml
+++ b/netsim/ansible/tasks/deploy-custom-config.yml
@@ -12,6 +12,8 @@
       files:
       - "{{ custom_config + '/' + netlab_device_type + '.j2' }}"
       - "{{ custom_config + '.' + netlab_device_type + '.j2' }}"
+      - "{{ custom_config + '/' + ansible_network_os + '.j2' }}"
+      - "{{ custom_config + '.' + ansible_network_os + '.j2' }}"
       - "{{ custom_config }}"
       - "{{ custom_config + '.j2' }}"
 
@@ -32,6 +34,8 @@
   with_first_found:
   - "../../extra/{{ custom_config }}/deploy.{{ netlab_device_type }}.yml"
   - "deploy-config/{{netlab_device_type}}.yml"
+  - "../../extra/{{ custom_config }}/deploy.{{ ansible_network_os }}.yml"
+  - "deploy-config/{{ansible_network_os}}.yml"
   - "../missing.yml"
   args:
     apply:

--- a/netsim/ansible/tasks/deploy-module.yml
+++ b/netsim/ansible/tasks/deploy-module.yml
@@ -25,8 +25,8 @@
       verbosity: 1
     tags: [ test,module ]
     with_first_found:
-    - "../templates/{{ config_module }}/{{ device }}.j2"
     - "../templates/{{ config_module }}/{{ netlab_device_type }}.j2"
+    - "../templates/{{ config_module }}/{{ ansible_network_os }}.j2"
     - "../templates/missing.j2"
   
   - set_fact:
@@ -37,16 +37,16 @@
         paths:
         - "../templates/"
         files:
-        - "{{ config_module }}/{{device}}.j2"
         - "{{ config_module }}/{{netlab_device_type}}.j2"
+        - "{{ config_module }}/{{ansible_network_os}}.j2"
   
   - include_tasks: "{{ item }}"
     tags: [ module ]
     with_first_found:
-    - "{{device}}/{{ config_module }}.yml"
-    - "deploy-config/{{device}}.yml"
     - "{{netlab_device_type}}/{{ config_module }}.yml"
     - "deploy-config/{{netlab_device_type}}.yml"
+    - "{{ansible_network_os}}/{{ config_module }}.yml"
+    - "deploy-config/{{ansible_network_os}}.yml"
     - "../missing.yml"
     args:
       apply:

--- a/netsim/ansible/tasks/deploy-module.yml
+++ b/netsim/ansible/tasks/deploy-module.yml
@@ -25,19 +25,33 @@
       verbosity: 1
     tags: [ test,module ]
     with_first_found:
+    - "../templates/{{ config_module }}/{{ device }}.j2"
     - "../templates/{{ config_module }}/{{ netlab_device_type }}.j2"
     - "../templates/missing.j2"
-
+  
+  - set_fact:
+      config_template: "{{ lookup('first_found',params,errors='ignore') }}"
+    tags: [ always ]
+    vars:
+      params:
+        paths:
+        - "../templates/"
+        files:
+        - "{{ config_module }}/{{device}}.j2"
+        - "{{ config_module }}/{{netlab_device_type}}.j2"
+  
   - include_tasks: "{{ item }}"
     tags: [ module ]
     with_first_found:
+    - "{{device}}/{{ config_module }}.yml"
+    - "deploy-config/{{device}}.yml"
     - "{{netlab_device_type}}/{{ config_module }}.yml"
     - "deploy-config/{{netlab_device_type}}.yml"
     - "../missing.yml"
     args:
       apply:
         vars:
-          config_template: "../templates/{{ config_module }}/{{netlab_device_type}}.j2"
+          config_template: "{{ config_template }}"
           netsim_action: "{{ config_module }}"
         tags: [ always ]
 

--- a/netsim/ansible/tasks/vmx/initial.yml
+++ b/netsim/ansible/tasks/vmx/initial.yml
@@ -1,0 +1,21 @@
+
+# In case vMX is running on clab, with vrnetlab, the container is answering to pings 
+# even if the vMX virtual machines are not ready.
+# Furthermore, the TCP 3-way handshake for the SSH port is working as well (because the port 22 is proxied with socat).
+# That breaks very badly the different junos_config and junos_command modules.
+# This is a workaround for checking that the vMX CP is really ready to answer on SSH.
+
+- name: Execute local ssh command to check vMX CP readiness
+  local_action:
+    module: command
+    cmd: "sshpass -p '{{ ansible_ssh_pass }}' ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ ansible_user }}@{{ ansible_host }} 'show system information'"
+  register: command_out
+  until: command_out.rc == 0
+  retries: 10
+  delay: 30
+  when: clab.kind is defined
+
+- name: "junos_config: deploying initial config from {{ config_template }}"
+  junos_config:
+    src: "{{ config_template }}"
+  tags: [ print_action, always ]

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -28,7 +28,7 @@ def provider_inventory_settings(node: Box, defaults: Box) -> None:
         node[v] = p_data['forwarded'][k] + node['id']
 
 topo_to_host = { 'mgmt.ipv4': 'ansible_host', 'hostname': 'ansible_host', 'id': 'id' }
-topo_to_host_skip = [ 'name' ]
+topo_to_host_skip = [ 'name','device' ]
 
 def ansible_inventory_host(node: Box, defaults: Box) -> Box:
   host = Box({})

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -28,7 +28,7 @@ def provider_inventory_settings(node: Box, defaults: Box) -> None:
         node[v] = p_data['forwarded'][k] + node['id']
 
 topo_to_host = { 'mgmt.ipv4': 'ansible_host', 'hostname': 'ansible_host', 'id': 'id' }
-topo_to_host_skip = [ 'name','device' ]
+topo_to_host_skip = [ 'name' ]
 
 def ansible_inventory_host(node: Box, defaults: Box) -> Box:
   host = Box({})

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -746,6 +746,7 @@ devices:
       ansible_network_os: junos
       ansible_connection: netconf
       netlab_console_connection: ssh
+      netlab_device_type: vmx
     features:
       initial:
         ipv4:

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -47,7 +47,7 @@ attributes:
 # Built-in module defaults
 #
 bgp:
-  supported_on: [ cumulus, cumulus_nvue, eos, frr, csr, iosv, nxos, asav, vsrx, vyos, routeros, srlinux, sros, none, dellos10, routeros7, none ]
+  supported_on: [ cumulus, cumulus_nvue, eos, frr, csr, iosv, nxos, asav, vsrx, vyos, routeros, srlinux, sros, none, dellos10, routeros7, vmx, none ]
   ebgp_role: external
   advertise_roles: [ stub ]
   advertise_loopback: True
@@ -70,7 +70,7 @@ bgp:
     interface: [ local_as, replace_global_as ]
 
 isis:
-  supported_on: [ eos, frr, csr, iosv, nxos, asav, vsrx, srlinux, sros, vyos, none ]
+  supported_on: [ eos, frr, csr, iosv, nxos, asav, vsrx, srlinux, sros, vyos, vmx, none ]
   area: 49.0001
   type: level-2
   transform_after: [ vlan,vrf ]
@@ -84,7 +84,7 @@ ospf:
   area: 0.0.0.0
   supported_on: [
     arcos, cumulus, cumulus_nvue, eos, fortios, frr, csr, iosv, nxos, vsrx, vyos, routeros,
-    srlinux, sros, dellos10, routeros7, none ]
+    srlinux, sros, dellos10, routeros7, vmx, none ]
   transform_after: [ vlan,vrf ]
   config_after: [ vlan ]
   attributes:
@@ -116,7 +116,7 @@ bfd: # see RFC5880
 
 sr:
   requires: [ isis ]
-  supported_on: [ csr, eos, srlinux, sros, vsrx, none ]
+  supported_on: [ csr, eos, srlinux, sros, vsrx, vmx, none ]
   transform_after: [ vlan ]
   attributes:
     global: [ srgb_range_start, srgb_range_size, ipv6_sid_offset ]
@@ -735,6 +735,38 @@ devices:
     external:
       image: none
     graphite.icon: firewall
+
+  vmx:
+    interface_name: ge-0/0/{ifindex}
+    ifindex_offset: 0
+    mgmt_if: fxp0
+    group_vars:
+      ansible_user: admin
+      ansible_ssh_pass: "admin@123"
+      ansible_network_os: junos
+      ansible_connection: netconf
+      netlab_console_connection: ssh
+    features:
+      initial:
+        ipv4:
+          unnumbered: True
+        ipv6:
+          lla: True
+      ospf:
+        unnumbered: True
+      isis:
+        unnumbered:
+          ipv4: True
+          ipv6: True
+    clab:
+      image: vrnetlab/vr-vmx:18.2R1.9
+      node:
+        kind: vr-vmx
+      interface:
+        name: eth{ifindex+1}
+    external:
+      image: none
+    graphite.icon: router
 
   arcos:
     interface_name: swp%d

--- a/tests/integration/platform/vmx-clab.yml
+++ b/tests/integration/platform/vmx-clab.yml
@@ -1,0 +1,26 @@
+provider: clab
+defaults:
+  device: vmx
+
+
+addressing:
+  loopback:
+    ipv4: 10.255.0.0/24
+    prefix: 32
+  router_id:
+    ipv4: 10.255.0.0/24
+    prefix: 32
+
+module: [ bgp ]
+
+nodes:
+  r1:
+    bgp.as: 101
+  r2:
+    bgp.as: 102
+
+links:
+- r1:
+  r2:
+
+


### PR DESCRIPTION
As per #668 

Specific device types "children" of a vendor can be supported (in this case, vmx is configurable using junos templates and tasks, apart from the initial stuff) - but this can be generic, of course.
