### PR TITLE
Dell OS10: fix on bgp template definition

### DIFF
--- a/netsim/ansible/templates/bgp/dellos10.j2
+++ b/netsim/ansible/templates/bgp/dellos10.j2
@@ -6,6 +6,7 @@ router bgp {{ bgp.as }}
 ! define a generic unnumbered template to be used for eBGP unnumbered...
 ! WTF Dell...
   template unnumbered_ebgp
+  exit
 
 {% if bgp.router_id|ipv4 %}
   router-id {{ bgp.router_id }}


### PR DESCRIPTION
Apparently, with newer OS10 ansible collection, it's required to explicitly exit the bgp template stanza before running other commands.