### PR TITLE
Change default password for ASAv

### DIFF
--- a/netsim/devices/asav.yml
+++ b/netsim/devices/asav.yml
@@ -4,9 +4,9 @@ ifindex_offset: 0
 mgmt_if: Management0/0
 group_vars:
   ansible_user: vagrant
-  ansible_ssh_pass: vagrant
+  ansible_ssh_pass: vagrant1
   ansible_become_method: enable
-  ansible_become_password: vagrant
+  ansible_become_password: vagrant1
   ansible_network_os: asa
   ansible_connection: network_cli
 external:

--- a/netsim/install/libvirt/asav.txt
+++ b/netsim/install/libvirt/asav.txt
@@ -5,7 +5,7 @@ Initial configuration for the ASAv device is prepared in bootstrap ISO image.
 
 You must only set the enable password:
 * type 'enable'
-* Set enable password to 'vagrant'
+* Set enable password to 'vagrant1'
 * 'write memory'
 * 'copy running-config startup-config'
 * Disconnect from console (ctrl-] usually works).

--- a/netsim/install/libvirt/asav/day0-config
+++ b/netsim/install/libvirt/asav/day0-config
@@ -11,7 +11,7 @@ interface Management0/0
 hostname asav
 !
 username enable_1 privilege 15
-username vagrant password vagrant privilege 15
+username vagrant password vagrant1 privilege 15
 aaa authentication ssh console LOCAL
 aaa authentication http console LOCAL
 aaa authorization exec LOCAL auto-enable

--- a/netsim/install/libvirt/asav/day0-config
+++ b/netsim/install/libvirt/asav/day0-config
@@ -8,8 +8,6 @@ interface Management0/0
  ip address dhcp
  no shutdown
 !
-hostname asav
-!
 username enable_1 privilege 15
 username vagrant password vagrant1 privilege 15
 aaa authentication ssh console LOCAL


### PR DESCRIPTION
In newer version ASAv enforces a minimum password length of 8.
Therefore I have changed the default password to match this criteria.

Users have to rebuild old vagrant boxes to be able to work with them after this change.