### PR TITLE
Extend vlan mode test case to include node local override to 'bridge'

### DIFF
--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -27,7 +27,7 @@ def parser_add_debug(parser: argparse.ArgumentParser) -> None:
                     'vlan','vrf','quirks','validate','addressing','groups','quirks','status',
                     'external','defaults'
                   ],
-                  help=argparse.SUPPRESS)
+                  help='Debug specific transformation logic')
 
 def common_parse_args(debugging: bool = False) -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(description='Common argument parsing',add_help=False)

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -43,16 +43,16 @@ def routed_access_vlan(link: Box, topology: Box, vlan: str) -> bool:
     print(f'routed_access_vlan: {link}')
     print(f'... vlan {vlan} def_mode {def_vlan}')
   for intf in link.interfaces:
+    node_vlan_mode = topology.nodes[intf.node].get('vlan.mode',def_vlan)
     mode = (
       intf.get('vlan.mode',def_link) or
-      topology.nodes[intf.node].get(f'vlans.{vlan}.mode',def_vlan) or
-      topology.nodes[intf.node].get('vlan.mode',def_global) or
-      'irb')
+      topology.nodes[intf.node].get(f'vlans.{vlan}.mode',node_vlan_mode) or
+      def_global)
     if mode != 'route':
       return False
 
   if log.debug_active('vlan'):
-    print(f'... VLAN is routed (returning True)')
+    print('... VLAN is routed (returning True)')
   return True
 
 #

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -150,12 +150,14 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: eth2.1004
-      ipv4: 172.16.5.1/24
-      name: s1 -> s2
+      ipv4: 172.16.4.1/24
+      name: s1 -> [s2,s3]
       neighbors:
-      - ifname: eth2.1004
-        ipv4: 172.16.5.2/24
+      - ifname: vlan1004
+        ipv4: 172.16.4.2/24
         node: s2
+      - ifname: vlan1004
+        node: s3
       parent_ifindex: 2
       parent_ifname: eth2
       type: vlan_member
@@ -163,7 +165,6 @@ nodes:
       vlan:
         access_id: 1004
         mode: route
-        routed_link: true
     - ifindex: 6
       ifname: eth2.1001
       parent_ifindex: 2
@@ -203,11 +204,13 @@ nodes:
     - bridge_group: 2
       ifindex: 10
       ifname: eth4.1004
-      ipv4: 172.16.6.1/24
-      name: s1 -> s3
+      ipv4: 172.16.4.1/24
+      name: s1 -> [s2,s3]
       neighbors:
-      - ifname: eth1.1004
-        ipv4: 172.16.6.3/24
+      - ifname: vlan1004
+        ipv4: 172.16.4.2/24
+        node: s2
+      - ifname: vlan1004
         node: s3
       parent_ifindex: 4
       parent_ifname: eth4
@@ -216,7 +219,6 @@ nodes:
       vlan:
         access_id: 1004
         mode: route
-        routed_link: true
     - ifindex: 11
       ifname: eth4.1001
       parent_ifindex: 4
@@ -245,7 +247,6 @@ nodes:
         ipv4: 172.16.0.2/24
         node: s2
       - ifname: vlan1000
-        ipv4: 172.16.0.3/24
         node: s3
       type: svi
       virtual_interface: true
@@ -261,7 +262,6 @@ nodes:
         ipv4: 172.16.1.2/24
         node: s2
       - ifname: vlan1001
-        ipv4: 172.16.1.3/24
         node: s3
       type: svi
       virtual_interface: true
@@ -372,23 +372,15 @@ nodes:
         node: s1
       subif_index: 1
       type: p2p
-    - bridge_group: 2
-      ifindex: 4
+    - ifindex: 4
       ifname: eth2.1004
-      ipv4: 172.16.5.2/24
-      name: s2 -> s1
-      neighbors:
-      - ifname: eth2.1004
-        ipv4: 172.16.5.1/24
-        node: s1
       parent_ifindex: 2
       parent_ifname: eth2
       type: vlan_member
       virtual_interface: true
       vlan:
+        access: black
         access_id: 1004
-        mode: route
-        routed_link: true
     - ifindex: 5
       ifname: eth2.1001
       parent_ifindex: 2
@@ -442,14 +434,28 @@ nodes:
         ipv4: 172.16.0.1/24
         node: s1
       - ifname: vlan1000
-        ipv4: 172.16.0.3/24
+        node: s3
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: n_irb
+    - bridge_group: 2
+      ifindex: 10
+      ifname: vlan1004
+      ipv4: 172.16.4.2/24
+      name: VLAN black (1004) -> [s1,s3]
+      neighbors:
+      - ifname: eth4.1004
+        ipv4: 172.16.4.1/24
+        node: s1
+      - ifname: vlan1004
         node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: n_irb
     - bridge_group: 3
-      ifindex: 10
+      ifindex: 11
       ifname: vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s1,s3]
@@ -458,14 +464,13 @@ nodes:
         ipv4: 172.16.1.1/24
         node: s1
       - ifname: vlan1001
-        ipv4: 172.16.1.3/24
         node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: n_irb
     - bridge_group: 4
-      ifindex: 11
+      ifindex: 12
       ifname: vlan1002
       name: VLAN green (1002) -> [s1]
       neighbors:
@@ -493,6 +498,15 @@ nodes:
         bridge_group: 2
         id: 1004
         mode: n_irb
+        neighbors:
+        - ifname: eth4.1004
+          ipv4: 172.16.4.1/24
+          node: s1
+        - ifname: vlan1004
+          ipv4: 172.16.4.2/24
+          node: s2
+        - ifname: vlan1004
+          node: s3
         prefix:
           allocation: id_based
           ipv4: 172.16.4.0/24
@@ -508,7 +522,6 @@ nodes:
           ipv4: 172.16.1.1/24
           node: s1
         - ifname: vlan1001
-          ipv4: 172.16.1.3/24
           node: s3
         prefix:
           allocation: id_based
@@ -584,10 +597,24 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge_group: 2
+    - bridge_group: 1
       ifindex: 5
+      ifname: vlan1004
+      name: VLAN black (1004) -> [s1,s2]
+      neighbors:
+      - ifname: eth4.1004
+        ipv4: 172.16.4.1/24
+        node: s1
+      - ifname: vlan1004
+        ipv4: 172.16.4.2/24
+        node: s2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+    - bridge_group: 2
+      ifindex: 6
       ifname: vlan1001
-      ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [s2,s1]
       neighbors:
       - ifname: vlan1001
@@ -599,11 +626,10 @@ nodes:
       type: svi
       virtual_interface: true
       vlan:
-        mode: n_bridge
+        mode: bridge
     - bridge_group: 3
-      ifindex: 6
+      ifindex: 7
       ifname: vlan1000
-      ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [s2,s1]
       neighbors:
       - ifname: vlan1000
@@ -615,7 +641,7 @@ nodes:
       type: svi
       virtual_interface: true
       vlan:
-        mode: n_bridge
+        mode: bridge
     loopback:
       ipv4: 10.0.0.3/32
     mgmt:
@@ -627,19 +653,28 @@ nodes:
     name: s3
     vlan:
       max_bridge_group: 3
-      mode: n_bridge
+      mode: bridge
     vlans:
       black:
         bridge_group: 1
         id: 1004
-        mode: n_bridge
+        mode: bridge
+        neighbors:
+        - ifname: eth4.1004
+          ipv4: 172.16.4.1/24
+          node: s1
+        - ifname: vlan1004
+          ipv4: 172.16.4.2/24
+          node: s2
+        - ifname: vlan1004
+          node: s3
         prefix:
           allocation: id_based
           ipv4: 172.16.4.0/24
       blue:
         bridge_group: 2
         id: 1001
-        mode: n_bridge
+        mode: bridge
         neighbors:
         - ifname: vlan1001
           ipv4: 172.16.1.2/24
@@ -648,7 +683,6 @@ nodes:
           ipv4: 172.16.1.1/24
           node: s1
         - ifname: vlan1001
-          ipv4: 172.16.1.3/24
           node: s3
         prefix:
           allocation: id_based
@@ -656,7 +690,7 @@ nodes:
       red:
         bridge_group: 3
         id: 1000
-        mode: n_bridge
+        mode: bridge
         neighbors:
         - ifname: vlan1000
           ipv4: 172.16.0.2/24
@@ -665,7 +699,6 @@ nodes:
           ipv4: 172.16.0.1/24
           node: s1
         - ifname: vlan1000
-          ipv4: 172.16.0.3/24
           node: s3
         prefix:
           allocation: id_based
@@ -675,8 +708,18 @@ vlan:
   mode: g_irb
 vlans:
   black:
+    host_count: 0
     id: 1004
     mode: route
+    neighbors:
+    - ifname: eth4.1004
+      ipv4: 172.16.4.1/24
+      node: s1
+    - ifname: vlan1004
+      ipv4: 172.16.4.2/24
+      node: s2
+    - ifname: vlan1004
+      node: s3
     prefix:
       allocation: id_based
       ipv4: 172.16.4.0/24
@@ -691,7 +734,6 @@ vlans:
       ipv4: 172.16.1.1/24
       node: s1
     - ifname: vlan1001
-      ipv4: 172.16.1.3/24
       node: s3
     prefix:
       allocation: id_based
@@ -734,7 +776,6 @@ vlans:
       ipv4: 172.16.0.1/24
       node: s1
     - ifname: vlan1000
-      ipv4: 172.16.0.3/24
       node: s3
     prefix:
       allocation: id_based

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -147,15 +147,23 @@ nodes:
         node: s3
       subif_index: 3
       type: p2p
-    - ifindex: 5
+    - bridge_group: 2
+      ifindex: 5
       ifname: eth2.1004
+      ipv4: 172.16.5.1/24
+      name: s1 -> s2
+      neighbors:
+      - ifname: eth2.1004
+        ipv4: 172.16.5.2/24
+        node: s2
       parent_ifindex: 2
       parent_ifname: eth2
       type: vlan_member
       virtual_interface: true
       vlan:
-        access: black
         access_id: 1004
+        mode: route
+        routed_link: true
     - ifindex: 6
       ifname: eth2.1001
       parent_ifindex: 2
@@ -192,15 +200,23 @@ nodes:
       vlan:
         access: orange
         access_id: 1003
-    - ifindex: 10
+    - bridge_group: 2
+      ifindex: 10
       ifname: eth4.1004
+      ipv4: 172.16.6.1/24
+      name: s1 -> s3
+      neighbors:
+      - ifname: eth1.1004
+        ipv4: 172.16.6.3/24
+        node: s3
       parent_ifindex: 4
       parent_ifname: eth4
       type: vlan_member
       virtual_interface: true
       vlan:
-        access: black
         access_id: 1004
+        mode: route
+        routed_link: true
     - ifindex: 11
       ifname: eth4.1001
       parent_ifindex: 4
@@ -235,24 +251,8 @@ nodes:
       virtual_interface: true
       vlan:
         mode: vl_irb
-    - bridge_group: 2
-      ifindex: 14
-      ifname: vlan1004
-      ipv4: 172.16.4.1/24
-      name: VLAN black (1004) -> [s2,s3]
-      neighbors:
-      - ifname: vlan1004
-        ipv4: 172.16.4.2/24
-        node: s2
-      - ifname: vlan1004
-        ipv4: 172.16.4.3/24
-        node: s3
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: vl_route
     - bridge_group: 3
-      ifindex: 15
+      ifindex: 14
       ifname: vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [s2,s3]
@@ -268,7 +268,7 @@ nodes:
       vlan:
         mode: g_irb
     - bridge_group: 4
-      ifindex: 16
+      ifindex: 15
       ifname: vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [s2]
@@ -280,7 +280,7 @@ nodes:
       vlan:
         mode: vl_irb
     - bridge_group: 5
-      ifindex: 17
+      ifindex: 16
       ifname: vlan1003
       ipv4: 172.16.3.1/24
       name: VLAN orange (1003) -> [s2]
@@ -307,7 +307,7 @@ nodes:
       black:
         bridge_group: 2
         id: 1004
-        mode: vl_route
+        mode: route
         prefix:
           allocation: id_based
           ipv4: 172.16.4.0/24
@@ -372,15 +372,23 @@ nodes:
         node: s1
       subif_index: 1
       type: p2p
-    - ifindex: 4
+    - bridge_group: 2
+      ifindex: 4
       ifname: eth2.1004
+      ipv4: 172.16.5.2/24
+      name: s2 -> s1
+      neighbors:
+      - ifname: eth2.1004
+        ipv4: 172.16.5.1/24
+        node: s1
       parent_ifindex: 2
       parent_ifname: eth2
       type: vlan_member
       virtual_interface: true
       vlan:
-        access: black
         access_id: 1004
+        mode: route
+        routed_link: true
     - ifindex: 5
       ifname: eth2.1001
       parent_ifindex: 2
@@ -440,24 +448,8 @@ nodes:
       virtual_interface: true
       vlan:
         mode: n_irb
-    - bridge_group: 2
-      ifindex: 10
-      ifname: vlan1004
-      ipv4: 172.16.4.2/24
-      name: VLAN black (1004) -> [s1,s3]
-      neighbors:
-      - ifname: vlan1004
-        ipv4: 172.16.4.1/24
-        node: s1
-      - ifname: vlan1004
-        ipv4: 172.16.4.3/24
-        node: s3
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: n_irb
     - bridge_group: 3
-      ifindex: 11
+      ifindex: 10
       ifname: vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s1,s3]
@@ -473,7 +465,7 @@ nodes:
       vlan:
         mode: n_irb
     - bridge_group: 4
-      ifindex: 12
+      ifindex: 11
       ifname: vlan1002
       name: VLAN green (1002) -> [s1]
       neighbors:
@@ -501,16 +493,6 @@ nodes:
         bridge_group: 2
         id: 1004
         mode: n_irb
-        neighbors:
-        - ifname: vlan1004
-          ipv4: 172.16.4.2/24
-          node: s2
-        - ifname: vlan1004
-          ipv4: 172.16.4.1/24
-          node: s1
-        - ifname: vlan1004
-          ipv4: 172.16.4.3/24
-          node: s3
         prefix:
           allocation: id_based
           ipv4: 172.16.4.0/24
@@ -602,24 +584,8 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge_group: 1
-      ifindex: 5
-      ifname: vlan1004
-      ipv4: 172.16.4.3/24
-      name: VLAN black (1004) -> [s2,s1]
-      neighbors:
-      - ifname: vlan1004
-        ipv4: 172.16.4.2/24
-        node: s2
-      - ifname: vlan1004
-        ipv4: 172.16.4.1/24
-        node: s1
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: n_bridge
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 5
       ifname: vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [s2,s1]
@@ -635,7 +601,7 @@ nodes:
       vlan:
         mode: n_bridge
     - bridge_group: 3
-      ifindex: 7
+      ifindex: 6
       ifname: vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [s2,s1]
@@ -667,16 +633,6 @@ nodes:
         bridge_group: 1
         id: 1004
         mode: n_bridge
-        neighbors:
-        - ifname: vlan1004
-          ipv4: 172.16.4.2/24
-          node: s2
-        - ifname: vlan1004
-          ipv4: 172.16.4.1/24
-          node: s1
-        - ifname: vlan1004
-          ipv4: 172.16.4.3/24
-          node: s3
         prefix:
           allocation: id_based
           ipv4: 172.16.4.0/24
@@ -719,19 +675,8 @@ vlan:
   mode: g_irb
 vlans:
   black:
-    host_count: 0
     id: 1004
-    mode: vl_route
-    neighbors:
-    - ifname: vlan1004
-      ipv4: 172.16.4.2/24
-      node: s2
-    - ifname: vlan1004
-      ipv4: 172.16.4.1/24
-      node: s1
-    - ifname: vlan1004
-      ipv4: 172.16.4.3/24
-      node: s3
+    mode: route
     prefix:
       allocation: id_based
       ipv4: 172.16.4.0/24

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -30,6 +30,7 @@ links:
     node: s1
     vlan:
       trunk:
+        black: {}
         blue: {}
         green: {}
         red: {}
@@ -38,6 +39,7 @@ links:
     node: s2
     vlan:
       trunk:
+        black: {}
         blue: {}
         green: {}
         red: {}
@@ -47,6 +49,7 @@ links:
   type: p2p
   vlan:
     trunk:
+      black: {}
       blue: {}
       green: {}
       red: {}
@@ -72,6 +75,32 @@ links:
   vlan:
     trunk:
       orange: {}
+- interfaces:
+  - ifindex: 4
+    ifname: eth4
+    node: s1
+    vlan:
+      trunk:
+        black: {}
+        blue: {}
+        red: {}
+  - ifindex: 1
+    ifname: eth1
+    node: s3
+    vlan:
+      trunk:
+        black: {}
+        blue: {}
+        red: {}
+  linkindex: 4
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      black: {}
+      blue: {}
+      red: {}
 module:
 - vlan
 name: input
@@ -98,7 +127,7 @@ nodes:
       neighbors:
       - ifname: eth2
         node: s2
-      subif_index: 3
+      subif_index: 4
       type: p2p
     - ifindex: 3
       ifname: eth3
@@ -110,6 +139,24 @@ nodes:
       subif_index: 1
       type: p2p
     - ifindex: 4
+      ifname: eth4
+      linkindex: 4
+      name: s1 -> s3
+      neighbors:
+      - ifname: eth1
+        node: s3
+      subif_index: 3
+      type: p2p
+    - ifindex: 5
+      ifname: eth2.1004
+      parent_ifindex: 2
+      parent_ifname: eth2
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: black
+        access_id: 1004
+    - ifindex: 6
       ifname: eth2.1001
       parent_ifindex: 2
       parent_ifname: eth2
@@ -118,7 +165,7 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - ifindex: 5
+    - ifindex: 7
       ifname: eth2.1002
       parent_ifindex: 2
       parent_ifname: eth2
@@ -127,7 +174,7 @@ nodes:
       vlan:
         access: green
         access_id: 1002
-    - ifindex: 6
+    - ifindex: 8
       ifname: eth2.1000
       parent_ifindex: 2
       parent_ifname: eth2
@@ -136,7 +183,7 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - ifindex: 7
+    - ifindex: 9
       ifname: eth3.1003
       parent_ifindex: 3
       parent_ifname: eth3
@@ -145,34 +192,83 @@ nodes:
       vlan:
         access: orange
         access_id: 1003
+    - ifindex: 10
+      ifname: eth4.1004
+      parent_ifindex: 4
+      parent_ifname: eth4
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: black
+        access_id: 1004
+    - ifindex: 11
+      ifname: eth4.1001
+      parent_ifindex: 4
+      parent_ifname: eth4
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: blue
+        access_id: 1001
+    - ifindex: 12
+      ifname: eth4.1000
+      parent_ifindex: 4
+      parent_ifname: eth4
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 13
       ifname: vlan1000
       ipv4: 172.16.0.1/24
-      name: VLAN red (1000) -> [s2]
+      name: VLAN red (1000) -> [s2,s3]
       neighbors:
       - ifname: vlan1000
         ipv4: 172.16.0.2/24
         node: s2
+      - ifname: vlan1000
+        ipv4: 172.16.0.3/24
+        node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: vl_irb
     - bridge_group: 2
-      ifindex: 9
+      ifindex: 14
+      ifname: vlan1004
+      ipv4: 172.16.4.1/24
+      name: VLAN black (1004) -> [s2,s3]
+      neighbors:
+      - ifname: vlan1004
+        ipv4: 172.16.4.2/24
+        node: s2
+      - ifname: vlan1004
+        ipv4: 172.16.4.3/24
+        node: s3
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: vl_route
+    - bridge_group: 3
+      ifindex: 15
       ifname: vlan1001
       ipv4: 172.16.1.1/24
-      name: VLAN blue (1001) -> [s2]
+      name: VLAN blue (1001) -> [s2,s3]
       neighbors:
       - ifname: vlan1001
         ipv4: 172.16.1.2/24
         node: s2
+      - ifname: vlan1001
+        ipv4: 172.16.1.3/24
+        node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: g_irb
-    - bridge_group: 3
-      ifindex: 10
+    - bridge_group: 4
+      ifindex: 16
       ifname: vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [s2]
@@ -183,8 +279,8 @@ nodes:
       virtual_interface: true
       vlan:
         mode: vl_irb
-    - bridge_group: 4
-      ifindex: 11
+    - bridge_group: 5
+      ifindex: 17
       ifname: vlan1003
       ipv4: 172.16.3.1/24
       name: VLAN orange (1003) -> [s2]
@@ -206,24 +302,31 @@ nodes:
     - vlan
     name: s1
     vlan:
-      max_bridge_group: 4
+      max_bridge_group: 5
     vlans:
-      blue:
+      black:
         bridge_group: 2
+        id: 1004
+        mode: vl_route
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.4.0/24
+      blue:
+        bridge_group: 3
         id: 1001
         mode: g_irb
         prefix:
           allocation: id_based
           ipv4: 172.16.1.0/24
       green:
-        bridge_group: 3
+        bridge_group: 4
         id: 1002
         mode: vl_irb
         prefix:
           allocation: id_based
           ipv4: 172.16.2.0/24
       orange:
-        bridge_group: 4
+        bridge_group: 5
         id: 1003
         mode: g_irb
         prefix:
@@ -258,7 +361,7 @@ nodes:
       neighbors:
       - ifname: eth2
         node: s1
-      subif_index: 3
+      subif_index: 4
       type: p2p
     - ifindex: 3
       ifname: eth3
@@ -270,6 +373,15 @@ nodes:
       subif_index: 1
       type: p2p
     - ifindex: 4
+      ifname: eth2.1004
+      parent_ifindex: 2
+      parent_ifname: eth2
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: black
+        access_id: 1004
+    - ifindex: 5
       ifname: eth2.1001
       parent_ifindex: 2
       parent_ifname: eth2
@@ -278,7 +390,7 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - ifindex: 5
+    - ifindex: 6
       ifname: eth2.1002
       parent_ifindex: 2
       parent_ifname: eth2
@@ -287,7 +399,7 @@ nodes:
       vlan:
         access: green
         access_id: 1002
-    - ifindex: 6
+    - ifindex: 7
       ifname: eth2.1000
       parent_ifindex: 2
       parent_ifname: eth2
@@ -296,8 +408,8 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge_group: 4
-      ifindex: 7
+    - bridge_group: 5
+      ifindex: 8
       ifname: eth3.1003
       ipv4: 172.16.3.2/24
       name: s2 -> [s1]
@@ -313,33 +425,55 @@ nodes:
         access_id: 1003
         mode: route
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 9
       ifname: vlan1000
       ipv4: 172.16.0.2/24
-      name: VLAN red (1000) -> [s1]
+      name: VLAN red (1000) -> [s1,s3]
       neighbors:
       - ifname: vlan1000
         ipv4: 172.16.0.1/24
         node: s1
+      - ifname: vlan1000
+        ipv4: 172.16.0.3/24
+        node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: n_irb
     - bridge_group: 2
-      ifindex: 9
-      ifname: vlan1001
-      ipv4: 172.16.1.2/24
-      name: VLAN blue (1001) -> [s1]
+      ifindex: 10
+      ifname: vlan1004
+      ipv4: 172.16.4.2/24
+      name: VLAN black (1004) -> [s1,s3]
       neighbors:
-      - ifname: vlan1001
-        ipv4: 172.16.1.1/24
+      - ifname: vlan1004
+        ipv4: 172.16.4.1/24
         node: s1
+      - ifname: vlan1004
+        ipv4: 172.16.4.3/24
+        node: s3
       type: svi
       virtual_interface: true
       vlan:
         mode: n_irb
     - bridge_group: 3
-      ifindex: 10
+      ifindex: 11
+      ifname: vlan1001
+      ipv4: 172.16.1.2/24
+      name: VLAN blue (1001) -> [s1,s3]
+      neighbors:
+      - ifname: vlan1001
+        ipv4: 172.16.1.1/24
+        node: s1
+      - ifname: vlan1001
+        ipv4: 172.16.1.3/24
+        node: s3
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: n_irb
+    - bridge_group: 4
+      ifindex: 12
       ifname: vlan1002
       name: VLAN green (1002) -> [s1]
       neighbors:
@@ -360,11 +494,28 @@ nodes:
     - vlan
     name: s2
     vlan:
-      max_bridge_group: 4
+      max_bridge_group: 5
       mode: n_irb
     vlans:
-      blue:
+      black:
         bridge_group: 2
+        id: 1004
+        mode: n_irb
+        neighbors:
+        - ifname: vlan1004
+          ipv4: 172.16.4.2/24
+          node: s2
+        - ifname: vlan1004
+          ipv4: 172.16.4.1/24
+          node: s1
+        - ifname: vlan1004
+          ipv4: 172.16.4.3/24
+          node: s3
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.4.0/24
+      blue:
+        bridge_group: 3
         id: 1001
         mode: n_irb
         neighbors:
@@ -374,18 +525,21 @@ nodes:
         - ifname: vlan1001
           ipv4: 172.16.1.1/24
           node: s1
+        - ifname: vlan1001
+          ipv4: 172.16.1.3/24
+          node: s3
         prefix:
           allocation: id_based
           ipv4: 172.16.1.0/24
       green:
-        bridge_group: 3
+        bridge_group: 4
         id: 1002
         mode: bridge
         prefix:
           allocation: id_based
           ipv4: 172.16.2.0/24
       orange:
-        bridge_group: 4
+        bridge_group: 5
         id: 1003
         mode: n_irb
         neighbors:
@@ -405,10 +559,182 @@ nodes:
         prefix:
           allocation: id_based
           ipv4: 172.16.0.0/24
+  s3:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: frr
+    id: 3
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      linkindex: 4
+      name: s3 -> s1
+      neighbors:
+      - ifname: eth4
+        node: s1
+      subif_index: 3
+      type: p2p
+    - ifindex: 2
+      ifname: eth1.1004
+      parent_ifindex: 1
+      parent_ifname: eth1
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: black
+        access_id: 1004
+    - ifindex: 3
+      ifname: eth1.1001
+      parent_ifindex: 1
+      parent_ifname: eth1
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: blue
+        access_id: 1001
+    - ifindex: 4
+      ifname: eth1.1000
+      parent_ifindex: 1
+      parent_ifname: eth1
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1004
+      ipv4: 172.16.4.3/24
+      name: VLAN black (1004) -> [s2,s1]
+      neighbors:
+      - ifname: vlan1004
+        ipv4: 172.16.4.2/24
+        node: s2
+      - ifname: vlan1004
+        ipv4: 172.16.4.1/24
+        node: s1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: n_bridge
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      ipv4: 172.16.1.3/24
+      name: VLAN blue (1001) -> [s2,s1]
+      neighbors:
+      - ifname: vlan1001
+        ipv4: 172.16.1.2/24
+        node: s2
+      - ifname: vlan1001
+        ipv4: 172.16.1.1/24
+        node: s1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: n_bridge
+    - bridge_group: 3
+      ifindex: 7
+      ifname: vlan1000
+      ipv4: 172.16.0.3/24
+      name: VLAN red (1000) -> [s2,s1]
+      neighbors:
+      - ifname: vlan1000
+        ipv4: 172.16.0.2/24
+        node: s2
+      - ifname: vlan1000
+        ipv4: 172.16.0.1/24
+        node: s1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: n_bridge
+    loopback:
+      ipv4: 10.0.0.3/32
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    module:
+    - vlan
+    name: s3
+    vlan:
+      max_bridge_group: 3
+      mode: n_bridge
+    vlans:
+      black:
+        bridge_group: 1
+        id: 1004
+        mode: n_bridge
+        neighbors:
+        - ifname: vlan1004
+          ipv4: 172.16.4.2/24
+          node: s2
+        - ifname: vlan1004
+          ipv4: 172.16.4.1/24
+          node: s1
+        - ifname: vlan1004
+          ipv4: 172.16.4.3/24
+          node: s3
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.4.0/24
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: n_bridge
+        neighbors:
+        - ifname: vlan1001
+          ipv4: 172.16.1.2/24
+          node: s2
+        - ifname: vlan1001
+          ipv4: 172.16.1.1/24
+          node: s1
+        - ifname: vlan1001
+          ipv4: 172.16.1.3/24
+          node: s3
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 3
+        id: 1000
+        mode: n_bridge
+        neighbors:
+        - ifname: vlan1000
+          ipv4: 172.16.0.2/24
+          node: s2
+        - ifname: vlan1000
+          ipv4: 172.16.0.1/24
+          node: s1
+        - ifname: vlan1000
+          ipv4: 172.16.0.3/24
+          node: s3
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
 provider: libvirt
 vlan:
   mode: g_irb
 vlans:
+  black:
+    host_count: 0
+    id: 1004
+    mode: vl_route
+    neighbors:
+    - ifname: vlan1004
+      ipv4: 172.16.4.2/24
+      node: s2
+    - ifname: vlan1004
+      ipv4: 172.16.4.1/24
+      node: s1
+    - ifname: vlan1004
+      ipv4: 172.16.4.3/24
+      node: s3
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.4.0/24
   blue:
     host_count: 0
     id: 1001
@@ -419,6 +745,9 @@ vlans:
     - ifname: vlan1001
       ipv4: 172.16.1.1/24
       node: s1
+    - ifname: vlan1001
+      ipv4: 172.16.1.3/24
+      node: s3
     prefix:
       allocation: id_based
       ipv4: 172.16.1.0/24
@@ -459,6 +788,9 @@ vlans:
     - ifname: vlan1000
       ipv4: 172.16.0.1/24
       node: s1
+    - ifname: vlan1000
+      ipv4: 172.16.0.3/24
+      node: s3
     prefix:
       allocation: id_based
       ipv4: 172.16.0.0/24

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -47,15 +47,13 @@ links:
     ipv4: 172.16.1.0/24
   type: lan
   vrf: blue
-- interfaces:
+- bridge: input_3
+  interfaces:
   - ifindex: 2
     ifname: eth2
-    ipv4: true
-    ipv6: true
     node: s2
     vlan:
       access: green
-      mode: route
   - ifindex: 1
     ifname: eth1
     ipv4: true
@@ -65,11 +63,10 @@ links:
   node_count: 2
   pool: unnumbered
   prefix:
+    allocation: id_based
     ipv4: true
     ipv6: true
-  type: p2p
-  vlan:
-    mode: route
+  type: lan
   vrf: green
 - interfaces:
   - ifindex: 2
@@ -258,21 +255,30 @@ nodes:
     hostname: clab-input-h3
     id: 7
     interfaces:
-    - ifindex: 1
+    - bridge: input_3
+      ifindex: 1
       ifname: eth1
       ipv4: true
       ipv6: true
       linkindex: 3
       mtu: 1500
-      name: h3 -> s2
+      name: h3 -> [r1,r2,s2,s1]
       neighbors:
-      - ifname: eth2
+      - ifname: eth1.1002
         ipv4: true
         ipv6: true
+        node: r1
+      - ifname: eth1.1002
+        ipv4: true
+        ipv6: true
+        node: r2
+      - ifname: vlan1002
         node: s2
         vrf: green
+      - ifname: Vlan1002
+        node: s1
       pool: unnumbered
-      type: p2p
+      type: lan
     loopback:
       ipv4: 10.0.0.7/32
     mgmt:
@@ -342,13 +348,21 @@ nodes:
       ifname: eth1.1002
       ipv4: true
       ipv6: true
-      name: r1 -> [s2,s1]
+      name: r1 -> [r2,s2,s1,h3]
       neighbors:
+      - ifname: eth1.1002
+        ipv4: true
+        ipv6: true
+        node: r2
       - ifname: vlan1002
         node: s2
         vrf: green
       - ifname: Vlan1002
         node: s1
+      - ifname: eth1
+        ipv4: true
+        ipv6: true
+        node: h3
       parent_ifindex: 1
       parent_ifname: eth1
       pool: unnumbered
@@ -516,11 +530,21 @@ nodes:
       ifname: eth1.1002
       ipv4: true
       ipv6: true
-      name: r2 -> s2
+      name: r2 -> [r1,s2,s1,h3]
       neighbors:
-      - ifname: eth4.1002
+      - ifname: eth1.1002
+        ipv4: true
+        ipv6: true
+        node: r1
+      - ifname: vlan1002
         node: s2
         vrf: green
+      - ifname: Vlan1002
+        node: s1
+      - ifname: eth1
+        ipv4: true
+        ipv6: true
+        node: h3
       parent_ifindex: 1
       parent_ifname: eth1
       pool: unnumbered
@@ -529,7 +553,6 @@ nodes:
       vlan:
         access_id: 1002
         mode: route
-        routed_link: true
       vrf: green
     - bridge_group: 3
       ifindex: 4
@@ -741,15 +764,23 @@ nodes:
     - bridge_group: 3
       ifindex: 12
       ifname: Vlan1002
-      name: VLAN green (1002) -> [r1,s2]
+      name: VLAN green (1002) -> [r1,r2,s2,h3]
       neighbors:
       - ifname: eth1.1002
         ipv4: true
         ipv6: true
         node: r1
+      - ifname: eth1.1002
+        ipv4: true
+        ipv6: true
+        node: r2
       - ifname: vlan1002
         node: s2
         vrf: green
+      - ifname: eth1
+        ipv4: true
+        ipv6: true
+        node: h3
       pool: unnumbered
       type: svi
       virtual_interface: true
@@ -861,9 +892,6 @@ nodes:
   s2:
     af:
       ipv4: true
-      ipv6: true
-      vpnv4: true
-      vpnv6: true
     box: quay.io/frrouting/frr:9.0.1
     clab:
       binds:
@@ -884,25 +912,15 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - _vlan_mode: route
-      bridge_group: 2
+    - bridge: input_3
       ifindex: 2
       ifname: eth2
-      ipv4: true
-      ipv6: true
       linkindex: 3
       mtu: 1500
-      name: s2 -> h3
-      neighbors:
-      - ifname: eth1
-        ipv4: true
-        ipv6: true
-        node: h3
-      pool: unnumbered
-      type: p2p
+      type: lan
       vlan:
-        mode: route
-      vrf: green
+        access: green
+        access_id: 1002
     - ifindex: 3
       ifname: eth3
       linkindex: 4
@@ -959,26 +977,15 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - bridge_group: 2
-      ifindex: 9
+    - ifindex: 9
       ifname: eth4.1002
-      name: s2 -> r2
-      neighbors:
-      - ifname: eth1.1002
-        ipv4: true
-        ipv6: true
-        node: r2
-        vrf: green
       parent_ifindex: 4
       parent_ifname: eth4
-      pool: unnumbered
       type: vlan_member
       virtual_interface: true
       vlan:
+        access: green
         access_id: 1002
-        mode: route
-        routed_link: true
-      vrf: green
     - ifindex: 10
       ifname: eth4.1000
       parent_ifindex: 4
@@ -1013,14 +1020,22 @@ nodes:
     - bridge_group: 2
       ifindex: 12
       ifname: vlan1002
-      name: VLAN green (1002) -> [r1,s1]
+      name: VLAN green (1002) -> [r1,r2,s1,h3]
       neighbors:
       - ifname: eth1.1002
         ipv4: true
         ipv6: true
         node: r1
+      - ifname: eth1.1002
+        ipv4: true
+        ipv6: true
+        node: r2
       - ifname: Vlan1002
         node: s1
+      - ifname: eth1
+        ipv4: true
+        ipv6: true
+        node: h3
       pool: unnumbered
       type: svi
       virtual_interface: true
@@ -1097,11 +1112,19 @@ nodes:
           ipv4: true
           ipv6: true
           node: r1
+        - ifname: eth1.1002
+          ipv4: true
+          ipv6: true
+          node: r2
         - ifname: vlan1002
           node: s2
           vrf: green
         - ifname: Vlan1002
           node: s1
+        - ifname: eth1
+          ipv4: true
+          ipv6: true
+          node: h3
         pool: unnumbered
         prefix:
           allocation: id_based
@@ -1144,9 +1167,6 @@ nodes:
         rd: '65000:2'
         vrfidx: 101
       green:
-        af:
-          ipv4: true
-          ipv6: true
         export:
         - '65000:3'
         id: 3
@@ -1196,11 +1216,19 @@ vlans:
       ipv4: true
       ipv6: true
       node: r1
+    - ifname: eth1.1002
+      ipv4: true
+      ipv6: true
+      node: r2
     - ifname: vlan1002
       node: s2
       vrf: green
     - ifname: Vlan1002
       node: s1
+    - ifname: eth1
+      ipv4: true
+      ipv6: true
+      node: h3
     pool: unnumbered
     prefix:
       allocation: id_based

--- a/tests/topology/input/vlan-mode-priority.yml
+++ b/tests/topology/input/vlan-mode-priority.yml
@@ -5,13 +5,13 @@
 
 # First, extend the attribute values
 defaults.attributes.vlan:
-  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb, n_bridge ]
+  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb ]
 
 defaults.vlan.attributes:
   global.mode.valid_values: [ bridge, irb, route, g_irb, vl_irb ]
   node.mode:
     type: str
-    valid_values: [ bridge, irb, route, n_irb, n_bridge ]
+    valid_values: [ bridge, irb, route, n_irb ]
 
 defaults.device: frr
 module: [ vlan ]
@@ -36,7 +36,7 @@ nodes:
         mode: bridge      # VLAN-specific mode must take precedence over anything else
       red:                # Let's see what happens if we have node VLAN without the "mode" attribute
   s3:
-    vlan.mode: n_bridge   # Node overriding global and per-vlan mode setting
+    vlan.mode: bridge   # Node overriding global and per-vlan mode setting
 
 links:
 - s1:

--- a/tests/topology/input/vlan-mode-priority.yml
+++ b/tests/topology/input/vlan-mode-priority.yml
@@ -5,13 +5,13 @@
 
 # First, extend the attribute values
 defaults.attributes.vlan:
-  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb ]
+  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb, n_bridge, vl_route ]
 
 defaults.vlan.attributes:
   global.mode.valid_values: [ bridge, irb, route, g_irb, vl_irb ]
   node.mode:
     type: str
-    valid_values: [ bridge, irb, route, n_irb ]
+    valid_values: [ bridge, irb, route, n_irb, n_bridge ]
 
 defaults.device: frr
 module: [ vlan ]
@@ -24,6 +24,8 @@ vlans:
   green:
     mode: vl_irb          # Another VLAN with explicit mode
   orange:                 # Used to test interface-specific override
+  black:
+    mode: vl_route        # Used to test a node level override to bridge in a trunk
 
 nodes:
   s1:
@@ -33,6 +35,8 @@ nodes:
       green:
         mode: bridge      # VLAN-specific mode must take precedence over anything else
       red:                # Let's see what happens if we have node VLAN without the "mode" attribute
+  s3:
+    vlan.mode: n_bridge   # Node overriding global and per-vlan mode setting
 
 links:
 - s1:
@@ -44,6 +48,7 @@ links:
     red:
     blue:
     green:
+    black:
 - s1:
   s2:
     vlan.trunk:
@@ -51,3 +56,6 @@ links:
         vlan.mode: route
   vlan.trunk:
     orange:
+- s1:
+  s3:
+  vlan.trunk: [ red, blue, black ]

--- a/tests/topology/input/vlan-mode-priority.yml
+++ b/tests/topology/input/vlan-mode-priority.yml
@@ -5,7 +5,7 @@
 
 # First, extend the attribute values
 defaults.attributes.vlan:
-  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb, n_bridge, vl_route ]
+  mode.valid_values: [ bridge, irb, route, g_irb, vl_irb, n_irb, n_bridge ]
 
 defaults.vlan.attributes:
   global.mode.valid_values: [ bridge, irb, route, g_irb, vl_irb ]
@@ -25,7 +25,7 @@ vlans:
     mode: vl_irb          # Another VLAN with explicit mode
   orange:                 # Used to test interface-specific override
   black:
-    mode: vl_route        # Used to test a node level override to bridge in a trunk
+    mode: route           # Used to test a node level override to bridge in a trunk
 
 nodes:
   s1:


### PR DESCRIPTION
See https://github.com/ipspace/netlab/issues/881

Bug is triggered by `mode: route`, using `mode: vl_route` does not trigger the logic that generates the routed subinterface

Note: One could argue that `neighbors` should not contain an IP for s3:
```
vlans:
      black:
        bridge_group: 2
        id: 1004
        mode: n_irb
        neighbors:
        - ifname: vlan1004
          ipv4: 172.16.4.2/24
          node: s2
        - ifname: vlan1004
          ipv4: 172.16.4.1/24
          node: s1
        - ifname: vlan1004
          ipv4: 172.16.4.3/24  <-- not allocated on s3 due to 'bridge' mode
          node: s3
        prefix:
          allocation: id_based
          ipv4: 172.16.4.0/24
```