### PR TITLE
Fix the checking for stub_loopback feature

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -749,10 +749,10 @@ def set_link_loopback_type(link: Box, nodes: Box, defaults: Box) -> None:
   if not lb_name:
     return
 
-  if features.stub_loopback is False:
+  if 'stub_loopback' not in features:
     return
-
-  if not defaults.links.stub_loopback and not features.stub_loopback:
+  
+  if not defaults.links.stub_loopback and 'stub_loopback' not in features:
     return
 
   link.type = 'loopback'

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -32,6 +32,7 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+  stub_loopback: True
   vlan:
     model: router
     svi_interface_name: "irb0.{vlan}"


### PR DESCRIPTION
Enable it by default for SR Linux devices

Fixes isis/12-passive.yml test case