### PR TITLE
Doc fix: Aruba CX box-building recipe

### DIFF
--- a/docs/labs/arubacx.md
+++ b/docs/labs/arubacx.md
@@ -3,29 +3,30 @@
 Aruba AOS-CX 10 is supported by the **netlab libvirt package** command. To build it:
 
 * Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
-* Download the `Aruba_AOS-CX_Switch_Simulator` (*see below*) OVA image into that directory, and uncompress it (and the OVA file - which is a tarball)
-* Convert the vmdk image to the *qcow2* format (`qemu-img convert -f vmdk -O qcow2 arubaoscx-disk-image-genericx86-p4-20231110145644.vmdk arubacx-10.13.qcow2`)
-* Execute **netlab libvirt package arubacx _virtual-disk-file-name_** and follow the instructions
+* Download the `Aruba_AOS-CX_Switch_Simulator` (*see below*) OVA image into that directory.
+* Starting with the *netlab* release 1.8.2, execute **netlab libvirt package arubacx _ova-file-name_**
+* If you're using a *netlab* release older than 1.8.2, unpack the OVA file with **tar xvf _ova-file-name_** and execute **netlab libvirt package arubacx _vmdk-disk-file-name_**
+* Follow the instructions given by the **netlab libvirt package** script
 
 ```{warning}
-* The **‌netlab libvirt package arubacx** command has been tested on Ubuntu 20.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Aruba AOS-CX download notes
 
-The *Aruba AOS-CX 10 Switch Simulator* image can be download from the *Aruba Support Portal* (after user registration), searching for: `Aruba_AOS-CX_Switch_Simulator`. In example, release **10.13** can be downloaded from [here](https://asp.arubanetworks.com/downloads/software/RmlsZTowOTRjZDU3ZS04Y2VkLTExZWUtOGRiNy0yMzkyMDY4ZjdmZmU%3D).
+The *Aruba AOS-CX 10 Switch Simulator* image can be downloaded from the *Aruba Support Portal* (requires user registration). Search for the `Aruba_AOS-CX_Switch_Simulator`. For example, the release **10.13** can be downloaded from [here](https://asp.arubanetworks.com/downloads/software/RmlsZTowOTRjZDU3ZS04Y2VkLTExZWUtOGRiNy0yMzkyMDY4ZjdmZmU%3D).
 
 ## Initial Device Configuration
 
-During the box-building process you'll have to copy-paste initial device configuration. **netlab libvirt config arubacx** command displays the build recipe:
+You'll have to copy-paste the initial device configuration during the box-building process. The **netlab libvirt config arubacx** command displays the build recipe:
 
 ```{eval-rst}
 .. include:: arubacx.txt
    :literal:
 ```
-**NOTE**: It seems it's not possible to create a user called *vagrant* on AOS-CX, so the configuration creates a *netlab* user (with password: *netlab*).
+
+**NOTE**: It seems impossible to create a user called *vagrant* on AOS-CX, so the configuration creates a *netlab* user (with password: *netlab*).
 
 ## Ansible Galaxy for Aruba AOS-CX
 
-You need to install the Ansible modules for Aruba AOS-CX with: `ansible-galaxy collection install arubanetworks.aoscx`.
+You must install the Ansible modules for Aruba AOS-CX with the  `ansible-galaxy collection install arubanetworks.aoscx` command.

--- a/docs/labs/asav.md
+++ b/docs/labs/asav.md
@@ -7,8 +7,7 @@ Cisco ASAv is supported by the **netlab libvirt package** command. To build a AS
 * Execute **netlab libvirt package asav _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package asav** command has been tested on Ubuntu 20.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Preparing the Box Configuration

--- a/docs/labs/csr.md
+++ b/docs/labs/csr.md
@@ -8,7 +8,7 @@ Cisco CSR 1000v is supported by the **netlab libvirt package** command. To build
 
 ```{warning}
 * You MUST have a CSR disk image that expects to be configured through the serial interface for this procedure to work. If all you have is an image that expects a graphics card, the [original recipe on codingpackets.com](https://codingpackets.com/blog/cisco-iosv-vagrant-libvirt-box-install/) might still work for you.
-* The **‌netlab libvirt package csr** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
+* If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration

--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -4,8 +4,7 @@ Dell OS10 is supported by the **netlab libvirt package** command.
 
 ```{warning}
 * Dell provides the OS10 Virtual image as a set of vmdk and gns3a files to be used within GNS3. The following procedure will "convert" the required files for using them with Vagrant.
-* The **‌netlab libvirt package dellos10** command has been tested on Ubuntu and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+* If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 To prepare for the build:

--- a/docs/labs/eos.md
+++ b/docs/labs/eos.md
@@ -12,7 +12,7 @@ Use the `eos-downloader` Python package to simplify vEOS image download. See the
 * Execute **netlab libvirt package eos _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package eos** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration

--- a/docs/labs/iosv.md
+++ b/docs/labs/iosv.md
@@ -7,7 +7,7 @@ Cisco IOSv is supported by the **netlab libvirt package** command. To build a IO
 * Execute **netlab libvirt package iosv _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package iosv** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration

--- a/docs/labs/iosxr.md
+++ b/docs/labs/iosxr.md
@@ -3,17 +3,16 @@
 Cisco IOS XR is supported by the **netlab libvirt package** command. To build an IOS XR box:
 
 * Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
-* Download IOS XR software, and unpack the image archive to get the `qcow2` disk image (example: `xrv9k-fullk9-x-7.4.2.qcow2`).
+* Download IOS XR software and unpack the image archive to get the `qcow2` disk image (example: `xrv9k-fullk9-x-7.4.2.qcow2`).
 * Execute **netlab libvirt package iosxr _virtual-disk-file-name_** and follow the instructions.
 
 ```{warning}
-* The **netlab libvirt package iosxr** command has been tested on Ubuntu 20.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration
 
-During the box-building process (inspired by [this solution](https://codingpackets.com/blog/cisco-iosxrv-vagrant-libvirt-box-install/)) you'll have to copy-paste initial device configuration. **netlab libvirt config iosxr** command displays the build recipe:
+During the box-building process (inspired by [this solution](https://codingpackets.com/blog/cisco-iosxrv-vagrant-libvirt-box-install/)), you'll have to copy-paste the initial device configuration. **netlab libvirt config iosxr** command displays the build recipe:
 
 ```{eval-rst}
 .. include:: iosxr.txt

--- a/docs/labs/libvirt-box-caveats.md
+++ b/docs/labs/libvirt-box-caveats.md
@@ -1,0 +1,9 @@
+# Box-Building Caveats
+
+The Vagrant box-building process relies on numerous Linux tools that have changed their behavior across Ubuntu releases. These caveats might apply if you're not using the *netlab* release 1.8.2 or later:
+
+* On Ubuntu 22.04 LTS (and later), the `libvirt-qemu` user needs read- and execute access to the VM disk file. It’s easiest to create Vagrant boxes in a subdirectory of the /tmp directory. This caveat does not apply to Ubuntu 20.04. Starting with release 1.8.2, the **netlab libvirt package** script always builds boxes within the /tmp directory.
+* *‌virt-install* might report a fatal error on Ubuntu 22.04 (and later). Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process. Starting with release 1.8.1, the **netlab libvirt package** script sets this parameter.
+* If you downloaded an OVA file, you have to unpack it with the **tar xvf _ova_filename_** command. Starting with release 1.8.2, the **netlab libvirt package** script automatically unpacks the OVA files.
+
+Finally, we tested the box-building scripts on Ubuntu 20.04 or 22.04. The **netlab libvirt package** might not work correctly on other Linux distributions.

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -252,6 +252,7 @@ The virtual machines are batched based on their order in **‌nodes** list/dicti
    :maxdepth: 1
    :hidden:
 
+   libvirt-box-caveats.md
    eos.md
    arubacx.md
    asav.md

--- a/docs/labs/nxos.md
+++ b/docs/labs/nxos.md
@@ -24,7 +24,7 @@ Cisco Nexus 9300v is supported by the **netlab libvirt package** command. To bui
 
 ```{warning}
 * The box building process generates a random device serial number that will be used by all Nexus 9300v devices created from the Vagrant box. As NX-OS uses device serial number as its DHCP client ID, you might experience problems starting a lab with more than one Nexus 9300v device on newer versions of KVM/libvirt. The workaround-of-last-resort is [setting libvirt **batch_size** to 1](libvirt.md#starting-virtual-machines-in-batches).
-* The **‌netlab libvirt package nxos** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
+* If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ```{tip}

--- a/docs/labs/routeros7.md
+++ b/docs/labs/routeros7.md
@@ -8,8 +8,7 @@ Mikrotik RouterOS 7 CHR is supported by the **netlab libvirt package** command. 
 * Execute **netlab libvirt package routeros7 _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package routeros7** command has been tested on Ubuntu 20.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration

--- a/docs/labs/vptx.md
+++ b/docs/labs/vptx.md
@@ -8,8 +8,8 @@ Juniper vPTX (known as `vJunos EVO` or `vJunos Evolved`) is supported by the **n
 
 ```{warning}
 * Use *netlab* release 1.7.0 or higher with Juniper vPTX devices.
-* The **‌netlab libvirt package vptx** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
 * Juniper vJunos EVO uses Linux instead of BSD as the underlying OS. The management interface name became `re0:mgmt-0`.
+* If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Initial Device Configuration

--- a/docs/labs/vsrx.md
+++ b/docs/labs/vsrx.md
@@ -7,8 +7,7 @@ Juniper vSRX 3.0 is supported by the **netlab libvirt package** command. To buil
 * Execute **netlab libvirt package vsrx _virtual-disk-file-name_** and follow the instructions
 
 ```{warning}
-* The **‌netlab libvirt package vsrx** command has been tested on Ubuntu 20.04 LTS and 22.04 LTS and might not work on other Linux distros.
-* *‌virt-install* might report a fatal error on Ubuntu 22.04. Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process.
+If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
 ## Preparing the Box Configuration

--- a/netsim/install/libvirt/arubacx.txt
+++ b/netsim/install/libvirt/arubacx.txt
@@ -4,6 +4,9 @@ Creating initial configuration for ArubaOS-CX
 * Wait for the 'login' prompt
 * Login as 'admin' (no password)
 * Set the new 'admin' password as 'admin'
+* Save the initial configuration with 'write memory'
+* Reload the device with 'boot system'
+* Login as 'admin' password 'admin'
 * Copy-paste the following configuration
 
 =============================================
@@ -13,26 +16,23 @@ configure
 user netlab group administrators password plaintext netlab
 user netlab authorized-key ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==
 !
+ntp vrf mgmt
 ssh server vrf mgmt
-https server vrf mgmt
 !
 interface mgmt
   no shutdown
   ip dhcp
 !
-ntp vrf mgmt
+https-server vrf mgmt
 !
 end
-!
-write memory
-!
-! reload cycle is required
-!
-boot system
-!
 
 =============================================
 
-* After the reboot, check that the management interface is up (sometimes you may need to apply the config and reboot twice)
+* Save the configuration with 'write memory'
+* Reload the device with 'boot system'
+* Verify that the startup- and running config contain the above configuration
+  commands. Repeat the 'configure, write, reboot' cycle if needed
+* Check that the management interface is up and has an IP address 
 * Disconnect from console (ctrl-] usually works).
 * Shutdown the VM, if needed


### PR DESCRIPTION
It seems that Aruba CX 10.13 consistently messes up startup configuration on first reboot. Changed the box-building recipe to reboot the device first, then apply the desired configuraton. Fixes #1117