### PR TITLE
VyOS: controlled community propagation

### DIFF
--- a/netsim/ansible/templates/bgp/vyos.macro.j2
+++ b/netsim/ansible/templates/bgp/vyos.macro.j2
@@ -31,6 +31,14 @@ set protocols bgp neighbor {{ peer }} address-family {{ af }}-unicast nexthop-se
 {%   if bgp.rr|default('') and not n.rr|default('') and n.type == 'ibgp' %}
   set protocols bgp neighbor {{ peer }} address-family {{ af }}-unicast route-reflector-client
 {%   endif %}
+
+{# community handling -> need to configure what NOT TO SEND (set protocols bgp neighbor XXX address-family XXX disable-send-community <extended|standard>) #}
+{%   for ctype in ['standard', 'extended'] %}
+{%     if not ctype in bgp.community[n.type] %}
+set protocols bgp neighbor {{ peer }} address-family {{ af }}-unicast disable-send-community {{ ctype }}
+{%     endif %}
+{%   endfor %}
+
 {%- endmacro -%}
 {#
    BGP network statement


### PR DESCRIPTION
Fixes #1079 

**NOTE**: only `standard` and `extended` values allowed (for now).

```
[session]      Check BGP sessions with DUT [ node(s): rc,r2,x1 ]
[PASS]         rc: Neighbor 10.0.0.1 (dut) is in state Established
[PASS]         r2: Neighbor 10.0.0.1 (dut) is in state Established
[PASS]         x1: Neighbor 10.1.0.9 (dut) is in state Established
[PASS]         Test succeeded

[prefix]       Check whether DUT propagates the beacon prefix [ node(s): r2,x1 ]
[PASS]         r2: The prefix 172.0.42.0/24 is in the BGP table
[PASS]         x1: The prefix 172.0.42.0/24 is in the BGP table
[PASS]         Test succeeded

[ibgp_comm]    Check community propagation on IBGP sessions [ node(s): r2 ]
[PASS]         r2: The prefix 172.0.42.0/24 contains the expected communities
[PASS]         Test succeeded

[ebgp_comm]    Check community propagation on EBGP sessions [ node(s): x1 ]
[PASS]         x1: The prefix 172.0.42.0/24 contains the expected communities
[PASS]         Test succeeded

[ebgp_no_comm] Check for lack of extended communities on EBGP sessions [ node(s): x1 ]
[PASS]         x1: The prefix 172.0.42.0/24 contains the expected communities
[PASS]         Test succeeded

[SUCCESS]      Tests passed: 8
```