### PR TITLE
VyOS: support for sending IPv6 RA

### DIFF
--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -89,6 +89,11 @@ set interfaces {{ ns.iface_level }} {{ ns.ifname }} vrf {{ l.vrf }}
 set service lldp interface all
 set service lldp interface {{ mgmt.ifname|default('eth0') }} disable
 
+{# IPv6 RA config #}
+{% for l in netlab_interfaces if 'ipv6' in l and l.type != 'loopback' %}
+set service router-advert interface {{ l.ifname }}
+{% endfor %}
+
 # Commit, save and exit from subshell
 
 commit


### PR DESCRIPTION
Fixes #1064 

```
[ping]    IPv4 ping H1 => H2 [ node(s): h1 ]
[PASS]    h1: Ping to h2 succeeded
[PASS]    Test succeeded

[pmtud]   ICMP DF error when pinging H2 => H1 (succeeds once) [ node(s): h2 ]
[PASS]    h2: Ping to h1 size 1400 failed as expected
[PASS]    Test succeeded

[mtud]    H2 => H1 MTU discovered [ node(s): h2 ]
[PASS]    h2: Ping to h1 size 1400 succeeded
[PASS]    Test succeeded

[ra]      Check RA-generated default route [ node(s): h1,h2 ]
[PASS]    h1: IPv6 default route is present
[PASS]    h2: IPv6 default route is present
[PASS]    Test succeeded

[ping6]   IPv6 ping H1 => H2 [ node(s): h1 ]
[PASS]    h1: Ping to ipv6 2001:db8:1:1::3 succeeded
[PASS]    Test succeeded

[SUCCESS] Tests passed: 6
```