### PR TITLE
ArubaCX: local-as is not supported for iBGP

### DIFF
--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -32,7 +32,7 @@ features:
   bgp:
     activate_af: true
     local_as: true
-    local_as_ibgp: true
+    local_as_ibgp: false
     vrf_local_as: true
   evpn:
     asymmetrical_irb: true


### PR DESCRIPTION
fix #1146 ... not a real fix, since this was not supported from the beginning...