### PR TITLE
Use consistent interface name templates (fixes #723)

### DIFF
--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -10,6 +10,7 @@ import typing
 from box import Box
 
 from .. import common
+from .. import utils
 from .. import addressing
 from .. import providers
 from . import devices
@@ -90,7 +91,9 @@ def augment_mgmt_if(node: Box, defaults: Box, addrs: typing.Optional[Box]) -> No
       ifindex_offset = devices.get_device_attribute(node,'ifindex_offset',defaults)
       if ifindex_offset is None:
         ifindex_offset = 1
-      mgmt_if = ifname_format % (ifindex_offset - 1)
+
+      mgmt_if = utils.strings.eval_format(ifname_format,{'ifindex': ifindex_offset - 1 })
+
     node.mgmt.ifname = mgmt_if
 
   # If the mgmt ipaddress is statically set (IPv4/IPv6)

--- a/netsim/cli/test.py
+++ b/netsim/cli/test.py
@@ -14,6 +14,7 @@ from box import Box
 from pathlib import Path
 
 from .. import common
+from .. import utils
 from .. import read_topology
 from . import external_commands
 
@@ -98,7 +99,8 @@ def run(cli_args: typing.List[str]) -> None:
     common.fatal("Directory %s already exists, aborting" % args.workdir,"test")
 
   if args.verbose:
-    common.set_verbose(args.verbose)
+    utils.log.set_logging_flags(args)
+
   external_commands.run_probes(settings,args.provider,1)
   copy_topology(args)
   create_configs()

--- a/netsim/common.py
+++ b/netsim/common.py
@@ -13,86 +13,15 @@ from jinja2 import Environment, PackageLoader, FileSystemLoader, StrictUndefined
 from box import Box,BoxList
 from .data.global_vars import get_topology
 
-LOGGING : bool = False
-VERBOSE : int = 0
-DEBUG : typing.Optional[typing.List[str]] = None
-QUIET : bool = False
-
-RAISE_ON_ERROR : bool = False
-WARNING : bool = False
+from .utils.log import LOGGING, VERBOSE, DEBUG, QUIET, RAISE_ON_ERROR, WARNING
+from .utils.log import MissingValue, IncorrectAttr, IncorrectValue, IncorrectType, FatalError, ErrorAbort
+from .utils.log import fatal, error, exit_on_error, set_logging_flags, set_flag, print_verbose, debug_active
+from .utils.strings import extra_data_printout,format_structured_dict,print_structured_dict
 
 AF_LIST = ['ipv4','ipv6']
 BGP_SESSIONS = ['ibgp','ebgp']
 
-err_count : int = 0
 netsim_package_path = os.path.abspath(os.path.dirname(__file__))
-
-class MissingValue(Warning):
-  pass
-
-class IncorrectValue(Warning):
-  pass
-
-class IncorrectAttr(Warning):
-  pass
-
-class IncorrectType(Warning):
-  pass
-
-class FatalError(Warning):
-  pass
-
-class ErrorAbort(Exception):
-  pass
-
-def fatal(text: str, module: str = 'netlab') -> None:
-  global err_count
-  err_count = err_count + 1
-  if RAISE_ON_ERROR:
-    raise ErrorAbort(text)
-  else:
-    if WARNING:
-      warnings.warn_explicit(text,FatalError,filename=module,lineno=err_count)
-    else:
-      print(f'Fatal error in {module}: {text}',file=sys.stderr)
-    sys.exit(1)
-
-def error(text: str, category: typing.Type[Warning] = UserWarning, module: str = 'topology', hint: typing.Optional[str] = None) -> None:
-  global err_count
-  err_count = err_count + 1
-  if WARNING:
-    warnings.warn_explicit(text,category,filename=module,lineno=err_count)
-    return
-  else:
-    print(f'{category.__name__} in {module}: {text}',file=sys.stderr)
-
-  if hint is None:                                  # No extra hints
-    return
-
-  topology = get_topology()
-  if topology is None:                              # No valid topology ==> no hints
-    return
-
-  mod_hints = topology.defaults.hints[module]       # Get hints for current module
-
-  if mod_hints[hint]:
-    print(extra_data_printout(mod_hints[hint],width=90),file=sys.stderr)
-    mod_hints[hint] = ''
-
-def exit_on_error() -> None:
-  global err_count
-  if err_count > 0:
-    fatal('Cannot proceed beyond this point due to errors, exiting')
-
-def extra_data_printout(s : str, width: int = 70) -> str:
-  lines = []
-  for line in s.split('\n'):
-    lines.append(textwrap.TextWrapper(
-      initial_indent="... ",
-      subsequent_indent="      ",
-      width=width).fill(line))
-
-  return "\n".join(lines)
 
 #
 # File functions
@@ -163,95 +92,3 @@ def write_template(in_folder: str, j2: str, data: typing.Dict, out_folder: str, 
   out_file = f"{out_folder}/{filename}"
   with open(out_file,mode='w') as output:
     output.write(template(j2,data,in_folder))
-
-#
-# Logging and debugging functions
-#
-
-def set_verbose(value: typing.Optional[int] = 1) -> None:
-  global VERBOSE
-  VERBOSE = 0 if value is None else value
-
-def print_verbose(t: typing.Any) -> None:
-  if VERBOSE:
-    print(t)
-
-def format_structured_dict(d: Box, prefix: str = '') -> str:
-  lines = []
-  for k,v in d.items():
-    if v and (isinstance(v,dict) or isinstance(v,list)):
-      lines.append(f'{prefix}{k}:')
-      lines.append(f'{prefix}  {v}')
-    else:
-      lines.append(f'{prefix}{k}: {v}')
-
-  return "\n".join(lines)
-
-def print_structured_dict(d: Box, prefix: str = '') -> None:
-  print(format_structured_dict(d,prefix))
-
-#
-# Sets common flags based on parsed arguments.
-#
-# Internal debugging flags (RAISE_ON_ERROR, WARNING) cannot be set with this function
-#
-def set_logging_flags(args: typing.Union[argparse.Namespace,Box]) -> None:
-  global VERBOSE, LOGGING, DEBUG, QUIET, WARNING, RAISE_ON_ERROR
-  
-  if 'verbose' in args and args.verbose:
-    VERBOSE = args.verbose
-
-  if 'logging' in args and args.logging:
-    LOGGING = True
-
-  if 'debug' in args:
-    if args.debug is None:
-      DEBUG = None
-    else:
-      DEBUG = args.debug if args.debug else ['all']
-      print(f'Debugging flags set: {DEBUG}')
-
-  if 'quiet' in args and args.quiet:
-    QUIET = True
-
-  if 'warning' in args and args.warning:
-    WARNING = True
-
-  if 'raise_on_error' in args and args.raise_on_error:
-    RAISE_ON_ERROR = True
-
-#
-# Sets zero or more common flags and returns current settings.
-#
-# There must be a better way of doing it, but this is simple and it works
-#
-def set_flag(
-      debug: typing.Optional[typing.List[str]] = None,
-      quiet: typing.Optional[bool] = None,
-      verbose: typing.Optional[int] = None,
-      logging: typing.Optional[bool] = None,
-      warning: typing.Optional[bool] = None,
-      raise_error: typing.Optional[bool] = None) -> dict:
-  global DEBUG, VERBOSE, LOGGING, QUIET, RAISE_ON_ERROR, WARNING
-
-  DEBUG = debug if debug is not None else DEBUG
-  QUIET = quiet if quiet is not None else QUIET
-  VERBOSE = verbose if verbose is not None else VERBOSE
-  LOGGING = logging if logging is not None else LOGGING
-  WARNING = warning if warning is not None else WARNING
-  RAISE_ON_ERROR = raise_error  if raise_error is not None else RAISE_ON_ERROR
-
-  return {
-    'debug': DEBUG,
-    'quiet': QUIET,
-    'verbose': VERBOSE,
-    'logging': LOGGING,
-    'raise_on_error': RAISE_ON_ERROR,
-    'warning': WARNING
-  }
-
-def debug_active(flag: str) -> bool:
-  if not DEBUG:
-    return False
-
-  return 'all' in DEBUG or flag in DEBUG

--- a/netsim/devices/asav.yml
+++ b/netsim/devices/asav.yml
@@ -1,7 +1,7 @@
 #
 # Cisco ASAv
 #
-interface_name: GigabitEthernet0/%d
+interface_name: GigabitEthernet0/{ifindex}
 ifindex_offset: 0
 mgmt_if: Management0/0
 group_vars:

--- a/netsim/devices/csr.yml
+++ b/netsim/devices/csr.yml
@@ -1,7 +1,7 @@
 #
 # Cisco CSR 1000v
 #
-interface_name: GigabitEthernet%d
+interface_name: GigabitEthernet{ifindex}
 loopback_interface_name: Loopback{ifindex}
 ifindex_offset: 2
 virtualbox:

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -1,7 +1,7 @@
 #
 # Cumulus VX 4.x or 5.x configured without NVUE
 #
-interface_name: swp%d
+interface_name: swp{ifindex}
 loopback_interface_name: "lo{ifindex}"
 mgmt_if: eth0
 libvirt:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,7 +1,7 @@
 #
 # Cumulus VX 5.x configured with NVUE
 #
-interface_name: swp%d
+interface_name: swp{ifindex}
 mgmt_if: eth0
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.2.0

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -1,7 +1,7 @@
 #
 # Dell OS10
 #
-interface_name: ethernet1/1/%d
+interface_name: ethernet1/1/{ifindex}
 mgmt_if: mgmt1/1/1
 loopback_interface_name: loopback{ifindex}
 features:
@@ -29,7 +29,7 @@ clab:
   node:
     kind: vr-ftosv
   interface:
-    name: eth%d
+    name: eth{ifindex}
 libvirt:
   image: dell/os10
   create:

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -1,7 +1,7 @@
 #
 # Fortinet FortiOS
 #
-interface_name: port%d
+interface_name: port{ifindex}
 mgmt_if: port1
 ifindex_offset: 2
 libvirt:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -1,7 +1,7 @@
 #
 # FRR container
 #
-interface_name: eth%d
+interface_name: eth{ifindex}
 mgmt_if: eth0
 loopback_interface_name: "lo{ifindex}"
 group_vars:

--- a/netsim/devices/iosv.yml
+++ b/netsim/devices/iosv.yml
@@ -1,7 +1,7 @@
 #
 # Cisco IOSv
 #
-interface_name: GigabitEthernet0/%d
+interface_name: GigabitEthernet0/{ifindex}
 loopback_interface_name: Loopback{ifindex}
 group_vars:
   ansible_user: vagrant

--- a/netsim/devices/iosxr.yml
+++ b/netsim/devices/iosxr.yml
@@ -2,7 +2,7 @@
 # Cisco IOS XRv
 #
 mgmt_if: MgmtEth0/RP0/CPU0/0
-interface_name: GigabitEthernet0/0/0/%d
+interface_name: GigabitEthernet0/0/0/{ifindex}
 ifindex_offset: 0
 group_vars:
   ansible_user: vagrant

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -1,7 +1,7 @@
 #
 # Generic Linux host
 #
-interface_name: eth%d
+interface_name: eth{ifindex}
 mgmt_if: eth0
 role: host
 libvirt:

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -4,7 +4,7 @@
 # Most features are enabled on the dummy device -- this file is a pretty
 # good template if you want to figure out what device features there are.
 #
-interface_name: eth%d
+interface_name: eth{ifindex}
 loopback_interface_name: Loopback{ifindex}
 virtualbox:
   image: none

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -1,6 +1,6 @@
 # Cisco Nexus 9300v
 #
-interface_name: Ethernet1/%d
+interface_name: Ethernet1/{ifindex}
 mgmt_if: mgmt0
 loopback_interface_name: loopback{ifindex}
 virtualbox:

--- a/netsim/devices/routeros.yml
+++ b/netsim/devices/routeros.yml
@@ -1,6 +1,6 @@
 # Mikrotik RouterOS
 #
-interface_name: ether%d
+interface_name: ether{ifindex}
 mgmt_if: ether1
 ifindex_offset: 2
 libvirt:

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -1,6 +1,6 @@
 # Mikrotik RouterOS version 7
 #
-interface_name: ether%d
+interface_name: ether{ifindex}
 mgmt_if: ether1
 loopback_interface_name: loopback{ifindex}
 ifindex_offset: 2

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -1,7 +1,7 @@
 # Nokia SR Linux
 #
 mgmt_if: mgmt0
-interface_name: ethernet-1/%d
+interface_name: ethernet-1/{ifindex}
 loopback_interface_name: "lo0.{ifindex}"
 group_vars:
   ansible_user: admin
@@ -22,7 +22,7 @@ clab:
     kind: srl
     type: ixrd2
   interface:
-    name: e1-%d
+    name: e1-{ifindex}
   group_vars:
     srlinux_grpc_port: 57400
 features:

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -1,7 +1,7 @@
 # Nokia SR OS
 #
 mgmt_if: A/1
-interface_name: 1/1/c%d
+interface_name: 1/1/c{ifindex}
 loopback_interface_name: "loopback.{ifindex}"
 group_vars:
   ansible_user: admin
@@ -64,7 +64,7 @@ clab:
     type: sr-1 # By default emulate SR-1
     license: /Projects/SR_OS_VSR-SIM_license.txt
   interface:
-    name: eth%d
+    name: eth{ifindex}
   group_vars:
     sros_grpc_port: 57400
 external:

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -1,6 +1,6 @@
 # Juniper vSRX 3.0
 #
-interface_name: ge-0/0/%d
+interface_name: ge-0/0/{ifindex}
 loopback_interface_name: "lo0.{ifindex}"
 ifindex_offset: 0
 mgmt_if: fxp0

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -1,6 +1,6 @@
 # Vyatta VyOS VM/container
 #
-interface_name: eth%d
+interface_name: eth{ifindex}
 loopback_interface_name: "dum{ifindex}"
 mgmt_if: eth0
 libvirt:

--- a/netsim/utils/__init__.py
+++ b/netsim/utils/__init__.py
@@ -1,0 +1,4 @@
+# Import the whole augmentation tree
+
+from . import log
+from . import strings

--- a/netsim/utils/log.py
+++ b/netsim/utils/log.py
@@ -1,0 +1,158 @@
+#
+# Common routines for create-topology script
+#
+import sys
+import typing
+import warnings
+import typing
+import argparse
+from box import Box
+
+LOGGING : bool = False
+VERBOSE : int = 0
+DEBUG : typing.Optional[typing.List[str]] = None
+QUIET : bool = False
+
+RAISE_ON_ERROR : bool = False
+WARNING : bool = False
+
+AF_LIST = ['ipv4','ipv6']
+BGP_SESSIONS = ['ibgp','ebgp']
+
+err_count : int = 0
+
+class MissingValue(Warning):
+  pass
+
+class IncorrectValue(Warning):
+  pass
+
+class IncorrectAttr(Warning):
+  pass
+
+class IncorrectType(Warning):
+  pass
+
+class FatalError(Warning):
+  pass
+
+class ErrorAbort(Exception):
+  pass
+
+def fatal(text: str, module: str = 'netlab') -> None:
+  global err_count
+  err_count = err_count + 1
+  if RAISE_ON_ERROR:
+    raise ErrorAbort(text)
+  else:
+    if WARNING:
+      warnings.warn_explicit(text,FatalError,filename=module,lineno=err_count)
+    else:
+      print(f'Fatal error in {module}: {text}',file=sys.stderr)
+    sys.exit(1)
+
+def error(text: str, category: typing.Type[Warning] = UserWarning, module: str = 'topology', hint: typing.Optional[str] = None) -> None:
+  global err_count
+  err_count = err_count + 1
+  if WARNING:
+    warnings.warn_explicit(text,category,filename=module,lineno=err_count)
+    return
+  else:
+    print(f'{category.__name__} in {module}: {text}',file=sys.stderr)
+
+  if hint is None:                                  # No extra hints
+    return
+
+  from ..common import get_topology,extra_data_printout
+  topology = get_topology()
+  if topology is None:                              # No valid topology ==> no hints
+    return
+
+  mod_hints = topology.defaults.hints[module]       # Get hints for current module
+
+  if mod_hints[hint]:
+    print(extra_data_printout(mod_hints[hint],width=90),file=sys.stderr)
+    mod_hints[hint] = ''
+
+def exit_on_error() -> None:
+  global err_count
+  if err_count > 0:
+    fatal('Cannot proceed beyond this point due to errors, exiting')
+
+#
+# Logging and debugging functions
+#
+
+def set_verbose(value: typing.Optional[int] = 1) -> None:
+  global VERBOSE
+  VERBOSE = 0 if value is None else value
+
+def print_verbose(t: typing.Any) -> None:
+  if VERBOSE:
+    print(t)
+
+#
+# Sets common flags based on parsed arguments.
+#
+# Internal debugging flags (RAISE_ON_ERROR, WARNING) cannot be set with this function
+#
+def set_logging_flags(args: typing.Union[argparse.Namespace,Box]) -> None:
+  global VERBOSE, LOGGING, DEBUG, QUIET, WARNING, RAISE_ON_ERROR
+  
+  if 'verbose' in args and args.verbose:
+    VERBOSE = args.verbose
+
+  if 'logging' in args and args.logging:
+    LOGGING = True
+
+  if 'debug' in args:
+    if args.debug is None:
+      DEBUG = None
+    else:
+      DEBUG = args.debug if args.debug else ['all']
+      print(f'Debugging flags set: {DEBUG}')
+
+  if 'quiet' in args and args.quiet:
+    QUIET = True
+
+  if 'warning' in args and args.warning:
+    WARNING = True
+
+  if 'raise_on_error' in args and args.raise_on_error:
+    RAISE_ON_ERROR = True
+
+#
+# Sets zero or more common flags and returns current settings.
+#
+# There must be a better way of doing it, but this is simple and it works
+#
+def set_flag(
+      debug: typing.Optional[typing.List[str]] = None,
+      quiet: typing.Optional[bool] = None,
+      verbose: typing.Optional[int] = None,
+      logging: typing.Optional[bool] = None,
+      warning: typing.Optional[bool] = None,
+      raise_error: typing.Optional[bool] = None) -> dict:
+  global DEBUG, VERBOSE, LOGGING, QUIET, RAISE_ON_ERROR, WARNING
+
+  DEBUG = debug if debug is not None else DEBUG
+  QUIET = quiet if quiet is not None else QUIET
+  VERBOSE = verbose if verbose is not None else VERBOSE
+  LOGGING = logging if logging is not None else LOGGING
+  WARNING = warning if warning is not None else WARNING
+  RAISE_ON_ERROR = raise_error  if raise_error is not None else RAISE_ON_ERROR
+
+  return {
+    'debug': DEBUG,
+    'quiet': QUIET,
+    'verbose': VERBOSE,
+    'logging': LOGGING,
+    'raise_on_error': RAISE_ON_ERROR,
+    'warning': WARNING
+  }
+
+def debug_active(flag: str) -> bool:
+  if not DEBUG:
+    return False
+
+  return 'all' in DEBUG or flag in DEBUG

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -1,0 +1,35 @@
+#
+# Common routines for create-topology script
+#
+import textwrap
+from box import Box
+
+def extra_data_printout(s : str, width: int = 70) -> str:
+  lines = []
+  for line in s.split('\n'):
+    lines.append(textwrap.TextWrapper(
+      initial_indent="... ",
+      subsequent_indent="      ",
+      width=width).fill(line))
+
+  return "\n".join(lines)
+
+def format_structured_dict(d: Box, prefix: str = '') -> str:
+  lines = []
+  for k,v in d.items():
+    if v and (isinstance(v,dict) or isinstance(v,list)):
+      lines.append(f'{prefix}{k}:')
+      lines.append(f'{prefix}  {v}')
+    else:
+      lines.append(f'{prefix}{k}: {v}')
+
+  return "\n".join(lines)
+
+def print_structured_dict(d: Box, prefix: str = '') -> None:
+  print(format_structured_dict(d,prefix))
+
+#
+# eval_format: emulate f'strings' evaluated on a data structure
+#
+def eval_format(fmt: str, data: dict) -> str:
+  return str(eval(f"f'{fmt}'",dict(data)))                            # An awful hack to use f-string specified in a string variable

--- a/tests/errors/addr-no-pools.yml
+++ b/tests/errors/addr-no-pools.yml
@@ -22,7 +22,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: x
 

--- a/tests/errors/addr-pool-errors.yml
+++ b/tests/errors/addr-pool-errors.yml
@@ -44,7 +44,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: x
 

--- a/tests/errors/isis-capability.yml
+++ b/tests/errors/isis-capability.yml
@@ -7,7 +7,7 @@ defaults:
     supported_on: [ iosv, fake_1, fake_2 ]
   devices:
     fake_1:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
         virtualbox: cisco/iosv
@@ -18,7 +18,7 @@ defaults:
           ipv6:
             lla: True
     fake_2:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
         virtualbox: cisco/iosv

--- a/tests/errors/ospf-unnumbered.yml
+++ b/tests/errors/ospf-unnumbered.yml
@@ -7,7 +7,7 @@ defaults:
     supported_on: [ iosv, fake_1, fake_2 ]
   devices:
     fake_1:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
         virtualbox: cisco/iosv

--- a/tests/errors/rid-no-pool.yml
+++ b/tests/errors/rid-no-pool.yml
@@ -25,7 +25,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: x
       features:

--- a/tests/errors/unnumbered-capability.yml
+++ b/tests/errors/unnumbered-capability.yml
@@ -5,12 +5,12 @@
 defaults:
   devices:
     fake_1:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
         virtualbox: cisco/iosv
     fake_2:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
         virtualbox: cisco/iosv

--- a/tests/minimal_errors/addrs-mgmt-no-start.yml
+++ b/tests/minimal_errors/addrs-mgmt-no-start.yml
@@ -11,7 +11,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: x
 

--- a/tests/minimal_errors/bgp-no-defaults.yml
+++ b/tests/minimal_errors/bgp-no-defaults.yml
@@ -10,7 +10,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
   bgp:

--- a/tests/minimal_errors/bgp-no-params.yml
+++ b/tests/minimal_errors/bgp-no-params.yml
@@ -11,7 +11,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
   bgp:

--- a/tests/minimal_errors/device-image-datatype.yml
+++ b/tests/minimal_errors/device-image-datatype.yml
@@ -12,7 +12,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image: Wrong data type
 
 nodes:

--- a/tests/minimal_errors/device-image-missing.yml
+++ b/tests/minimal_errors/device-image-missing.yml
@@ -12,7 +12,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
 
 nodes:
   r1:

--- a/tests/minimal_errors/device-no-provider-image.yml
+++ b/tests/minimal_errors/device-no-provider-image.yml
@@ -12,7 +12,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         virtualbox: x
 

--- a/tests/minimal_errors/no-mgmt-addr.yml
+++ b/tests/minimal_errors/no-mgmt-addr.yml
@@ -7,7 +7,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
   bgp:

--- a/tests/minimal_errors/no-provider.yml
+++ b/tests/minimal_errors/no-provider.yml
@@ -9,7 +9,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
   bgp:

--- a/tests/minimal_errors/unknown-provider.yml
+++ b/tests/minimal_errors/unknown-provider.yml
@@ -10,7 +10,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       image:
         libvirt: cisco/iosv
   bgp:

--- a/tests/topology/input/addrs-no-pool.yml
+++ b/tests/topology/input/addrs-no-pool.yml
@@ -27,7 +27,7 @@ defaults:
       config: Vagrantfile
   devices:
     iosv:
-      interface_name: GigabitEthernet0/%d
+      interface_name: GigabitEthernet0/{ifindex}
       libvirt.image: x
 
 nodes:


### PR DESCRIPTION
Also:
* Move string functions from 'common' to 'utils.strings'
* Move logging/error functions from 'common' to 'utils.log'
* Remove 'set_verbose' function that was used exactly once
* Fix way too many test cases ;)