### PR TITLE
FRR: don't lose interface IPv6 address after VRF enslavement

### DIFF
--- a/netsim/ansible/templates/vrf/frr.j2
+++ b/netsim/ansible/templates/vrf/frr.j2
@@ -13,6 +13,7 @@ ip link set {{vname}} up
 
 # Move interfaces and loopbacks to vrfs
 {% for i in interfaces if i.vrf is defined %}
+sysctl -qw net.ipv6.conf.{{ i.ifname }}.keep_addr_on_down=1
 ip link set {{ i.ifname }} master {{ i.vrf }}
 {% endfor %}
 


### PR DESCRIPTION
VRF enslavement leads to link flap. Linux kernel doesn't keep IPv6 address by default in this case. keep_addr_on_down sysctl knob fix this behavior.