### PR TITLE
Fix SROS OSPF Stub interface naming

### DIFF
--- a/netsim/ansible/templates/ospf/sros.j2
+++ b/netsim/ansible/templates/ospf/sros.j2
@@ -14,7 +14,11 @@
    area:
    - area-id: "{{ l.ospf.area }}"
      interface:
-     - interface-name: "{{ if_name(l.ifname) }}"
+{%  if l.type|default("") == "stub" %}
+     - interface-name: "{{ if_name("stub-"+l.ifname) }}"
+{%  else %}
+     - interface-name: "{{ if_name(l.ifname) }}" 
+{%  endif %}
 {%  if l.ospf.passive|default(False) %}
        passive: True
 {%  endif %}


### PR DESCRIPTION
Reuse the interface naming logic of the inital config in SROS OSPF module. This results in consistent interface naming for stub interfaces
Fix the OSPF config deployment as described in #942 

Is this the intended way to fix this @jbemmel ?