### PR TITLE
Add frr gateway support

### DIFF
--- a/netsim/ansible/templates/gateway/frr.j2
+++ b/netsim/ansible/templates/gateway/frr.j2
@@ -18,7 +18,7 @@ ip link set dev {{ ifname }} up
 {%   elif intf.gateway.protocol == 'vrrp' %}
 {%    set id = intf.gateway.vrrp.group|default(1)|int %}
 {%    for i in ['4','6'] if ('ipv'+i) in intf.gateway %}
-{%     set ifname = "vrrp"+i+"-"+id %}
+{%     set ifname = "vrrp"+i+"-"+intf.ifindex|string+"-"+id|string %}
 ip link add {{ ifname }} link {{ intf.ifname }} addrgenmode random type macvlan mode bridge
 ip link set {{ ifname }} address 00:00:5e:00:{{ '01' if i=='4' else '02' }}:{{ '%02x' % id }}
 ip addr add {{ intf.gateway['ipv'+i] }} dev {{ ifname }}

--- a/netsim/ansible/templates/gateway/frr.j2
+++ b/netsim/ansible/templates/gateway/frr.j2
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+set -e # Exit immediately when any command fails
+#
+{% for intf in interfaces if 'gateway' in intf %}
+{%   if intf.gateway.protocol == 'anycast' %}
+{%    set ifname = "any-" + intf.ifname %}
+ip link add {{ ifname }} link {{ intf.ifname }} addrgenmode none type macvlan mode bridge
+ip link set {{ ifname }} address {{ intf.gateway.anycast.mac|hwaddr('linux') }}
+
+# Stop the interface from responding to ARPs for the virtual IP
+echo 1 > /proc/sys/net/ipv4/conf/{{ intf.ifname }}/arp_ignore
+
+{%    for i in ['ipv4','ipv6'] if i in intf.gateway %}
+ip addr add {{ intf.gateway[i] }} dev {{ ifname }}
+{%    endfor %}
+ip link set dev {{ ifname }} up
+{%   elif intf.gateway.protocol == 'vrrp' %}
+{%    set id = intf.gateway.vrrp.group|default(1)|int %}
+{%    for i in ['4','6'] if ('ipv'+i) in intf.gateway %}
+{%     set ifname = "vrrp"+i+"-"+id %}
+ip link add {{ ifname }} link {{ intf.ifname }} addrgenmode random type macvlan mode bridge
+ip link set {{ ifname }} address 00:00:5e:00:{{ '01' if i=='4' else '02' }}:{{ '%02x' % id }}
+ip addr add {{ intf.gateway['ipv'+i] }} dev {{ ifname }}
+ip link set dev {{ ifname }} up
+{%    endfor %}
+{%   endif %}
+{% endfor %}
+
+cat >/tmp/gateway_config <<CONFIG
+{% for intf in interfaces if 'gateway' in intf %}
+interface {{ intf.ifname }}
+{% if intf.gateway.protocol == 'vrrp' %}
+{%   for af in 'ipv4','ipv6' if af in intf.gateway %}
+  vrrp {{ intf.gateway.vrrp.group }} {{ af|replace('ipv4','ip') }} {{ intf.gateway[af]|ipaddr('address') }}
+{%   endfor %}
+{%     if 'priority' in intf.gateway.vrrp %}
+  vrrp {{ intf.gateway.vrrp.group }} priority {{ intf.gateway.vrrp.priority }}
+{%     endif %}
+{%     if intf.gateway.vrrp.preempt|default(False) %}
+  vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     endif %}
+{% endif %}
+{% endfor %}
+do write
+CONFIG
+if [ -s /tmp/gateway_config ]; then
+  vtysh -f /tmp/gateway_config
+fi

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -59,6 +59,12 @@ echo "{{ frr_m }}=yes" >>/etc/frr/daemons
 {%   endfor %}
 {% endfor %}
 
+{% if 'gateway' in module|default([]) %}
+{%  if interfaces|selectattr('gateway','defined')|map(attribute='gateway')|selectattr('protocol','equalto','vrrp')|list != [] %}
+echo "vrrpd=yes" >>/etc/frr/daemons
+{%  endif %}
+{% endif %}
+
 /usr/lib/frr/frrinit.sh restart
 {% endif %}
 

--- a/netsim/ansible/templates/vxlan/frr.j2
+++ b/netsim/ansible/templates/vxlan/frr.j2
@@ -3,11 +3,13 @@
 set -e # Exit immediately when any command fails
 #
 
+{% set use_evpn = vxlan.flooding|default('') == 'evpn' %}
+
 {% macro create_vxlan_interface(vni,br_name,vrf=None,mtu=1500) %}
 ip link add vxlan{{ vni }} type vxlan \
   id {{ vni }} \
   dstport 4789 \
-  local {{ vxlan.vtep }} {{ 'nolearning' if vxlan.flooding|default('') == 'evpn' else '' }}
+  local {{ vxlan.vtep }} {{ 'nolearning' if use_evpn else '' }}
 #
 # Add it to the VLAN bridge (create if needed for l3 vnis); disable STP
 if [ ! -e /sys/devices/virtual/net/{{ br_name}} ]; then
@@ -16,7 +18,12 @@ ip link set up dev {{ br_name }}
 fi
 brctl addif {{ br_name }} vxlan{{ vni }}
 brctl stp {{ br_name }} off
-ip link set mtu {{ mtu }} dev vxlan{{ vni }}
+# Do not generate ipv6 link-local address for VXLAN devices
+ip link set mtu {{ mtu }} addrgenmode none dev vxlan{{ vni }}
+{% if use_evpn %}
+# Disable dynamic MAC learning for evpn, see https://docs.frrouting.org/en/latest/evpn.html
+bridge link set dev vxlan{{ vni }} learning off
+{% endif %}
 ip link set up dev vxlan{{ vni }}
 {% if vrf %}
 ip link set {{ br_name }} master {{ vrf }}

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -55,4 +55,6 @@ features:
   mpls:
     ldp: True
     vpn: True
+  gateway:
+    protocol: [ anycast,vrrp ]
 graphite.icon: router

--- a/netsim/modules/gateway.yml
+++ b/netsim/modules/gateway.yml
@@ -1,6 +1,6 @@
 # Gateway (FHRP) default settings and attributes
 #
-supported_on: [ none, eos, cumulus, iosv, csr, nxos, sros, srlinux, vyos, dellos10, arubacx ]
+supported_on: [ none, eos, cumulus, iosv, csr, nxos, sros, srlinux, vyos, dellos10, arubacx, frr ]
 transform_after: [ vlan, vrf, ospf, isis, eigrp ]
 config_after: [ vlan,vrf ]
 id: -2

--- a/netsim/templates/provider/clab/frr/daemons.j2
+++ b/netsim/templates/provider/clab/frr/daemons.j2
@@ -94,3 +94,9 @@ frr_profile="datacenter"
 {{ frr_m }}=yes
 {%   endfor %}
 {% endfor %}
+
+{% if 'gateway' in module|default([]) %}
+{%  if interfaces|selectattr('gateway','defined')|map(attribute='gateway')|selectattr('protocol','equalto','vrrp')|list != [] %}
+vrrpd=yes
+{%  endif %}
+{% endif %}


### PR DESCRIPTION
There are still some issues to be solved:
```
/ # arping -I eth1 172.16.0.1 # VRRP VIP
ARPING 172.16.0.1 from 172.16.0.5 eth1
Unicast reply from 172.16.0.1 [aa:c1:ab:95:31:67] 0.022ms
Unicast reply from 172.16.0.1 [aa:c1:ab:69:50:ee] 0.030ms
Unicast reply from 172.16.0.1 [00:00:5e:00:01:01] 0.034ms
Unicast reply from 172.16.0.1 [00:00:5e:00:01:01] 0.012ms
Unicast reply from 172.16.0.1 [00:00:5e:00:01:01] 0.011ms
^CSent 3 probe(s) (1 broadcast(s))
Received 5 response(s) (0 request(s), 0 broadcast(s))
/ # arping -I eth1 172.16.0.3 # interface IP
ARPING 172.16.0.3 from 172.16.0.5 eth1
Unicast reply from 172.16.0.3 [aa:c1:ab:95:31:67] 0.006ms
Unicast reply from 172.16.0.3 [aa:c1:ab:95:31:67] 0.009ms
Unicast reply from 172.16.0.3 [aa:c1:ab:95:31:67] 0.010ms
^CSent 3 probe(s) (1 broadcast(s))
```
The above is the vrrp case, 3 different interfaces respond to ARP. For anycast I was able to remove 1 response, but ARP requests are still sourced from the wrong MAC

The PR creates a macvtap device on top of the Linux bridge for a vlan, in bridge mode. It could be that this model needs to be changed (the example at https://docs.frrouting.org/en/latest/vrrp.html uses a physical interface)
