### PR TITLE
FRR: use "ip ospf passive"

### DIFF
--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -2,9 +2,6 @@ router ospf
 {% if ospf.router_id|ipv4 %}
  ospf router-id {{ ospf.router_id }}
 {% endif %}
-{% for l in interfaces|default([]) if l.ospf.passive|default(False) %}
- passive-interface {{ l.ifname }}
-{% endfor %}
 {% if ospf.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
@@ -24,6 +21,9 @@ interface {{ l.ifname }}
 {%   endif %}
 {%   if l.ospf.cost is defined %}
  ip ospf cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ ip ospf passive
 {%   endif %}
 !
 {% endfor %}

--- a/netsim/ansible/templates/vrf/frr.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/frr.ospfv2-vrf.j2
@@ -3,9 +3,6 @@ router ospf vrf {{ vname }}
 {% if ospf.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
-{% for l in vdata.ospf.interfaces|default([]) if l.ospf.passive|default(False) %}
- passive-interface {{ l.ifname }}
-{% endfor %}
 {% if bgp.as is defined %}
  redistribute bgp
 {% endif %}
@@ -22,6 +19,9 @@ interface {{ l.ifname }}
 {%   endif %}
 {%   if l.ospf.bfd|default(False) %}
  ip ospf bfd
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ ip ospf passive
 {%   endif %}
 !
 {% endfor %}


### PR DESCRIPTION
"passive-interface IFNAME" is deprecated and emits warning [1].

1. https://github.com/FRRouting/frr/commit/3eec4ee0773786b7ba366bc7499ed6bbd28fdf79