### PR TITLE
Add support for containerized VyOS.

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -80,7 +80,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Mikrotik RouterOS 7                                |          ✅           |              ❌               |            ❌             |
 | Nokia SR Linux                                     |          ❌           |              ❌               |            ✅             |
 | Nokia SR OS                                        |          ❌           |              ❌               |            ✅             |
-| VyOS                                               |          ✅           |              ❌               |            ❌             |
+| VyOS                                               |          ✅           |              ❌               |            ✅             |
 
 **Note:**
 

--- a/netsim/ansible/tasks/deploy-config/vyos.yml
+++ b/netsim/ansible/tasks/deploy-config/vyos.yml
@@ -1,3 +1,18 @@
+- block:
+  - wait_for_connection:
+      timeout: 120
+      sleep: 3
+  - command: /usr/bin/systemctl status vyos.target
+    retries: 20
+    delay: 3
+    register: result
+    until: result.rc == 0
+  when: |
+    netlab_provider == 'clab' and vyos_target_reached is not defined
+
+- set_fact:
+    vyos_target_reached: 1
+
 - template:
     src: "{{ config_template }}"
     dest: /tmp/config-{{ netsim_action }}.sh

--- a/netsim/ansible/tasks/deploy-config/vyos.yml
+++ b/netsim/ansible/tasks/deploy-config/vyos.yml
@@ -2,16 +2,14 @@
   - wait_for_connection:
       timeout: 120
       sleep: 3
-  - command: /usr/bin/systemctl status vyos.target
-    retries: 20
-    delay: 3
-    register: result
-    until: result.rc == 0
+  - wait_for:
+      timeout: 120
+      path: /tmp/vyos-config-status
   when: |
-    netlab_provider == 'clab' and vyos_target_reached is not defined
+    netlab_provider == 'clab' and vyos_booted is not defined
 
 - set_fact:
-    vyos_target_reached: 1
+    vyos_booted: 1
 
 - template:
     src: "{{ config_template }}"

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -1048,6 +1048,16 @@ devices:
         asymmetrical_irb: True
       gateway:
         protocol: [ vrrp ]
+    clab:
+      image: ghcr.io/sysoleg/vyos-container
+      mtu: 1500
+      node:
+        kind: linux
+        binds:
+          '/lib/modules': '/lib/modules'
+      group_vars:
+        ansible_connection: docker
+        ansible_user: vyos
     external:
       image: none
     graphite.icon: router

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -1019,6 +1019,7 @@ devices:
       ansible_connection: paramiko
       ansible_user: vyos
       ansible_ssh_pass: vyos
+      docker_shell: su - vyos
     features:
       initial:
         ipv4:


### PR DESCRIPTION
We can't use the official 1.3-epa2 image from Docker Hub because it's outdated and doesn't work correctly with virtual network devices [1]. The thing is critical for the container environment with veth devices. Hence for now we can use the unofficial image [2] that is based on VyOS nightly ISO.

1. https://github.com/vyos/vyos-1x/commit/8cf5a4f023c5459cad4c84e93f73a9ddd69be81a
2. https://github.com/sysoleg/vyos-container