### PR TITLE
Add SROS to OSPF module testing suite

### DIFF
--- a/tests/module/ospf-feature-test.yml
+++ b/tests/module/ospf-feature-test.yml
@@ -43,6 +43,9 @@ links:
   j_vsrx:
     ospf:
       cost: 40
+  n_sros:
+    ospf:
+      cost: 50
   ospf:
     area: 0.0.0.1
 
@@ -51,6 +54,7 @@ links:
 - c_csr:
 - a_eos:
 - j_vsrx:
+- n_sros:
 
 # Stub link (by role) - should be passive
 # Testing OSPF cost specified on the link
@@ -61,6 +65,7 @@ links:
   c_csr:
   a_eos:
   j_vsrx:
+  n_sros:
 
 # External link - should no be in OSPF process
 - role: external
@@ -68,6 +73,7 @@ links:
   c_csr:
   a_eos:
   j_vsrx:
+  n_sros:
 
 # P2P links - test unnumbered interfaces
 # NX-OS has a different default area, the area number has to be specified on the link
@@ -90,3 +96,4 @@ links:
 - a_eos-j_vsrx
 - a_eos-c_csr
 - c_csr-j_vsrx
+- n_sros-c_csr


### PR DESCRIPTION
Nokia SR-OS was not actually connected to the OSPF topology, it had no links configured.