### PR TITLE
Add an explicit feature flag for IS-IS multi-topology support

### DIFF
--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -6,7 +6,7 @@ The module supports the following IS-IS features:
 
 * IPv4 and IPv6
 * IS type (L1 and/or L2)
-* Multi-topology IPv6 (enabled by default as soon as the node has at least one IPv6 address, cannot be disabled)
+* Multi-topology IPv6 (enabled for dual-stack configurations)
 * Wide metrics (enabled by default, cannot be turned off)
 * Unnumbered IPv4 interfaces
 * Passive interfaces
@@ -36,7 +36,7 @@ The following table describes per-platform support of individual IS-IS features:
 | Juniper vMX        | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | Juniper vPTX       | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
 | Juniper vSRX       | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ |
-| Nokia SR Linux     | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | 
+| Nokia SR Linux     | ✅  | ✅  | ❌  | ✅  | ✅  | ✅ | 
 | Nokia SR OS        | ✅  | ✅  | ✅  | ✅  | ✅  | ✅ | 
 | VyOS               | ✅  | ✅  | ✅  |  ❌  | ✅  | ✅ |
 

--- a/netsim/ansible/templates/isis/frr.j2
+++ b/netsim/ansible/templates/isis/frr.j2
@@ -13,7 +13,7 @@ router isis Gandalf
 {% elif isis.area is defined %}
   net {{ "%s.0000.0000.%04d.00" % (isis.area,id) }}
 {% endif %}
-{% if isis.af.ipv6 is defined %}
+{% if 'ipv6' in isis.af and 'ipv4' in isis.af %}
   topology ipv6-unicast
 {% endif %}
 !

--- a/netsim/ansible/templates/isis/srlinux.j2
+++ b/netsim/ansible/templates/isis/srlinux.j2
@@ -6,14 +6,10 @@ updates:
      admin-state: enable
      net: [ "{{ isis.net | default( "%s.0000.0000.%04d.00" % (isis.area,id) ) }}" ]
      level-capability: "{{ 'L2' if isis.type=='level-2' else 'L1' if isis.type=='level-1' else 'L1L2' }}"
-{%   if isis.af.ipv6 is defined %}
+     ipv4-unicast:
+      admin-state: {{ 'enable' if isis.af.ipv4|default(False) else 'disable' }}
      ipv6-unicast:
-      admin-state: enable
-{%    if clab.type in ['ixr6','ixr10','ixr6e','ixr10e'] %}
-      multi-topology: {{ 'sr' not in module|default([]) }}
-      _annotate_multi-topology: "Not supported in combination with SR"
-{%    endif %}
-{%   endif %}
+      admin-state: {{ 'enable' if isis.af.ipv6|default(False) else 'disable' }}
 {% if ldp is defined and ldp.igp_sync|default(True) %}
      ldp-synchronization: { }
 {% endif %}
@@ -21,9 +17,9 @@ updates:
      - interface-name: system0.0
        passive: True
        ipv4-unicast:
-        admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
+        admin-state: {{ 'enable' if 'ipv4' in loopback and isis.af.ipv4|default(False) else 'disable' }}
        ipv6-unicast:
-        admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
+        admin-state: {{ 'enable' if 'ipv6' in loopback and isis.af.ipv6|default(False) else 'disable' }}
 
 {%   for l in interfaces if (l.vlan is not defined or l.vlan.mode|default('irb')!='bridge') and l.subif_index is not defined %}
 {%    set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
@@ -33,16 +29,12 @@ updates:
      - interface-name: {{ ifname }}
        circuit-type: {{ l.isis.network_type|default("broadcast") }}
        passive: {{ l.isis.passive }}
-{%     if 'ipv4' in l and 'ipv4' in isis.af %}
        ipv4-unicast:
-        admin-state: enable
+        admin-state: {{ 'enable' if 'ipv4' in l and isis.af.ipv4|default(False) else 'disable' }}
         enable-bfd: {{ l.isis.bfd.ipv4|default(False) }}
-{%     endif %}
-{%     if 'ipv6' in l and 'ipv6' in isis.af  %}
        ipv6-unicast:
-        admin-state: enable
+        admin-state: {{ 'enable' if 'ipv6' in l and isis.af.ipv6|default(False) else 'disable' }}
         enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
-{%     endif %}
 {%     if l.isis.metric is defined or l.isis.cost is defined %}
        level:
        - level-number: 1

--- a/netsim/ansible/templates/isis/sros.j2
+++ b/netsim/ansible/templates/isis/sros.j2
@@ -1,17 +1,17 @@
-{% from "templates/initial/sros.j2" import if_name with context %}
+{% from "templates/initial/sros.j2" import if_name, declare_router with context %}
 
-{% macro isis_config(l,vrf=None) %}
-{% set path = "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" %}
-- path: configure/{{ path }}
+{% macro isis_config(l) %}
+{{ declare_router(l) }}
   val:
    isis:
    - isis-instance: 0
      admin-state: enable
      area-address: ["{{ isis.net | default( "%s.0000.0000.%04d.00" % (isis.area,id) ) }}"]
      level-capability: "{{ '2' if isis.type=='level-2' else ('1' if isis.type=='level-1' else '1/2') }}"
-{%   if isis.af.ipv6 is defined %}
+{%   if isis.af.ipv6 is defined and isis.af.ipv4 is defined %}
      multi-topology:
       ipv6-unicast: True
+      ipv4-unicast: True
 {%   endif %}
      interface:
      - interface-name: {{ if_name(l,l.ifname) }}
@@ -44,5 +44,5 @@ updates:
 {{ isis_config( { 'ifname': 'system', 'isis': { 'passive' : True } } ) }}
 
 {% for l in interfaces|default([]) if 'isis' in l %}
-{{ isis_config(l,l.vrf|default('default' if l.vlan.mode|default('irb')!='route' else None)) }}
+{{ isis_config(l) }}
 {% endfor %}

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -48,6 +48,7 @@ features:
       ipv4: true
       ipv6: true
       network: true
+    multi_topology: true
   mpls:
     6pe: true
     bgp: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -62,6 +62,7 @@ features:
       ipv4: true
       ipv6: true
       network: true
+    multi_topology: true
   mpls:
     ldp: true
     vpn: true

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -24,6 +24,7 @@ features:
     unnumbered:
       ipv4: true
       ipv6: true
+    multi_topology: true
   mpls:
     ldp: true
     vpn: true

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -57,6 +57,7 @@ features:
       ipv4: True
       ipv6: True
       network: True
+    multi_topology: False               # No longer supported from 23.10 onwards
   vrf:
     keep_module: True
     ospfv2: True

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -31,6 +31,7 @@ features:
       ipv4: True
       ipv6: True
       network: False          # SROS treats the interfaces as point-to-point and forms at most 1 adjacency
+    multi_topology: true
   bfd: True
   bgp:
     local_as: True

--- a/netsim/modules/isis.py
+++ b/netsim/modules/isis.py
@@ -74,3 +74,10 @@ class ISIS(_Module):
     _routing.remove_vrf_interfaces(node,'isis')
     _routing.routing_af(node,'isis')
     _routing.remove_unused_igp(node,'isis',topology.defaults.get('isis.warnings.inactive',False))
+
+    # If multi-topology is requested, check that it is supported
+    if node.get('isis.af.ipv4',False) and node.get('isis.af.ipv6',False):
+      if not features.get('isis.multi_topology',False):
+        log.error( f'Device {node.name} (device {node.device}) does not support ' +
+                    'multi-topology (ipv4+ipv6) for IS-IS', 
+                    category=log.IncorrectValue, module='isis')

--- a/netsim/modules/isis.yml
+++ b/netsim/modules/isis.yml
@@ -42,5 +42,6 @@ features:
     ipv4: IPv4 unnumbered interfaces
     ipv6: IPv6 unnumbered interfaces
     network: multi-access unnumbered links
+  multi_topology: Supports multi-topology i.e. both ipv4 and ipv6 in parallel
 warnings:
   inactive: True


### PR DESCRIPTION
And don't require it for ipv6-only scenarios

SR Linux removed support for IS-IS multi-topology in 23.10, but can still support ipv6-only deployments

Fixes https://github.com/ipspace/netlab/issues/1169