### PR TITLE
VyOS: add cluster-id in rr config

### DIFF
--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -15,6 +15,9 @@ set protocols bgp system-as {{ bgp.as }}
 {% if bgp.router_id|ipv4 %}
 set protocols bgp parameters router-id {{ bgp.router_id }}
 {% endif %}
+{% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
+set protocols bgp parameters cluster-id {{ bgp.rr_cluster_id }}
+{% endif %}
 
 {% for n in bgp.neighbors %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}


### PR DESCRIPTION
Fixes #1063 

```
[ospf_adj_dut] Check OSPF adjacencies with DUT [ node(s): r1 ]
[WAITING]      Waiting for OSPF adjacency process to complete (retrying for 40 seconds)
[PASS]         Validation succeeded on r1
[PASS]         Succeeded in 5.2 seconds
[PASS]         Test succeeded

[ospf_adj_r1]  Check OSPF adjacencies with R1 [ node(s): r2,rr2 ]
[PASS]         Validation succeeded on r2
[PASS]         Validation succeeded on rr2
[PASS]         Test succeeded

[session]      Check BGP sessions with DUT [ node(s): r1,r2,rr2,x1 ]
[PASS]         x1: Neighbor 10.1.0.13 (dut) is in state Established
[WAITING]      Wait for BGP sessions to be established (retrying for 30 seconds)
[PASS]         rr2: Neighbor 10.0.0.1 (dut) is in state Established
[PASS]         r1: Neighbor 10.0.0.1 (dut) is in state Established
[PASS]         r2: Neighbor 10.0.0.1 (dut) is in state Established
[PASS]         Succeeded in 11.1 seconds
[PASS]         Test succeeded

[prefix]       Check whether DUT1 propagates the external beacon prefix [ node(s): r1,r2,rr2 ]
[PASS]         r1: The prefix 172.42.42.0/24 is in the BGP table
[PASS]         r2: The prefix 172.42.42.0/24 is in the BGP table
[PASS]         rr2: The prefix 172.42.42.0/24 is in the BGP table
[PASS]         Test succeeded

[nhs]          Check next-hop handling on DUT [ node(s): r1,r2 ]
[PASS]         r1: One of the next hops for prefix 172.42.42.0/24 is 10.0.0.1
[PASS]         r2: One of the next hops for prefix 172.42.42.0/24 is 10.0.0.1
[PASS]         Test succeeded

[reflect]      Check route reflection on DUT [ node(s): r2 ]
[PASS]         r2: The prefix 172.0.42.0/24 is in the BGP table
[PASS]         Test succeeded

[inact]        Check route reflection of inactive routes on DUT [ node(s): r2 ]
[PASS]         r2: The prefix 10.0.0.10/32 is in the BGP table
[PASS]         Test succeeded

[nhu]          Check next-hop handling of reflected routes [ node(s): r2 ]
[PASS]         r2: One of the next hops for prefix 172.0.42.0/24 is 10.0.0.10
[PASS]         Test succeeded

[cluster]      Check cluster-id attribute in the BGP update from RR [ node(s): r2 ]
[PASS]         r2: Cluster ID 10.0.0.42 found in at least one path for prefix 172.0.42.0/24
[PASS]         Test succeeded

[SUCCESS]      Tests passed: 16
```