### PR TITLE
Fix Dell OS10 Ansible-related information

### DIFF
--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -34,5 +34,8 @@ During the box-building process you'll have to copy-paste initial device configu
    :literal:
 ```
 
+## Ansible Galaxy for Dell OS10
+
+You must install the Ansible modules for Dell OS10 with the  `ansible-galaxy collection install arubanetworks.aoscx` command.
 
 

--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -36,6 +36,6 @@ During the box-building process you'll have to copy-paste initial device configu
 
 ## Ansible Galaxy for Dell OS10
 
-You must install the Ansible modules for Dell OS10 with the  `ansible-galaxy collection install arubanetworks.aoscx` command.
+You must install the Ansible modules for Dell OS10 with the  `ansible-galaxy collection install dellemc.os10` command.
 
 

--- a/netsim/ansible/tasks/deploy-config/dellos10.yml
+++ b/netsim/ansible/tasks/deploy-config/dellos10.yml
@@ -6,7 +6,7 @@
 - name: "dellos10_config: deploying {{ netsim_action }} from {{ config_template }}"
   dellemc.os10.os10_config:
     match: "none"
-    src: "{{ lookup('template', config_template) }}"
+    src: "{{ config_template }}"
     save: "yes"
   tags: [ print_action, always ]
   register: os10_output


### PR DESCRIPTION
* It looks like OS10 requires dellemc.os10 Ansible collection to work. Added that information to the box-building instructions
* The 'dellos10.yml' configuration deployment task failed for me. It looks like the newer versions of the dellemc.os10 Ansible collection expect a filename, not the actual commands, as the parameter to dellemc.os10.os10_config.