### PR TITLE
Remove dependency on bgp module

### DIFF
--- a/netsim/ansible/templates/vrf/sros.j2
+++ b/netsim/ansible/templates/vrf/sros.j2
@@ -7,8 +7,8 @@ updates:
   val:
    service-id: {{ vdata.vrfidx }}
    customer: "1"
-   autonomous-system: {{ bgp.as }}
-   router-id: {{ vdata.bgp.router_id|default(bgp.router_id) }}
+   autonomous-system: {{ bgp.as|default(vrf.as) }}
+   router-id: {{ vdata.bgp.router_id|default(bgp.router_id if bgp is defined else loopback.ipv4|ipaddr('address')) }}
    ecmp: 64
    admin-state: enable
 


### PR DESCRIPTION
Template implicitly assumed bgp module was being used, it may not be

Note that we may want to simplify the router_id modeling to a single, global attribute per node - instead of per protocol, vrf, etc. There is bgp.router_id, ospf.router_id, etc. but in the typical case each router has a single unique ID