### PR TITLE
Refactor the "netlab status" printout (fixes #1044)

### DIFF
--- a/docs/netlab/status.md
+++ b/docs/netlab/status.md
@@ -7,98 +7,136 @@ This command uses the *netlab* status file (default: `~/.netlab/status.yml`) to 
 ## Usage
 
 ```
-usage: netlab status [-h] [--all] [-v] {list,show,cleanup,reset} [instance ...]
+$ netlab status -h
+usage: netlab status [-h] [-i INSTANCE] [-l] [--cleanup] [--reset] [--all] [-v] [-q]
 
 Display lab status
 
-positional arguments:
-  {list,show,cleanup,reset}
-                        Lab status action
-  instance              Display or cleanup specific lab instance(s)
-
 options:
   -h, --help            show this help message and exit
-  --all                 Display or cleanup all lab instance(s)
-  -v, --verbose         Verbose printout(s)
+  -i INSTANCE, --instance INSTANCE
+                        Display or cleanup specific lab instance(s)
+  -l, --log             Display the lab instance event log
+  --cleanup             Cleanup the current or specified lab instance
+  --reset               Reset the lab instance tracking system
+  --all                 Display an overview of all lab instance(s)
+  -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
+  -q, --quiet           Report only major errors
 ```
 
-* **netlab status** or **netlab status list** displays the currently-running lab instances.
-* **netlab status show** displays detailed state (including state change log) of selected lab instance(s)
-* **netlab status cleanup** shuts down selected lab instance(s). It changes the current directory to the lab directory saved in the status file and executes **netlab down --cleanup** in that directory
-* **netlab status reset** deletes the status file. Use this command only if the status file becomes corrupted.
+* **netlab status** displays the status and workload (VMs or containers) of the current or selected lab instance.
+* **netlab status --all** displays an overview of all currently running lab instances.
+* **netlab status --log** displays detailed status log (including state changes and executed commands) of the current- or selected lab instance(s)
+* **netlab status --cleanup** shuts down selected lab instance(s). It changes the current directory to the lab directory saved in the status file and executes **netlab down --cleanup** in that directory
+* **netlab status --reset** deletes the status file. Use this command only if the status file becomes corrupted.
+
+## Display Lab Instance State
+
+The **netlab status** command displays the selected lab instance and its VMs and containers:
+
+```
+Lab default in /home/user/net101/tools/X
+  status: started
+  provider(s): clab
+
+┏━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ node    ┃ device ┃ image                       ┃ mgmt IPv4       ┃ connection ┃ provider ┃ VM/container   ┃ status       ┃
+┡━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ host-1  │ linux  │ python:3.9-alpine           │ 192.168.121.107 │ docker     │ clab     │ clab-X-host-1  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ host-2  │ linux  │ python:3.9-alpine           │ 192.168.121.108 │ docker     │ clab     │ clab-X-host-2  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ leaf-1  │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.101 │ docker     │ clab     │ clab-X-leaf-1  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ leaf-2  │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.102 │ docker     │ clab     │ clab-X-leaf-2  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ leaf-3  │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.103 │ docker     │ clab     │ clab-X-leaf-3  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ leaf-4  │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.104 │ docker     │ clab     │ clab-X-leaf-4  │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ spine-1 │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.105 │ docker     │ clab     │ clab-X-spine-1 │ Up 4 minutes │
+├─────────┼────────┼─────────────────────────────┼─────────────────┼────────────┼──────────┼────────────────┼──────────────┤
+│ spine-2 │ frr    │ quay.io/frrouting/frr:9.1.0 │ 192.168.121.106 │ docker     │ clab     │ clab-X-spine-2 │ Up 4 minutes │
+└─────────┴────────┴─────────────────────────────┴─────────────────┴────────────┴──────────┴────────────────┴──────────────┘
+```
+
+## Display Lab Instance Log
+
+The **netlab status --log** command displays a detailed lab instance log, including state changes and executed commands:
+
+```
+$ netlab status --log
+Lab default in /home/pipi/net101/tools/X
+  status: started
+  provider(s): clab
+
+2024-03-21T15:49:53.405969+00:00: OK: containerlab version
+2024-03-21T15:49:53.428919+00:00: OK: bash -c [[ `containerlab version|awk '/version/ {print $2}'` > '0.42' ]] && echo OK
+2024-03-21T15:49:53.430807+00:00: restarting lab
+2024-03-21T15:49:53.432369+00:00: starting provider clab
+2024-03-21T15:49:56.009208+00:00: OK: sudo -E containerlab deploy -t clab.yml
+2024-03-21T15:49:56.011297+00:00: clab workload started
+2024-03-21T15:49:56.014699+00:00: deploying initial configuration
+2024-03-21T15:49:56.405222+00:00: deploying configuration: complete configuration
+2024-03-21T15:50:01.851112+00:00: OK: ansible-playbook /home/pipi/net101/tools/netsim/ansible/initial-config.ansible
+2024-03-21T15:50:01.893476+00:00: OK: netlab initial --no-message
+2024-03-21T15:50:01.895433+00:00: initial configuration complete
+2024-03-21T15:50:01.897105+00:00: started
+```
 
 ## Running Lab Instances
 
-The **netlab status list** command displays all running lab instances[^LI], their working directories, and the virtual machines (domains) and containers running on the current server.
+The **netlab status --all** command displays all running lab instances[^LI], their working directories, and the virtual machines (domains) and containers running on the current server.
 
 [^LI]: You could run multiple lab instances on the same server if you're using **[multilab](../plugins/multilab.md)** plugin.
 
 ```
-$ netlab status
-Lab default in /home/user/net101/tools/X
-  status: started
-  provider(s): clab
+$ netlab status --all
+Active lab instance(s)
 
-Running containers
-================================================================================
-CONTAINER ID   IMAGE                COMMAND        CREATED          STATUS          PORTS     NAMES
-20878d36c187   networkop/cx:4.4.0   "/sbin/init"   19 seconds ago   Up 18 seconds             clab-ospfv2-r1
-799cf6091c03   networkop/cx:4.4.0   "/sbin/init"   19 seconds ago   Up 18 seconds             clab-ospfv2-r2
-
-
-KVM/libvirt domains (virtual machines)
-================================================================================
- Id   Name   State
---------------------
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
+┃ id      ┃ directory                 ┃ status  ┃ providers ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
+│ default │ /home/pipi/net101/tools/X │ started │ clab      │
+└─────────┴───────────────────────────┴─────────┴───────────┘
 ```
 
-## Display Lab Instance State
-
-The **netlab status show** command displays more details about selected lab instance(s), including the state change log:
-
-```
-Lab default in /home/user/net101/tools/X
-  status: started
-  provider(s): clab
-
-Log:
-================================================================================
-2023-03-29T10:28:22.609058+02:00: starting lab
-2023-03-29T10:28:22.610693+02:00: starting provider clab
-2023-03-29T10:28:25.188872+02:00: clab workload started
-2023-03-29T10:28:25.194336+02:00: deploying initial configuration
-2023-03-29T10:28:25.681063+02:00: deploying configuration: complete configuration
-2023-03-29T10:28:36.042937+02:00: configuration deployment complete
-2023-03-29T10:28:36.059921+02:00: initial configuration complete
-2023-03-29T10:28:36.062101+02:00: started
-```
 
 ## Cleanup a Lab Instance
 
 The **netlab status cleanup _instance_** command shuts down the specified lab instance:
 
 ```
-$ netlab status cleanup default
-Cleanup will remove all specified lab instances. Are you sure? [Y/n]y
+$ netlab status --cleanup
+Cleanup will remove lab instance "default" in /home/user/net101/tools/X. Are you sure? [y/n]y
 Shutting down lab default in /home/user/net101/tools/X
-Reading transformed lab topology from snapshot file netlab.snapshot.yml
+Read transformed lab topology from snapshot file netlab.snapshot.yml
 
-Step 2: Checking virtualization provider installation
-============================================================
-.. all tests succeeded, moving on
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ CHECKING virtualization provider installation                                    │
+└──────────────────────────────────────────────────────────────────────────────────┘
+[SUCCESS] clab installed and working correctly
 
-
-Step 2: stopping the lab
-============================================================
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ STOPPING clab nodes                                                              │
+└──────────────────────────────────────────────────────────────────────────────────┘
 INFO[0000] Parsing & checking topology file: clab.yml
-INFO[0000] Destroying lab: ospfv2
-INFO[0000] Removed container: clab-ospfv2-r2
-INFO[0000] Removed container: clab-ospfv2-r1
-INFO[0000] Removing containerlab host entries from /etc/hosts file
+INFO[0000] Destroying lab: X
+INFO[0000] Removed container: clab-X-host-2
+INFO[0000] Removed container: clab-X-spine-2
+INFO[0000] Removed container: clab-X-leaf-3
+INFO[0000] Removed container: clab-X-spine-1
+INFO[0000] Removed container: clab-X-leaf-1
+INFO[0001] Removed container: clab-X-leaf-2
+INFO[0001] Removed container: clab-X-host-1
+INFO[0001] Removed container: clab-X-leaf-4
+INFO[0001] Removing containerlab host entries from /etc/hosts file
 
-Step 3: Cleanup configuration files
-============================================================
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ CLEANUP configuration files                                                      │
+└──────────────────────────────────────────────────────────────────────────────────┘
 ... removing clab.yml
+... removing directory tree clab_files
 ... removing ansible.cfg
 ... removing hosts.yml
 ... removing directory tree group_vars

--- a/netsim/cli/ansible.py
+++ b/netsim/cli/ansible.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 
 from ..utils import log
+from . import external_commands
 
 try:
   from importlib import resources
@@ -54,7 +55,6 @@ def playbook(name: str, args: typing.List[str]) -> None:
   cmd = ['ansible-playbook',pbname]
   cmd.extend(args)
 
-  try:
-    subprocess.check_call(cmd)
-  except Exception as ex:
-    log.fatal(f"Executing Ansible playbook {pbname} failed:\n  {ex}")
+  OK = external_commands.run_command(cmd)
+  if not OK:
+    log.fatal(f"Executing Ansible playbook {pbname} failed")

--- a/netsim/cli/down.py
+++ b/netsim/cli/down.py
@@ -180,6 +180,7 @@ def run(cli_args: typing.List[str]) -> None:
   mismatch = lab_dir_mismatch(topology)
 
   probes_OK = True
+  external_commands.LOG_COMMANDS = True
   lab_status_change(topology,f'lab shutdown requested{" in conflicting directory" if mismatch else ""}')
   try:
     provider_probes(topology)

--- a/netsim/cli/initial.py
+++ b/netsim/cli/initial.py
@@ -8,6 +8,7 @@ import os
 import argparse
 
 from . import common_parse_args,get_message,load_snapshot_or_topology,lab_status_change
+from . import external_commands
 from . import ansible
 from box import Box
 
@@ -86,6 +87,8 @@ def run(cli_args: typing.List[str]) -> None:
     ansible.playbook('create-config.ansible',rest)
     print("\nInitial configurations have been created in the %s directory" % args.output)
   else:
+    external_commands.LOG_COMMANDS = True
+
     topology = load_snapshot_or_topology(Box({},default_box=True,box_dots=True))
     deploy_text = ', '.join(deploy_parts) or 'complete configuration'
     if not topology is None:

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -141,6 +141,16 @@ def print_lab_log(log: typing.List) -> None:
   newline = "\n"
   print(f'{newline.join(log)}{newline}')
 
+def get_lab_status(lab_state: Box) -> str:
+  if lab_state.status == 'started':
+    return lab_state.status
+
+  for line in lab_state.log:
+    if 'started' in line:
+      return line
+
+  return lab_state.status
+
 def show_lab(args: argparse.Namespace,lab_states: Box) -> None:
   iid = get_instance(args,lab_states)
   lab_state = lab_states[iid]
@@ -152,7 +162,8 @@ def show_lab(args: argparse.Namespace,lab_states: Box) -> None:
   if topology is None:
     log.fatal(f'Cannot read topology snapshot file {snapshot}')
 
-  if lab_state.status != 'started':
+  lab_status = get_lab_status(lab_state)
+  if 'started' not in lab_status:
     log.error(
       'Lab is not started, cannot display node/tool status. Displaying lab start/stop log',
       category=log.FatalError,
@@ -162,6 +173,13 @@ def show_lab(args: argparse.Namespace,lab_states: Box) -> None:
     return
 
   show_lab_nodes(topology)
+  if lab_status != 'started':
+    print()
+    log.error(
+      "Lab is not in 'started' state, inspect details with 'netlab status --log'",
+      category=Warning,
+      module=''
+    )
 
 def show_lab_log(args: argparse.Namespace, lab_states: Box) -> None:
   iid = get_instance(args,lab_states)

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -81,7 +81,7 @@ def display_active_labs(topology: Box,args: argparse.Namespace,lab_states: Box) 
   heading = [ 'id', 'directory', 'status', 'providers' ]
   rows = []
   for id,lab_state in lab_states.items():
-    rows.append([id,lab_state.dir,lab_state.status,",".join(lab_state.providers)])
+    rows.append([str(id),lab_state.dir,lab_state.status,",".join(lab_state.providers)])
 
   strings.print_table(heading,rows)
 

--- a/netsim/cli/up.py
+++ b/netsim/cli/up.py
@@ -303,6 +303,7 @@ def run(cli_args: typing.List[str]) -> None:
   if log.QUIET:
     os.environ["ANSIBLE_STDOUT_CALLBACK"] = "selective"
 
+  external_commands.LOG_COMMANDS = True
   provider_probes(topology)
 
   p_provider = topology.provider

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -213,6 +213,12 @@ class _Provider(Callback):
   def post_configuration_create(self, topology: Box) -> None:
     pass
 
+  def get_lab_status(self) -> Box:
+    return get_empty_box()
+  
+  def get_node_name(self, node: str, topology: Box) -> str:
+    return node
+
   """
   Generic provider pre-transform processing: Mark multi-provider links
   """

--- a/netsim/providers/virtualbox.py
+++ b/netsim/providers/virtualbox.py
@@ -2,10 +2,17 @@
 # Vagrant/libvirt provider module
 #
 
+import typing
+
 from . import _Provider
+from .libvirt import Libvirt
 from box import Box
 
 class Virtualbox(_Provider):
 
   def transform_node_images(self, topology: Box) -> None:
     self.node_image_version(topology)
+
+  @typing.no_type_check
+  def get_node_name(self, node: str, topology: Box) -> str:
+    return Libvirt.get_node_name(self,node,topology)

--- a/netsim/utils/callback.py
+++ b/netsim/utils/callback.py
@@ -36,7 +36,9 @@ class Callback():
         print(f"Failed to load specific module: {sys.exc_info()[1]}")
       return None
 
-  def call(self, name: str, *args: typing.Any, **kwargs: typing.Any) -> None:
+  def call(self, name: str, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
     method = getattr(self,name,None)
     if method:
-      method(*args, **kwargs)
+      return method(*args, **kwargs)
+    else:
+      return None


### PR DESCRIPTION
* Display workload of current lab instance in tabular format
* Display all running instances in tabular format
* Add CLI options to display log, reset system, or shut down a lab instance

Also:
* Add 'get_lab_status' provider function to retrieve provider-specific workload information
* Add 'get_node_name' provider function to retrieve provider-specific workload name
* Add 'lab_status_log' to add lines to lab log
* Use 'lab_status_log' to log external commands based on external_commands.LOG_COMMANDS variable
* Use external command logging in netlab up/down/initial
* Initialize global topology variable after loading topology or snapshot file
* Use 'external_commands' module to run Ansible playbooks
