### PR TITLE
VyOS: force BGP router-id on VRF

### DIFF
--- a/netsim/ansible/templates/vrf/vyos.bgp.j2
+++ b/netsim/ansible/templates/vrf/vyos.bgp.j2
@@ -2,6 +2,10 @@
 
 set protocols bgp system-as {{ bgp.as }}
 
+{# force router-id on vrf as well #}
+{% if bgp.router_id|ipv4 %}
+set protocols bgp parameters router-id {{ bgp.router_id }}
+{% endif %}
 
 {% for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}
 set protocols bgp address-family {{ af }}-unicast rd vpn export {{ vdata.rd }}


### PR DESCRIPTION
Fixes #1081 

```
[session]  Check EBGP sessions with DUT [ node(s): r1,r2,r3,r4 ]
[PASS]     r1: Neighbor 2001:db8:3::1 (dut) is in state Established
[PASS]     r2: Neighbor 2001:db8:3:1::1 (dut) is in state Established
[PASS]     r3: Neighbor 2001:db8:3:2::1 (dut) is in state Established
[PASS]     r4: Neighbor 2001:db8:3:3::1 (dut) is in state Established
[PASS]     Test succeeded

[pfx_red]  Check IPv6 BGP prefix on R1 [ node(s): r1 ]
[PASS]     r1: The prefix 2001:db8:1:3::/64 is in the BGP table
[PASS]     Test succeeded

[pfx_blue] Check IPv6 BGP prefix on R3 [ node(s): r3 ]
[PASS]     r3: The prefix 2001:db8:1:5::/64 is in the BGP table
[PASS]     Test succeeded

[lb_red]   Check DUT loopback IPv6 BGP prefix in red VRF [ node(s): r1 ]
[PASS]     r1: The prefix 2001:db8:c001:cafe::/64 is in the BGP table
[PASS]     Test succeeded

[lb_blue]  Check DUT loopback IPv6 BGP prefix in blue VRF [ node(s): r3 ]
[PASS]     r3: The prefix 2001:db8:c001:cafe::/64 is in the BGP table
[PASS]     Test succeeded

[red]      Ping-based reachability test in VRF red [ node(s): r1 ]
[PASS]     r1: Ping to ipv6 r2 succeeded
[PASS]     Test succeeded

[ping]     Ping-based reachability test in VRF blue [ node(s): r3 ]
[PASS]     r3: Ping to ipv6 r4 succeeded
[PASS]     Test succeeded

[red_lb]   Pinging red VRF loopback [ node(s): r1 ]
[PASS]     r1: Ping to ipv6 2001:db8:c001:cafe::1 succeeded
[PASS]     Test succeeded

[blue_lb]  Pinging blue VRF loopback [ node(s): r3 ]
[PASS]     r3: Ping to ipv6 2001:db8:c001:cafe::1 succeeded
[PASS]     Test succeeded

[SUCCESS]  Tests passed: 12
```