### PR TITLE
Initial implementation of control-plane daemons

### DIFF
--- a/docs/netlab/show.md
+++ b/docs/netlab/show.md
@@ -219,29 +219,40 @@ options:
 $ netlab show devices
 Virtual network devices supported by netlab
 
-+--------------+-----------------------------------------------+
-| device       | description                                   |
-+==============+===============================================+
-| asav         | Cisco ASAv                                    |
-| csr          | Cisco CSR 1000v                               |
-| cumulus      | Cumulus VX 4.x or 5.x configured without NVUE |
-| cumulus_nvue | Cumulus VX 5.x configured with NVUE           |
-| dellos10     | Dell OS10                                     |
-| eos          | Arista vEOS                                   |
-| fortios      | Fortinet FortiOS firewall                     |
-| frr          | FRR container                                 |
-| iosv         | Cisco IOSv                                    |
-| iosxr        | Cisco IOS XRv                                 |
-| linux        | Generic Linux host                            |
-| nxos         | Cisco Nexus 9300v                             |
-| routeros     | Mikrotik RouterOS version 6                   |
-| routeros7    | Mikrotik RouterOS version 7                   |
-| srlinux      | Nokia SR Linux container                      |
-| sros         | Nokia SR OS container                         |
-| vmx          | Juniper vMX container                         |
-| vsrx         | Juniper vSRX 3.0                              |
-| vyos         | Vyatta VyOS VM/container                      |
-+--------------+-----------------------------------------------+
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ device       ┃ description                                               ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ arubacx      │ ArubaOS-CX                                                │
+│ asav         │ Cisco ASAv                                                │
+│ csr          │ Cisco CSR 1000v                                           │
+│ cumulus      │ Cumulus VX 4.x or 5.x configured without NVUE             │
+│ cumulus_nvue │ Cumulus VX 5.x configured with NVUE                       │
+│ dellos10     │ Dell OS10                                                 │
+│ eos          │ Arista vEOS VM or cEOS container                          │
+│ fortios      │ Fortinet FortiOS firewall                                 │
+│ frr          │ FRR container                                             │
+│ iosv         │ Cisco IOSv                                                │
+│ iosxr        │ Cisco IOS XRv                                             │
+│ junos        │ Generic Juniper device (meta device, used only as parent) │
+│ linux        │ Generic Linux host                                        │
+│ nxos         │ Cisco Nexus 9300v                                         │
+│ routeros     │ Mikrotik RouterOS version 6                               │
+│ routeros7    │ Mikrotik RouterOS version 7                               │
+│ srlinux      │ Nokia SR Linux container                                  │
+│ sros         │ Nokia SR OS container                                     │
+│ vmx          │ Juniper vMX container                                     │
+│ vptx         │ Juniper vPTX                                              │
+│ vsrx         │ Juniper vSRX 3.0                                          │
+│ vyos         │ Vyatta VyOS VM/container                                  │
+└──────────────┴───────────────────────────────────────────────────────────┘
+
+Networking daemons supported by netlab
+
+┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ daemon ┃ description                  ┃
+┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ bird   │ BIRD Internet Routing Daemon │
+└────────┴──────────────────────────────┘
 ```
 
 * Displays Arista EOS information in YAML format:
@@ -249,6 +260,16 @@ Virtual network devices supported by netlab
 ```yaml
 $ netlab show devices -d eos --format yaml
 eos: Arista vEOS VM or cEOS container
+```
+
+* Displays BIRD information in YAML format:
+
+```yaml
+$ netlab show devices -d bird --format yaml
+bird:
+  daemon: true
+  description: BIRD Internet Routing Daemon
+  parent: linux
 ```
 
 (netlab-show-images)=

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -8,7 +8,7 @@
 
 ## Supported Virtual Network Devices
 
-*netlab* supports these virtual network devices or their physical equivalents (when using *external* [virtualization provider](providers.md)). If you want to use an unsupported device in a *netlab*-managed lab, use [an unknown device](platform-unknown) or [contribute a new device implementation](dev/devices.md).
+*netlab* supports these virtual network devices or their physical equivalents (when using *external* [virtualization provider](providers.md)).
 
 | Virtual network device                    | netlab device type |
 | ----------------------------------------- | ------------------ |
@@ -34,30 +34,17 @@
 | Nokia SR OS [❗](caveats-sros)            | sros               |
 | VyOS 1.4 [❗](caveats-vyos)               | vyos               |
 
+*netlab* also supports the following daemons (control-plane software running on Linux VMs or containers):
+
+| Daemon                         | netlab device type |
+| ------------------------------ | ------------------ |
+| BIRD Internet Routing Daemon   | bird               |                               
+
 **Notes:**
 
-To specify the device type of a node in your virtual lab:
-
-* Specify **device** property in node data
-
-```
-nodes:
-- name: c_ios
-  device: iosv
-- name: c_csr
-  device: csr
-```
-
-* Use **defaults.device** setting in lab topology
-
-```
-defaults:
-  device: cumulus
-
-nodes: [ s1, s2, s3 ]
-```
-
-See [lab topology overview](topology-overview.md) for more details.
+* Use the **[netlab show devices](netlab-show-devices)** command to display the list of supported devices and daemons.
+* You can specify the device type in the **device** property of the [node data](node-attributes) or the topology-wide **[defaults.device](defaults.md)** setting. See [lab topology overview](topology-overview.md) for more details.
+* If you want to use an unsupported device in a *netlab*-managed lab, use [an unknown device](platform-unknown) or [contribute a new device implementation](dev/devices.md).
 
 ## Supported Virtualization Providers
 
@@ -152,7 +139,7 @@ Ansible playbooks included with **netlab** can deploy and collect device configu
 
 ## Initial Device Configurations
 
-The following system-wide features are configured on supported network operating systems as part of initial device configuration:
+The following system-wide features are configured on supported network operating systems as part of the initial device configuration:
 
 (platform-initial-config)=
 | Operating system      | Hostname | IPv4 hosts |           LLDP            | Loopback<br />IPv4 address | Loopback<br />IPv6 address |
@@ -179,7 +166,7 @@ The following system-wide features are configured on supported network operating
 | VyOS                  |    ✅     |     ✅      |             ✅             |             ✅              |             ✅              |
 
 (platform-initial-interfaces)=
-The following interface parameters are configured on supported network operating systems as part of initial device configuration:
+The following interface parameters are configured on supported network operating systems as part of the initial device configuration:
 
 | Operating system      | Interface<br />description | Interface<br />bandwidth | MTU | Additional<br />loopbacks
 | --------------------- |:---:|:---:|:---:|:---:|
@@ -263,8 +250,14 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 **Notes:**
 * FRHP = First-Hop Redundancy Protocol (anycast gateway or VRRP)
 
+Routing protocol [configuration modules](module-reference.md) are also supported on these daemons:
+
+| Operating system      | [OSPF](module/ospf.md) | [IS-IS](module/isis.md) | [BGP](module/bgp.md) | [BFD](module/bfd.md) | |
+|------------------------------|:--:|:--:|:--:|:--:|
+| BIRD Internet Routing Daemon | ❌  | ✅ | ❌  | ❌  |
+
 (platform-dataplane-support)=
-The following data plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
+The data plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
 
 | Operating system      | [VLAN](module/vlan.md) | [VRF](module/vrf.md) | [VXLAN](module/vxlan.md) | [MPLS](module/mpls.md) | [SR-MPLS](module/sr-mpls.md) | [SRv6](module/srv6.md) |
 | --------------------- | :--: | :-: | :---: | :--: | :-----: | :--: |
@@ -288,7 +281,7 @@ The following data plane [configuration modules](module-reference.md) are suppor
 
 ## IPv6 Support
 
-Core *netlab* functionality and all multi-protocol routing protocol configuration modules fully supports IPv6. OSPFv3 is implemented only on some platforms.
+Core *netlab* functionality and all multi-protocol routing protocol configuration modules fully support IPv6. OSPFv3 is implemented only on some platforms.
 
 | Operating system      | IPv6<br />addresses | OSPFv3 | IS-IS MT | EIGRP<br />IPv6 AF | BGP<br />IPv6 AF | SR-MPLS |
 | --------------------- | :-----------------: | :----: | :------: | :----------------: | :--------------: | :-----: |

--- a/netsim/ansible/tasks/deploy-module.yml
+++ b/netsim/ansible/tasks/deploy-module.yml
@@ -33,7 +33,7 @@
         {{ config_module }} configuration for {{ inventory_hostname }}
         =========================================
         {{ lookup('template',config_template or paths[0]+'/missing.j2') }}
-      verbosity: 1  
+    when: ansible_verbosity
   
   - include_tasks: "{{ item }}"
     with_first_found:
@@ -53,4 +53,7 @@
           netsim_action: "{{ config_module }}"
         tags: [ always ]
 
-  when: config_module in module|default([]) or config_module == 'initial'
+  when: 
+    (config_module in module|default([]) and
+     config_module not in _daemon_config|default([]))
+    or config_module == 'initial'

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -136,7 +136,7 @@ def build_module_support_lists(topology: Box) -> None:
   sets = topology.defaults
   devs = sets.devices
 
-  for dname in list(devs.keys()):                           # Iterate over all known devices
+  for dname in sorted(list(devs.keys())):                   # Iterate over all known devices
     ddata = devs[dname]
     if not 'features' in ddata:                             # Skip devices without features
       continue
@@ -167,6 +167,30 @@ def build_module_support_lists(topology: Box) -> None:
         mdata.supported_on.append(dname)
 
 """
+Merge daemons definitions into device definitions
+"""
+def merge_daemons(topology: Box) -> None:
+  if not 'daemons' in topology.defaults:
+    return
+
+  daemons = topology.defaults.daemons
+  devices = topology.defaults.devices
+
+  for dname in daemons.keys():                              # To be on the safe side...
+    if not isinstance(daemons[dname],Box):                  # ... validate daemon definition data type
+      log.fatal(f'Internal error: definition of daemon {dname} is not a dictionary')
+    if dname in devices:                                    # ... and check for duplicate names
+      log.fatal(f'Internal error: duplicate name {dname} for a device and a daemon')
+
+  for dname in list(daemons):
+    devices[dname] = daemons[dname]
+    devices[dname].daemon = True                          # Mark the device as a daemon
+    if not 'parent' in devices[dname]:
+      devices[dname].parent = 'linux'                     # Most daemons run on Linux
+
+    devices[dname].daemon_parent = devices[dname].parent  # Save the parent for future use (it is removed when merging parent device data)
+
+"""
 Initial device setting augmentation:
 
 * Build supported_on module lists
@@ -174,14 +198,15 @@ Initial device setting augmentation:
 """
 def augment_device_settings(topology: Box) -> None:
   devices = topology.defaults.devices
+
   if not isinstance(devices,Box):
     log.fatal('Internal error: defaults.devices must be a dictionary')
 
-  for dname in list(devices.keys()):                        # To be on the safe side...
+  for dname in devices.keys():                              # To be on the safe side...
     if not isinstance(devices[dname],Box):                  # ... validate device definition data type
       log.fatal(f'Internal error: definition of device {dname} is not a dictionary')
 
-
+  merge_daemons(topology)
   process_device_inheritance(topology)
   build_module_support_lists(topology)
 

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -23,7 +23,7 @@ DRY_RUN: bool = False
 def parser_add_debug(parser: argparse.ArgumentParser) -> None:
   parser.add_argument('--debug', dest='debug', action='store',nargs='*',
                   choices=sorted([
-                    'all','addr','cli','links','libvirt','modules','plugin','template',
+                    'all','addr','cli','links','libvirt','clab','modules','plugin','template',
                     'vlan','vrf','quirks','validate','addressing','groups','status',
                     'external','defaults']),
                   help=argparse.SUPPRESS)

--- a/netsim/cli/show_commands/devices.py
+++ b/netsim/cli/show_commands/devices.py
@@ -28,12 +28,23 @@ def show(settings: Box, args: argparse.Namespace) -> None:
       continue
 
     row = [ device,dev_data.description ]
+    if dev_data.daemon:
+      row[1] = {
+        'daemon': True,
+        'description': dev_data.description,
+        'parent': dev_data.daemon_parent
+      }
     rows.append(row)
-    result[device] = dev_data.description
+    result[device] = row[1]
 
   if args.format == 'table':
     print('Virtual network devices supported by netlab')
     print("")
-    strings.print_table(heading,rows,inter_row_line=False)
+    strings.print_table(heading,[ r for r in rows if isinstance(r[1],str) ],inter_row_line=False)
+    daemons = [ [ r[0],r[1]['description']] for r in rows if isinstance(r[1],dict) and r[1]['daemon'] ]
+    if daemons:
+      print('\nNetworking daemons supported by netlab\n')
+      strings.print_table(['daemon','description'],daemons,inter_row_line=False)
+
   elif args.format in ['text','yaml']:
     print(strings.get_yaml_string(result))

--- a/netsim/daemons/bird.dockerfile
+++ b/netsim/daemons/bird.dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 LABEL maintainer="Netlab project <netlab.tools>"
 LABEL description="BIRD Internet Routing Daemon (bird.network.cz)"
 
-RUN mkdir /etc/bird && apt-get update && apt-get install -y iputils-ping net-tools bird
+RUN mkdir /etc/bird && mkdir /run/bird && apt-get update && apt-get install -y iputils-ping net-tools bird
 
 WORKDIR /root
 

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -1,0 +1,19 @@
+---
+description: BIRD Internet Routing Daemon
+packages:
+  bird: bird
+daemon_config:
+  bird: /etc/bird/bird.conf
+  bgp: /etc/bird/bgp.mod.conf
+  ospf: /etc/bird/ospf.mod.conf
+clab:
+  group_vars:
+    netlab_show_command: [ birdc, 'show $@' ]
+  image: netlab/bird:latest
+libvirt:                        # Not yet available on libvirt or virtualbox
+  image: 
+virtualbox:
+  image: 
+features:
+  bgp:
+    activate_af: true

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -1,0 +1,16 @@
+{% if 'router_id' in bgp %}
+router id {{ bgp.router_id }};
+{% endif %}
+
+{% for n in bgp.neighbors %}
+{%   for af in [ 'ipv4','ipv6' ] if af in n %}
+protocol bgp {
+  local as {{ n.local_as|default(bgp.as) }};
+  neighbor {{ n[af] }} as {{ n['as'] }};
+  import all;
+{%     if 'next_hop_self' in bgp and bgp.next_hop_self %}
+  next hop self;
+{%     endif %}
+}
+{%   endfor %}
+{% endfor %}

--- a/netsim/daemons/bird/bird.j2
+++ b/netsim/daemons/bird/bird.j2
@@ -1,0 +1,11 @@
+protocol device {
+  scan time 10;
+}
+
+protocol kernel {
+  export all;
+}
+
+{% if 'bgp' in module %}
+include "/etc/bird/bgp.mod.conf";
+{% endif %}

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -89,10 +89,21 @@ def normalize_clab_filemaps(node: Box) -> None:
       continue
     filemaps.normalize_file_mapping(node,f'nodes.{node.name}',undot_key,'clab')
 
+'''
+add_daemon_filemaps: add device-level daemon_config dictionary to clab.config_templates dictionary
+'''
+
+def add_daemon_filemaps(node: Box, topology: Box) -> None:
+  if '_daemon_config' not in node:                # Does the current node need daemon-specific binds?
+    return                                        # ... nope, get out of here
+
+  node.clab.config_templates = node.clab.config_templates + node._daemon_config
+
 class Containerlab(_Provider):
   
   def augment_node_data(self, node: Box, topology: Box) -> None:
     node.hostname = "clab-%s-%s" % (topology.name,node.name)
+    add_daemon_filemaps(node,topology)
     normalize_clab_filemaps(node)
 
     self.create_extra_files_mappings(node,topology)

--- a/netsim/topology-defaults.yml
+++ b/netsim/topology-defaults.yml
@@ -30,6 +30,10 @@ devices:
   _include:
   - devices/*.yml
 
+daemons:
+  _include:
+  - daemons/*.yml
+  
 # Output settings
 #
 outputs:


### PR DESCRIPTION
Limitations:
* Includes a minimal implementation of BGP on Bird
* Supports daemons in containers, not in VMs

Changes:
* Include daemons/*.yml configurations into 'daemons:' default key
* Merge 'daemons:' with 'devices:' during device initialization step
* Set _daemon, _daemon_parent and _daemon_config node variables from device data to skip lookups into device data
* Copy topology modules into host modules if the host is a daemon
* Trim _daemon_config node dictionary based on modules active on the node (skips extraneous generation of irrelevant config files later on)
* Merge _daemon_config dictionary into clab.config_template to generate daemon config files as clab.binds
* Consider parent device and daemons directory when generating files from clab.config_templates
* Skip module configuration if _daemon_config dictionary contains a module configuration file
* Display daemons as separate table in 'netlab show devices'
* Add daemon data to YAML-formatted 'netlab show devices'