### PR TITLE
Fix path to root CA for 'netlab collect'

### DIFF
--- a/netsim/ansible/tasks/fetch-config/srlinux.yml
+++ b/netsim/ansible/tasks/fetch-config/srlinux.yml
@@ -7,7 +7,7 @@
    ansible_port: "{{ srlinux_grpc_port }}" # Uses gNMI over TLS to this port
    clab_base: "{{ hostname|replace('-'+inventory_hostname,'') }}"
    clab_ca_dir: "{{ inventory_dir }}/{{ clab_base }}/ca"
-   ansible_root_certificates_file: '{{ clab_ca_dir }}/root/root-ca.pem'
+   ansible_root_certificates_file: '{{ inventory_dir }}/clab-{{ netlab_name }}/.tls/ca/ca.pem'
    ansible_certificate_chain_file: ''
 
   nokia.grpc.gnmi_config:


### PR DESCRIPTION
Latest containerlab uses a different path