### PR TITLE
SR Linux can now support OSPF over unnumbered ipv4 interfaces

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -98,7 +98,7 @@ The following table documents the interface-level OSPF features:
 | Juniper vSRX 3.0         | ✅ | ✅ | ✅ | ✅ |
 | Mikrotik RouterOS 6      | ✅ | ✅ | ❌  | ✅ |
 | Mikrotik RouterOS 7      | ✅ | ✅ | ❌  | ✅ |
-| Nokia SR Linux           | ✅ | ✅ | ❌  | ✅ |
+| Nokia SR Linux           | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR OS              | ✅ | ✅ | ✅ | ✅ |
 | VyOS                     | ✅ | ✅ | ✅ | ✅ |
 

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -51,7 +51,7 @@ features:
     irb: True
     asymmetrical_irb: True
   ospf:
-    unnumbered: False
+    unnumbered: True
   isis:
     unnumbered:
       ipv4: True


### PR DESCRIPTION
fixes test ospfv2/05-unnumbered.yml