### PR TITLE
Deal with Python Box expanding dots in keys read from YAML files

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -68,7 +68,7 @@ nodes:
 
 ## Using File Binds
 
-You can use **clab.binds** to map container paths to host file system paths. Host file paths (dictionary keys) in **clab.binds** might contain dots which would trigger the expansion of keys-with-dots into hierarchical dictionary. To prevent that, all host file paths should have at least one '/' character, for example:
+You can use **clab.binds** to map container paths to host file system paths, for example:
 
 ```
 nodes:
@@ -77,8 +77,12 @@ nodes:
   image: ghcr.io/openconfig/gnmic:latest
   clab:
     binds:
-      './gnmic.yaml': '/app/gnmic.yaml:ro'
+      gnmic.yaml: '/app/gnmic.yaml:ro'
       '/var/run/docker.sock': '/var/run/docker.sock'
+```
+
+```{tip}
+You don't have to worry about dots in filenames: _netlab_ knows that the keys of the **‌clab.binds** and **‌clab.config_templates** dictionaries are filenames and does not expand them into hierarchical dictionaries.
 ```
 
 (clab-config-template)=

--- a/netsim/data/filemaps.py
+++ b/netsim/data/filemaps.py
@@ -1,0 +1,108 @@
+#
+# This module handles file map - lists of strings in a:b format - that
+# are used in clab to map files from the host to the container.
+#
+# We used to store them in boxes, but that stopped being an option with
+# python-box 7.0 (or so) that started turning dotted keys into hierarchies.
+#
+
+import typing
+from box import Box
+from ..utils.log import error,IncorrectType,IncorrectValue
+from ..data.types import must_be_list,must_be_dict
+
+"""
+Convert a box into a traditional dictionary, turning a hierarchy
+into keys with dots in them.
+"""
+def box_to_dict(b: Box) -> dict:
+  cvalue: dict = {}
+  for k in list(b.keys()):
+    v = b[k]
+    while isinstance(v,dict) and len(v) == 1:
+      k = k + '.' + list(v.keys())[0]
+      v = list(v.values())[0]
+    cvalue[k] = v
+
+  return cvalue
+
+"""
+Convert a dictionary into a file mapping -- list of strings in a:b format
+"""
+def dict_to_mapping(d: typing.Union[Box,dict]) -> list:
+  return [ f"{k}:{v}" for k,v in d.items() ]
+
+"""
+Convert a file mapping -- list of strings in a:b format -- into a dictionary
+"""
+def mapping_to_dict(m: list) -> dict:
+  return { k:v for k,v in [ l.split(':') for l in m ] }
+
+"""
+Check mapping list -- it must be a list of strings, and each string must have exactly one :
+"""
+def check_mapping_list(map_list: list, path: str, module: str) -> bool:
+  OK = True
+  for (idx,value) in enumerate(map_list):
+    if not isinstance(value,str):
+      error(
+        f"{path}[{idx+1}] should be a string, found {type(value)}",
+        category=IncorrectType,
+        module=module)
+      OK = False
+      continue
+    vals = value.split(':')
+    if len(vals) != 2:
+      error(
+        f"{path}[{idx+1}] should be a string in host:target format, found {value}",
+        category=IncorrectValue,
+        module=module)
+      OK = False
+      continue
+
+  return OK
+
+"""
+Check mapping dict -- it must be a dictionary, and each key must be a string
+"""
+def check_mapping_dict(value: dict, path: str, module: str) -> bool:
+  OK = True
+  for k,v in value.items():
+    if not isinstance(v,str):
+      error(
+          f"{path}.{k} should be a string, found {type(v)}",
+          category=IncorrectType,
+          module=module)
+      OK = False
+
+  return OK
+
+"""
+Normalize file mapping:
+
+* Validate its value: it must be a list of strings in a:b format, or a dictionary of strings
+* Convert it into a list of strings in a:b format
+"""
+def normalize_file_mapping(parent: Box, path: str, key: str, module: str) -> None:
+  if not key in parent:
+    return
+  
+  value = parent[key]
+  if value is None:
+    parent[key] = []
+    return
+
+  if isinstance(value,Box):
+    value = box_to_dict(value)
+    if not check_mapping_dict(value,f'{path}.{key}',module):
+      parent[key] = []
+      return
+    parent[key] = dict_to_mapping(value)
+  elif isinstance(value,list):
+    if not check_mapping_list(value,f'{path}.{key}',module):
+      parent[key] = []
+  else:
+    error(
+      f"{path}.{key} should be a list of strings in a:b format or a dictionary of strings, found {type(value)}",
+      category=IncorrectType,
+      module=module)

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -8,7 +8,7 @@ from box import Box
 
 from . import _Provider
 from .. import common
-from ..data import get_from_box
+from ..data import get_from_box,filemaps
 
 def list_bridges( topology: Box ) -> typing.Set[str]:
   return { l.bridge for l in topology.links if l.bridge and l.node_count != 2 and not 'external_bridge' in l.clab }
@@ -69,10 +69,21 @@ def destroy_ovs_bridge( brname: str ) -> bool:
 
 GENERATED_CONFIG_PATH = "clab_files"
 
+'''
+normalize_clab_filemaps: convert clab templates and file binds into host:target lists
+'''
+def normalize_clab_filemaps(node: Box) -> None:
+  for undot_key in ['clab.binds','clab.config_templates']:
+    if not undot_key in node:
+      continue
+    filemaps.normalize_file_mapping(node,f'nodes.{node.name}',undot_key,'clab')
+
 class Containerlab(_Provider):
   
   def augment_node_data(self, node: Box, topology: Box) -> None:
     node.hostname = "clab-%s-%s" % (topology.name,node.name)
+    normalize_clab_filemaps(node)
+
     self.create_extra_files_mappings(node,topology)
 
   def post_configuration_create(self, topology: Box) -> None:

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -42,8 +42,8 @@ topology:
 {% endif %}
 {% if 'binds' in clab %}
       binds:
-{% for f,m in clab.binds.items() %}
-      - {{ f }}:{{ m }}
+{% for bind_item in clab.binds %}
+      - {{ bind_item }}
 {% endfor %}
 {% endif %}
 {% if 'startup-config' in clab %}

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -366,9 +366,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/c1/daemons: /etc/frr/daemons
+      - clab_files/c1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-c1
@@ -447,9 +447,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/c2/daemons: /etc/frr/daemons
+      - clab_files/c2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-c2
@@ -520,9 +520,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/leaf/daemons: /etc/frr/daemons
+      - clab_files/leaf/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-leaf
@@ -599,9 +599,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/srv/hosts: /etc/hosts
+      - clab_files/srv/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-srv
@@ -661,9 +661,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/leaf/daemons: /etc/frr/daemons
+      - clab_files/leaf/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-leaf
@@ -740,9 +740,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/srv/hosts: /etc/hosts
+      - clab_files/srv/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-srv
@@ -815,9 +815,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/s1/daemons: /etc/frr/daemons
+      - clab_files/s1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-s1
@@ -925,9 +925,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/s2/daemons: /etc/frr/daemons
+      - clab_files/s2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-s2
@@ -1022,9 +1022,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/leaf/daemons: /etc/frr/daemons
+      - clab_files/leaf/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-leaf
@@ -1101,9 +1101,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/srv/hosts: /etc/hosts
+      - clab_files/srv/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-srv
@@ -1163,9 +1163,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/leaf/daemons: /etc/frr/daemons
+      - clab_files/leaf/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-leaf
@@ -1242,9 +1242,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/srv/hosts: /etc/hosts
+      - clab_files/srv/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-srv
@@ -1317,9 +1317,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/s1/daemons: /etc/frr/daemons
+      - clab_files/s1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-s1
@@ -1427,9 +1427,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/s2/daemons: /etc/frr/daemons
+      - clab_files/s2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-s2

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -48,9 +48,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h1/hosts: /etc/hosts
+      - clab_files/h1/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -84,9 +84,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h2/hosts: /etc/hosts
+      - clab_files/h2/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -72,9 +72,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/r1/daemons: /etc/frr/daemons
+      - clab_files/r1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     evpn:
@@ -154,9 +154,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/r2/daemons: /etc/frr/daemons
+      - clab_files/r2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     evpn:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -132,9 +132,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h1/hosts: /etc/hosts
+      - clab_files/h1/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -187,9 +187,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h2/hosts: /etc/hosts
+      - clab_files/h2/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -85,9 +85,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h1/hosts: /etc/hosts
+      - clab_files/h1/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -126,9 +126,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h2/hosts: /etc/hosts
+      - clab_files/h2/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -105,9 +105,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h1/hosts: /etc/hosts
+      - clab_files/h1/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -149,9 +149,9 @@ nodes:
     box: python:3.9-alpine
     clab:
       binds:
-        clab_files/h2/hosts: /etc/hosts
+      - clab_files/h2/hosts:/etc/hosts
       config_templates:
-        hosts: /etc/hosts
+      - hosts:/etc/hosts
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -162,9 +162,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/h1/daemons: /etc/frr/daemons
+      - clab_files/h1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-h1
@@ -206,9 +206,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/h2/daemons: /etc/frr/daemons
+      - clab_files/h2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-h2
@@ -252,9 +252,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/h3/daemons: /etc/frr/daemons
+      - clab_files/h3/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-h3
@@ -302,9 +302,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/r1/daemons: /etc/frr/daemons
+      - clab_files/r1/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-r1
@@ -487,9 +487,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/r2/daemons: /etc/frr/daemons
+      - clab_files/r2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-r2

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -179,9 +179,9 @@ nodes:
     box: frrouting/frr:v8.4.0
     clab:
       binds:
-        clab_files/r2/daemons: /etc/frr/daemons
+      - clab_files/r2/daemons:/etc/frr/daemons
       config_templates:
-        daemons: /etc/frr/daemons
+      - daemons:/etc/frr/daemons
       kind: linux
     device: frr
     hostname: clab-input-r2


### PR DESCRIPTION
The clab.binds and clab.config_templates dictionaries could contain dots in keys (filenames) which results in weird values in clab.yml configuration file. This patch:

* Checks the validity of clab.binds and clab.config_templates parameters
* Converts them into lists of host:target strings
* Converts those strings into dicts and back as needed