### PR TITLE
BGP policy support for SR Linux supporting MED and local-pref

### DIFF
--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -145,7 +145,7 @@ def build_module_support_lists(topology: Box) -> None:
       if not 'supported_on' in mdata:                       # Create 'supported_on' list if needed
         mdata.supported_on = []
 
-      if ddata.feature[m] is False and dname in mdata.supported_on:       
+      if ddata.features[m] is False and dname in mdata.supported_on:
         mdata.supported_on.remove(dname)                    # The device DOES NOT support the module
         ddata.features.pop(m)                               # Remove the feature so it won't crash the transformation
         continue

--- a/netsim/extra/bgp.policy/defaults.yml
+++ b/netsim/extra/bgp.policy/defaults.yml
@@ -30,6 +30,10 @@ devices:
     locpref: True
     med: True
     weight: True
+  srlinux.features.bgp:
+    locpref: True
+    med: True
+    weight: False
 
 bgp:
   attributes:

--- a/netsim/extra/bgp.policy/plugin.py
+++ b/netsim/extra/bgp.policy/plugin.py
@@ -1,8 +1,7 @@
 import typing
 from box import Box
-from netsim.utils import log,bgp as _bgp
+from netsim.utils import bgp as _bgp
 from netsim import api,data
-from netsim.augment import devices
 
 _config_name = 'bgp.policy'
 
@@ -77,14 +76,14 @@ def post_transform(topology: Box) -> None:
   _attr_list = _direct + list(_compound.keys())
 
   for n, ndata in topology.nodes.items():
-    if not 'bgp' in ndata.module:                           # Skip nodes not running BGP
+    if 'bgp' not in ndata.module:                           # Skip nodes not running BGP
       continue
 
     _bgp.cleanup_neighbor_attributes(ndata,topology,_attr_list)
     policy_idx = 0
 
     # Get _default_locpref feature flag (could be None), then figure out if we need to copy
-    # node-level locpref to all EBGP neighbors. That thest is a bit convolutaed to make
+    # node-level locpref to all EBGP neighbors. That test is a bit convolutaed to make
     # sure we don't get tripped up by None values
     #
     default_locpref = _bgp.get_device_bgp_feature('_default_locpref',ndata,topology)

--- a/netsim/extra/bgp.policy/srlinux.j2
+++ b/netsim/extra/bgp.policy/srlinux.j2
@@ -1,0 +1,51 @@
+{% macro ebgp_neighbor(n,af,vrf) -%}
+- path: network-instance[name={{vrf}}]/protocols/bgp
+  val:
+{% if n.type=='ebgp' and af=='ipv6' and n.ipv6|default(0) == True %}
+   group: {# Note: This doesn't allow for different policies per individual neighbor #}
+   - group-name: "ebgp-unnumbered{{ ('-' + n.local_as|string()) if n.local_as is defined else '' }}"
+{% else %}
+   neighbor:
+   - peer-address: {{ n[af]|ipaddr('address') }}
+{% endif %}
+{% for direction in [ 'in','out' ] if direction in n.policy %}
+     {{ 'import' if direction=='in' else 'export' }}-policy: bp-{{ n._policy_name }}-{{ direction }}
+{% endfor %}
+
+{% for direction in [ 'in','out' ] if direction in n.policy %}
+- path: routing-policy/policy[name=bp-{{ n._policy_name }}-{{ direction }}]
+  val:
+{%  for entry in n.policy[direction] %}
+{%   if loop.first %}
+   default-action:
+    policy-result: "accept"
+    bgp:
+{%    if 'locpref' in entry.set %}
+     local-preference:
+      set: {{ entry.set.locpref }}
+{%    endif %}
+{%    if 'med' in entry.set %}
+     med:
+      set: {{ entry.set.med }}
+{%    endif %}
+{%   endif %}
+{%  endfor %}
+{% endfor %}
+{%- endmacro %}
+
+updates:
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined and 'policy' in n %}
+{{     ebgp_neighbor(n,af,'default') -}}
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%     for af in ['ipv4','ipv6'] %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined and 'policy' in n %}
+{{         ebgp_neighbor(n,af,vname) -}}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}

--- a/netsim/extra/ebgp.multihop/srlinux.j2
+++ b/netsim/extra/ebgp.multihop/srlinux.j2
@@ -21,7 +21,7 @@
 {% if vrfs is defined %}
 {%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
 {%     for af in ['ipv4','ipv6'] %}
-{%       for n in bgp.neighbors if n[af] is defined %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined %}
 {{         ebgp_session(n,af,vname) -}}
 {%       endfor %}
 {%     endfor %}


### PR DESCRIPTION
Creates a single default policy per neighbor to set either MED or local-preference

- unnumbered BGP peers are treated as a group -> all get the same MED or local-pref (sorry)