### PR TITLE
Dell OS10: update command indent on bgp

### DIFF
--- a/netsim/ansible/templates/bgp/dellos10.j2
+++ b/netsim/ansible/templates/bgp/dellos10.j2
@@ -6,7 +6,7 @@ router bgp {{ bgp.as }}
 ! define a generic unnumbered template to be used for eBGP unnumbered...
 ! WTF Dell...
   template unnumbered_ebgp
-  exit
+    exit
 
 {% if bgp.router_id|ipv4 %}
   router-id {{ bgp.router_id }}


### PR DESCRIPTION
should fix #1154

On the worst case, we can call another time the `router bgp XXX` to "restart" from the main bgp context.