### PR TITLE
Merge global VRF data with node VRF data in post-transform hook

### DIFF
--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -293,21 +293,23 @@ def export_group_node_data(
   for gname,gdata in topology.groups.items():
     #
     # Find groups with node_data dictionaries
+    # and check that the key within node_data dictionary we're interested in is also a dictionary
+    #
     if must_be_dict(gdata,f'node_data.{key}',f'groups.{gname}',module=module,create_empty=False):
-      for obj_name in list(gdata.node_data[key].keys()):
-        if gdata.node_data[key][obj_name] is None:
-          gdata.node_data[key][obj_name] = {}
-        obj_data =  gdata.node_data[key][obj_name]
+      for obj_name in list(gdata.node_data[key].keys()):              # Iterate over VLANs/VRFs within the group
+        if gdata.node_data[key][obj_name] is None:                    # ... replace None values with
+          gdata.node_data[key][obj_name] = {}                         # ... empty dictionaries
+        obj_data =  gdata.node_data[key][obj_name]                    # Now get the data to work with
         if not obj_name in topology[key] or topology[key][obj_name] is None:
-          topology[key][obj_name] = {}
-        for attr in unique_keys:
+          topology[key][obj_name] = {}                                # Make sure global object is also a dictionary
+        for attr in unique_keys:                                      # Check whether we have an overlap in unique keys
           if attr in topology[key][obj_name] and attr in obj_data and \
-             topology[key][obj_name][attr] != obj_data[attr]:                          # Unique key present on both ends and not equal
+             topology[key][obj_name][attr] != obj_data[attr]:         # Unique key present on both ends and not equal
             common.error(
               f'Cannot redefine {key} attribute {attr} for {key}.{obj_name} from node_data in group {gname}',
               common.IncorrectValue,
               module)
-        for attr in copy_keys:
+        for attr in copy_keys:                                        # Finally, copy missing values from group to global object
           if attr in obj_data and attr not in topology[key][obj_name]:
             topology[key][obj_name][attr] = obj_data[attr]
 

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -1,0 +1,156 @@
+bgp:
+  advertise_loopback: true
+  as: 65000
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+evpn:
+  session:
+  - ibgp
+  vrfs:
+  - tenant
+groups:
+  as65000:
+    members:
+    - a
+input:
+- topology/input/evpn-node-vrf.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.1.1/24
+    node: a
+  linkindex: 1
+  node_count: 1
+  prefix:
+    ipv4: 172.16.1.0/24
+  type: stub
+module:
+- vlan
+- bgp
+- vrf
+- evpn
+name: input
+nodes:
+  a:
+    af:
+      ipv4: true
+      vpnv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        - extended
+      neighbors: []
+      next_hop_self: true
+      router_id: 10.0.0.1
+    box: arista/veos
+    device: eos
+    evpn:
+      session:
+      - ibgp
+      vrfs:
+      - tenant
+    id: 1
+    interfaces:
+    - bgp:
+        advertise: true
+      bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 172.16.1.1/24
+      linkindex: 1
+      name: a -> stub
+      neighbors: []
+      type: stub
+    - bgp:
+        advertise: true
+      bridge_group: 1
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN red (1000)
+      neighbors: []
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+      vrf: tenant
+    loopback:
+      ipv4: 10.0.0.1/32
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vlan
+    - bgp
+    - vrf
+    - evpn
+    name: a
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        vrf: tenant
+    vrf:
+      as: 65000
+    vrfs:
+      tenant:
+        af:
+          ipv4: true
+        evpn:
+          evi: 1
+          rd: 10.0.0.1:1
+          transit_vni: 200000
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        rd: '65000:1'
+        vrfidx: 100
+provider: libvirt
+vlans:
+  red:
+    host_count: 0
+    id: 1000
+    neighbors:
+    - ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      node: a
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24
+    vrf: tenant
+vrf:
+  as: 65000
+vrfs:
+  tenant:
+    evpn:
+      evi: 1
+      transit_vni: 200000
+    export:
+    - '65000:1'
+    id: 1
+    import:
+    - '65000:1'
+    rd: '65000:1'

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -342,7 +342,7 @@ nodes:
         id: 2
         import:
         - '65000:2'
-        rd: null
+        rd: '65000:2'
         vrfidx: 100
   r3:
     af:

--- a/tests/topology/input/evpn-node-vrf.yml
+++ b/tests/topology/input/evpn-node-vrf.yml
@@ -1,0 +1,20 @@
+defaults.device: eos
+module: [ vlan, bgp, evpn, vrf ]
+
+vrfs:
+  tenant:
+    evpn.transit_vni: True
+
+vlans:
+  red:
+    vrf: tenant
+
+bgp.as: 65000
+nodes:
+  a:
+    vrfs:
+      tenant:
+    vlans:
+      red:
+
+links: [ a ]


### PR DESCRIPTION
Some module (like EVPN) modify global VRF data and expect the modified global VRF data to be used for node VRF data. Code introduced in #482 pulls global VRF data into node VRF data very early in the transformation process -- in those cases, the global changes are never copied into the node VRF data.

This PR fixes the #482 logic to create stub node VRF structures, and carefully populates them with auto-generated or global ID/RD/RT values. The full global VRF data is then merged with node VRF data in post_transform hook.