### PR TITLE
Fix node vlan.mode override, update test case

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -52,7 +52,7 @@ def routed_access_vlan(link: Box, topology: Box, vlan: str) -> bool:
       return False
 
   if log.debug_active('vlan'):
-    print(f'... VLAN is routed (returning True)')
+    print('... VLAN is routed (returning True)')
   return True
 
 #
@@ -81,7 +81,7 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
   obj_path = 'vlans' if obj is topology else f'nodes.{obj.name}.vlans'
   default_fwd_mode = obj.get('vlan.mode',None) or get_global_parameter(topology,'vlan.mode')
 
-  if not 'vlans' in obj:
+  if 'vlans' not in obj:
     return
 
   for vname in list(obj.vlans.keys()):
@@ -615,7 +615,7 @@ def create_node_vlan(node: Box, vlan: str, topology: Box) -> typing.Optional[Box
       if not m in node.module and m in topology.module:             # ... it's safe to use direct references, everyone is using VLAN module
         node.vlans[vlan].pop(m,None)
 
-  if not 'mode' in node.vlans[vlan]:                                # Make sure vlan.mode is set
+  if not 'mode' in node.vlans[vlan] or node.get('vlan.mode',None):  # Make sure vlan.mode is set, apply any override
     node.vlans[vlan].mode = get_vlan_mode(node,topology)
 
   if not 'bridge_group' in node.vlans[vlan]:                        # Set bridge group in VLAN data

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -565,6 +565,7 @@ vlans:
   red:
     host_count: 0
     id: 1000
+    mode: irb
     neighbors:
     - ifname: Ethernet1
       ipv4: 172.16.0.3/24

--- a/tests/topology/input/vlan-router-stick.yml
+++ b/tests/topology/input/vlan-router-stick.yml
@@ -20,6 +20,7 @@ groups:
 vlans:
   red:
     ospf.cost: 10
+    mode: irb      # JvB: added to catch a regression bug regarding node vlan.mode override
   blue:
     ospf.cost: 20
 


### PR DESCRIPTION
Fix for https://github.com/ipspace/netlab/issues/874

Note how explicitly adding the default vlan.mode setting changes things - it could be argued that the code should consistently spell out attribute values for each object (and hence the 'blue' vlan would also have a 'mode' attribute)