### PR TITLE
Evpn ebgp test/example

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -142,12 +142,14 @@
 {%  if vrf_bgp.rr|default(0) %}
     passive-mode: True
     _annotate_passive-mode: "Improve robustness during startup"
-   route-reflector:
-    cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
-    client: True
 {%  else %}
    next-hop-self: {{ vrf_bgp.next_hop_self|default(False) }}
 {%  endif %}
+{% endif %}
+{% if vrf_bgp.rr|default(0) %}
+   route-reflector:
+    cluster-id: {{ vrf_bgp.rr_cluster_id|default(False) or router_id }}
+    client: True
 {% endif %}
 {% endmacro %}
 

--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -10,12 +10,15 @@ updates:
   val:
    group:
    - group-name: {{ 'ibgp-ipv4' if type=='ibgp' else 'ebgp' }} # Could create a dedicated group for EVPN only?
+{%  if type=='ebgp' %}
+     export-policy: "accept_all"
+{%  endif %}
      afi-safi:
      - afi-safi-name: evpn
        admin-state: enable
-{% if bgp.rr|default(0) %}
+{%  if bgp.rr|default(0) %}
      next-hop-self: False
-{% endif %}
+{%  endif %}
    route-advertisement:
     rapid-withdrawal: True
    afi-safi:

--- a/netsim/extra/ebgp.utils/frr.j2
+++ b/netsim/extra/ebgp.utils/frr.j2
@@ -1,0 +1,49 @@
+!
+router bgp {{ bgp.as }}
+!
+! Password
+{% for n in bgp.neighbors if n.password is defined %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+ neighbor {{ n[af] }} password {{ n.password }}
+{%   endfor %}
+{% endfor %}
+!
+! Global address families
+{% for af in ['ipv4','ipv6'] if af in bgp %}
+ address-family {{ af }}
+{%   for n in bgp.neighbors if n[af] is defined %}
+{%     if n.allowas_in is defined %}
+  neighbor {{ n[af] }} allowas-in {{ n.allowas_in }}
+{%     endif %}
+{%     if n.as_override is defined %}
+  neighbor {{ n[af] }} as-override
+{%     endif %}
+{%     if n.default_originate is defined %}
+  neighbor {{ n[af] }} default-originate
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined and vdata.bgp.neighbors is defined %}
+{%     for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined %}
+{%         if loop.first %}
+ address-family {{ af }} vrf {{ vname }}
+{%         endif %}
+{%         if n.password is defined %}
+  neighbor {{ n[af] }} password {{ n.password }}
+{%         endif %}
+{%         if n.allowas_in is defined %}
+  neighbor {{ n[af] }} allowas-in {{ n.allowas_in }}
+{%         endif %}
+{%         if n.as_override is defined %}
+  neighbor {{ n[af] }} as-override
+{%         endif %}
+{%         if n.default_originate is defined %}
+  neighbor {{ n[af] }} default-originate
+{%         endif %}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}

--- a/tests/integration/evpn/vxlan-ebgp-to-hosts.yml
+++ b/tests/integration/evpn/vxlan-ebgp-to-hosts.yml
@@ -1,5 +1,3 @@
-defaults.vxlan.start_vni: 20000
-
 message: |
   This test case builds a leaf-and-spine fabric with VLAN-over-VXLAN bridging and eBGP to the hosts. 
   The hosts and leaf switches are doing VLAN/VXLAN encap/decap, the spine switches are IP routers running eBGP, and EVPN eBGP RR.
@@ -15,6 +13,7 @@ defaults:
  provider: clab
  device: srlinux
  interfaces.mtu: 1550 # Increased for VXLAN
+ vxlan.start_vni: 20000
 
 plugin: [ ebgp.utils ] # for allowas_in
 

--- a/tests/integration/evpn/vxlan-ebgp-to-hosts.yml
+++ b/tests/integration/evpn/vxlan-ebgp-to-hosts.yml
@@ -1,0 +1,103 @@
+defaults.vxlan.start_vni: 20000
+
+message: |
+  This test case builds a leaf-and-spine fabric with VLAN-over-VXLAN bridging and eBGP to the hosts. 
+  The hosts and leaf switches are doing VLAN/VXLAN encap/decap, the spine switches are IP routers running eBGP, and EVPN eBGP RR.
+
+  Assuming the 'vxlan-bridging' test case succeeded, this test case
+  validates that EVPN works with eBGP, MTU settings and Centralized IRB.
+
+  * both hosts on the same VLAN should be able to ping each other
+
+  To change the devices under test, use netlab up -d parameter
+
+defaults:
+ provider: clab
+ device: srlinux
+ interfaces.mtu: 1550 # Increased for VXLAN
+
+plugin: [ ebgp.utils ] # for allowas_in
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    # device: frr
+    module: [ vlan,vxlan,bgp,evpn,vrf ]
+    node_data:
+      bgp.as: 65004 # same AS on every host requires allowas_in
+  leafs:
+    members: [ leaf1, leaf2 ]
+    module: [ vlan,vxlan,bgp,evpn,vrf ]
+    vlans:
+      red:
+      #  vrf: tenant
+      blue:
+      #  vrf: tenant
+  spines:
+    members: [ spine ]
+    module: [ bgp,evpn ]
+    node_data:
+      bgp.rr: True # one way to pass eBGP EVPN routes between leaves
+      bgp.as: 65001
+
+vrfs:
+ tenant:
+  evpn.transit_vni: True # FRR does not support asymmetrical
+
+vlans:
+ red:
+  vrf: tenant
+  bgp: False
+ blue:
+  #  vrf: tenant
+  bgp: False
+
+bgp.as: 65000
+evpn.vlans: [ red, blue ]
+
+bgp.sessions: # create only eBGP sessions
+  ipv4: [ ebgp ]
+  ipv6: [ ebgp ]
+
+evpn.session: ebgp
+
+nodes:
+  h1:
+  h2:
+  h3:
+  h4:
+  leaf1:
+    vlan.mode: irb
+    bgp.as: 65002
+  leaf2:
+    vlan.mode: bridge
+    bgp.as: 65003
+  spine:
+
+links:
+- h1:
+   bgp.allowas_in: True
+  leaf1:
+- h2:
+   bgp.allowas_in: True
+  leaf2:
+- h3:
+   bgp.allowas_in: True
+  leaf1:
+- h4:
+   bgp.allowas_in: True
+  leaf2:
+- leaf1:
+  spine:
+- leaf2:
+  spine:
+
+# Stub links to emulate VMs
+- h1:
+  vlan.access: red
+- h2:
+  vlan.access: red
+- h3:
+  vlan.access: blue
+- h4:
+  vlan.access: blue


### PR DESCRIPTION
An example topology using only eBGP sessions for IPv4 and EVPN, and no IGP. The spine is configured as a route reflector; leaf1 is doing IRB, leaf2 is purely L2 with no IP or interface participating in the service

For some reason it doesn't yet work when using FRR as hosts; to be investigated