### PR TITLE
Doc fix: Aruba CX box-building recipe

### DIFF
--- a/netsim/install/libvirt/arubacx.txt
+++ b/netsim/install/libvirt/arubacx.txt
@@ -4,6 +4,9 @@ Creating initial configuration for ArubaOS-CX
 * Wait for the 'login' prompt
 * Login as 'admin' (no password)
 * Set the new 'admin' password as 'admin'
+* Save the initial configuration with 'write memory'
+* Reload the device with 'boot system'
+* Login as 'admin' password 'admin'
 * Copy-paste the following configuration
 
 =============================================
@@ -13,26 +16,23 @@ configure
 user netlab group administrators password plaintext netlab
 user netlab authorized-key ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ==
 !
+ntp vrf mgmt
 ssh server vrf mgmt
-https server vrf mgmt
 !
 interface mgmt
   no shutdown
   ip dhcp
 !
-ntp vrf mgmt
+https-server vrf mgmt
 !
 end
-!
-write memory
-!
-! reload cycle is required
-!
-boot system
-!
 
 =============================================
 
-* After the reboot, check that the management interface is up (sometimes you may need to apply the config and reboot twice)
+* Save the configuration with 'write memory'
+* Reload the device with 'boot system'
+* Verify that the startup- and running config contain the above configuration
+  commands. Repeat the 'configure, write, reboot' cycle if needed
+* Check that the management interface is up and has an IP address 
 * Disconnect from console (ctrl-] usually works).
 * Shutdown the VM, if needed


### PR DESCRIPTION
It seems that Aruba CX 10.13 consistently messes up startup configuration on first reboot. Changed the box-building recipe to reboot the device first, then apply the desired configuraton.

Fixes #1117