### PR TITLE
Set correct first-hop gateway on VLANs with partial FHRP support (fix #671)

### DIFF
--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -234,6 +234,7 @@ gateway:
     protocols: [ anycast, vrrp ]
     vrrp: [ group ]
     link: [ id, ipv4, protocol, stub, anycast, vrrp ]
+    link_to_neighbor: True
 
 #
 # Network automation defaults

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -37,11 +37,15 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 1
+  - gateway:
+      ipv4: 172.16.1.254/24
+    ifindex: 1
     ifname: Ethernet1
     ipv4: 172.16.1.2/24
     node: r1
-  - ifindex: 1
+  - gateway:
+      ipv4: 172.16.1.254/24
+    ifindex: 1
     ifname: Ethernet1
     ipv4: 172.16.1.3/24
     node: r2
@@ -69,7 +73,9 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 2
+  - gateway:
+      ipv4: 172.16.0.1/24
+    ifindex: 2
     ifname: Ethernet2
     ipv4: 172.16.0.2/24
     node: r1
@@ -98,7 +104,9 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 2
+  - gateway:
+      ipv4: 172.16.0.1/24
+    ifindex: 2
     ifname: Ethernet2
     ipv4: 172.16.0.3/24
     node: r2
@@ -127,7 +135,9 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 3
+  - gateway:
+      ipv4: 10.42.42.13/28
+    ifindex: 3
     ifname: Ethernet3
     ipv4: 10.42.42.1/28
     node: r2
@@ -152,7 +162,9 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 4
+  - gateway:
+      ipv4: 10.42.42.1/29
+    ifindex: 4
     ifname: Ethernet4
     ipv4: 10.42.42.2/29
     node: r2
@@ -178,7 +190,10 @@ links:
     vrrp:
       group: 1
   interfaces:
-  - ifindex: 5
+  - gateway:
+      ipv4: 172.31.31.1/24
+      ipv6: 2001:db8:cafe:1::1/64
+    ifindex: 5
     ifname: Ethernet5
     ipv4: 172.31.31.3/24
     ipv6: 2001:db8:cafe:1::3/64
@@ -224,10 +239,28 @@ nodes:
       linkindex: 1
       name: h1 -> [r1,r2,h2]
       neighbors:
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.2/24
         node: r1
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
@@ -263,10 +296,28 @@ nodes:
       linkindex: 1
       name: h2 -> [r1,r2,h1]
       neighbors:
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.2/24
         node: r1
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
@@ -354,35 +405,49 @@ nodes:
       type: lan
     - bridge: input_4
       gateway:
-        ipv4: 10.42.42.1/28
+        ipv4: 10.42.42.13/28
       ifindex: 2
       ifname: eth2
       ipv4: 10.42.42.2/28
       linkindex: 4
       name: h4 -> r2
       neighbors:
-      - ifname: Ethernet3
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -3
+          ipv4: 10.42.42.13/28
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet3
         ipv4: 10.42.42.1/28
         node: r2
       role: stub
       type: lan
     - bridge: input_5
-      gateway:
-        ipv4: 10.42.42.2/29
       ifindex: 3
       ifname: eth3
       ipv4: 10.42.42.3/29
       linkindex: 5
       name: h4 -> r2
       neighbors:
-      - ifname: Ethernet4
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: 1
+          ipv4: 10.42.42.1/29
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet4
         ipv4: 10.42.42.2/29
         node: r2
       role: stub
       type: lan
     - bridge: input_6
-      gateway:
-        ipv4: 172.31.31.3/24
       ifindex: 4
       ifname: eth4
       ipv4: 172.31.31.13/24
@@ -390,7 +455,17 @@ nodes:
       linkindex: 6
       name: h4 -> r2
       neighbors:
-      - ifname: Ethernet5
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: 1
+          ipv4: 172.31.31.1/24
+          ipv6: 2001:db8:cafe:1::1/64
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet5
         ipv4: 172.31.31.3/24
         ipv6: 2001:db8:cafe:1::3/64
         node: r2
@@ -426,7 +501,16 @@ nodes:
       linkindex: 1
       name: r1 -> [r2,h1,h2]
       neighbors:
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
@@ -528,7 +612,16 @@ nodes:
       linkindex: 1
       name: r2 -> [r1,h1,h2]
       neighbors:
-      - ifname: Ethernet1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: false
+          id: -2
+          ipv4: 172.16.1.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Ethernet1
         ipv4: 172.16.1.2/24
         node: r1
       - ifname: eth1

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -1,0 +1,324 @@
+gateway:
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: true
+  vrrp:
+    group: 1
+input:
+- topology/input/rt-vlan-anycast.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  gateway: true
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.1/24
+    node: h
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.2/24
+    node: s1
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 172.16.1.0/24
+  role: stub
+  type: lan
+- bridge: input_2
+  gateway: true
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.0.1/24
+    node: h
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.2/24
+    node: s1
+    vlan:
+      access: blue
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: blue
+- interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    node: s1
+    vlan:
+      trunk:
+        blue: {}
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s2
+    vlan:
+      trunk:
+        blue: {}
+  linkindex: 3
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      blue: {}
+module:
+- vlan
+- gateway
+name: input
+nodes:
+  h:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 1
+    interfaces:
+    - bridge: input_1
+      gateway:
+        ipv4: 172.16.1.2/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.1/24
+      linkindex: 1
+      name: h -> s1
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.1.2/24
+        node: s1
+      role: stub
+      type: lan
+    - bridge: input_2
+      gateway:
+        ipv4: 172.16.0.254/24
+      ifindex: 2
+      ifname: eth2
+      ipv4: 172.16.0.1/24
+      linkindex: 2
+      name: h -> [s1,s2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08-4F-A9-00-00-01
+    name: h
+    role: host
+  s1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 2
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 172.16.1.2/24
+      linkindex: 1
+      name: s1 -> h
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.1/24
+        node: h
+      role: stub
+      type: lan
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1000
+    - ifindex: 3
+      ifname: Ethernet3
+      linkindex: 3
+      name: s1 -> s2
+      neighbors:
+      - ifname: Ethernet1
+        node: s2
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+        trunk_id:
+        - 1000
+    - bridge_group: 1
+      ifindex: 5
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN blue (1000) -> [h,s2]
+      neighbors:
+      - ifname: eth2
+        ipv4: 172.16.0.1/24
+        node: h
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: anycast
+          vrrp:
+            group: 1
+        ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: s2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - vlan
+    name: s1
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      blue:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+    id: 3
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 3
+      name: s2 -> s1
+      neighbors:
+      - ifname: Ethernet3
+        node: s1
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+        trunk_id:
+        - 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: anycast
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      name: VLAN blue (1000) -> [h,s1]
+      neighbors:
+      - ifname: eth2
+        ipv4: 172.16.0.1/24
+        node: h
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - vlan
+    - gateway
+    name: s2
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      blue:
+        bridge_group: 1
+        gateway: true
+        id: 1000
+        mode: irb
+        neighbors:
+        - ifname: eth2
+          ipv4: 172.16.0.1/24
+          node: h
+        - ifname: Vlan1000
+          ipv4: 172.16.0.2/24
+          node: s1
+        - gateway:
+            anycast:
+              mac: 0200.cafe.00ff
+              unicast: true
+            id: -2
+            ipv4: 172.16.0.254/24
+            protocol: anycast
+            vrrp:
+              group: 1
+          ifname: Vlan1000
+          ipv4: 172.16.0.3/24
+          node: s2
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+provider: libvirt
+vlans:
+  blue:
+    gateway: true
+    host_count: 1
+    id: 1000
+    neighbors:
+    - ifname: eth2
+      ipv4: 172.16.0.1/24
+      node: h
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: s1
+    - gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: anycast
+        vrrp:
+          group: 1
+      ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      node: s2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/rt-vlan-anycast.yml
+++ b/tests/topology/input/rt-vlan-anycast.yml
@@ -1,0 +1,26 @@
+# Regression test for #671
+#
+defaults.device: eos
+
+nodes:
+  h:
+    device: linux
+  s1:
+    module: [ vlan ]
+  s2:
+    module: [ vlan,gateway ]
+
+vlans:
+  blue:
+    gateway: True
+
+links:
+- h:
+  s1:
+  gateway: True
+- h:
+  s1:
+  vlan.access: blue
+- s1:
+  s2:
+  vlan.trunk: [ blue ]


### PR DESCRIPTION
The 'gateway' and 'vlan' modules incorrectly assumed that L3 switches connected to a VLAN consistently use the 'gateway' module. When that's not the case, the host default gateway is set to a switch IP address, not to the FHRP IP address.

This commit:
* Copies gateway data from links to interfaces of switches using the 'gateway' module
* Survives 'gateway: True' on links where no attached nodes are using the 'gateway' module
* Prefers 'gateway.ipv4' on a VLAN over a switch IPv4 address when fixing VLAN first-hop gateways