### PR TITLE
Remove dependency on Python being installed in Linux containers

### DIFF
--- a/netsim/ansible/tasks/deploy-config/linux.yml
+++ b/netsim/ansible/tasks/deploy-config/linux.yml
@@ -1,7 +1,13 @@
 - template:
     src: "{{ config_template }}"
-    dest: /tmp/config.sh
+    dest: /tmp/{{inventory_hostname}}_config.sh
+  delegate_to: localhost # Run on controller, to avoid dependency on Python
+
+- name: Copy template file into running container
+  shell: docker cp /tmp/{{inventory_hostname}}_config.sh clab-{{ netlab_name }}-{{inventory_hostname}}:/tmp/config.sh
+  delegate_to: localhost
+
 - name: "Execute /tmp/config.sh to deploy {{ netsim_action }} config from {{ config_template }}"
-  command: "{{ docker_shell|default('bash') }} /tmp/config.sh"
-  become: true
+  delegate_to: "{{ inventory_hostname }}"
+  raw: "{{ docker_shell|default('sh') }} /tmp/config.sh"
   tags: [ print_action, always ]


### PR DESCRIPTION
The 'template' action gets executed inside the target container, and hence requires Python to be installed. This change processes the template on the controller, and copies the result