### PR TITLE
MANIFEST.in: missing include for show-usage.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,5 @@ recursive-include netsim/install *
 recursive-include netsim *.yml
 include requirements.txt
 include netsim/cli/usage.txt
+include netsim/cli/show-usage.txt
 include netsim/cli/alias.txt


### PR DESCRIPTION
ubuntu@libvirt:~$ netlab show
Traceback (most recent call last):
  File "/usr/local/bin/netlab", line 8, in <module>
    sys.exit(lab_commands())
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/__init__.py", line 256, in lab_commands
    mod.run(sys.argv[arg_start:])   # type: ignore
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/show.py", line 85, in run
    args = parse_show_args(cli_args)
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/show.py", line 64, in parse_show_args
    show_usage()
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/show.py", line 59, in show_usage
    print_usage('show-usage.txt')
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/usage.py", line 16, in print_usage
    with resources.open_text(package,fname) as fid:
  File "/usr/lib/python3.10/importlib/resources.py", line 82, in open_text
    open_binary(package, resource), encoding=encoding, errors=errors
  File "/usr/lib/python3.10/importlib/resources.py", line 46, in open_binary
    return reader.open_resource(resource)
  File "/usr/lib/python3.10/importlib/abc.py", line 433, in open_resource
    return self.files().joinpath(resource).open('rb')
  File "/usr/lib/python3.10/pathlib.py", line 1119, in open
    return self._accessor.open(self, mode, buffering, encoding, errors,
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.10/dist-packages/netsim/cli/show-usage.txt'

HEAD is now at 4ffb2dd Merge release 1.6.0 into master branch
➜ netlab git:(release_1.6.0) ls -al netsim/cli/show-usage.txt
-rw-r--r-- 1 schmidt staff 733 Aug 17 17:03 netsim/cli/show-usage.txt