### PR TITLE
ROS7: update for bgp.session

### DIFF
--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -91,6 +91,7 @@ devices:
     allowas_in: True
     as_override: True
     password: True
+    remove_private_as: True
   srlinux.features.bgp:
     default_originate: True
     allowas_in: True

--- a/netsim/extra/bgp.session/routeros7.j2
+++ b/netsim/extra/bgp.session/routeros7.j2
@@ -1,7 +1,7 @@
 # AllowAS-IN
 {% for n in bgp.neighbors if n.allowas_in is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
-/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=default] input.allow-as={{ n.allowas_in }}
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=main] input.allow-as={{ n.allowas_in }}
 {%   endfor %}
 {% endfor %}
 
@@ -18,7 +18,7 @@
 # AS-Override
 {% for n in bgp.neighbors if n.as_override is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
-/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=default] as-override=yes
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=main] as-override=yes
 {%   endfor %}
 {% endfor %}
 
@@ -35,7 +35,7 @@
 # Default Originate
 {% for n in bgp.neighbors if n.default_originate is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined and n.default_originate %}
-/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=default] output.default-originate=always
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=main] output.default-originate=always
 {%   endfor %}
 {% endfor %}
 
@@ -52,7 +52,7 @@
 # Password
 {% for n in bgp.neighbors if n.password is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
-/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=default] tcp-md5-key={{ n.password }}
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=main] tcp-md5-key={{ n.password }}
 {%   endfor %}
 {% endfor %}
 
@@ -61,6 +61,23 @@
 {%   for n in vdata.bgp.neighbors|default([]) if n.password is defined %}
 {%     for af in ['ipv4','ipv6'] if n[af] is defined and n.password %}
 /routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates={{vname}}] tcp-md5-key={{ n.password }}
+{%     endfor %}
+{%   endfor %}
+{% endfor %}
+{% endif %}
+
+# Remove Private AS
+{% for n in bgp.neighbors if n.remove_private_as|default([]) %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined and n.remove_private_as %}
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates=main] output.remove-private-as=yes
+{%   endfor %}
+{% endfor %}
+
+{% if vrfs is defined %}
+{% for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+{%   for n in vdata.bgp.neighbors|default([]) if n.remove_private_as|default([]) %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined and n.remove_private_as %}
+/routing/bgp/connection set [/routing/bgp/connection find remote.address={{ n[af] }} and templates={{vname}}] output.remove-private-as=yes
 {%     endfor %}
 {%   endfor %}
 {% endfor %}


### PR DESCRIPTION
* Fix #1151 (stupid typo)
* Add support for remove-private-as

Test for **bgp.session-08** (*remove-private-as*):
```

bgpse08# netlab validate
[session_v4]     Check IPv4 EBGP sessions with DUT [ node(s): x1,x2 ]
[PASS]           x1: Neighbor 172.16.0.1 (dut) is in state Established
[PASS]           x2: Neighbor 172.16.1.1 (dut) is in state Established
[PASS]           Test succeeded

[session_v6]     Check IPv6 EBGP sessions with DUT [ node(s): x1,x2 ]
[PASS]           x1: Neighbor 2001:db8:4::1 (dut) is in state Established
[PASS]           x2: Neighbor 2001:db8:4:1::1 (dut) is in state Established
[PASS]           Test succeeded

[pfx_x2_v4]      Check for X1 IPv4 prefix on X2 [ node(s): x2 ]
[PASS]           x2: The prefix 172.42.42.0/24 is in the BGP table
[PASS]           Test succeeded

[pfx_x2_v6]      Check for X1 IPv6 prefix on X2 [ node(s): x1 ]
[PASS]           x1: The prefix 2001:db8:a01::/64 is in the BGP table
[PASS]           Test succeeded

[pfx_as64500_v4] Check that the IPv4 X1 prefix on X2 does not contain AS 65100 [ node(s): x2 ]
[PASS]           x2: The prefix 172.42.42.0/24 has the expected AS-path 64500
[PASS]           Test succeeded

[pfx_as64500_v6] Check that the IPv6 X1 prefix on X2 does not contain AS 65100 [ node(s): x2 ]
[PASS]           x2: The prefix 2001:db8:a01::/64 has the expected AS-path 64500
[PASS]           Test succeeded

[SUCCESS]        Tests passed: 8
```