### PR TITLE
SR Linux allow activation of bgp ipv4 af over ipv6 session and vice versa

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -51,14 +51,14 @@
 {% set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
    afi-safi:
    - afi-safi-name: ipv4-unicast
-     admin-state: {{ 'enable' if activate.ipv4|default(False) and ipv4 else 'disable' }}
+     admin-state: {{ 'enable' if activate.ipv4|default(False) else 'disable' }}
 {% if neighbor.ipv4_rfc8950|default(False) %}
      ipv4-unicast:
       advertise-ipv6-next-hops: True
       receive-ipv6-next-hops: True
 {% endif %}
    - afi-safi-name: ipv6-unicast
-     admin-state: {{ 'enable' if activate.ipv6|default(False) and ipv6 else 'disable' }}
+     admin-state: {{ 'enable' if activate.ipv6|default(False) else 'disable' }}
 {% if 'evpn' in neighbor and neighbor.evpn %}
    - afi-safi-name: evpn
      admin-state: enable # Must have at least 1 address family enabled


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1071