### PR TITLE
Cannot configure L2 MTU on IXR-H platforms

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -40,13 +40,15 @@
 updates:
 {% if mtu is defined %}
 {% if (clab.type in ['ixr6','ixr10'] and (mtu+14)>9486)
-   or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2'] and (mtu+14)>9398) %}
+   or (clab.type in ['ixrd1','ixrd2','ixrd3','ixrh1','ixrh2','ixrh3','ixrd2l','ixrd3l'] and (mtu+14)>9398) %}
 {{ mtu_too_large | mandatory( 'IP MTU '+str(mtu)+' too large for given hardware platform: ' + clab.type ) }}
 {% else %}
 - path: system/mtu
   val:
    default-port-mtu: {{ [mtu + 14,1500]|max }}
+{%  if 'ixrh' not in clab.type %}
    default-l2-mtu: {{ [mtu + 14,1500]|max }}
+{%  endif %}
    default-ip-mtu: {{ mtu }}
    _annotate_default-ip-mtu: "Custom system wide setting, overrides default 1500"
 {% endif %}


### PR DESCRIPTION
Also add a few more platforms to the MTU max length check