### PR TITLE
Add 'bgp.link_bandwidth' knob to the bgp.session plugin

### DIFF
--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -18,6 +18,7 @@ The plugin adds the following BGP session attributes:
 * **bgp.bfd** is a boolean attribute that enables BFD with BGP neighbors.
 * **bgp.default_originate** is a boolean attribute that controls whether a BGP router advertises a default route to its neighbor(s).
 * **bgp.gtsm** is an integer attribute that enables the Generic TTL Security Mechanism (GTSM). A *true* value sets it to 1 (remote router can be up to one hop away).
+* **bgp.link_bandwidth** is an flag that enables link bandwidth to be considered as a factor for weighted ECMP
 * **bgp.passive** is a boolean attribute that makes a node act as a passive BGP peer[^PBP] on an interface or on all applicable sessions (when specified as a node parameter).
 * **bgp.password** is a string attribute that specifies the MD5  or TCP-AO password used on EBGP sessions.
 * **bgp.remove_private_as** is a boolean/string/list attribute that describes the desired removal of private autonomous system(s) from AS path. See [](bgp-session-remove-private-as) section for more details.
@@ -109,6 +110,24 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Nokia SR Linux      |  ✅  |  ✅  |   ✅  |
 | Nokia SR OS         |  ✅  |  ✅  |   ❌  |
 | VyOS                |  ✅  |  ✅  |   ❌  |
+
+(bgp-session-link-bandwidth)=
+The plugin implements a link-bandwidth nerd knob to enable weighted ECMP based on link capacity
+
+| Operating system    | link-bandwidth |
+| ------------------- | :--: |
+| Arista EOS          | ❌  |
+| Aruba AOS-CX        | ❌  |
+| Cisco IOSv          | ❌  |
+| Cisco IOS-XE        | ❌  |
+| Cisco Nexus OS      | ❌  |
+| Cumulus Linux       | ❌  |
+| FRR                 | ❌  |
+| Juniper vMX/vPTX/vSRX | ❌  |
+| Mikrotik RouterOS 7 | ❌  |
+| Nokia SR Linux      | ❌  |
+| Nokia SR OS         |  ✅  |
+| VyOS                | ❌  |
 
 (bgp-session-apply)=
 ## Applying BGP Session Attributes to IBGP Sessions

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -108,6 +108,7 @@ devices:
     as_override: True
     password: True
     tcp_ao: True
+    link_bandwidth: True
   vyos.features.bgp:
     default_originate: True
     allowas_in: True
@@ -141,7 +142,7 @@ attributes:                   # User-defined data types (see dev/validate.md#val
 bgp:
   attributes:
     session: # All bgp.session attributes
-      attr:  [ as_override,allowas_in,default_originate,password,passive,gtsm,timers,tcp_ao,bfd,remove_private_as ]
+      attr:  [ as_override,allowas_in,default_originate,password,passive,gtsm,timers,tcp_ao,bfd,remove_private_as,link_bandwidth ]
 
     global:
       bfd:
@@ -158,6 +159,7 @@ bgp:
         true_value: 1
       timers: exbs_timers
       password: str
+      link_bandwidth: bool
       session:
         apply:
           _list_to_dict: True
@@ -183,6 +185,7 @@ bgp:
       timers: exbs_timers
       passive: bool
       password: str
+      link_bandwidth: bool
       session:
         copy: global
 
@@ -196,6 +199,7 @@ bgp:
       default_originate: bool
       passive: bool
       password: str
+      link_bandwidth: bool
       tcp_ao:
         copy: global
       gtsm:
@@ -211,6 +215,7 @@ bgp:
 
     link:
       password: str
+      link_bandwidth: bool
       tcp_ao:
         copy: global
       gtsm:

--- a/netsim/extra/bgp.session/sros.j2
+++ b/netsim/extra/bgp.session/sros.j2
@@ -1,33 +1,41 @@
 # See https://documentation.nokia.com/sr/23-7-1/books/system-management/security-system-management.html?hl=tcp%20enhanced%20authentication%20option
 
 {% macro ebgp_neighbor(n,af,vrf) -%}
-{% set path = "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" %}
-- path: configure/{{ path }}/bgp
+- path: configure/{{ "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" }}
   val:
+{% if n.link_bandwidth|default(False) %}
+   weighted-ecmp: "true" # Enabled due to bgp.link_bandwidth to support UECMP proportional to bandwidth
+{% endif %}
+   bgp:
 {% if n.type=='ebgp' and af=='ipv6' and n.ipv6|default(0) == True %}
-   group:
-   - group-name: "ebgp-unnumbered{{ ('-' + n.local_as|string()) if n.local_as is defined else '' }}"
-{% else %}
-   neighbor:
-   - ip-address: {{ n[af]|ipaddr('address') }}
+    group:
+    - group-name: "ebgp-unnumbered{{ ('-' + n.local_as|string()) if n.local_as is defined else '' }}"
+{%  else %}
+    neighbor:
+    - ip-address: {{ n[af]|ipaddr('address') }}
 {% endif %}
 {% if n.default_originate|default(False) %}
 {%   set activate = n.activate|default( {'ipv4':True,'ipv6':True} ) %}
-     send-default:
-      ipv4: {{ activate.ipv4|default(False) }}
-      ipv6: {{ activate.ipv6|default(False) }}
+      send-default:
+       ipv4: {{ activate.ipv4|default(False) }}
+       ipv6: {{ activate.ipv6|default(False) }}
 {% endif %}
 {%   if n.allowas_in is defined %}
-     # allow-own-as: {{ n.allowas_in|int }}
+      allow-own-as: {{ n.allowas_in|int }}
 {%   endif %}
 {%   if n.as_override|default(False) %}
-     as-override: True
+      as-override: True
 {%   endif %}
+{% if n.link_bandwidth|default(False) %}
+      link-bandwidth:
+       add-to-received-ebgp:
+        {{ af }}: True
+{% endif %}
 {%   if n.password is defined and (n.type!='ebgp' or n.ipv6|default('') is string) %}
 {%    if n.tcp_ao|default('x')=='' or bgp.tcp_ao|default('')=='' %}
-     authentication-key: "{{ n.password }}"
+      authentication-key: "{{ n.password }}"
 {%    else %}
-     authentication-keychain: "peer-{{n.name}}"
+      authentication-keychain: "peer-{{n.name}}"
 
 - path: configure/system/security/keychains/keychain[keychain-name=peer-{{n.name}}]
   val:


### PR DESCRIPTION
Enables weighted ECMP based on link capacity

Inspired by https://bgplabs.net/lb/2-dmz-bw/