### PR TITLE
Extend BGP session support for SR Linux

### DIFF
--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -59,7 +59,7 @@ The plugin implements generic BGP session features for the following platforms:
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |
 | Mikrotik RouterOS 7 |  ✅  |   ❌  |   ❌  |   ❌  |
-| Nokia SR Linux      |  ✅  |   ❌  |   ❌  |   ❌  |
+| Nokia SR Linux      |  ✅  |   ✅  |   ✅  |   ✅  |
 | Nokia SR OS         |  ✅  |   ❌  |   ❌  |   ❌  |
 | VyOS                |  ✅  |   ❌  |   ❌  |   ❌  |
 
@@ -96,7 +96,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | FRR                 |  ✅  |  ✅  |  ✅  |
 | Juniper vMX/vPTX/vSRX | ❌  |  ✅  |   ❌  |
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |
-| Nokia SR Linux      |  ✅  |  ✅  |   ❌  |
+| Nokia SR Linux      |  ✅  |  ✅  |   ✅  |
 | Nokia SR OS         |  ✅  |  ✅  |   ❌  |
 | VyOS                |  ✅  |  ✅  |   ❌  |
 
@@ -162,6 +162,7 @@ The implementations of **neighbor remove-private-as** command vary widely across
 | Cisco IOS-XE        |  ✅  |  ❗  |  ❗  |   ❌  |   ❌  |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
+| Nokia SR Linux      |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
 
 **Notes:**
 
@@ -176,7 +177,7 @@ The following test topology illustrates a subset of plugin capabilities. You mig
 defaults:
   device: eos
 
-module: [ bgp, vrf ]
+module: [ bgp, vrf, bfd ]
 plugin: [ bgp.session ]
 
 vrfs:
@@ -186,6 +187,8 @@ vrfs:
 bgp.timers:
   hold: 10
   keepalive: 3
+
+bgp.bfd: True
 
 nodes:
   y1:

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -73,7 +73,11 @@ devices:
     allowas_in: True
     as_override: True
     password: True
-    tcp_ao: True
+    tcp_ao: False
+    timers: True
+    remove_private_as: True
+    bfd: True
+    passive: True
   sros.features.bgp:
     default_originate: True
     allowas_in: True

--- a/netsim/extra/bgp.session/srlinux.j2
+++ b/netsim/extra/bgp.session/srlinux.j2
@@ -14,12 +14,35 @@
       ipv4-unicast: {{ activate.ipv4|default(False) }}
       ipv6-unicast: {{ activate.ipv6|default(False) }}
 {% endif %}
+{% if n.timers is defined %}
+     timers:
+      keepalive-interval: {{ n.timers.keepalive|default(60) }}
+      hold-time: {{ n.timers.hold|default(180) }}
+{% endif %}
+{% if n.bfd|default(False) %}
+     failure-detection:
+      enable-bfd: True
+{% endif %}
+{% if n.passive|default(False) %}
+     transport:
+      passive-mode: True
+{% endif %}
      as-path-options:
-{%   if n.allowas_in is defined %}
+{% if n.allowas_in is defined %}
       allow-own-as: {{ n.allowas_in|int }}
-{%   endif %}
+{% endif %}
       replace-peer-as: {{ True if n.as_override|default(False) else False }}
-{%   if n.password is defined and (n.type!='ebgp' or n.ipv6|default('') is string) %}
+{% if n.remove_private_as|default([]) %}
+{%  if 'replace' in n.remove_private_as %}
+      remove-private-as:
+       mode: replace
+{%  elif 'on' in n.remove_private_as or 'all' in n.remove_private_as %}
+      remove-private-as:
+       mode: delete
+       leading-only: {{ 'all' not in n.remove_private_as }}
+{%  endif %}
+{% endif %}
+{% if n.password is defined and (n.type!='ebgp' or n.ipv6|default('') is string) %}
      authentication:
       keychain: "peer-{{n.name}}"
 


### PR DESCRIPTION
* BGP timers
* BFD
* remove_private_as ('on', 'all' or 'replace')
* passive

Note: `replace` implies `all` for consistency with other devices, could distinguish `remove_private_as: [ replace, all ]`