### PR TITLE
SROS LDP: Allow BGP next-hop resolution via LDP

### DIFF
--- a/netsim/ansible/templates/mpls/sros.ldp.j2
+++ b/netsim/ansible/templates/mpls/sros.ldp.j2
@@ -42,3 +42,17 @@
    ldp-sync: False
 {% endif %}
 {% endif %}
+
+{# If BGP is used, allow next hop resolution via LDP #}
+{% if 'bgp' in module %}
+- path: configure/router[router-name=Base]/bgp/next-hop-resolution
+  val:
+   shortcut-tunnel:
+    family:
+{%  for af in ('ipv4','ipv6') if af in loopback %}
+    - family-type: {{ af }}
+      resolution: filter
+      resolution-filter:
+       ldp: True
+{%  endfor %}
+{% endif %}


### PR DESCRIPTION
To make the BGP free core example work, LDP tunnels must be allowed to get used