### PR TITLE
Update CA file path to match latest Containerlab changes

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -14,6 +14,10 @@
    :backlinks: none
 ```
 
+## Minimal supported version: 0.37.1 (2023-2-27)
+Version 0.37 introduced some changes to the location of generated certificate files.
+Use ```sudo containerlab version upgrade``` to upgrade to the latest version
+
 ## Container Images
 
 Lab topology file created by **[netlab up](../netlab/up.md)** or **[netlab create](../netlab/create.md)** command uses these container images (use **netlab show images** to display the actual system settings):

--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -69,10 +69,8 @@
     d: "{{ cfg.delete | default([]) }}"
     u: "{{ cfg.updates | default([]) }}"
     r: "{{ cfg.replace | default([]) }}"
-    clab_base: "{{ hostname|replace('-'+inventory_hostname,'') }}"
-    clab_ca_dir: "{{ inventory_dir }}/{{ clab_base }}/ca"
     # ansible_private_key_file: '{{ clab_ca_dir }}/{{ inventory_hostname }}/{{ inventory_hostname }}-key.pem'
-    ansible_root_certificates_file: '{{ clab_ca_dir }}/root/root-ca.pem'
+    ansible_root_certificates_file: '{{ inventory_dir }}/clab-{{ inventory_dir | basename }}/.tls/ca/ca.pem'
     ansible_certificate_chain_file: ''
     # ansible_grpc_channel_options:
     #  ssl_target_name_override: ""


### PR DESCRIPTION
Containerlab 0.37 introduced a change to the path location of generated CA files.

A breaking change - this PR fixes it, and calls out the minimum required version (easy to upgrade)