### PR TITLE
Split large topology into smaller 'vagrant up' batches (fixes #732)

### DIFF
--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -119,6 +119,8 @@ module: [ ospf ]
 links: [ a-x, a-z, b-x, b-z, c-x, c-z ]
 ```
 
+Please note that the `batch_size` is set artificially low so that this pretty small topology generates three batches. Realistic `batch_size` depends on your hardware resources (CPU, memory) and VM type.
+
 ```{tip}
 The virtual machines are batched based on their order in **‌nodes** list/dictionary. You might want to adjust the node order to group virtual machines with long start times (example: Cisco Nexus OS or Juniper vSRX) into as few batches as possible.
 ```

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -98,6 +98,31 @@ You can change the parameters of the management network in the **addressing.mgmt
 * **\_network**: The *libvirt* network name (default: `vagrant-libvirt`)
 * **\_bridge**: The name of the underlying Linux bridge (default: `libvirt-mgmt`)
 
+## Starting Virtual Machines in Batches
+
+*vagrant-libvirt* plugin tries to start all the virtual machines specified in `Vagrantfile` in parallel. The resulting strain on CPU resources might cause VM boot failures in very large topologies. As a workaround, you can configure **libvirt** virtualization provider to execute a series of `vagrant up` commands to start the virtual machines in smaller batches:
+
+* Configure the batch size with **defaults.providers.libvirt.batch_size** parameter (an integer between 1 and 50)
+* Configure idle interval between batches (if needed) with **defaults.providers.libvirt.batch_interval** parameter (between 1 and 1000 seconds).
+
+Example:
+
+```
+provider: libvirt
+defaults.device: cumulus
+defaults.providers.libvirt.batch_size: 2
+defaults.providers.libvirt.batch_interval: 10
+
+nodes: [ a,b,c,x,z ]
+module: [ ospf ]
+
+links: [ a-x, a-z, b-x, b-z, c-x, c-z ]
+```
+
+```{tip}
+The virtual machines are batched based on their order in **‌nodes** list/dictionary. You might want to adjust the node order to group virtual machines with long start times (example: Cisco Nexus OS or Juniper vSRX) into as few batches as possible.
+```
+
 ```{eval-rst}
 .. toctree::
    :caption: Box Building Recipes

--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -69,9 +69,9 @@ def run_probes(settings: Box, provider: str, step: int = 0) -> None:
     print(".. all tests succeeded, moving on\n")
 
 def start_lab(settings: Box, provider: str, step: int = 2, cli_command: str = "test", exec_command: typing.Optional[str] = None) -> None:
-  print_step(step,f"starting the lab -- {provider}")
   if exec_command is None:
     exec_command = settings.providers[provider].start
+  print_step(step,f"starting the lab -- {provider}: {exec_command}")
   if not run_command(exec_command):
     common.fatal(f"{exec_command} failed, aborting...",cli_command)
 

--- a/netsim/cli/up.py
+++ b/netsim/cli/up.py
@@ -85,19 +85,23 @@ def provider_probes(topology: Box) -> None:
 Start lab topology for a single provider
 """
 def start_provider_lab(topology: Box, pname: str, sname: typing.Optional[str] = None) -> None:
-  p_name = sname or pname
-  p_module   = providers._Provider.load(p_name,topology.defaults.providers[p_name])
-
-  exec_command = None
+  p_name   = sname or pname
+  p_module = providers._Provider.load(p_name,topology.defaults.providers[p_name])
 
   if sname is not None:
     p_topology = providers.select_topology(topology,p_name)
-    exec_command = topology.defaults.providers[pname][sname].start
   else:
     p_topology = topology
 
   p_module.call('pre_start_lab',p_topology)
-  external_commands.start_lab(topology.defaults,sname or pname,3,"netlab up",exec_command)
+  if sname is not None:
+    exec_command = topology.defaults.providers[pname][sname].start
+  else:
+    exec_command = topology.defaults.providers[pname].start
+
+  exec_list = exec_command if isinstance(exec_command,list) else [ exec_command ]
+  for cmd in exec_list:
+    external_commands.start_lab(topology.defaults,sname or pname,3,"netlab up",cmd)
   p_module.call('post_start_lab',p_topology)
 
 """

--- a/tests/integration/vagrant-batches/topology.yml
+++ b/tests/integration/vagrant-batches/topology.yml
@@ -1,0 +1,15 @@
+provider: libvirt
+defaults.device: cumulus
+defaults.providers.libvirt.batch_size: 2
+defaults.providers.libvirt.batch_interval: 10
+
+nodes: [ a,b,c,x,z ]
+module: [ ospf ]
+
+links:
+- a-x
+- a-z
+- b-x
+- b-z
+- c-x
+- c-z


### PR DESCRIPTION
Documentation @ docs/labs/libvirt.md

@petercrocker This one is based on the discussions we had about Vagrant DHCP failures. Could you please test it out on one of your large topologies (please note that this is a parallel branch to the `multilab` one, so you can't use both features in parallel while testing it ;)