### PR TITLE
Correct clab directory name for labs in sub-directories

### DIFF
--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -70,7 +70,7 @@
     u: "{{ cfg.updates | default([]) }}"
     r: "{{ cfg.replace | default([]) }}"
     # ansible_private_key_file: '{{ clab_ca_dir }}/{{ inventory_hostname }}/{{ inventory_hostname }}-key.pem'
-    ansible_root_certificates_file: '{{ inventory_dir }}/clab-{{ inventory_dir | basename }}/.tls/ca/ca.pem'
+    ansible_root_certificates_file: '{{ inventory_dir }}/clab-{{ netlab_name }}/.tls/ca/ca.pem'
     ansible_certificate_chain_file: ''
     # ansible_grpc_channel_options:
     #  ssl_target_name_override: ""


### PR DESCRIPTION
inventory_dir | basename happens to work when the lab is in the same directory, but...