### PR TITLE
Add box preinstall hook that copies extra Dell OS10 files to build directory

### DIFF
--- a/docs/labs/dellos10.md
+++ b/docs/labs/dellos10.md
@@ -3,31 +3,23 @@
 Dell OS10 is supported by the **netlab libvirt package** command.
 
 ```{warning}
-* Dell provides the OS10 Virtual image as a set of vmdk and gns3a files to be used within GNS3. The following procedure will "convert" the required files for using them with Vagrant.
+* Dell [provides the OS10 Virtual image](https://www.dell.com/support/home/en-us/product-support/product/smartfabric-os10-emp-partner/drivers) as a ZIP archive `.vmdk` and `.gns3a` files. **netlab libvirt package** converts these files into a Vagrant box.
 * If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
-To prepare for the build:
+* Download the OS10 ZIP archive into an empty directory
+* Unzip the archive with the **unzip *zip-file-name*** command
+* Execute **netlab libvirt package dellos10 OS10-Disk-1.0.0.vmdk**[^NCFN] and follow the instructions
 
-* Download OS10 files into `/tmp` directory
-* Create an empty directory on a Ubuntu machine with *libvirt* and *Vagrant*.
-* Convert these *vmdk* files into *qcow2* format with *qemu-img* utility:
-  * OS10-Disk-1.0.0.vmdk
-  * OS10-Installer-`<VERSION>`.vmdk
-  * OS10-platform-`<PLATFORM>`-`<VERSION>`.vmdk
+[^NCFN]: Hoping Dell doesn't decide to change the filename ;)
+
+```{tip}
+The box-building process creates a Vagrant box based on the S5224F platform. If you'd like to work with a different switch model, you'll have to fix the installation script; if you make the platform selection configurable, please submit a Pull Request.
 ```
-qemu-img convert -O qcow2 /tmp/OS10-Disk-1.0.0.vmdk OS10-Disk-1.qcow2
-qemu-img convert -O qcow2 /tmp/OS10-Installer-10.5.3.4.108.vmdk hdb_OS10-installer.qcow2
-qemu-img convert -O qcow2 /tmp/OS10-platform-S5224F-10.5.3.4.108.vmdk hdc_OS10-platform.qcow2
-```
-
-To build a Dell OS10 box based on the above install image:
-
-* Execute **netlab libvirt package dellos10 OS10-Disk-1.qcow2** and follow the instructions
 
 ## Initial Device Configuration
 
-During the box-building process you'll have to copy-paste initial device configuration. **netlab libvirt config dellos10** command displays the build recipe:
+You'll have to copy-paste the initial device configuration during the box-building process. **netlab libvirt config dellos10** command displays the build recipe:
 
 ```{eval-rst}
 .. include:: dellos10.txt

--- a/netsim/cli/libvirt_actions/package.py
+++ b/netsim/cli/libvirt_actions/package.py
@@ -384,10 +384,12 @@ def run(cli_args: typing.List[str], topology: Box) -> None:
   workdir = f'/tmp/build_{args.device}'
   homedir = os.path.realpath(os.getcwd())
 
-  if not 'preinstall' in skip:
-    lp_preinstall_hook(args,settings)
   if workdir:
     create_workdir(workdir,args)
+    os.environ["NETLAB_PACKAGE_WORKDIR"] = workdir          # Pass the build directory to preinstall hooks
+
+  if not 'preinstall' in skip:
+    lp_preinstall_hook(args,settings)
   try:
     if not 'disk' in skip:
       lp_create_vm_disk(args,workdir)

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -45,6 +45,7 @@ libvirt:
       --disk path=vm.qcow2,format=qcow2,bus=sata
       --disk path=hdb_OS10-installer.qcow2,format=qcow2,bus=virtio
       --disk path=hdc_OS10-platform.qcow2,format=qcow2,bus=virtio
+  pre_install: dellos10
 group_vars:
   ansible_network_os: dellos10
   ansible_connection: network_cli

--- a/netsim/install/libvirt/dellos10/run.sh
+++ b/netsim/install/libvirt/dellos10/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+#
+import sys
+import os
+import netsim.utils.strings as strings
+import netsim.cli.external_commands as _xt
+import netsim.cli.libvirt_actions.package as _pkg
+import netsim.utils.files as _files
+import netsim.utils.log as log
+
+def find_file(glob: str) -> str:
+  flist = _files.get_globbed_files('.',glob)
+  if not flist:
+    log.fatal(f'Cannot find {glob} in current directory','dellos10')
+
+  if len(flist) > 1:
+    log.fatal(
+      f'More than one file matches the {glob} pattern. You must have a single OS10 version in current directory',
+      module='dellos10')
+    
+  return flist[0]
+
+def main() -> None:
+  workdir = os.environ["NETLAB_PACKAGE_WORKDIR"]
+  strings.print_colored_text('[CONVERT] ','green',None)
+  print("Converting OS10 installer disk to qcow2 and copying it to build directory")
+  inst_disk = find_file('OS10-Installer-*.vmdk')
+  _pkg.abort_on_failure(f"qemu-img convert -f vmdk -O qcow2 {inst_disk} {workdir}/hdb_OS10-installer.qcow2")
+
+  strings.print_colored_text('[INFO]    ','bright_cyan',None)
+  print("Assuming S5224F as the hardware platform")
+  hw_disk = find_file('OS10-platform*S5224F*vmdk')
+
+  strings.print_colored_text('[CONVERT] ','green',None)
+  print("Converting OS10 platform disk to qcow2 and copying it to build directory")
+  _pkg.abort_on_failure(f"qemu-img convert -f vmdk -O qcow2 {hw_disk} {workdir}/hdc_OS10-platform.qcow2")
+
+  return
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Trying to simplify the OS10 box building process, I added a simple preinstall hook that copies installation- and platform disks to the build directory.