### PR TITLE
Dell OS10: do not set IPv6 ND on loopbacks

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -59,9 +59,12 @@ interface {{ l.ifname }}
     Set interface IPv6 addresses
 #}
 {% if 'ipv6' in l %}
+{# do not set nd on loopback interfaces #}
+{%   if l.type|default('') != 'loopback' %}
  ipv6 nd max-ra-interval 4
  ipv6 nd min-ra-interval 3
  ipv6 nd send-ra
+{%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable
 {%   elif l.ipv6|ipv6 %}


### PR DESCRIPTION
Fix #1153

```
# netlab validate
[WARNING] Initial wait time extended by 30 seconds required by dellos10
[red]     Ping-based reachability test in VRF red [ node(s): h1 ]
[PASS]    h1: Ping to ipv6 h2 succeeded
[PASS]    Test succeeded

[ping]    Ping-based reachability test in VRF blue [ node(s): h3 ]
[PASS]    h3: Ping to ipv6 h4 succeeded
[PASS]    Test succeeded

[red_lb]  Pinging red VRF IPv6 loopback [ node(s): h1 ]
[PASS]    h1: Ping to ipv6 2001:db8:c001:cafe::1 succeeded
[PASS]    Test succeeded

[blue_lb] Pinging blue VRF IPv6 loopback [ node(s): h3 ]
[PASS]    h3: Ping to ipv6 2001:db8:c001:cafe::1 succeeded
[PASS]    Test succeeded

[SUCCESS] Tests passed: 4
```