### PR TITLE
Reduce the Dell OS10 boot waiting time to two minutes

### DIFF
--- a/netsim/templates/provider/libvirt/dellos10-domain.j2
+++ b/netsim/templates/provider/libvirt/dellos10-domain.j2
@@ -2,7 +2,7 @@
     {{ name }}.ssh.insert_key = false
     {{ name }}.ssh.shell = "show version"
     {{ name }}.vm.guest = :freebsd
-    {{ name }}.vm.boot_timeout = 600
+    {{ name }}.vm.boot_timeout = 120
 
     {{ name }}.vm.provider :libvirt do |domain|
       domain.disk_bus = 'ide'


### PR DESCRIPTION
I think two minutes should be enough for a recent OS10 to boot, and it would reduce the wasted time in automated tests when the SSH server does not start.