### PR TITLE
Fix bgp communities inside VRFs

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -128,7 +128,7 @@
     connect-retry: 10
     _annotate_connect-retry: "Reduce default 120s to 10s"
     minimum-advertisement-interval: 1
-{% set list = vrf_bgp.community[type]|default([]) %}
+{% set list = bgp.community[type]|default([]) %}
    send-community:
     standard: {{ 'standard' in list }}
     large: {{ 'standard' in list }}


### PR DESCRIPTION
The config has a 'community' array at the global level, not per VRF