### PR TITLE
Move Nokia SROS interface naming logic to initial.j2 if_name macro

### DIFF
--- a/netsim/ansible/templates/initial/sros.j2
+++ b/netsim/ansible/templates/initial/sros.j2
@@ -1,5 +1,6 @@
-{% macro if_name(n) -%}
-{{- (('oc_%s/1_0' if sros_use_openconfig|default(true) else 'i%s' if n[0].isdigit() else '%s')|format(n)).replace(':','_') -}}
+{% macro if_name(i, name) -%}
+{% set _pre = "stub-" if i.type|default()=='stub' else 'i' if name[0].isdigit() else "" %}
+{{- (('oc_%s%s/1_0' if sros_use_openconfig|default(true) else '%s%s')|format(_pre,name)).replace(':','_') -}}
 {%- endmacro %}
 
 {% macro declare_router(i,sub_path="") -%}
@@ -21,7 +22,7 @@
 {%- endmacro %}
 
 {% macro declare_interface(i,name=None) %}
-{% set ifname = if_name(name or i.ifname) %}
+{% set ifname = if_name(i,name or i.ifname) %}
 {{ declare_router(i,sub_path="/interface[interface-name=" + ifname + "]") }}
 {% endmacro %}
 
@@ -123,7 +124,7 @@
 {%  if l.type not in ['loopback','stub','svi'] %}
 {{ interface(l.ifname,desc,v4,v6,portname,l,vlan=vlan) }}
 {%  else %}
-{{ interface("stub-"+l.ifname if l.type=='stub' else l.ifname,desc,v4,v6,None,l) }}
+{{ interface(l.ifname,desc,v4,v6,None,l) }}
 {%  endif %}
 {% endif %}
 {%- endmacro -%}

--- a/netsim/ansible/templates/ospf/sros.j2
+++ b/netsim/ansible/templates/ospf/sros.j2
@@ -14,7 +14,7 @@
    area:
    - area-id: "{{ l.ospf.area }}"
      interface:
-     - interface-name: "{{ if_name(l.ifname) }}"
+     - interface-name: "{{ if_name(l,l.ifname) }}"
 {%  if l.ospf.passive|default(False) %}
        passive: True
 {%  endif %}


### PR DESCRIPTION
Alternative fix for #942 . Moved the naming logic of SROS interfaces to the macro in intial.j2