### PR TITLE
Force use of YAML version 1.2 when using ruamel

### DIFF
--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -113,7 +113,7 @@ def write_yaml(data: Box, fname: str, header: str) -> None:
   with open(fname,"w") as output:
     output.write(header)
     if callable(getattr(data,"to_yaml",None)):
-      output.write(data.to_yaml())
+      output.write(data.to_yaml(ruamel_attrs={'version': (1,2)}))
     else:                            # pragma: no cover -- this should never happen as we're using Box, but just in case...
       output.write(yaml.dump(data))
     output.close()


### PR DESCRIPTION
Box defaults to ruamel.yang YAML package, which supports both YAML 1.2 and 1.1. 

See https://github.com/ipspace/netlab/pull/669 on an issue with YAML 1.1 and interpretation of 65000:1 as an int value; YAML 1.2 removes support for such 'sexagesimal' numbers

ruamel.yang is a dependency of Box, but may or may not be installed in the environment. Netlab writes inventory files using ruamel, and Ansible then reads back these same files again using ruamel - so this 'round trip' workflow should work