### PR TITLE
Simplify RouterOS7 box building process

### DIFF
--- a/docs/labs/routeros7.md
+++ b/docs/labs/routeros7.md
@@ -1,34 +1,32 @@
-# Building an Mikrotik RouterOS 7 CHR Libvirt Box
+# Building a Mikrotik RouterOS 7 CHR Libvirt Box
 
 Mikrotik RouterOS 7 CHR is supported by the **netlab libvirt package** command. To build it:
 
 * Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
-* Download the CHR 7 vmdk disk image into that directory
-* Convert the image to the *qcow2* format (`qemu-img convert -f vmdk -O qcow2 chr-7.5.vmdk chr-7.5.qcow2`)
+* Download the CHR 7 vmdk disk image into that directory (unzip the ZIP archive if you downloaded a .zip file)
 * Execute **netlab libvirt package routeros7 _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package routeros7** command has been tested on Ubuntu 20.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+* The **‌netlab libvirt package routeros7** command has been tested on Ubuntu 22.04 LTS and might not work on other Linux distros.
 ```
 
 ## Initial Device Configuration
 
-During the box-building process (inspired by the [step-by-step instructions by Stefano Sasso](http://stefano.dscnet.org/a/mikrotik_vagrant/)) you'll have to copy-paste initial device configuration. **netlab libvirt config routeros7** command displays the build recipe:
+During the box-building process (inspired by the [step-by-step instructions by Stefano Sasso](http://stefano.dscnet.org/a/mikrotik_vagrant/)), you'll have to copy-paste the initial device configuration. **netlab libvirt config routeros7** command displays the build recipe:
 
 ```{eval-rst}
 .. include:: routeros7.txt
    :literal:
 ```
 
-## Hack for ether1 interface
+## Hack for the ether1 Interface
 
-The initial device configuration includes an hack for having a DHCP address on the first ethernet interface of the new VM (*ether1*).
+The initial device configuration includes a hack to create a DHCP address on the new VM's first ethernet interface (*ether1*).
 
-*RouterOS* saves somewhere the existing network interfaces, together with their own names, checking for their existance on the subsequent boots. Every time it founds a new ethernet interface, this will be added to the list with a "sequence number", i.e., ether2, ether3, and so on.
+*RouterOS* saves the existing network interfaces, together with their names, and checks for their existence on subsequent boots. Every time it finds a new ethernet interface, the new interface is added to the list with a "sequence number," i.e., ether2, ether3, and so on.
 
-The network interface we are using during the installation won't be present anymore on the next boot time, and the "new" first interface will be called *ether2* - which we don’t like.
+The network interface we used during the installation will no longer be present at the next boot time, and the "new" first interface will be called *ether2*, which we don’t like.
 
-But, we can simply rename the current interface to something different than *ether1*. Doing so, the "new" first interface will be called exactly *ether1*. Much better!
+However, if we rename the current interface to something other than *ether1*, the "new" first interface will be called *ether1* -- exactly what we need.
 
-At the same time, since any configuration about DHCP Client is linked to the current interface (and the configuration is referenced by ID, not by interface name), we need to change the DHCP Client config on every boot to use the new *ether1* interface. This can be done using a system scheduler script at every system startup.
+At the same time, since the DHCP client configuration is linked to the current interface (and the configuration is referenced by ID, not by interface name), we need to change the DHCP Client configuration on every boot to use the new *ether1* interface -- that's the role of the system scheduler script included in the initial configuration.

--- a/netsim/install/libvirt/routeros7.txt
+++ b/netsim/install/libvirt/routeros7.txt
@@ -4,15 +4,10 @@ Creating initial configuration for RouterOS 7
 * Wait for the 'login' prompt
 * Login as 'admin' (no password)
 * Set the new 'admin' password as 'admin'
-* From your Linux box, copy the "vagrant ssh key" to the RouterOS VM:
-  * IP address here is just an example - use `/ip/address/print` from the VM to discover it
-  * `scp ~/.vagrant.d/insecure_private_key admin@192.168.121.50:`
+  (do not use a different password, this is what netlab expects)
 * Copy-paste the following configuration
 
 =============================================
-
-/user add group=full name=vagrant password=vagrant
-/user ssh-keys import public-key-file=insecure_private_key user=vagrant
 
 /interface ethernet set 0 name=temp
 

--- a/netsim/templates/provider/libvirt/routeros7-domain.j2
+++ b/netsim/templates/provider/libvirt/routeros7-domain.j2
@@ -1,6 +1,8 @@
     {{ name }}.vm.guest = :freebsd
     {{ name }}.ssh.insert_key = false
     {{ name }}.ssh.shell = "/ip/address/print"
+    {{ name }}.ssh.username = "admin"
+    {{ name }}.ssh.password = "admin"
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
 
     {{ name }}.vm.provider :libvirt do |domain|


### PR DESCRIPTION
netlab is using admin/admin username/password to access RouterOS7 devices. There's no need to add 'vagrant' user to the initial configuration or copy Vagrant key to the device.