### PR TITLE
Fix srlinux asymmetric irb evpn, add validation for integration test

### DIFF
--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -29,9 +29,9 @@ updates:
 
 {# Enable IP advertisement for all irb interfaces in EVPN vlans #}
 {% if vrfs is defined and vrfs %}
-{% for i in interfaces if i.vrf is defined and vrfs[i.vrf].evpn is defined and i.type=='svi' and i.vlan.mode|default('irb')=='irb' %}
+{% for i in interfaces if i.vrf is defined and i.type=='svi' and i.vlan.mode|default('irb')=='irb' %}
 {%  set vrf = vrfs[i.vrf] %}
-{%  set symmetric_irb = 'transit_vni' in vrf.evpn %}
+{%  set symmetric_irb = 'transit_vni' in vrf.evpn|default('') %}
 - path: /interface[name=irb0]/subinterface[index={{ i.ifname.split('.')[1] }}]
   val:
 {%  for ip,arpnd in [('ipv4','arp'),('ipv6','neighbor-discovery')] %}

--- a/tests/integration/evpn/vxlan-asymmetric-irb-ospf.yml
+++ b/tests/integration/evpn/vxlan-asymmetric-irb-ospf.yml
@@ -56,3 +56,29 @@ links:
 
 - s1:
   s2:
+
+validate:
+  ping-h4:
+    description: Host reachability
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    nodes: [ h1,h2,h3 ]
+    plugin: ping('h4')
+  ping-h3:
+    description: Host reachability
+    wait_msg: Waiting for STP to enable the ports
+    wait: 5
+    nodes: [ h1,h2,h4 ]
+    plugin: ping('h3')
+  ping-h2:
+    description: Host reachability
+    wait_msg: Waiting for STP to enable the ports
+    wait: 5
+    nodes: [ h1,h3,h4 ]
+    plugin: ping('h2')
+  ping-h1:
+    description: Host reachability
+    wait_msg: Waiting for STP to enable the ports
+    wait: 5
+    nodes: [ h2,h3,h4 ]
+    plugin: ping('h1')


### PR DESCRIPTION
In the asymmetric irb case, vrf.evpn is not defined

Adds a validation test that allowed me to identify this issue