### PR TITLE
FRR template fixes/enhancements

### DIFF
--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -19,6 +19,7 @@ router bgp {{ bgp.as }}
 {%  for af in ['ipv4','ipv6'] if af in n %}
 {%   set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }} activate
+  neighbor {{ peer }} soft-reconfiguration inbound
 {%   if bgp.rr|default('') and not n.rr|default('') %}
   neighbor {{ peer }} route-reflector-client
 {%   endif %}

--- a/netsim/extra/ebgp.utils/frr.j2
+++ b/netsim/extra/ebgp.utils/frr.j2
@@ -25,6 +25,21 @@ router bgp {{ bgp.as }}
 {%   endfor %}
 {% endfor %}
 
+{% for n in bgp.neighbors if n.evpn|default(False) and n.type == 'ebgp' %}
+{%  if loop.first %}
+ address-family l2vpn evpn
+{%  endif %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+{%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
+{%     if n.allowas_in is defined %}
+  neighbor {{ peer }} allowas-in {{ n.allowas_in }}
+{%     endif %}
+{%     if n.as_override is defined %}
+  neighbor {{ peer }} as-override
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
 {% if vrfs is defined %}
 {%   for vname,vdata in vrfs.items() if vdata.bgp is defined and vdata.bgp.neighbors is defined %}
 {%     for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}


### PR DESCRIPTION
* Enable allowas-in also for ebgp evpn neighbors (l2vpn address family)
* Enable soft-reconfiguration inbound to see/debug incoming routes

(1) was the reason why FRR hosts weren't working in the ebgp topology shared earlier