### PR TITLE
IGP BFD status should not be present on interfaces without IGP

### DIFF
--- a/netsim/modules/bfd.py
+++ b/netsim/modules/bfd.py
@@ -17,33 +17,42 @@ def bfd_link_state(node: Box,proto: str) -> None:
     return
   if not 'bfd' in node[proto]:
     return
-  if not 'interfaces' in node:    # pragma: no cover (pretty hard to get here ;)
-    return
+  if not 'bfd' in node.module:    # Disable IGP BFD on nodes that have no BFD enabled
+    node[proto].bfd = False
 
   node[proto].bfd = True if node[proto].bfd else False   # Convert protocol-level BFD setting into Boolean
 
   for l in node.interfaces:
+    if proto in l and l[proto] is False:   # Skip interfaces that have disabled routing protocol
+      continue
     if not proto in l:                     # No protocol-specific link parameters?
       l[proto] = {}                        # ... start with an empty dictionary
 
     if not 'bfd' in l[proto]:              # No BFD protocol-specific parameters?
-      l[proto].bfd = node[proto].bfd       # ... copy from node value and move on
+      l[proto].bfd = node[proto].bfd       # ... copy default link settings from from node value
 
     p = l[proto]
     disable_bfd = False
     disable_bfd = disable_bfd or ('bfd' in l and not l.bfd)     # BFD is disabled on the interface
     disable_bfd = disable_bfd or ('bfd' in p and not p.bfd)
+
     if disable_bfd:
       l[proto].pop('bfd',None)
 
     if not l[proto]:
       l.pop(proto,None)
 
+  if not node[proto].bfd:                  # Finally, remove empty IGP BFD status
+    node[proto].pop('bfd',None)
+
 def multiprotocol_bfd_link_state(node: Box,proto: str) -> None:
   if not proto in node:           # pragma: no cover (impossible to be called from an IGP module if that module is not enabled)
     return
   if not 'bfd' in node[proto]:
     return
+
+  if not 'bfd' in node.module:
+    node[proto].bfd = False
 
   # Transform boolean BFD routing protocol state into per-AF-state
   #
@@ -56,10 +65,9 @@ def multiprotocol_bfd_link_state(node: Box,proto: str) -> None:
     else:
       node[proto].bfd = {}
 
-  if not 'interfaces' in node:
-    return
-
   for l in node.interfaces:
+    if proto in l and l[proto] is False:   # Skip interfaces that have disabled routing protocol
+      continue
     if not proto in l:                     # No protocol-specific link parameters?
       l[proto] = {}                        # ... start with an empty dictionary
 
@@ -86,3 +94,6 @@ def multiprotocol_bfd_link_state(node: Box,proto: str) -> None:
 
     if not l[proto]:                       # Last check: if we didn't get any useful protocol data
       l.pop(proto,None)                    # ... remove protocol data from the interface
+
+  if not node[proto].bfd:                  # Finally, remove empty IGP BFD status
+    node[proto].pop('bfd',None)

--- a/netsim/modules/eigrp.py
+++ b/netsim/modules/eigrp.py
@@ -13,6 +13,6 @@ class EIGRP(_Module):
       if not _routing.external(intf,'eigrp'):
         _routing.passive(intf,'eigrp')
 
-    _routing.remove_unaddressed_intf(node,'ospf')
-    _routing.remove_vrf_interfaces(node,'isis')
+    _routing.remove_unaddressed_intf(node,'eigrp')
+    _routing.remove_vrf_interfaces(node,'eigrp')
     _routing.routing_af(node,'eigrp')

--- a/netsim/modules/isis.py
+++ b/netsim/modules/isis.py
@@ -8,36 +8,47 @@ from . import bfd
 from .. import common
 from ..augment import devices
 
+def isis_unnumbered(node: Box, features: Box) -> bool:
+  for af in ('ipv4','ipv6'):
+    is_unnumbered = False
+    for l in node.get('interfaces',[]):
+      is_unnumbered = is_unnumbered or \
+        'unnumbered' in l or \
+        (af in l and isinstance(l[af],bool) and l[af])
+
+    if is_unnumbered and not features.isis.unnumbered[af]:
+      common.error(
+        f'Device {node.device} used on node {node.name} cannot run IS-IS over {"unnumbered" if af == "ipv4" else "LLA"} {af} interfaces',
+        common.IncorrectValue,
+        'interfaces')
+      return False
+
+  OK = True
+  for l in node.get('interfaces',[]):
+    unnum_v4 = 'unnumbered' in l or ('ipv4' in l and l.ipv4 is True)
+    if unnum_v4 and \
+        len(l.neighbors) > 1 and \
+        not features.isis.unnumbered.network:
+      common.error(
+        f'Device {node.device} used on node {node.name} cannot run IS-IS over\n'+
+        f'.. unnumbered multi-access interfaces (link {l.name})',
+        common.IncorrectValue,
+        'interfaces')
+      OK = False
+
+  return OK
+
 class ISIS(_Module):
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
     features = devices.get_device_features(node,topology.defaults)
 
-    for af in ('ipv4','ipv6'):
-      is_unnumbered = False
-      for l in node.get('interfaces',[]):
-        is_unnumbered = is_unnumbered or \
-          'unnumbered' in l or \
-          (af in l and isinstance(l[af],bool) and l[af])
+    if not isis_unnumbered(node,features):
+      return
 
-      if is_unnumbered and not features.isis.unnumbered[af]:
-        common.error(
-          f'Device {node.device} used on node {node.name} cannot run IS-IS over {"unnumbered" if af == "ipv4" else "LLA"} {af} interfaces',
-          common.IncorrectValue,
-          'interfaces')
-
+    bfd.multiprotocol_bfd_link_state(node,'isis')
     for l in node.get('interfaces',[]):
-      unnum_v4 = 'unnumbered' in l or ('ipv4' in l and isinstance(l.ipv4,bool) and l.ipv4)
-      if unnum_v4 and \
-          len(l.neighbors) > 1 and \
-          features.isis.unnumbered.ipv4 and \
-          not features.isis.unnumbered.network:
-        common.error(
-          f'Device {node.device} used on node {node.name} cannot run IS-IS over\n'+
-          f'.. unnumbered multi-access interfaces (link {l.name})',
-          common.IncorrectValue,
-          'interfaces')
-      elif _routing.external(l,'isis') or not (l.get('ipv4',False) or l.get('ipv6',False)):
+      if _routing.external(l,'isis') or not (l.get('ipv4',False) or l.get('ipv6',False)):
         l.pop('isis',None) # Don't run IS-IS on external interfaces, or l2-only
       else:
         _routing.passive(l,'isis')
@@ -56,5 +67,4 @@ class ISIS(_Module):
     _routing.remove_unaddressed_intf(node,'isis')
     _routing.remove_vrf_interfaces(node,'isis')
     _routing.routing_af(node,'isis')
-    bfd.multiprotocol_bfd_link_state(node,'isis')
     _routing.remove_unused_igp(node,'isis')

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -10,14 +10,57 @@ from . import bfd
 from .. import common
 from ..augment import devices
 
+# We need to set ospf.unnumbered if we happen to have OSPF running over an unnumbered
+# link -- Arista EOS needs an extra nerd knob to make it work
+#
+# An interface can be unnumbered if it has the 'unnumbered' flag set or if it
+# has IPv4 enabled but no IPv4 address (ipv4: true)
+#
+# While doing that, we also check for the number of neighbors on unnumbered interfaces
+# and report an error if there are none (in which case the interface should not be unnumbered)
+# or more than one (in which case OSPF won't work)
+#
+def ospf_unnumbered(node: Box, features: Box) -> bool:
+  OK = True
+
+  for l in node.get('interfaces',[]):
+    is_unnumbered = \
+      'unnumbered' in l or \
+      ('ipv4' in l and isinstance(l.ipv4,bool) and l.ipv4)
+    if is_unnumbered and 'ospf' in l:
+      node.ospf.unnumbered = True
+      if len(l.get('neighbors',[])) > 1:
+        common.error(
+          f'OSPF does not work over multi-access unnumbered IPv4 interfaces: node {node.name} link {l.name}',
+          common.IncorrectValue,
+          'ospf')
+        OK = False
+      elif not len(l.get('neighbors',[])):
+        common.error(
+          f'Configuring OSPF on an unnumbered stub interface makes no sense: node {node.name} link {l.name}',
+          common.IncorrectValue,
+          'ospf')
+        OK = False
+
+  if 'unnumbered' in node.ospf:
+    if not features.ospf.unnumbered:
+      common.error(
+        f'Device {node.device} used on node {node.name} cannot run OSPF over unnumbered interface',
+        common.IncorrectValue,
+        'interfaces')
+      OK = False
+
+  return OK
+
 class OSPF(_Module):
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
     features = devices.get_device_features(node,topology.defaults)
 
     _routing.router_id(node,'ospf',topology.pools)
+    bfd.bfd_link_state(node,'ospf')
     #
-    # Initial cleanup
+    # Cleanup routing protocol from external/disabled interfaces
     for intf in node.get('interfaces',[]):
       if not _routing.external(intf,'ospf'):                # Remove external interfaces from OSPF process
         _routing.passive(intf,'ospf')                       # Set passive flag on other OSPF interfaces
@@ -25,39 +68,8 @@ class OSPF(_Module):
         if err:
           common.error(f'{err}\n... node {node.name} link {intf}')
 
-    # We need to set ospf.unnumbered if we happen to have OSPF running over an unnumbered
-    # link -- Arista EOS needs an extra nerd knob to make it work
-    #
-    # An interface can be unnumbered if it has the 'unnumbered' flag set or if it
-    # has IPv4 enabled but no IPv4 address (ipv4: true)
-    #
-    # While doing that, we also check for the number of neighbors on unnumbered interfaces
-    # and report an error if there are none (in which case the interface should not be unnumbered)
-    # or more than one (in which case OSPF won't work)
-    #
-    for l in node.get('interfaces',[]):
-      is_unnumbered = \
-        'unnumbered' in l or \
-        ('ipv4' in l and isinstance(l.ipv4,bool) and l.ipv4)
-      if is_unnumbered and 'ospf' in l:
-        node.ospf.unnumbered = True
-        if len(l.get('neighbors',[])) > 1:
-          common.error(
-            f'OSPF does not work over multi-access unnumbered IPv4 interfaces: node {node.name} link {l.name}',
-            common.IncorrectValue,
-            'ospf')
-        elif not len(l.get('neighbors',[])):
-          common.error(
-            f'Configuring OSPF on an unnumbered stub interface makes no sense: node {node.name} link {l.name}',
-            common.IncorrectValue,
-            'ospf')
-
-    if 'unnumbered' in node.ospf:
-      if not features.ospf.unnumbered:
-        common.error(
-          f'Device {node.device} used on node {node.name} cannot run OSPF over unnumbered interface',
-          common.IncorrectValue,
-          'interfaces')
+    if not ospf_unnumbered(node,features):
+      return
 
     #
     # Final steps:
@@ -69,6 +81,5 @@ class OSPF(_Module):
     _routing.remove_unaddressed_intf(node,'ospf')
     _routing.build_vrf_interface_list(node,'ospf',topology)
     _routing.routing_af(node,'ospf')
-    bfd.bfd_link_state(node,'ospf')
     _routing.remove_vrf_routing_blocks(node,'ospf')
     _routing.remove_unused_igp(node,'ospf')

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -14,57 +14,55 @@ links:
 - bridge: input_1
   interfaces:
   - ifindex: 1
-    ifname: 1/1/c1
+    ifname: Ethernet1
     ipv4: 172.16.0.1/24
-    node: sros_r1
+    node: r1
   - ifindex: 1
-    ifname: ethernet-1/1
+    ifname: Ethernet1
     ipv4: 172.16.0.2/24
-    node: srlinux_r2
+    node: r2
   - ifindex: 1
-    ifname: ethernet-1/1
-    ipv4: 172.16.0.6/24
+    ifname: Ethernet1
+    ipv4: 172.16.0.5/24
     node: n6
   linkindex: 1
-  name: Regular link, BFD enabled
+  name: Regular (IPv4-only) link, BFD enabled
   node_count: 3
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- bfd: false
-  interfaces:
+- interfaces:
   - ifindex: 2
-    ifname: 1/1/c2
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: sros_r1
-  - ifindex: 2
-    ifname: ethernet-1/2
+    ifname: Ethernet2
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
+    node: r1
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 10.1.0.2/30
+    ipv6: 2001:db8:1::2/64
+    node: r2
   linkindex: 2
-  name: Link with BFD disabled
+  name: Regular (dual-stack) P2P link, BFD enabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
   type: p2p
-- interfaces:
+- bfd: false
+  interfaces:
   - ifindex: 3
-    ifname: 1/1/c3
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: sros_r1
-  - ifindex: 3
-    ifname: ethernet-1/3
+    ifname: Ethernet3
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
-  isis:
-    bfd: false
+    node: r1
+  - ifindex: 3
+    ifname: Ethernet3
+    ipv4: 10.1.0.6/30
+    ipv6: 2001:db8:1:1::2/64
+    node: r2
   linkindex: 3
-  name: Link with ISIS BFD disabled
+  name: Link with BFD disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -72,21 +70,19 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 4
-    ifname: 1/1/c4
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: sros_r1
-  - ifindex: 4
-    ifname: ethernet-1/4
+    ifname: Ethernet4
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
+    node: r1
+  - ifindex: 4
+    ifname: Ethernet4
+    ipv4: 10.1.0.10/30
+    ipv6: 2001:db8:1:2::2/64
+    node: r2
   isis:
-    bfd:
-      ipv4: true
-      ipv6: false
+    bfd: false
   linkindex: 4
-  name: Link with IPv4-only BFD
+  name: Link with ISIS BFD disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
@@ -94,21 +90,18 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 5
-    ifname: 1/1/c5
-    ipv4: 10.1.0.14/30
-    ipv6: 2001:db8:1:3::2/64
-    node: sros_r1
-  - ifindex: 5
-    ifname: ethernet-1/5
+    ifname: Ethernet5
     ipv4: 10.1.0.13/30
     ipv6: 2001:db8:1:3::1/64
-    node: srlinux_r2
-  isis:
-    bfd:
-      ipv4: false
-      ipv6: true
+    node: r1
+  - ifindex: 5
+    ifname: Ethernet5
+    ipv4: 10.1.0.14/30
+    ipv6: 2001:db8:1:3::2/64
+    node: r2
+  isis: false
   linkindex: 5
-  name: Link with IPv6-only BFD
+  name: Link with ISIS disabled
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
@@ -116,52 +109,96 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 6
-    ifname: 1/1/c6
-    ipv4: 10.42.42.2/24
-    node: sros_r1
+    ifname: Ethernet6
+    ipv4: 10.1.0.17/30
+    ipv6: 2001:db8:1:4::1/64
+    node: r1
   - ifindex: 6
-    ifname: ethernet-1/6
+    ifname: Ethernet6
+    ipv4: 10.1.0.18/30
+    ipv6: 2001:db8:1:4::2/64
+    node: r2
+  isis:
+    bfd:
+      ipv4: true
+      ipv6: false
+  linkindex: 6
+  name: Link with IPv4-only BFD
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.16/30
+    ipv6: 2001:db8:1:4::/64
+  type: p2p
+- interfaces:
+  - ifindex: 7
+    ifname: Ethernet7
+    ipv4: 10.1.0.21/30
+    ipv6: 2001:db8:1:5::1/64
+    node: r1
+  - ifindex: 7
+    ifname: Ethernet7
+    ipv4: 10.1.0.22/30
+    ipv6: 2001:db8:1:5::2/64
+    node: r2
+  isis:
+    bfd:
+      ipv4: false
+      ipv6: true
+  linkindex: 7
+  name: Link with IPv6-only BFD
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.20/30
+    ipv6: 2001:db8:1:5::/64
+  type: p2p
+- interfaces:
+  - ifindex: 8
+    ifname: Ethernet8
     ipv4: 10.42.42.1/24
+    node: r1
+  - ifindex: 8
+    ifname: Ethernet8
+    ipv4: 10.42.42.2/24
     isis:
       bfd: true
-    node: srlinux_r2
-  linkindex: 6
+    node: r2
+  linkindex: 8
   name: IPv4-only link with BFD
   node_count: 2
   prefix:
     ipv4: 10.42.42.0/24
   type: p2p
 - interfaces:
-  - ifindex: 7
-    ifname: 1/1/c7
-    ipv6: 2001:db8:42:1::2/64
-    node: sros_r1
-  - ifindex: 7
-    ifname: ethernet-1/7
+  - ifindex: 9
+    ifname: Ethernet9
     ipv6: 2001:db8:42:1::1/64
-    node: srlinux_r2
-  linkindex: 7
+    node: r1
+  - ifindex: 9
+    ifname: Ethernet9
+    ipv6: 2001:db8:42:1::2/64
+    node: r2
+  linkindex: 9
   name: IPv6-only link with BFD
   node_count: 2
   prefix:
     ipv6: 2001:db8:42:1::/64
   type: p2p
 - interfaces:
-  - ifindex: 8
-    ifname: 1/1/c8
-    ipv4: 10.42.43.2/24
-    node: sros_r1
-  - ifindex: 8
-    ifname: ethernet-1/8
+  - ifindex: 10
+    ifname: Ethernet10
     ipv4: 10.42.43.1/24
+    node: r1
+  - ifindex: 10
+    ifname: Ethernet10
+    ipv4: 10.42.43.2/24
     isis:
       bfd:
         ipv6: true
-    node: srlinux_r2
+    node: r2
   isis:
     bfd:
       ipv6: true
-  linkindex: 8
+  linkindex: 10
   name: IPv4-only link with IPv6-only BFD
   node_count: 2
   prefix:
@@ -169,80 +206,106 @@ links:
   type: p2p
 - interfaces:
   - ifindex: 1
-    ifname: 1/1/c1
-    ipv4: 10.1.0.17/30
-    ipv6: 2001:db8:1:4::1/64
+    ifname: Ethernet1
+    ipv4: 10.1.0.25/30
+    ipv6: 2001:db8:1:6::1/64
     node: n4
   - ifindex: 1
-    ifname: 1/1/c1
-    ipv4: 10.1.0.18/30
-    ipv6: 2001:db8:1:4::2/64
+    ifname: Ethernet1
+    ipv4: 10.1.0.26/30
+    ipv6: 2001:db8:1:6::2/64
     node: n5
-  linkindex: 9
+  linkindex: 11
   node_count: 2
   prefix:
-    ipv4: 10.1.0.16/30
-    ipv6: 2001:db8:1:4::/64
+    ipv4: 10.1.0.24/30
+    ipv6: 2001:db8:1:6::/64
   type: p2p
 module:
 - bfd
 - isis
 name: input
 nodes:
-  n3:
-    af:
-      ipv4: true
-    box: vrnetlab/vr-sros
-    clab:
-      kind: vr-sros
-      license: /Projects/SR_OS_VSR-SIM_license.txt
-      type: sr-1
-    device: sros
-    hostname: clab-input-n3
-    id: 3
-    interfaces: []
-    loopback:
-      ipv4: 10.0.0.3/32
-    mgmt:
-      ifname: A/1
-      ipv4: 192.168.121.103
-      mac: 08-4F-A9-00-00-03
-    module: []
-    mtu: 1500
-    name: n3
   n4:
     af:
       ipv4: true
       ipv6: true
-    box: vrnetlab/vr-sros
+    box: ceos:4.26.4M
     clab:
-      kind: vr-sros
-      license: /Projects/SR_OS_VSR-SIM_license.txt
-      type: sr-1
-    device: sros
+      env:
+        INTFTYPE: et
+      kind: ceos
+    device: eos
     hostname: clab-input-n4
+    id: 3
+    interfaces:
+    - clab:
+        name: et1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 10.1.0.25/30
+      ipv6: 2001:db8:1:6::1/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 11
+      name: n4 -> n5
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 10.1.0.26/30
+        ipv6: 2001:db8:1:6::2/64
+        node: n5
+      type: p2p
+    isis:
+      af:
+        ipv4: true
+        ipv6: true
+      area: 49.0002
+      type: level-2
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: Management0
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - isis
+    name: n4
+  n5:
+    af:
+      ipv4: true
+      ipv6: true
+    bfd:
+      min_echo_rx: 0
+      multiplier: 3
+    box: ceos:4.26.4M
+    clab:
+      env:
+        INTFTYPE: et
+      kind: ceos
+    device: eos
+    hostname: clab-input-n5
     id: 4
     interfaces:
     - clab:
-        name: eth1
+        name: et1
       ifindex: 1
-      ifname: 1/1/c1
-      ipv4: 10.1.0.17/30
-      ipv6: 2001:db8:1:4::1/64
+      ifname: Ethernet1
+      ipv4: 10.1.0.26/30
+      ipv6: 2001:db8:1:6::2/64
       isis:
         bfd:
           ipv4: true
           ipv6: true
         network_type: point-to-point
         passive: false
-      linkindex: 9
-      mtu: 1500
-      name: n4 -> n5
+      linkindex: 11
+      name: n5 -> n4
       neighbors:
-      - ifname: 1/1/c1
-        ipv4: 10.1.0.18/30
-        ipv6: 2001:db8:1:4::2/64
-        node: n5
+      - ifname: Ethernet1
+        ipv4: 10.1.0.25/30
+        ipv6: 2001:db8:1:6::1/64
+        node: n4
       type: p2p
     isis:
       af:
@@ -256,471 +319,254 @@ nodes:
     loopback:
       ipv4: 10.0.0.4/32
     mgmt:
-      ifname: A/1
+      ifname: Management0
       ipv4: 192.168.121.104
       mac: 08-4F-A9-00-00-04
     module:
     - isis
-    mtu: 1500
-    name: n4
-  n5:
-    af:
-      ipv4: true
-      ipv6: true
-    bfd:
-      min_echo_rx: 0
-      min_rx: 100
-      min_tx: 100
-      multiplier: 3
-    box: vrnetlab/vr-sros
-    clab:
-      kind: vr-sros
-      license: /Projects/SR_OS_VSR-SIM_license.txt
-      type: sr-1
-    device: sros
-    hostname: clab-input-n5
-    id: 5
-    interfaces:
-    - clab:
-        name: eth1
-      ifindex: 1
-      ifname: 1/1/c1
-      ipv4: 10.1.0.18/30
-      ipv6: 2001:db8:1:4::2/64
-      isis:
-        bfd:
-          ipv4: true
-          ipv6: true
-        network_type: point-to-point
-        passive: false
-      linkindex: 9
-      mtu: 1500
-      name: n5 -> n4
-      neighbors:
-      - ifname: 1/1/c1
-        ipv4: 10.1.0.17/30
-        ipv6: 2001:db8:1:4::1/64
-        node: n4
-      type: p2p
-    isis:
-      af:
-        ipv4: true
-        ipv6: true
-      area: 49.0002
-      bfd:
-        ipv4: true
-        ipv6: true
-      type: level-2
-    loopback:
-      ipv4: 10.0.0.5/32
-    mgmt:
-      ifname: A/1
-      ipv4: 192.168.121.105
-      mac: 08-4F-A9-00-00-05
-    module:
-    - isis
     - bfd
-    mtu: 1500
     name: n5
   n6:
     af:
       ipv4: true
     bfd:
       min_echo_rx: 0
-      min_rx: 100
-      min_tx: 100
       multiplier: 3
-    box: ghcr.io/nokia/srlinux
+    box: ceos:4.26.4M
     clab:
-      kind: srl
-      type: ixrd2
-    device: srlinux
+      env:
+        INTFTYPE: et
+      kind: ceos
+    device: eos
     hostname: clab-input-n6
-    id: 6
+    id: 5
     interfaces:
     - bridge: input_1
       clab:
-        name: e1-1
+        name: et1
       ifindex: 1
-      ifname: ethernet-1/1
-      ipv4: 172.16.0.6/24
+      ifname: Ethernet1
+      ipv4: 172.16.0.5/24
       isis:
         passive: false
       linkindex: 1
-      name: Regular link, BFD enabled
+      name: Regular (IPv4-only) link, BFD enabled
       neighbors:
-      - ifname: 1/1/c1
+      - ifname: Ethernet1
         ipv4: 172.16.0.1/24
-        node: sros_r1
-      - ifname: ethernet-1/1
+        node: r1
+      - ifname: Ethernet1
         ipv4: 172.16.0.2/24
-        node: srlinux_r2
+        node: r2
       type: lan
     isis:
       af:
         ipv4: true
       area: 49.0002
-      bfd: {}
       type: level-2
     loopback:
-      ipv4: 10.0.0.6/32
+      ipv4: 10.0.0.5/32
     mgmt:
-      ifname: mgmt0
-      ipv4: 192.168.121.106
-      mac: 08-4F-A9-00-00-06
+      ifname: Management0
+      ipv4: 192.168.121.105
+      mac: 08-4F-A9-00-00-05
     module:
     - isis
     - bfd
     name: n6
-  srlinux_r2:
+  r1:
     af:
       ipv4: true
       ipv6: true
     bfd:
       min_echo_rx: 0
-      min_rx: 100
-      min_tx: 100
       multiplier: 3
-    box: ghcr.io/nokia/srlinux
+    box: ceos:4.26.4M
     clab:
-      kind: srl
-      type: ixrd2
-    device: srlinux
-    hostname: clab-input-srlinux_r2
-    id: 2
-    interfaces:
-    - bridge: input_1
-      clab:
-        name: e1-1
-      ifindex: 1
-      ifname: ethernet-1/1
-      ipv4: 172.16.0.2/24
-      isis:
-        bfd:
-          ipv4: true
-        passive: false
-      linkindex: 1
-      name: Regular link, BFD enabled
-      neighbors:
-      - ifname: 1/1/c1
-        ipv4: 172.16.0.1/24
-        node: sros_r1
-      - ifname: ethernet-1/1
-        ipv4: 172.16.0.6/24
-        node: n6
-      type: lan
-    - bfd: false
-      clab:
-        name: e1-2
-      ifindex: 2
-      ifname: ethernet-1/2
-      ipv4: 10.1.0.1/30
-      ipv6: 2001:db8:1::1/64
-      isis:
-        network_type: point-to-point
-        passive: false
-      linkindex: 2
-      name: Link with BFD disabled
-      neighbors:
-      - ifname: 1/1/c2
-        ipv4: 10.1.0.2/30
-        ipv6: 2001:db8:1::2/64
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-3
-      ifindex: 3
-      ifname: ethernet-1/3
-      ipv4: 10.1.0.5/30
-      ipv6: 2001:db8:1:1::1/64
-      isis:
-        network_type: point-to-point
-        passive: false
-      linkindex: 3
-      name: Link with ISIS BFD disabled
-      neighbors:
-      - ifname: 1/1/c3
-        ipv4: 10.1.0.6/30
-        ipv6: 2001:db8:1:1::2/64
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-4
-      ifindex: 4
-      ifname: ethernet-1/4
-      ipv4: 10.1.0.9/30
-      ipv6: 2001:db8:1:2::1/64
-      isis:
-        bfd:
-          ipv4: true
-          ipv6: false
-        network_type: point-to-point
-        passive: false
-      linkindex: 4
-      name: Link with IPv4-only BFD
-      neighbors:
-      - ifname: 1/1/c4
-        ipv4: 10.1.0.10/30
-        ipv6: 2001:db8:1:2::2/64
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-5
-      ifindex: 5
-      ifname: ethernet-1/5
-      ipv4: 10.1.0.13/30
-      ipv6: 2001:db8:1:3::1/64
-      isis:
-        bfd:
-          ipv4: false
-          ipv6: true
-        network_type: point-to-point
-        passive: false
-      linkindex: 5
-      name: Link with IPv6-only BFD
-      neighbors:
-      - ifname: 1/1/c5
-        ipv4: 10.1.0.14/30
-        ipv6: 2001:db8:1:3::2/64
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-6
-      ifindex: 6
-      ifname: ethernet-1/6
-      ipv4: 10.42.42.1/24
-      isis:
-        bfd:
-          ipv4: true
-        network_type: point-to-point
-        passive: false
-      linkindex: 6
-      name: IPv4-only link with BFD
-      neighbors:
-      - ifname: 1/1/c6
-        ipv4: 10.42.42.2/24
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-7
-      ifindex: 7
-      ifname: ethernet-1/7
-      ipv6: 2001:db8:42:1::1/64
-      isis:
-        bfd:
-          ipv6: true
-        network_type: point-to-point
-        passive: false
-      linkindex: 7
-      name: IPv6-only link with BFD
-      neighbors:
-      - ifname: 1/1/c7
-        ipv6: 2001:db8:42:1::2/64
-        node: sros_r1
-      type: p2p
-    - clab:
-        name: e1-8
-      ifindex: 8
-      ifname: ethernet-1/8
-      ipv4: 10.42.43.1/24
-      isis:
-        network_type: point-to-point
-        passive: false
-      linkindex: 8
-      name: IPv4-only link with IPv6-only BFD
-      neighbors:
-      - ifname: 1/1/c8
-        ipv4: 10.42.43.2/24
-        node: sros_r1
-      type: p2p
-    isis:
-      af:
-        ipv4: true
-        ipv6: true
-      area: 49.0002
-      bfd:
-        ipv4: true
-        ipv6: true
-      type: level-2
-    loopback:
-      ipv4: 10.0.0.2/32
-    mgmt:
-      ifname: mgmt0
-      ipv4: 192.168.121.102
-      mac: 08-4F-A9-00-00-02
-    module:
-    - isis
-    - bfd
-    name: srlinux_r2
-  sros_r1:
-    af:
-      ipv4: true
-      ipv6: true
-    bfd:
-      min_echo_rx: 0
-      min_rx: 100
-      min_tx: 100
-      multiplier: 3
-    box: vrnetlab/vr-sros
-    clab:
-      kind: vr-sros
-      license: /Projects/SR_OS_VSR-SIM_license.txt
-      type: sr-1
-    device: sros
-    hostname: clab-input-sros_r1
+      env:
+        INTFTYPE: et
+      kind: ceos
+    device: eos
+    hostname: clab-input-r1
     id: 1
     interfaces:
     - bridge: input_1
       clab:
-        name: eth1
+        name: et1
       ifindex: 1
-      ifname: 1/1/c1
+      ifname: Ethernet1
       ipv4: 172.16.0.1/24
       isis:
         bfd:
           ipv4: true
         passive: false
       linkindex: 1
-      mtu: 1500
-      name: Regular link, BFD enabled
+      name: Regular (IPv4-only) link, BFD enabled
       neighbors:
-      - ifname: ethernet-1/1
+      - ifname: Ethernet1
         ipv4: 172.16.0.2/24
-        node: srlinux_r2
-      - ifname: ethernet-1/1
-        ipv4: 172.16.0.6/24
+        node: r2
+      - ifname: Ethernet1
+        ipv4: 172.16.0.5/24
         node: n6
       type: lan
-    - bfd: false
-      clab:
-        name: eth2
+    - clab:
+        name: et2
       ifindex: 2
-      ifname: 1/1/c2
-      ipv4: 10.1.0.2/30
-      ipv6: 2001:db8:1::2/64
+      ifname: Ethernet2
+      ipv4: 10.1.0.1/30
+      ipv6: 2001:db8:1::1/64
       isis:
+        bfd:
+          ipv4: true
+          ipv6: true
         network_type: point-to-point
         passive: false
       linkindex: 2
-      mtu: 1500
-      name: Link with BFD disabled
+      name: Regular (dual-stack) P2P link, BFD enabled
       neighbors:
-      - ifname: ethernet-1/2
-        ipv4: 10.1.0.1/30
-        ipv6: 2001:db8:1::1/64
-        node: srlinux_r2
+      - ifname: Ethernet2
+        ipv4: 10.1.0.2/30
+        ipv6: 2001:db8:1::2/64
+        node: r2
       type: p2p
-    - clab:
-        name: eth3
+    - bfd: false
+      clab:
+        name: et3
       ifindex: 3
-      ifname: 1/1/c3
-      ipv4: 10.1.0.6/30
-      ipv6: 2001:db8:1:1::2/64
+      ifname: Ethernet3
+      ipv4: 10.1.0.5/30
+      ipv6: 2001:db8:1:1::1/64
       isis:
         network_type: point-to-point
         passive: false
       linkindex: 3
-      mtu: 1500
-      name: Link with ISIS BFD disabled
+      name: Link with BFD disabled
       neighbors:
-      - ifname: ethernet-1/3
-        ipv4: 10.1.0.5/30
-        ipv6: 2001:db8:1:1::1/64
-        node: srlinux_r2
+      - ifname: Ethernet3
+        ipv4: 10.1.0.6/30
+        ipv6: 2001:db8:1:1::2/64
+        node: r2
       type: p2p
     - clab:
-        name: eth4
+        name: et4
       ifindex: 4
-      ifname: 1/1/c4
-      ipv4: 10.1.0.10/30
-      ipv6: 2001:db8:1:2::2/64
+      ifname: Ethernet4
+      ipv4: 10.1.0.9/30
+      ipv6: 2001:db8:1:2::1/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 4
+      name: Link with ISIS BFD disabled
+      neighbors:
+      - ifname: Ethernet4
+        ipv4: 10.1.0.10/30
+        ipv6: 2001:db8:1:2::2/64
+        node: r2
+      type: p2p
+    - clab:
+        name: et5
+      ifindex: 5
+      ifname: Ethernet5
+      ipv4: 10.1.0.13/30
+      ipv6: 2001:db8:1:3::1/64
+      linkindex: 5
+      name: Link with ISIS disabled
+      neighbors:
+      - ifname: Ethernet5
+        ipv4: 10.1.0.14/30
+        ipv6: 2001:db8:1:3::2/64
+        node: r2
+      type: p2p
+    - clab:
+        name: et6
+      ifindex: 6
+      ifname: Ethernet6
+      ipv4: 10.1.0.17/30
+      ipv6: 2001:db8:1:4::1/64
       isis:
         bfd:
           ipv4: true
           ipv6: false
         network_type: point-to-point
         passive: false
-      linkindex: 4
-      mtu: 1500
+      linkindex: 6
       name: Link with IPv4-only BFD
       neighbors:
-      - ifname: ethernet-1/4
-        ipv4: 10.1.0.9/30
-        ipv6: 2001:db8:1:2::1/64
-        node: srlinux_r2
+      - ifname: Ethernet6
+        ipv4: 10.1.0.18/30
+        ipv6: 2001:db8:1:4::2/64
+        node: r2
       type: p2p
     - clab:
-        name: eth5
-      ifindex: 5
-      ifname: 1/1/c5
-      ipv4: 10.1.0.14/30
-      ipv6: 2001:db8:1:3::2/64
+        name: et7
+      ifindex: 7
+      ifname: Ethernet7
+      ipv4: 10.1.0.21/30
+      ipv6: 2001:db8:1:5::1/64
       isis:
         bfd:
           ipv4: false
           ipv6: true
         network_type: point-to-point
         passive: false
-      linkindex: 5
-      mtu: 1500
+      linkindex: 7
       name: Link with IPv6-only BFD
       neighbors:
-      - ifname: ethernet-1/5
-        ipv4: 10.1.0.13/30
-        ipv6: 2001:db8:1:3::1/64
-        node: srlinux_r2
+      - ifname: Ethernet7
+        ipv4: 10.1.0.22/30
+        ipv6: 2001:db8:1:5::2/64
+        node: r2
       type: p2p
     - clab:
-        name: eth6
-      ifindex: 6
-      ifname: 1/1/c6
-      ipv4: 10.42.42.2/24
+        name: et8
+      ifindex: 8
+      ifname: Ethernet8
+      ipv4: 10.42.42.1/24
       isis:
         bfd:
           ipv4: true
         network_type: point-to-point
         passive: false
-      linkindex: 6
-      mtu: 1500
+      linkindex: 8
       name: IPv4-only link with BFD
       neighbors:
-      - ifname: ethernet-1/6
-        ipv4: 10.42.42.1/24
-        node: srlinux_r2
+      - ifname: Ethernet8
+        ipv4: 10.42.42.2/24
+        node: r2
       type: p2p
     - clab:
-        name: eth7
-      ifindex: 7
-      ifname: 1/1/c7
-      ipv6: 2001:db8:42:1::2/64
+        name: et9
+      ifindex: 9
+      ifname: Ethernet9
+      ipv6: 2001:db8:42:1::1/64
       isis:
         bfd:
           ipv6: true
         network_type: point-to-point
         passive: false
-      linkindex: 7
-      mtu: 1500
+      linkindex: 9
       name: IPv6-only link with BFD
       neighbors:
-      - ifname: ethernet-1/7
-        ipv6: 2001:db8:42:1::1/64
-        node: srlinux_r2
+      - ifname: Ethernet9
+        ipv6: 2001:db8:42:1::2/64
+        node: r2
       type: p2p
     - clab:
-        name: eth8
-      ifindex: 8
-      ifname: 1/1/c8
-      ipv4: 10.42.43.2/24
+        name: et10
+      ifindex: 10
+      ifname: Ethernet10
+      ipv4: 10.42.43.1/24
       isis:
         network_type: point-to-point
         passive: false
-      linkindex: 8
-      mtu: 1500
+      linkindex: 10
       name: IPv4-only link with IPv6-only BFD
       neighbors:
-      - ifname: ethernet-1/8
-        ipv4: 10.42.43.1/24
-        node: srlinux_r2
+      - ifname: Ethernet10
+        ipv4: 10.42.43.2/24
+        node: r2
       type: p2p
     isis:
       af:
@@ -734,12 +580,209 @@ nodes:
     loopback:
       ipv4: 10.0.0.1/32
     mgmt:
-      ifname: A/1
+      ifname: Management0
       ipv4: 192.168.121.101
       mac: 08-4F-A9-00-00-01
     module:
     - isis
     - bfd
-    mtu: 1500
-    name: sros_r1
+    name: r1
+  r2:
+    af:
+      ipv4: true
+      ipv6: true
+    bfd:
+      min_echo_rx: 0
+      multiplier: 3
+    box: ceos:4.26.4M
+    clab:
+      env:
+        INTFTYPE: et
+      kind: ceos
+    device: eos
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - bridge: input_1
+      clab:
+        name: et1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 172.16.0.2/24
+      isis:
+        passive: false
+      linkindex: 1
+      name: Regular (IPv4-only) link, BFD enabled
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 172.16.0.1/24
+        node: r1
+      - ifname: Ethernet1
+        ipv4: 172.16.0.5/24
+        node: n6
+      type: lan
+    - clab:
+        name: et2
+      ifindex: 2
+      ifname: Ethernet2
+      ipv4: 10.1.0.2/30
+      ipv6: 2001:db8:1::2/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 2
+      name: Regular (dual-stack) P2P link, BFD enabled
+      neighbors:
+      - ifname: Ethernet2
+        ipv4: 10.1.0.1/30
+        ipv6: 2001:db8:1::1/64
+        node: r1
+      type: p2p
+    - bfd: false
+      clab:
+        name: et3
+      ifindex: 3
+      ifname: Ethernet3
+      ipv4: 10.1.0.6/30
+      ipv6: 2001:db8:1:1::2/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 3
+      name: Link with BFD disabled
+      neighbors:
+      - ifname: Ethernet3
+        ipv4: 10.1.0.5/30
+        ipv6: 2001:db8:1:1::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et4
+      ifindex: 4
+      ifname: Ethernet4
+      ipv4: 10.1.0.10/30
+      ipv6: 2001:db8:1:2::2/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 4
+      name: Link with ISIS BFD disabled
+      neighbors:
+      - ifname: Ethernet4
+        ipv4: 10.1.0.9/30
+        ipv6: 2001:db8:1:2::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et5
+      ifindex: 5
+      ifname: Ethernet5
+      ipv4: 10.1.0.14/30
+      ipv6: 2001:db8:1:3::2/64
+      linkindex: 5
+      name: Link with ISIS disabled
+      neighbors:
+      - ifname: Ethernet5
+        ipv4: 10.1.0.13/30
+        ipv6: 2001:db8:1:3::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et6
+      ifindex: 6
+      ifname: Ethernet6
+      ipv4: 10.1.0.18/30
+      ipv6: 2001:db8:1:4::2/64
+      isis:
+        bfd:
+          ipv4: true
+          ipv6: false
+        network_type: point-to-point
+        passive: false
+      linkindex: 6
+      name: Link with IPv4-only BFD
+      neighbors:
+      - ifname: Ethernet6
+        ipv4: 10.1.0.17/30
+        ipv6: 2001:db8:1:4::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et7
+      ifindex: 7
+      ifname: Ethernet7
+      ipv4: 10.1.0.22/30
+      ipv6: 2001:db8:1:5::2/64
+      isis:
+        bfd:
+          ipv4: false
+          ipv6: true
+        network_type: point-to-point
+        passive: false
+      linkindex: 7
+      name: Link with IPv6-only BFD
+      neighbors:
+      - ifname: Ethernet7
+        ipv4: 10.1.0.21/30
+        ipv6: 2001:db8:1:5::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et8
+      ifindex: 8
+      ifname: Ethernet8
+      ipv4: 10.42.42.2/24
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 8
+      name: IPv4-only link with BFD
+      neighbors:
+      - ifname: Ethernet8
+        ipv4: 10.42.42.1/24
+        node: r1
+      type: p2p
+    - clab:
+        name: et9
+      ifindex: 9
+      ifname: Ethernet9
+      ipv6: 2001:db8:42:1::2/64
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 9
+      name: IPv6-only link with BFD
+      neighbors:
+      - ifname: Ethernet9
+        ipv6: 2001:db8:42:1::1/64
+        node: r1
+      type: p2p
+    - clab:
+        name: et10
+      ifindex: 10
+      ifname: Ethernet10
+      ipv4: 10.42.43.2/24
+      isis:
+        network_type: point-to-point
+        passive: false
+      linkindex: 10
+      name: IPv4-only link with IPv6-only BFD
+      neighbors:
+      - ifname: Ethernet10
+        ipv4: 10.42.43.1/24
+        node: r1
+      type: p2p
+    isis:
+      af: {}
+      area: 49.0002
+      type: level-2
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: Management0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - bfd
+    name: r2
 provider: clab

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -5,227 +5,83 @@ input:
 - topology/input/ospf-bfd-test.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- bridge: input_1
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
-    ipv6: 2001:db8:1::2/64
-    node: sros_r1
+    ipv4: 172.16.0.1/24
+    node: r1
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.1/30
-    ipv6: 2001:db8:1::1/64
-    node: srlinux_r2
+    ipv4: 172.16.0.2/24
+    node: r2
+  - ifindex: 1
+    ifname: GigabitEthernet0/1
+    ipv4: 172.16.0.3/24
+    node: r3
   linkindex: 1
   name: Regular link, BFD enabled
-  node_count: 2
+  node_count: 3
   prefix:
-    ipv4: 10.1.0.0/30
-    ipv6: 2001:db8:1::/64
-  type: p2p
+    ipv4: 172.16.0.0/24
+  type: lan
 - bfd: false
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.6/30
-    ipv6: 2001:db8:1:1::2/64
-    node: sros_r1
+    ipv4: 10.1.0.1/30
+    node: r1
   - ifindex: 2
     ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.5/30
-    ipv6: 2001:db8:1:1::1/64
-    node: srlinux_r2
+    ipv4: 10.1.0.2/30
+    node: r2
   linkindex: 2
   name: Link with BFD disabled
   node_count: 2
   prefix:
-    ipv4: 10.1.0.4/30
-    ipv6: 2001:db8:1:1::/64
+    ipv4: 10.1.0.0/30
   type: p2p
 - interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.10/30
-    ipv6: 2001:db8:1:2::2/64
-    node: sros_r1
+    ipv4: 10.1.0.5/30
+    node: r1
   - ifindex: 3
     ifname: GigabitEthernet0/3
-    ipv4: 10.1.0.9/30
-    ipv6: 2001:db8:1:2::1/64
-    node: srlinux_r2
+    ipv4: 10.1.0.6/30
+    node: r2
   linkindex: 3
   name: Link with OSPF BFD disabled
   node_count: 2
   ospf:
     bfd: false
   prefix:
-    ipv4: 10.1.0.8/30
-    ipv6: 2001:db8:1:2::/64
+    ipv4: 10.1.0.4/30
   type: p2p
-- bridge: input_4
-  interfaces:
-  - ifindex: 1
-    ifname: GigabitEthernet0/1
-    ipv4: 172.16.0.4/24
-    node: n4
+- interfaces:
+  - ifindex: 4
+    ifname: GigabitEthernet0/4
+    ipv4: 10.1.0.9/30
+    node: r1
+  - ifindex: 4
+    ifname: GigabitEthernet0/4
+    ipv4: 10.1.0.10/30
+    node: r2
   linkindex: 4
-  node_count: 1
+  name: Link with OSPF disabled
+  node_count: 2
+  ospf: false
   prefix:
-    ipv4: 172.16.0.0/24
-  type: stub
+    ipv4: 10.1.0.8/30
+  type: p2p
 module:
 - bfd
 - ospf
 name: input
 nodes:
-  n3:
+  r1:
     af:
       ipv4: true
-    box: cisco/iosv
-    device: iosv
-    id: 3
-    interfaces: []
-    loopback:
-      ipv4: 10.0.0.3/32
-    mgmt:
-      ifname: GigabitEthernet0/0
-      ipv4: 192.168.121.103
-      mac: 08-4F-A9-00-00-03
-    module: []
-    name: n3
-  n4:
-    af:
-      ipv4: true
-    box: cisco/iosv
-    device: iosv
-    id: 4
-    interfaces:
-    - bridge: input_4
-      ifindex: 1
-      ifname: GigabitEthernet0/1
-      ipv4: 172.16.0.4/24
-      linkindex: 4
-      name: n4 -> stub
-      neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: true
-      type: stub
-    loopback:
-      ipv4: 10.0.0.4/32
-    mgmt:
-      ifname: GigabitEthernet0/0
-      ipv4: 192.168.121.104
-      mac: 08-4F-A9-00-00-04
-    module:
-    - ospf
-    name: n4
-    ospf:
-      af:
-        ipv4: true
-      area: 0.0.0.0
-      router_id: 10.0.0.4
-  n5:
-    af:
-      ipv4: true
-    bfd:
-      min_echo_rx: 0
-      multiplier: 3
-    box: cisco/iosv
-    device: iosv
-    id: 5
-    interfaces: []
-    loopback:
-      ipv4: 10.0.0.5/32
-    mgmt:
-      ifname: GigabitEthernet0/0
-      ipv4: 192.168.121.105
-      mac: 08-4F-A9-00-00-05
-    module:
-    - bfd
-    name: n5
-  srlinux_r2:
-    af:
-      ipv4: true
-      ipv6: true
-    bfd:
-      min_echo_rx: 0
-      multiplier: 3
-    box: cisco/iosv
-    device: iosv
-    id: 2
-    interfaces:
-    - ifindex: 1
-      ifname: GigabitEthernet0/1
-      ipv4: 10.1.0.1/30
-      ipv6: 2001:db8:1::1/64
-      linkindex: 1
-      name: Regular link, BFD enabled
-      neighbors:
-      - ifname: GigabitEthernet0/1
-        ipv4: 10.1.0.2/30
-        ipv6: 2001:db8:1::2/64
-        node: sros_r1
-      ospf:
-        area: 0.0.0.0
-        bfd: true
-        network_type: point-to-point
-        passive: false
-      type: p2p
-    - bfd: false
-      ifindex: 2
-      ifname: GigabitEthernet0/2
-      ipv4: 10.1.0.5/30
-      ipv6: 2001:db8:1:1::1/64
-      linkindex: 2
-      name: Link with BFD disabled
-      neighbors:
-      - ifname: GigabitEthernet0/2
-        ipv4: 10.1.0.6/30
-        ipv6: 2001:db8:1:1::2/64
-        node: sros_r1
-      ospf:
-        area: 0.0.0.0
-        network_type: point-to-point
-        passive: false
-      type: p2p
-    - ifindex: 3
-      ifname: GigabitEthernet0/3
-      ipv4: 10.1.0.9/30
-      ipv6: 2001:db8:1:2::1/64
-      linkindex: 3
-      name: Link with OSPF BFD disabled
-      neighbors:
-      - ifname: GigabitEthernet0/3
-        ipv4: 10.1.0.10/30
-        ipv6: 2001:db8:1:2::2/64
-        node: sros_r1
-      ospf:
-        area: 0.0.0.0
-        network_type: point-to-point
-        passive: false
-      type: p2p
-    loopback:
-      ipv4: 10.0.0.2/32
-    mgmt:
-      ifname: GigabitEthernet0/0
-      ipv4: 192.168.121.102
-      mac: 08-4F-A9-00-00-02
-    module:
-    - ospf
-    - bfd
-    name: srlinux_r2
-    ospf:
-      af:
-        ipv4: true
-        ipv6: true
-      area: 0.0.0.0
-      bfd: true
-      router_id: 10.0.0.2
-  sros_r1:
-    af:
-      ipv4: true
-      ipv6: true
     bfd:
       min_echo_rx: 0
       multiplier: 3
@@ -233,35 +89,34 @@ nodes:
     device: iosv
     id: 1
     interfaces:
-    - ifindex: 1
+    - bridge: input_1
+      ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 10.1.0.2/30
-      ipv6: 2001:db8:1::2/64
+      ipv4: 172.16.0.1/24
       linkindex: 1
       name: Regular link, BFD enabled
       neighbors:
       - ifname: GigabitEthernet0/1
-        ipv4: 10.1.0.1/30
-        ipv6: 2001:db8:1::1/64
-        node: srlinux_r2
+        ipv4: 172.16.0.2/24
+        node: r2
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.3/24
+        node: r3
       ospf:
         area: 0.0.0.0
         bfd: true
-        network_type: point-to-point
         passive: false
-      type: p2p
+      type: lan
     - bfd: false
       ifindex: 2
       ifname: GigabitEthernet0/2
-      ipv4: 10.1.0.6/30
-      ipv6: 2001:db8:1:1::2/64
+      ipv4: 10.1.0.1/30
       linkindex: 2
       name: Link with BFD disabled
       neighbors:
       - ifname: GigabitEthernet0/2
-        ipv4: 10.1.0.5/30
-        ipv6: 2001:db8:1:1::1/64
-        node: srlinux_r2
+        ipv4: 10.1.0.2/30
+        node: r2
       ospf:
         area: 0.0.0.0
         network_type: point-to-point
@@ -269,19 +124,27 @@ nodes:
       type: p2p
     - ifindex: 3
       ifname: GigabitEthernet0/3
-      ipv4: 10.1.0.10/30
-      ipv6: 2001:db8:1:2::2/64
+      ipv4: 10.1.0.5/30
       linkindex: 3
       name: Link with OSPF BFD disabled
       neighbors:
       - ifname: GigabitEthernet0/3
-        ipv4: 10.1.0.9/30
-        ipv6: 2001:db8:1:2::1/64
-        node: srlinux_r2
+        ipv4: 10.1.0.6/30
+        node: r2
       ospf:
         area: 0.0.0.0
         network_type: point-to-point
         passive: false
+      type: p2p
+    - ifindex: 4
+      ifname: GigabitEthernet0/4
+      ipv4: 10.1.0.9/30
+      linkindex: 4
+      name: Link with OSPF disabled
+      neighbors:
+      - ifname: GigabitEthernet0/4
+        ipv4: 10.1.0.10/30
+        node: r2
       type: p2p
     loopback:
       ipv4: 10.0.0.1/32
@@ -292,14 +155,134 @@ nodes:
     module:
     - ospf
     - bfd
-    name: sros_r1
+    name: r1
     ospf:
       af:
         ipv4: true
-        ipv6: true
       area: 0.0.0.0
       bfd: true
       router_id: 10.0.0.1
+  r2:
+    af:
+      ipv4: true
+    bfd:
+      min_echo_rx: 0
+      multiplier: 3
+    box: cisco/iosv
+    device: iosv
+    id: 2
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: GigabitEthernet0/1
+      ipv4: 172.16.0.2/24
+      linkindex: 1
+      name: Regular link, BFD enabled
+      neighbors:
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.1/24
+        node: r1
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.3/24
+        node: r3
+      ospf:
+        area: 0.0.0.0
+        bfd: true
+        passive: false
+      type: lan
+    - bfd: false
+      ifindex: 2
+      ifname: GigabitEthernet0/2
+      ipv4: 10.1.0.2/30
+      linkindex: 2
+      name: Link with BFD disabled
+      neighbors:
+      - ifname: GigabitEthernet0/2
+        ipv4: 10.1.0.1/30
+        node: r1
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
+    - ifindex: 3
+      ifname: GigabitEthernet0/3
+      ipv4: 10.1.0.6/30
+      linkindex: 3
+      name: Link with OSPF BFD disabled
+      neighbors:
+      - ifname: GigabitEthernet0/3
+        ipv4: 10.1.0.5/30
+        node: r1
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
+    - ifindex: 4
+      ifname: GigabitEthernet0/4
+      ipv4: 10.1.0.10/30
+      linkindex: 4
+      name: Link with OSPF disabled
+      neighbors:
+      - ifname: GigabitEthernet0/4
+        ipv4: 10.1.0.9/30
+        node: r1
+      type: p2p
+    loopback:
+      ipv4: 10.0.0.2/32
+    mgmt:
+      ifname: GigabitEthernet0/0
+      ipv4: 192.168.121.102
+      mac: 08-4F-A9-00-00-02
+    module:
+    - ospf
+    - bfd
+    name: r2
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      bfd: true
+      router_id: 10.0.0.2
+  r3:
+    af:
+      ipv4: true
+    box: cisco/iosv
+    device: iosv
+    id: 3
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: GigabitEthernet0/1
+      ipv4: 172.16.0.3/24
+      linkindex: 1
+      name: Regular link, BFD enabled
+      neighbors:
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.1/24
+        node: r1
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.2/24
+        node: r2
+      ospf:
+        area: 0.0.0.0
+        passive: false
+      type: lan
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: GigabitEthernet0/0
+      ipv4: 192.168.121.103
+      mac: 08-4F-A9-00-00-03
+    module:
+    - ospf
+    name: r3
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.3
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/input/isis-bfd-test.yml
+++ b/tests/topology/input/isis-bfd-test.yml
@@ -16,72 +16,75 @@ isis:
 module: [ isis, bfd ]
 
 provider: clab
+defaults.device: eos
 
 nodes:
-  sros_r1:
-    device: sros
-  srlinux_r2:
-    device: srlinux
+  r1:
+    device: eos
+  r2:
     isis.bfd: True
-  n3:                     # No ISIS or BFD
-    device: sros
-    module: []
   n4:
-    device: sros          # No BFD
     module: [ isis ]
   n5:                     # No interfaces
-    device: sros          
   n6:                     # ISIS BFD disabled for the node
     isis.bfd: False
-    device: srlinux
 
 links:
-- name: Regular link, BFD enabled
-  sros_r1:
-  srlinux_r2:
+- name: Regular (IPv4-only) link, BFD enabled
+  r1:
+  r2:
   n6:
 
+- name: Regular (dual-stack) P2P link, BFD enabled
+  r1:
+  r2:
+
 - name: Link with BFD disabled
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   bfd: False
 
 - name: Link with ISIS BFD disabled
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   isis.bfd: False
 
+- name: Link with ISIS disabled
+  r1:
+  r2:
+  isis: False
+
 - name: Link with IPv4-only BFD
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   isis.bfd: { ipv4: True, ipv6: False }
 
 - name: Link with IPv6-only BFD
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   isis.bfd: { ipv4: False, ipv6: True }
 
 - name: IPv4-only link with BFD
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
     isis.bfd: True
   prefix:
     ipv4: 10.42.42.0/24
 
 - name: IPv6-only link with BFD
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   prefix:
     ipv6: 2001:db8:42:1::/64
 
 - name: IPv4-only link with IPv6-only BFD
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
     isis.bfd:
       ipv6: True
   prefix:
     ipv4: 10.42.43.0/24
   isis.bfd: { ipv6: True }
 
-- n4:         # An extra link needed to keep IS-IS active on N4 and N5
+- n4:         # An extra link needed to keep IS-IS active on N4
   n5:

--- a/tests/topology/input/ospf-bfd-test.yml
+++ b/tests/topology/input/ospf-bfd-test.yml
@@ -1,43 +1,32 @@
-#
-# Sample SRLinux/SROS configuration that test BFD feature with IS-IS configuration module
-#
-# Used in manual testing (feel free to write an automated test script ;)
-#
-addressing: # Enable IPv6 on links
-  p2p:
-    ipv6: 2001:db8:1::/48
-
 module: [ ospf, bfd ]
+defaults.device: iosv
 
 nodes:
-  sros_r1:
-    device: iosv
+  r1:
     ospf.bfd: True
-  srlinux_r2:
-    device: iosv
+  r2:
     ospf.bfd: YEAH
-  n3:                     # No ISIS or BFD
-    device: iosv
-    module: []
-  n4:
-    device: iosv          # No BFD
+  r3:
     module: [ ospf ]
-  n5:
-    device: iosv          # No interfaces
+    ospf.bfd: True
 
 links:
 - name: Regular link, BFD enabled
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
+  r3:
 
 - name: Link with BFD disabled
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   bfd: False
 
 - name: Link with OSPF BFD disabled
-  sros_r1:
-  srlinux_r2:
+  r1:
+  r2:
   ospf.bfd: False
 
-- n4:
+- name: Link with OSPF disabled
+  r1:
+  r2:
+  ospf: False


### PR DESCRIPTION
The sequence of operations used in IGP modules resulted in igp.bfd being set on an interface even when the IGP itself was disabled with 'igp: false'. This commit fixes #679:

* Changes the BFD IGP code to skip interfaces with IGP disabled
* Disables IGP BFD status if the node is not using BFD module
* Evaluates BFD state early in IGP data transformation to ensure the 'igp: false' flag is not lost

Other fixes:

* Moved OSPF and IS-IS unnumbered processing into a function to make the code more readable
* Fix EIGRP code (it was passing OSPF or IS-IS as parameters to _routing functions)