### PR TITLE
Use vagrant-libvirt plugin version 0.11.2 (fixes #667)

### DIFF
--- a/netsim/install/libvirt.sh
+++ b/netsim/install/libvirt.sh
@@ -63,14 +63,7 @@ curl -fsSL https://apt.releases.hashicorp.com/gpg | $SUDO gpg --dearmor -o /etc/
 $SUDO sh -c 'echo "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/vagrant.list'
 $SUDO apt-get update
 $SUDO apt-get install -y $FLAG_QUIET ruby-dev ruby-libvirt vagrant
-vagrant plugin install vagrant-libvirt --plugin-version=0.4.1
-#
-# Temporary fix: replace fog-libvirt 0.10.1 with fog-libvirt 0.9.0 until we can upgrade to the latest vagrant-libvirt plugin
-#
-echo ".. replacing fog-libvirt gem with an older version"
-GEMS_DIR=`echo ~/.vagrant.d/gems/*`
-GEM_HOME=$GEMS_DIR gem uninstall -aIx fog-libvirt
-GEM_HOME=$GEMS_DIR gem install 'fog-libvirt:0.9.0'
+vagrant plugin install vagrant-libvirt --plugin-version=0.11.2
 echo ".. vagrant installed"
 echo
 set +e

--- a/netsim/templates/provider/libvirt/nxos-domain.j2
+++ b/netsim/templates/provider/libvirt/nxos-domain.j2
@@ -1,4 +1,6 @@
     {{ name }}.vm.synced_folder ".", "/vagrant", disabled: true
+    {{ name }}.vm.allow_fstab_modification = false
+    {{ name }}.vm.allow_hosts_modification = false
     {{ name }}.ssh.insert_key = false
     {{ name }}.ssh.shell = "run bash"
     {{ name }}.vm.boot_timeout = 360


### PR DESCRIPTION
* Replace the plugin version in installation script and remove the workaround
* Tweak NXOS template until Nexus 9300v boots