### PR TITLE
Missing pip install step on Ubuntu 20.04

### DIFF
--- a/docs/install/ubuntu-vm.md
+++ b/docs/install/ubuntu-vm.md
@@ -78,6 +78,7 @@ end
 sudo apt-get update
 sudo apt-get install -y python3-pip
 sudo pip3 install --ignore-installed networklab
+sudo pip3 install cryptography==3.3.2
 netlab install -y ubuntu ansible libvirt containerlab
 ```
 

--- a/docs/install/ubuntu-vm.md
+++ b/docs/install/ubuntu-vm.md
@@ -59,6 +59,7 @@ Vagrant.configure("2") do |config|
     sudo apt-get update
     sudo apt-get install -y python3-pip
     sudo pip3 install --ignore-installed networklab
+    sudo pip3 install --upgrade pyopenssl cryptography
     netlab install -y ubuntu ansible libvirt containerlab
   SHELL
 end
@@ -78,7 +79,7 @@ end
 sudo apt-get update
 sudo apt-get install -y python3-pip
 sudo pip3 install --ignore-installed networklab
-sudo pip3 install cryptography==3.3.2
+sudo pip3 install --upgrade pyopenssl cryptography
 netlab install -y ubuntu ansible libvirt containerlab
 ```
 


### PR DESCRIPTION
As per https://stackoverflow.com/questions/71851185/unable-to-install-uninstall-with-pip-due-to-cryptographydeprecationwarning it is required to install cryptography version 3.3.2 on Ubuntu 20.04 before running the netlab install command

Tested on multipass Ubuntu 20.04 