### PR TITLE
Update containerlab.sh to release 0.41.2

### DIFF
--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install a specific version of Containerlab
-CONTAINERLAB_VERSION="0.41.0"
+CONTAINERLAB_VERSION="0.41.2"
 
 cat <<EOM
 Docker/Containerlab Installation Script


### PR DESCRIPTION
New release has backwards compatibility for old mgmt_ipv[x] attributes