### PR TITLE
Add ebgp.multihop support for SR Linux and SR OS

### DIFF
--- a/docs/plugins/ebgp.multihop.md
+++ b/docs/plugins/ebgp.multihop.md
@@ -14,6 +14,8 @@ The plugin includes Jinja2 templates for the following platforms:
 | Cisco IOSv / IOS-XE |  ✅  |  ❌   |
 | Cumulus Linux       |  ✅  |  ❌   |
 | FRR                 |  ✅  |  ❌   |
+| Nokia SR Linux      |  ✅  |  ✅   |
+| Nokia SR OS         |  ✅  |  ✅   |
 
 ## Specifying Multihop EBGP Sessions
 

--- a/netsim/ansible/templates/initial/sros.openconfig.j2
+++ b/netsim/ansible/templates/initial/sros.openconfig.j2
@@ -72,7 +72,7 @@ updates:
 {% endif %}
 - path: configure/port[port-id={{l.ifname}}]
   val: { connector: { "breakout": "c1-100g" } }
-{{ interface(ifname,"ethernetCsmacd",desc,v4,v6) }}
+{{ interface(ifname,"ethernetCsmacd",desc|default("?"),v4,v6) }}
 
 {# Add interface to the Base routing instance (default VRF) #}
 - path: openconfig-network-instance:network-instances/network-instance[name=Base]

--- a/netsim/extra/ebgp.multihop/srlinux.j2
+++ b/netsim/extra/ebgp.multihop/srlinux.j2
@@ -1,0 +1,29 @@
+{% macro ebgp_session(n,af,vrf) -%}
+{%   if n.multihop is defined %}
+- path: network-instance[name={{vrf}}]/protocols/bgp
+  val:
+   neighbor:
+   - peer-address: {{ n[af]|ipaddr('address') }}
+     multihop:
+      admin-state: enable
+      maximum-hops: {{ n.multihop|int }}
+     local-address: "{{ loopback[af]|ipaddr('address') }}"
+     description: "{{ n.name }} (multihop={{n.multihop|int}})"
+{%   endif %}
+{%- endmacro %}
+
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined %}
+{{     ebgp_session(n,af,'default') -}}
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%     for af in ['ipv4','ipv6'] %}
+{%       for n in bgp.neighbors if n[af] is defined %}
+{{         ebgp_session(n,af,vname) -}}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}

--- a/netsim/extra/ebgp.multihop/sros.j2
+++ b/netsim/extra/ebgp.multihop/sros.j2
@@ -1,0 +1,28 @@
+{% macro ebgp_session(n,af,vrf) -%}
+{%   if n.multihop is defined %}
+{% set path = "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" %}
+- path: configure/{{ path }}/bgp
+  val:
+   neighbor:
+   - ip-address: {{ n[af]|ipaddr('address') }}
+     multihop: {{ n.multihop|int }}
+     local-address: "{{ loopback[af.replace('vpn','ip')]|ipaddr('address') }}"
+     description: "{{ n.name }} (multihop={{n.multihop|int}})"
+{%   endif %}
+{%- endmacro %}
+
+{% for af in ['ipv4','ipv6','vpnv4','vpnv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined %}
+{{     ebgp_session(n,af,None) -}}
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%     for af in ['ipv4','ipv6','vpnv4','vpnv6'] %}
+{%       for n in bgp.neighbors if n[af] is defined %}
+{{         ebgp_session(n,af,vname) -}}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
* Docs says VRFs not supported, but templates do include support?
* No support yet for address family activation like the EVPN example
* Templates assume multihop is an integer between 1 and 255