### PR TITLE
Update frr.yml - update Docker image to 8.5.2 from new repo

### DIFF
--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -6,11 +6,11 @@ group_vars:
   ansible_network_os: frr
   ansible_python_interpreter: auto_silent
 clab:
-  # image: frrouting/frr:v7.5.0
   group_vars:
     ansible_connection: docker
     ansible_user: root
-  image: frrouting/frr:v8.4.0
+  # image: frrouting/frr:v8.4.0 # repo no longer updated, has moved
+  image: quay.io/frrouting/frr:8.5.2
   mtu: 1500
   node:
     kind: linux


### PR DESCRIPTION
The latest version includes some neat features to test, and the old repo is not receiving any updates for months