### PR TITLE
Add +1 to allow-own-as value

### DIFF
--- a/netsim/extra/bgp.session/srlinux.j2
+++ b/netsim/extra/bgp.session/srlinux.j2
@@ -29,7 +29,8 @@
 {% endif %}
      as-path-options:
 {% if n.allowas_in is defined %}
-      allow-own-as: {{ n.allowas_in|int }}
+      allow-own-as: {{ n.allowas_in|int + 1 }}
+      _annotate_allow-own-as: "The maximum number of matches in any received AS_PATH before it is considered a loop and considered invalid"
 {% endif %}
       replace-peer-as: {{ True if n.as_override|default(False) else False }}
 {% if n.remove_private_as|default([]) %}


### PR DESCRIPTION
current implementation rejects AS_PATH containing >= allow-own-as instances, somewhat counterintuitively