### PR TITLE
Bump clab version to 0.44.3

### DIFF
--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install a specific version of Containerlab
-CONTAINERLAB_VERSION="0.44.0"
+CONTAINERLAB_VERSION="0.44.3"
 
 cat <<EOM
 Docker/Containerlab Installation Script


### PR DESCRIPTION
0.44.0 has a bug which prevents any vrnetlab kind to run.
0.44.3 fixes the issue.