### PR TITLE
Add TCP-AO support to the ebgp.utils plugin, plus general SR OS support

### DIFF
--- a/netsim/extra/ebgp.utils/plugin.py
+++ b/netsim/extra/ebgp.utils/plugin.py
@@ -4,6 +4,7 @@ from netsim import api
 
 """
 Adds a custom bgp.{allowas_in,as_override,default_originate} as link->node (interface) attribute
+Also adds tcp_ao attribute as global and per-link option
 """
 def init(topology: Box) -> None:
     attr = topology.defaults.bgp.attributes
@@ -12,11 +13,19 @@ def init(topology: Box) -> None:
     attr.interface.default_originate = 'bool'
     attr.link.password = 'str'
 
+    # Add global, node and per-link tcp_ao option (see RFC5925 - https://datatracker.ietf.org/doc/html/rfc5925)
+    tcp_ao_algorithm = { 'type': 'str', 
+                         'valid_values': ['aes-128-cmac','hmac-sha-1',''], 
+                         'true_value': 'hmac-sha-1' } # Default to most common algo
+    attr['global'].tcp_ao = tcp_ao_algorithm
+    attr['node'].tcp_ao = tcp_ao_algorithm
+    attr['link'].tcp_ao = tcp_ao_algorithm
+
 def pre_link_transform(topology: Box) -> None:
     # Error if BGP module is not loaded
-    if not 'bgp' in topology.module:
+    if 'bgp' not in topology.module:
         log.error(
-            f'BGP Module is not loaded.',
+            'BGP Module is not loaded.',
             log.IncorrectValue,
             'ebgp_utils')
 

--- a/netsim/extra/ebgp.utils/srlinux.j2
+++ b/netsim/extra/ebgp.utils/srlinux.j2
@@ -24,11 +24,18 @@
       keychain: "peer-{{n.name}}"
 
 - path: system/authentication/keychain[name=peer-{{n.name}}]
+{% if n.tcp_ao|default('x')=='' or bgp.tcp_ao|default('')=='' %}
+{%  set type = 'tcp-md5' %}
+{%  set algorithm = 'md5' %}
+{% else %}
+{%  set type = 'tcp-ao' %} {# Note: Not yet supported in R23.7 #}
+{%  set algorithm = n.tcp_ao | default( bgp.tcp_ao ) %} 
+{% endif %}
   val:
-   type: tcp-md5
+   type: "{{ type }}"
    key:
    - index: 0
-     algorithm: md5
+     algorithm: "{{ algorithm }}"
      authentication-key: "{{ n.password }}"
 {%   endif %}
 {%- endmacro %}

--- a/netsim/extra/ebgp.utils/sros.j2
+++ b/netsim/extra/ebgp.utils/sros.j2
@@ -1,0 +1,62 @@
+# See https://documentation.nokia.com/sr/23-7-1/books/system-management/security-system-management.html?hl=tcp%20enhanced%20authentication%20option
+
+{% macro ebgp_neighbor(n,af,vrf) -%}
+{% set path = "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" %}
+- path: configure/{{ path }}/bgp
+  val:
+{% if n.type=='ebgp' and af=='ipv6' and n.ipv6|default(0) == True %}
+   group:
+   - group-name: "ebgp-unnumbered{{ ('-' + n.local_as|string()) if n.local_as is defined else '' }}"
+{% else %}
+   neighbor:
+   - ip-address: {{ n[af]|ipaddr('address') }}
+{% endif %}
+{% if n.default_originate|default(False) %}
+{%   set activate = n.activate|default( {'ipv4':True,'ipv6':True} ) %}
+     send-default:
+      ipv4: {{ activate.ipv4|default(False) }}
+      ipv6: {{ activate.ipv6|default(False) }}
+{% endif %}
+{%   if n.allowas_in is defined %}
+     # allow-own-as: {{ n.allowas_in|int }}
+{%   endif %}
+{%   if n.as_override|default(False) %}
+     as-override: True
+{%   endif %}
+{%   if n.password is defined and (n.type!='ebgp' or n.ipv6|default('') is string) %}
+{%    if n.tcp_ao|default('x')=='' or bgp.tcp_ao|default('')=='' %}
+     authentication-key: "{{ n.password }}"
+{%    else %}
+     authentication-keychain: "peer-{{n.name}}"
+
+- path: configure/system/security/keychains/keychain[keychain-name=peer-{{n.name}}]
+  val:
+   bidirectional:
+    entry:
+    - keychain-entry-index: 0
+      authentication-key: "{{ n.password }}"
+      algorithm: "{{ n.tcp_ao | default( bgp.tcp_ao ) }}-96"
+      begin-time: "{{ now(utc=True,fmt='%Y-%m-%dT%H:%M:%SZ') }}"
+   tcp-option-number:
+    receive: tcp-ao
+    send: tcp-ao
+{%    endif %}
+{%   endif %}
+{%- endmacro %}
+
+updates:
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined and (n[af] is string or (af=='ipv6' and n.ipv6)) %}
+{{     ebgp_neighbor(n,af,vrf=None) -}}
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{% for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%   for af in ['ipv4','ipv6'] %}
+{%     for n in vdata.bgp.neighbors if n[af] is defined and (n[af] is string or (af=='ipv6' and n.ipv6)) %}
+{{       ebgp_neighbor(n,af,vname) -}}
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
* Configure bgp.tcp_ao=True (or a specific algorithm like 'aes-128-cmac','hmac-sha-1') at global or link level
* SR Linux YANG model supports tcp-ao, but no algorithms yet