### PR TITLE
Fix SR Linux VRF BGP import/export policies

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -1,50 +1,3 @@
-{% macro bgp_policy(vrf,is_import,communities,vrf_context) %}
-{% set name = vrf + "_ebgp_" + ('import' if is_import else 'export') %}
-
-{% macro accept() %}
-{% if is_import or not communities %}
-      policy-result: "accept"
-{% else %}
-      policy-result: "accept"
-      # bgp:
-      #  communities:
-      #   add: "{{ name }}"
-{% endif %}
-{% endmacro %}
-
-- path: routing-policy/prefix-set[name={{vrf}}_export]
-  val:
-   prefix: [] # Make sure it exists
-
-- path: routing-policy/policy[name={{name}}]
-  val:
-   default-action:
-    policy-result: "reject"
-   statement:
-{% if is_import %}
-{%  for c in communities|default([]) %}
-   - name: {{ 10 + loop.index }}
-     match:
-      bgp:
-       community-set: "C{{ c|replace(':','_') }}"
-     action:
-{{    accept() }}
-{%  endfor %}
-{% else %}
-   - name: 5
-     match:
-      protocol: bgp
-      _annotate_protocol: "Accept and propagate prefixes received via BGP"
-     action:
-{{    accept() }}
-   - name: 10
-     match:
-      prefix-set: "{{ vrf }}_export"
-     action:
-{{    accept() }}
-{% endif %}
-{% endmacro %}
-
 {% macro bgp_export_prefix(vrf,prefix) %}
 - path: routing-policy/prefix-set[name={{vrf}}_export]
   val:
@@ -54,17 +7,6 @@
 {% endmacro %}
 
 {% macro bgp_config(vrf,_as,router_id,vrf_bgp,vrf_context) %}
-
-{% if 'import' in vrf_context %}
-{% set import_policy = vrf + "_ebgp_import" %}
-{{ bgp_policy(vrf,1,vrf_context.import,vrf_context) }}
-{% else %}
-{% set import_policy = "accept_all" %}
-{% endif -%}
-
-{% set export_policy = vrf + "_ebgp_export" %}
-{{ bgp_policy(vrf,0,vrf_context.export|default({}),vrf_context) }}
-
 - path: network-instance[name={{vrf}}]/protocols/bgp
   val:
    admin-state: enable
@@ -73,8 +15,8 @@
    ebgp-default-policy:
     export-reject-all: False
     import-reject-all: False
-   import-policy: {{ import_policy }}  # Set eBGP policy globally, override for iBGP
-   export-policy: {{ export_policy }}
+   import-policy: "accept_all"  # Set eBGP policy globally, override for iBGP
+   export-policy: "accept_all"
 
 {# Configure BGP address families globally #}
 {% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
@@ -87,6 +29,10 @@
 {% endfor %}
 
 {# Create route export policies #}
+- path: routing-policy/prefix-set[name={{vrf}}_export]
+  val:
+   prefix: [] # Make sure it exists
+
 {% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
 {% if loopback[af] is defined and bgp.advertise_loopback and vrf=='default' %}
 {{ bgp_export_prefix(vrf,loopback[af]|ipaddr('address')|ipaddr('host')) }}

--- a/netsim/ansible/templates/vrf/srlinux.j2
+++ b/netsim/ansible/templates/vrf/srlinux.j2
@@ -1,5 +1,6 @@
 {% from "templates/ospf/srlinux.macro.j2" import ospf_config %}
 {% from "templates/bgp/srlinux.macro.j2" import bgp_config with context %}
+
 updates:
 {% for vname,vdata in vrfs.items() %}
 
@@ -28,7 +29,7 @@ updates:
 - path: routing-policy/community-set[name=C{{ c|replace(':','_') }}]
   val:
    member:
-   - "{{c}}" # Single member, else matching is AND
+   - "target:{{ c }}" # Single member, else matching is AND
 {% endfor -%}
 {% endif %}
 
@@ -38,11 +39,49 @@ updates:
   val:
    member:
 {%  for c in vdata.export %}
-   - "{{ c }}"
+   - "target:{{ c }}"
 {%  endfor %}
 {% endif %}
 
 {% if 'bgp' in vdata %}
 {{ bgp_config(vname,bgp.as,bgp.router_id,vdata.bgp,vdata) }}
+{% endif %}
+
+- path: network-instance[name={{vname}}]/protocols/bgp-vpn
+  val:
+   bgp-instance:
+   - id: 1
+     route-distinguisher:
+      rd: "{{ vdata.rd }}"
+
+{% if vdata.export|default([]) and vdata.import|default([]) %}
+- path: network-instance[name={{vname}}]/inter-instance-policies
+  val:
+   apply-policy:
+    export-policy: "{{ vname }}_vpn_export"
+    import-policy: "{{ vname }}_vpn_import"
+
+- path: routing-policy/policy[name={{ vname }}_vpn_export]
+  val:
+   default-action:
+    policy-result: "accept"
+    bgp:
+     communities:
+      add: "{{vname}}_export"
+
+- path: routing-policy/policy[name={{ vname }}_vpn_import]
+  val:
+   default-action:
+    policy-result: "reject"
+   statement:
+{%  for c in vdata.import %}
+   - name: {{ 10 + loop.index }}
+     match:
+      bgp:
+       community-set: "C{{ c|replace(':','_') }}"
+     action:
+      policy-result: "accept"
+{%  endfor %}
+
 {% endif %}
 {% endfor %}

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -17,7 +17,7 @@ bfd:                                    # SR Linux supports lower BFD timers tha
   min_tx: 100
   min_rx: 100
 clab:
-  image: ghcr.io/nokia/srlinux:23.3.1   # latest version, changes YANG model
+  image: registry.srlinux.dev/pub/srlinux:24.3.1 # ghcr.io/nokia/srlinux:23.3.1   # latest version, changes YANG model
   node:
     kind: srl
     type: ixrd2
@@ -60,6 +60,7 @@ features:
   vrf:
     keep_module: True
     ospfv2: True
+    ospfv3: True
     bgp: True
   gateway:
     protocol: [ anycast ]


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1074

Note that integration tests 31-34 with common VRF fail; SR Linux currently supports route leaking based on prefix filters, but not communities