### PR TITLE
AOS-CX: Support for L3VNI (and release 10.13)

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -200,4 +200,6 @@ vSRX container built with *vrnetlab* uses **flow based forwarding**. You have tw
 ### VXLAN and EVPN Caveats
 
 * The VXLAN dataplane (at least, on the virtual version) seems not supporting VNI greater than 65535. If you set an higher value, an overflow will occur, and you may have overlapping VNIs. The workaround for this is to set, i.e., `defaults.vxlan.start_vni: 20000` (especially on multi-vendor topologies).
-* On the Aruba AOS-CX Virtual version *10.11.0001*, EVPN Symmetric IRB seems not supported.
+* EVPN Symmetric IRB is supported only from the Aruba AOS-CX Virtual version *10.13*. Additionally:
+  * CPU generated traffic does not get encapsulated in Symmetric IRB on AOS-CX Simulator.
+  * Active-Gateway MAC Addresses shall be the same across all VTEPs in AOS-CX Simulator.

--- a/docs/labs/arubacx.md
+++ b/docs/labs/arubacx.md
@@ -4,7 +4,7 @@ Aruba AOS-CX 10 is supported by the **netlab libvirt package** command. To build
 
 * Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
 * Download the `Aruba_AOS-CX_Switch_Simulator` (*see below*) OVA image into that directory, and uncompress it (and the OVA file - which is a tarball)
-* Convert the vmdk image to the *qcow2* format (`qemu-img convert -f vmdk -O qcow2 arubaoscx-disk-image-genericx86-p4-20221130174651.vmdk arubacx-10.11.qcow2`)
+* Convert the vmdk image to the *qcow2* format (`qemu-img convert -f vmdk -O qcow2 arubaoscx-disk-image-genericx86-p4-20231110145644.vmdk arubacx-10.13.qcow2`)
 * Execute **netlab libvirt package arubacx _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
@@ -14,7 +14,7 @@ Aruba AOS-CX 10 is supported by the **netlab libvirt package** command. To build
 
 ## Aruba AOS-CX download notes
 
-The *Aruba AOS-CX 10 Switch Simulator* image can be download from the *Aruba Support Portal* (after user registration), searching for: `Aruba_AOS-CX_Switch_Simulator`. In example, release 10.12 can be downloaded from [here](https://asp.arubanetworks.com/downloads/software/RmlsZTpkOGRiYjc2Ni0wMTdkLTExZWUtYTY3Yi00Zjg4YjUyOWExMzQ%3D).
+The *Aruba AOS-CX 10 Switch Simulator* image can be download from the *Aruba Support Portal* (after user registration), searching for: `Aruba_AOS-CX_Switch_Simulator`. In example, release **10.13** can be downloaded from [here](https://asp.arubanetworks.com/downloads/software/RmlsZTowOTRjZDU3ZS04Y2VkLTExZWUtOGRiNy0yMzkyMDY4ZjdmZmU%3D).
 
 ## Initial Device Configuration
 

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -23,7 +23,7 @@ The following table describes per-platform support of individual EVPN/VXLAN feat
 | Operating system   | VLAN-based<br>service | VLAN Bundle<br>service | Asymmetric<br>IRB | Symmetric<br>IRB |
 | ------------------ | :-: | :-: | :-: | :-: |
 | Arista EOS         | ✅  | ✅  | ✅  | ✅  |
-| Aruba AOS-CX       | ✅  |  ❌  |  ✅  | ❌[❗](caveats-aruba)  |
+| Aruba AOS-CX       | ✅  |  ❌  |  ✅  | ✅[❗](caveats-aruba)  |
 | Cisco Nexus OS     | ✅  |  ❌  |  ❌  | ✅  |
 | Cumulus Linux      | ✅  |  ❌  | ✅  | ✅  |
 | Dell OS 10         | ✅  |  ❌  |  ✅  | ✅  |

--- a/netsim/ansible/templates/evpn/arubacx.j2
+++ b/netsim/ansible/templates/evpn/arubacx.j2
@@ -26,7 +26,29 @@ evpn
 {%     if import_target == export_target %}
   route-target both {{ v.evpn.export|join(' ') }}
 {%     endif %}
+{# if symmetric irb, we want to redistribute host routes as well (redistribute host-route) #}
+{%     if v.evpn is defined and v.vrf is defined %}
+{%       if vrfs[v.vrf].evpn.transit_vni is defined %}
+  redistribute host-route
+{%       endif %}
+{%     endif %}
 
 {%   endfor %}
 {% endif %}
 
+{# L3VNI is defined on vxlan interface, even if it's only an EVPN stuff #}
+{% if vrfs is defined %}
+{# define evpn rt #}
+{%   for n,v in vrfs.items() if v.af is defined %}
+vrf {{ n }}
+  route-target import {{ v.import|join(' ') }} evpn
+  route-target export {{ v.export|join(' ') }} evpn
+{%   endfor %}
+{# define l3vni #}
+interface vxlan 1
+{%   for n,v in vrfs.items() if v.af is defined %}
+  vni {{ v.evpn.transit_vni }}
+    vrf {{ n }}
+    routing
+{%   endfor %}
+{% endif %}

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -11,7 +11,7 @@ libvirt:
       --ram=4096 --network=network:vagrant-libvirt,model=virtio --graphics none --import
       --disk path=vm.qcow2,format=qcow2,bus=ide
 clab:
-  image: vrnetlab/vr-aoscx:20230531220439
+  image: vrnetlab/vr-aoscx:20231110145644
   mtu: 1500
   node:
     kind: vr-aoscx


### PR DESCRIPTION
With AOS-CX Virtual release 10.13, we can support VXLAN EVPN L3VNI (Symmetric IRB)