### PR TITLE
Add parent interface data to unnumbered interface

### DIFF
--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -77,8 +77,8 @@ cat >/etc/network/interfaces.d/11-physical.intf <<CONFIG
 auto {{ l.ifname }}
 {%   if l.ipv4 is defined %}
 iface {{ l.ifname }} inet static
-{%     if l.ipv4 == True and loopback.ipv4 is defined %}
-  address {{ loopback.ipv4 }}
+{%     if l.ipv4 == True and l._parent_ipv4 is defined %}
+  address {{ l._parent_ipv4 }}
 {%     else %}
   address {{ l.ipv4 }}
 {%     endif %}

--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -77,8 +77,10 @@ cat >/etc/network/interfaces.d/11-physical.intf <<CONFIG
 auto {{ l.ifname }}
 {%   if l.ipv4 is defined %}
 iface {{ l.ifname }} inet static
-{%     if l.ipv4 == True and l._parent_ipv4 is defined %}
+{%     if l.ipv4 == True %}
+{%       if l._parent_ipv4 is defined %}
   address {{ l._parent_ipv4 }}
+{%       endif %}
 {%     else %}
   address {{ l.ipv4 }}
 {%     endif %}

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -62,7 +62,7 @@ interface {{ l.ifname }}
 #}
 {% if 'ipv4' in l %}
 {%   if l.ipv4 == True %}
- ip address unnumbered {{ loopback_name|default('Loopback 0') }}
+ ip address unnumbered {{ l._parent_intf }}
 {%   elif l.ipv4|ipv4 %}
  ip address {{ l.ipv4 }}
 {%   else %}

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -114,7 +114,7 @@ interface {{ l.ifname }}
 {% elif l.type|default("") == "stub" %}
  description Stub interface
 {% endif %}
-{% if l.ipv4 and (l.ipv4 is string or l._parent_ipv4 is defined) %}
+{% if l.ipv4 is defined and (l.ipv4 is string or l._parent_ipv4 is defined) %}
  ip address {{ l.ipv4 if l.ipv4 is string else l._parent_ipv4 }}
 {% else %}
  ! no ip address

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -114,8 +114,8 @@ interface {{ l.ifname }}
 {% elif l.type|default("") == "stub" %}
  description Stub interface
 {% endif %}
-{% if l.ipv4 is defined and (l.ipv4 is string or loopback.ipv4 is defined) %}
- ip address {{ l.ipv4 if l.ipv4 is string else loopback.ipv4 }}
+{% if l.ipv4 and (l.ipv4 is string or l._parent_ipv4 is defined) %}
+ ip address {{ l.ipv4 if l.ipv4 is string else l._parent_ipv4 }}
 {% else %}
  ! no ip address
 {% endif %}

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -65,7 +65,7 @@ interface {{ l.ifname }}
 #}
 {% if 'ipv4' in l %}
 {%   if l.ipv4 == True %}
- ip unnumbered {{ loopback_name|default('Loopback0') }} poll
+ ip unnumbered {{ l._parent_intf }} poll
 {%   elif l.ipv4|ipv4 %}
  ip address {{ l.ipv4|ipaddr('address') }} {{ l.ipv4|ipaddr('netmask') }}
 {%   else %}

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -366,7 +366,9 @@ nodes:
         node: r3
       pool: v4unnum
       type: lan
-    - bridge: input_3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      bridge: input_3
       ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true
@@ -459,7 +461,9 @@ nodes:
         node: r4
       pool: dualstack
       type: lan
-    - bridge: input_9
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      bridge: input_9
       ifindex: 10
       ifname: GigabitEthernet10
       ipv4: true
@@ -533,7 +537,9 @@ nodes:
         ipv6: 2001:db8:42:42::2a/64
         node: r3
       type: lan
-    - ifindex: 15
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      ifindex: 15
       ifname: GigabitEthernet15
       ipv4: true
       ipv6: 2001:db8:42:43::1/64
@@ -579,7 +585,9 @@ nodes:
         ipv6: 2001:db8:1::2a/64
         node: r3
       type: lan
-    - bridge: input_2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      bridge: input_2
       ifindex: 3
       ifname: GigabitEthernet3
       ipv4: true
@@ -595,7 +603,9 @@ nodes:
         node: r3
       pool: v4unnum
       type: lan
-    - bridge: input_3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      bridge: input_3
       ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true
@@ -762,7 +772,9 @@ nodes:
         ipv6: 2001:db8:42:42::2a/64
         node: r3
       type: lan
-    - ifindex: 15
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 15
       ifname: GigabitEthernet15
       ipv4: true
       ipv6: 2001:db8:42:43::2/64
@@ -808,7 +820,9 @@ nodes:
         ipv6: 2001:db8:1::15/64
         node: r2
       type: lan
-    - bridge: input_2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.42/32
+      bridge: input_2
       ifindex: 3
       ifname: GigabitEthernet3
       ipv4: true
@@ -824,7 +838,9 @@ nodes:
         node: r2
       pool: v4unnum
       type: lan
-    - bridge: input_3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.42/32
+      bridge: input_3
       ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -250,7 +250,9 @@ nodes:
     device: csr
     id: 7
     interfaces:
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      ifindex: 2
       ifname: GigabitEthernet2
       ipv4: true
       linkindex: 1
@@ -271,7 +273,9 @@ nodes:
         ipv6: 2001:db8:42:44::1/64
         node: r2
       type: p2p
-    - ifindex: 4
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true
       linkindex: 3
@@ -328,7 +332,9 @@ nodes:
         node: r2
       pool: dualstack
       type: p2p
-    - ifindex: 9
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      ifindex: 9
       ifname: GigabitEthernet9
       ipv4: true
       ipv6: 2001:db8:3:2::1/64
@@ -392,7 +398,9 @@ nodes:
         ipv6: 2001:db8:42:42::2/64
         node: r2
       type: p2p
-    - ifindex: 15
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.7/32
+      ifindex: 15
       ifname: GigabitEthernet15
       ipv4: true
       ipv6: 2001:db8:42:43::1/64
@@ -435,7 +443,9 @@ nodes:
     device: csr
     id: 21
     interfaces:
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 2
       ifname: GigabitEthernet2
       ipv4: true
       linkindex: 1
@@ -445,7 +455,9 @@ nodes:
         ipv4: true
         node: r1
       type: p2p
-    - ifindex: 3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 3
       ifname: GigabitEthernet3
       ipv4: true
       ipv6: 2001:db8:42:44::1/64
@@ -456,7 +468,9 @@ nodes:
         ipv4: 10.42.42.18/32
         node: r1
       type: p2p
-    - ifindex: 4
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true
       linkindex: 3
@@ -577,7 +591,9 @@ nodes:
         ipv6: 2001:db8:42:42::1/64
         node: r1
       type: p2p
-    - ifindex: 15
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 15
       ifname: GigabitEthernet15
       ipv4: true
       ipv6: 2001:db8:42:43::2/64
@@ -589,7 +605,9 @@ nodes:
         ipv6: 2001:db8:42:43::1/64
         node: r1
       type: p2p
-    - ifindex: 16
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.21/32
+      ifindex: 16
       ifname: GigabitEthernet16
       ipv4: true
       ipv6: 2001:db8:42:44::1/128

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -110,7 +110,9 @@ nodes:
     device: nxos
     id: 1
     interfaces:
-    - ifindex: 1
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 1
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 1
@@ -124,7 +126,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 3
@@ -192,7 +196,9 @@ nodes:
     device: eos
     id: 2
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       linkindex: 2
@@ -206,7 +212,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       linkindex: 4
@@ -281,7 +289,9 @@ nodes:
     device: nxos
     id: 3
     interfaces:
-    - ifindex: 1
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 1
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 1
@@ -295,7 +305,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 2
@@ -370,7 +382,9 @@ nodes:
     device: nxos
     id: 4
     interfaces:
-    - ifindex: 1
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.4/32
+      ifindex: 1
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 3
@@ -384,7 +398,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.4/32
+      ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 4

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -211,7 +211,9 @@ nodes:
     device: cumulus
     id: 1
     interfaces:
-    - ifindex: 1
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 1
       ifname: swp1
       ipv4: true
       ipv6: true
@@ -225,7 +227,9 @@ nodes:
       role: external
       type: p2p
       unnumbered: true
-    - ifindex: 2
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 2
       ifname: swp2
       ipv4: true
       ipv6: true
@@ -237,7 +241,9 @@ nodes:
         node: x1
       role: external
       type: p2p
-    - ifindex: 3
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 3
       ifname: swp3
       ipv4: true
       ipv6: true
@@ -274,7 +280,9 @@ nodes:
         node: x4
       role: external
       type: p2p
-    - ifindex: 6
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 6
       ifname: swp6
       ipv4: true
       ipv6: 2001:db8:1::1/64
@@ -343,7 +351,9 @@ nodes:
     device: cumulus
     id: 2
     interfaces:
-    - ifindex: 1
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 1
       ifname: swp1
       ipv4: true
       ipv6: true
@@ -357,7 +367,9 @@ nodes:
       role: external
       type: p2p
       unnumbered: true
-    - ifindex: 2
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 2
       ifname: swp2
       ipv4: true
       ipv6: true
@@ -416,7 +428,9 @@ nodes:
     device: cumulus
     id: 3
     interfaces:
-    - ifindex: 1
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 1
       ifname: swp1
       ipv4: true
       ipv6: true
@@ -552,7 +566,9 @@ nodes:
         node: test
       role: external
       type: p2p
-    - ifindex: 2
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.5/32
+      ifindex: 2
       ifname: swp2
       ipv4: true
       ipv6: 2001:db8:1::2/64

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -106,7 +106,9 @@ nodes:
     hostname: clab-input-r1
     id: 1
     interfaces:
-    - ifindex: 1
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 1
       ifname: swp1
       ipv4: true
       ipv6: true
@@ -183,7 +185,9 @@ nodes:
     hostname: clab-input-r2
     id: 2
     interfaces:
-    - ifindex: 1
+    - _parent_intf: lo
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 1
       ifname: swp1
       ipv4: true
       ipv6: true

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -101,7 +101,9 @@ nodes:
     device: eos
     id: 1
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       ipv6: true
@@ -120,7 +122,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       ipv6: true
@@ -175,7 +179,9 @@ nodes:
     device: eos
     id: 2
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       ipv6: true
@@ -230,7 +236,9 @@ nodes:
     device: eos
     id: 3
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       ipv6: true
@@ -249,7 +257,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       ipv6: true
@@ -303,7 +313,9 @@ nodes:
     device: eos
     id: 4
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.4/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       ipv6: true
@@ -322,7 +334,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.4/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       ipv6: true
@@ -377,7 +391,9 @@ nodes:
     device: eos
     id: 5
     interfaces:
-    - ifindex: 1
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.5/32
+      ifindex: 1
       ifname: Ethernet1
       ipv4: true
       ipv6: true

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -311,7 +311,9 @@ nodes:
         node: j_vsrx
       role: external
       type: lan
-    - ifindex: 5
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 5
       ifname: Ethernet5
       ipv4: true
       isis:
@@ -337,7 +339,9 @@ nodes:
         ipv6: true
         node: j_vsrx
       type: p2p
-    - ifindex: 7
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.3/32
+      ifindex: 7
       ifname: Ethernet7
       ipv4: true
       isis:
@@ -458,7 +462,9 @@ nodes:
         node: j_vsrx
       role: external
       type: lan
-    - ifindex: 6
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 6
       ifname: GigabitEthernet6
       ipv4: true
       isis:
@@ -471,7 +477,9 @@ nodes:
         ipv4: true
         node: c_nxos
       type: p2p
-    - ifindex: 7
+    - _parent_intf: Loopback0
+      _parent_ipv4: 10.0.0.2/32
+      ifindex: 7
       ifname: GigabitEthernet7
       ipv4: true
       isis:
@@ -598,7 +606,9 @@ nodes:
         node: j_vsrx
       role: external
       type: lan
-    - ifindex: 5
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 5
       ifname: Ethernet1/5
       ipv4: true
       isis:
@@ -611,7 +621,9 @@ nodes:
         ipv4: true
         node: a_eos
       type: p2p
-    - ifindex: 6
+    - _parent_intf: loopback0
+      _parent_ipv4: 10.0.0.1/32
+      ifindex: 6
       ifname: Ethernet1/6
       ipv4: true
       isis:

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -236,7 +236,9 @@ nodes:
         cost: 10
         passive: false
       type: lan
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.3/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       linkindex: 2
@@ -252,7 +254,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.3/32
+      ifindex: 3
       ifname: Ethernet3
       ipv4: true
       linkindex: 5
@@ -268,7 +272,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 4
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.3/32
+      ifindex: 4
       ifname: Ethernet4
       ipv4: true
       linkindex: 6
@@ -375,7 +381,9 @@ nodes:
         cost: 10
         passive: false
       type: lan
-    - ifindex: 3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.2/32
+      ifindex: 3
       ifname: GigabitEthernet3
       ipv4: true
       linkindex: 3
@@ -392,7 +400,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 4
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.2/32
+      ifindex: 4
       ifname: GigabitEthernet4
       ipv4: true
       linkindex: 6
@@ -409,7 +419,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 5
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.2/32
+      ifindex: 5
       ifname: GigabitEthernet5
       ipv4: true
       linkindex: 7
@@ -505,7 +517,9 @@ nodes:
         cost: 20
         passive: false
       type: lan
-    - ifindex: 2
+    - _parent_intf: loopback0
+      _parent_ipv4: 172.18.1.1/32
+      ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 2
@@ -522,7 +536,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 3
+    - _parent_intf: loopback0
+      _parent_ipv4: 172.18.1.1/32
+      ifindex: 3
       ifname: Ethernet1/3
       ipv4: true
       linkindex: 3
@@ -539,7 +555,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 4
+    - _parent_intf: loopback0
+      _parent_ipv4: 172.18.1.1/32
+      ifindex: 4
       ifname: Ethernet1/4
       ipv4: true
       linkindex: 4
@@ -650,7 +668,9 @@ nodes:
         cost: 10
         passive: false
       type: lan
-    - ifindex: 1
+    - _parent_intf: lo0.0
+      _parent_ipv4: 172.18.1.4/32
+      ifindex: 1
       ifname: ge-0/0/1.0
       ipv4: true
       junos_interface: ge-0/0/1
@@ -669,7 +689,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 2
+    - _parent_intf: lo0.0
+      _parent_ipv4: 172.18.1.4/32
+      ifindex: 2
       ifname: ge-0/0/2.0
       ipv4: true
       junos_interface: ge-0/0/2
@@ -688,7 +710,9 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - ifindex: 3
+    - _parent_intf: lo0.0
+      _parent_ipv4: 172.18.1.4/32
+      ifindex: 3
       ifname: ge-0/0/3.0
       ipv4: true
       junos_interface: ge-0/0/3

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -106,7 +106,9 @@ nodes:
         ipv6: 2001:db8:1::4/64
         node: n_cumulus
       type: lan
-    - ifindex: 2
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.2/32
+      ifindex: 2
       ifname: Ethernet2
       ipv4: true
       ipv6: true
@@ -119,7 +121,9 @@ nodes:
         node: c_nxos
       pool: core
       type: p2p
-    - ifindex: 3
+    - _parent_intf: Loopback0
+      _parent_ipv4: 172.18.1.2/32
+      ifindex: 3
       ifname: Ethernet3
       ipv4: true
       ipv6: true
@@ -173,7 +177,9 @@ nodes:
         ipv6: 2001:db8:1::4/64
         node: n_cumulus
       type: lan
-    - ifindex: 2
+    - _parent_intf: loopback0
+      _parent_ipv4: 172.18.1.1/32
+      ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
       ipv6: true
@@ -186,7 +192,9 @@ nodes:
         node: a_eos
       pool: core
       type: p2p
-    - ifindex: 3
+    - _parent_intf: loopback0
+      _parent_ipv4: 172.18.1.1/32
+      ifindex: 3
       ifname: Ethernet1/3
       ipv4: true
       ipv6: true
@@ -242,7 +250,9 @@ nodes:
         ipv6: 2001:db8:1::4/64
         node: n_cumulus
       type: lan
-    - ifindex: 1
+    - _parent_intf: lo0.0
+      _parent_ipv4: 172.18.1.3/32
+      ifindex: 1
       ifname: ge-0/0/1.0
       ipv4: true
       ipv6: true
@@ -298,7 +308,9 @@ nodes:
         ipv6: 2001:db8:1::3/64
         node: j_vsrx
       type: lan
-    - ifindex: 2
+    - _parent_intf: lo
+      _parent_ipv4: 172.18.1.4/32
+      ifindex: 2
       ifname: swp2
       ipv4: true
       ipv6: true

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -266,7 +266,9 @@ nodes:
     hostname: clab-input-h3
     id: 7
     interfaces:
-    - bridge: input_3
+    - _parent_intf: lo0
+      _parent_ipv4: 10.0.0.7/32
+      bridge: input_3
       ifindex: 1
       ifname: eth1
       ipv4: true
@@ -358,7 +360,9 @@ nodes:
         access_id: 1001
         mode: route
       vrf: blue
-    - bridge_group: 2
+    - _parent_intf: lo0
+      _parent_ipv4: 10.0.0.1/32
+      bridge_group: 2
       ifindex: 3
       ifname: eth1.1002
       ipv4: true
@@ -544,7 +548,9 @@ nodes:
         access_id: 1001
         mode: route
       vrf: blue
-    - bridge_group: 2
+    - _parent_intf: lo0
+      _parent_ipv4: 10.0.0.2/32
+      bridge_group: 2
       ifindex: 3
       ifname: eth1.1002
       ipv4: true

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -57,34 +57,34 @@ links:
 - interfaces:
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 10.1.0.9/30
+    ipv4: true
     node: pe1
   - ifindex: 2
     ifname: Ethernet2
-    ipv4: 10.1.0.10/30
+    ipv4: true
     node: pe2
   linkindex: 3
   node_count: 2
   prefix:
-    ipv4: 10.1.0.8/30
+    ipv4: true
   type: p2p
   vrf: blue
 - interfaces:
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 10.1.0.13/30
+    ipv4: 10.1.0.9/30
     node: pe2
     vrf: blue
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 10.1.0.14/30
+    ipv4: 10.1.0.10/30
     node: r3
     ospf:
       area: 0.0.0.1
   linkindex: 4
   node_count: 2
   prefix:
-    ipv4: 10.1.0.12/30
+    ipv4: 10.1.0.8/30
   type: p2p
 - bridge: input_5
   interfaces:
@@ -179,16 +179,18 @@ nodes:
       role: external
       type: p2p
       vrf: red
-    - clab:
+    - _parent_intf: Loopback1
+      _parent_ipv4: 10.2.0.1/32
+      clab:
         name: et3
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 10.1.0.9/30
+      ipv4: true
       linkindex: 3
       name: pe1 -> pe2
       neighbors:
       - ifname: Ethernet2
-        ipv4: 10.1.0.10/30
+        ipv4: true
         node: pe2
         vrf: blue
       type: p2p
@@ -242,16 +244,18 @@ nodes:
           active: true
           area: 0.0.0.2
           interfaces:
-          - clab:
+          - _parent_intf: Loopback1
+            _parent_ipv4: 10.2.0.1/32
+            clab:
               name: et3
             ifindex: 3
             ifname: Ethernet3
-            ipv4: 10.1.0.9/30
+            ipv4: true
             linkindex: 3
             name: pe1 -> pe2
             neighbors:
             - ifname: Ethernet2
-              ipv4: 10.1.0.10/30
+              ipv4: true
               node: pe2
               vrf: blue
             ospf:
@@ -272,6 +276,7 @@ nodes:
             virtual_interface: true
             vrf: blue
           router_id: 10.0.0.1
+          unnumbered: true
         rd: '65000:3'
         vrfidx: 101
       red:
@@ -339,16 +344,18 @@ nodes:
         ipv4: 10.1.0.1/30
         node: pe1
       type: p2p
-    - clab:
+    - _parent_intf: Loopback1
+      _parent_ipv4: 10.2.0.2/32
+      clab:
         name: et2
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 10.1.0.10/30
+      ipv4: true
       linkindex: 3
       name: pe2 -> pe1
       neighbors:
       - ifname: Ethernet3
-        ipv4: 10.1.0.9/30
+        ipv4: true
         node: pe1
         vrf: blue
       type: p2p
@@ -357,12 +364,12 @@ nodes:
         name: et3
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 10.1.0.13/30
+      ipv4: 10.1.0.9/30
       linkindex: 4
       name: pe2 -> r3
       neighbors:
       - ifname: Ethernet1
-        ipv4: 10.1.0.14/30
+        ipv4: 10.1.0.10/30
         node: r3
       type: p2p
       vrf: blue
@@ -416,16 +423,18 @@ nodes:
           active: true
           area: 0.0.0.1
           interfaces:
-          - clab:
+          - _parent_intf: Loopback1
+            _parent_ipv4: 10.2.0.2/32
+            clab:
               name: et2
             ifindex: 2
             ifname: Ethernet2
-            ipv4: 10.1.0.10/30
+            ipv4: true
             linkindex: 3
             name: pe2 -> pe1
             neighbors:
             - ifname: Ethernet3
-              ipv4: 10.1.0.9/30
+              ipv4: true
               node: pe1
               vrf: blue
             ospf:
@@ -438,12 +447,12 @@ nodes:
               name: et3
             ifindex: 3
             ifname: Ethernet3
-            ipv4: 10.1.0.13/30
+            ipv4: 10.1.0.9/30
             linkindex: 4
             name: pe2 -> r3
             neighbors:
             - ifname: Ethernet1
-              ipv4: 10.1.0.14/30
+              ipv4: 10.1.0.10/30
               node: r3
             ospf:
               area: 0.0.0.1
@@ -463,6 +472,7 @@ nodes:
             virtual_interface: true
             vrf: blue
           router_id: 10.0.0.2
+          unnumbered: true
         rd: '65000:3'
         vrfidx: 100
   r2:
@@ -545,12 +555,12 @@ nodes:
         name: et1
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 10.1.0.14/30
+      ipv4: 10.1.0.10/30
       linkindex: 4
       name: r3 -> pe2
       neighbors:
       - ifname: Ethernet3
-        ipv4: 10.1.0.13/30
+        ipv4: 10.1.0.9/30
         node: pe2
         vrf: blue
       ospf:

--- a/tests/topology/input/vrf-igp.yml
+++ b/tests/topology/input/vrf-igp.yml
@@ -37,6 +37,7 @@ links:
 - pe1:
   pe2:
   vrf: blue
+  prefix.ipv4: True
 - pe2:
     vrf: blue
   r3:


### PR DESCRIPTION
* Set _parent_intf and _parent_ipv4 on unnumbered IPv4 interfaces
* Fix _parent_intf and _parent_ipv4 to point to in-VRF loopback (where available) for in-VRF unnumbered IPv4 interfaces
* Use these attributes when configuring unnumbered interfaces on CSR, EOS, FRR and Cumulus Linux

Please note that we don't need corresponding IPv6 mechanism as IPv6 uses LLA.

Fixes #993, prepares the infrastructure for #1000