### PR TITLE
Proposal: VXLAN configurable VTEP address/interface

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -83,6 +83,22 @@ The VXLAN module builds ingress replication lists for all nodes with **vxlan.flo
 
 All VLAN-specific ingress replication lists are merged into a node-level ingress replication list. Some devices support per-VLAN replication lists while others might use node-level replication list; the only difference is the amount of irrelevant traffic replicated across the VXLAN transport network.
 
+## Changing the VXLAN VTEP Source interface/address
+
+By default, every node uses the first loopback interface/address as the default VTEP Source interface/address.
+
+If you want your node to use a different loopback interface as VXLAN source, you need to define a *loopback link*, and add the **vxlan.vtep** attribute set to **true**, i.e.:
+
+```
+links:
+- sw1:
+  type: loopback
+  pool: vteps
+  vxlan.vtep: true
+```
+
+If you specify multiple loopback links with the **vxlan.vtep** attribute, **only the first one will be considered**.
+
 ## Example
 
 We want to create a simple two-switch network transporting two VLANs across VXLAN backbone. We have to define the VLANs first:

--- a/netsim/ansible/templates/vxlan/arubacx.j2
+++ b/netsim/ansible/templates/vxlan/arubacx.j2
@@ -1,6 +1,6 @@
 !
 interface vxlan 1
-  source ip {{ loopback.ipv4|ipaddr('address') }}
+  source ip {{ vxlan.vtep }}
   no shutdown
 {% if vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}

--- a/netsim/ansible/templates/vxlan/csr.j2
+++ b/netsim/ansible/templates/vxlan/csr.j2
@@ -1,7 +1,7 @@
 {% if vxlan.vlans is defined %}
 interface nve1
  no shutdown
- source-interface Loopback0
+ source-interface {{ vxlan.vtep_interface|default('Loopback0') }}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}
  member vni {{ vlan.vni }}

--- a/netsim/ansible/templates/vxlan/dellos10.j2
+++ b/netsim/ansible/templates/vxlan/dellos10.j2
@@ -1,5 +1,5 @@
 nve
-  source-interface loopback 0
+  source-interface {{ vxlan.vtep_interface|default('loopback 0') }}
 
 {% if vxlan.vlans is defined and vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}

--- a/netsim/ansible/templates/vxlan/eos.j2
+++ b/netsim/ansible/templates/vxlan/eos.j2
@@ -1,5 +1,5 @@
 interface vxlan 1
-  vxlan source-interface loopback 0
+  vxlan source-interface {{ vxlan.vtep_interface|default('loopback 0') }}
 {% if vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}

--- a/netsim/ansible/templates/vxlan/nxos.j2
+++ b/netsim/ansible/templates/vxlan/nxos.j2
@@ -10,7 +10,7 @@ vlan {{ vdata.id }}
 {% endif %}
 !
 interface nve 1
- source-interface loopback 0
+ source-interface {{ vxlan.vtep_interface|default('loopback 0') }}
 {% if vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%     set vlan = vlans[vname] %}

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -43,7 +43,6 @@ link:
   interfaces:
   mtu: { type: int, min_value: 64, max_value: 65535 }
   vlan_name: id
-  use_as_vtep: bool
 link_internal:
   linkindex: int
   parentindex: int

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -43,6 +43,7 @@ link:
   interfaces:
   mtu: { type: int, min_value: 64, max_value: 65535 }
   vlan_name: id
+  use_as_vtep: bool
 link_internal:
   linkindex: int
   parentindex: int

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -96,7 +96,7 @@ def assign_vni(toponode: Box, obj_path: str, topology: Box) -> None:
 def node_set_vtep(node: Box, topology: Box) -> bool:
   # default vtep interface & interface name
   vtep_interface = node.loopback
-  loopback_name = devices.get_device_attribute(node,'loopback_interface_name',topology.defaults).format(ifindex=0)
+  loopback_name = str(devices.get_device_attribute(node,'loopback_interface_name',topology.defaults)).format(ifindex=0)
 
   # Search for additional loopback interfaces with vxlan.vtep' flag, and use the first one
   for intf in node.interfaces:

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -9,7 +9,7 @@ from . import _Module,get_effective_module_attribute,_dataplane
 from ..utils import log
 from .. import data
 from ..data.validate import must_be_int,must_be_string
-from ..augment import addressing
+from ..augment import addressing,devices
 
 """
 register_static_vni -- register all static VNIs
@@ -94,24 +94,36 @@ def assign_vni(toponode: Box, obj_path: str, topology: Box) -> None:
 # Set VTEP IPv4/IPv6 address
 #
 def node_set_vtep(node: Box, topology: Box) -> bool:
-  if topology.defaults.vxlan.use_v6_vtep and not 'ipv6' in node.loopback:
+  # default vtep interface & interface name
+  vtep_interface = node.loopback
+  loopback_name = devices.get_device_attribute(node,'loopback_interface_name',topology.defaults).format(ifindex=0)
+
+  if topology.defaults.vxlan.use_v6_vtep and not 'ipv6' in vtep_interface:
     log.error(
       f'You want to use IPv6 VTEP -- VXLAN module needs an IPv6 address on loopback interface of {node.name}',
       log.IncorrectValue,
       'vxlan')
     return False
 
-  if not 'ipv4' in node.loopback and not topology.defaults.vxlan.use_v6_vtep:
+  if not 'ipv4' in vtep_interface and not topology.defaults.vxlan.use_v6_vtep:
     log.error(
       f'VXLAN module needs an IPv4 address on loopback interface of {node.name}',
       log.IncorrectValue,
       'vxlan')
     return False
+  
+  # Search for additional loopback interfaces with 'use_as_vtep' flag, and use the first one
+  for intf in node.interfaces:
+    if intf.get('type', '') == 'loopback' and intf.get('use_as_vtep', False):
+      vtep_interface = intf
+      loopback_name = intf.ifname
+      break
 
   vtep_ip = ""
   vtep_af = 'ipv6' if topology.vxlan.use_v6_vtep else 'ipv4'
-  vtep_ip = node.loopback[vtep_af]
+  vtep_ip = vtep_interface[vtep_af]
   node.vxlan.vtep = str(netaddr.IPNetwork(vtep_ip).ip)              # ... and convert IPv4(v6) prefix into an IPv4(v6) address
+  node.vxlan.vtep_interface = loopback_name
   return True
 
 #

--- a/netsim/modules/vxlan.yml
+++ b/netsim/modules/vxlan.yml
@@ -16,9 +16,7 @@ attributes:
     domain:
     flooding:
     vlans:
+  link:
+    vtep: bool
 no_propagate: [ use_v6_vtep, start_vni ]
 use_v6_vtep: false
-_top:                               # Modification of global defaults
-  attributes:
-    link:
-      vxlan.vtep: bool

--- a/netsim/modules/vxlan.yml
+++ b/netsim/modules/vxlan.yml
@@ -18,3 +18,7 @@ attributes:
     vlans:
 no_propagate: [ use_v6_vtep, start_vni ]
 use_v6_vtep: false
+_top:                               # Modification of global defaults
+  attributes:
+    link:
+      vxlan.vtep: bool

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -542,6 +542,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.1
+      vtep_interface: Loopback0
   s2:
     af:
       ipv4: true
@@ -811,6 +812,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.2
+      vtep_interface: Loopback0
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -414,6 +414,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.1
+      vtep_interface: Loopback0
   s2:
     af:
       ipv4: true
@@ -525,6 +526,7 @@ nodes:
       vlans:
       - red
       vtep: 10.0.0.2
+      vtep_interface: Loopback0
   s3:
     af:
       ipv4: true
@@ -636,6 +638,7 @@ nodes:
       vlans:
       - blue
       vtep: 10.0.0.3
+      vtep_interface: Loopback0
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -171,6 +171,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.3
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.2
       - 10.0.0.4
@@ -279,6 +280,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.4
+      vtep_interface: lo0
       vtep_list:
       - 10.0.0.2
       - 10.0.0.3
@@ -506,6 +508,7 @@ nodes:
       - blue
       - red
       vtep: 10.0.0.2
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.3
       - 10.0.0.4

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -344,6 +344,7 @@ nodes:
       - red
       - blue
       vtep: 10.0.0.1
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.2
       - 10.0.0.3
@@ -419,6 +420,7 @@ nodes:
       vlans:
       - red
       vtep: 10.0.0.2
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.1
   s3:
@@ -493,6 +495,7 @@ nodes:
       vlans:
       - blue
       vtep: 10.0.0.3
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.1
 ospf:

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -632,6 +632,7 @@ nodes:
       - red_transport
       - blue_transport
       vtep: 10.0.0.6
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.7
       - 10.0.0.8
@@ -869,6 +870,7 @@ nodes:
       - red_transport
       - blue_transport
       vtep: 10.0.0.7
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.6
       - 10.0.0.8
@@ -1017,6 +1019,7 @@ nodes:
       vlans:
       - red_transport
       vtep: 10.0.0.8
+      vtep_interface: Loopback0
       vtep_list:
       - 10.0.0.6
       - 10.0.0.7


### PR DESCRIPTION
@ipspace This is a proposal to make the VXLAN VTEP source configurable, and not "hardcoded" to loopback 0.

It is based on a custom flag that can be set on an additional loopback interface. In that case, the first loopback interface with the flag will be used as vtep source (interface/address)

If this is ok for you, I will try to add the proper doc.

/cc @jbemmel 