### PR TITLE
srlinux: Add quirk to warn about extended communities not being filtered

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -285,6 +285,7 @@ sudo pip3 install --upgrade 'ansible>=9.5.1'
 * Nokia SR Linux needs an EVPN control plane to enable VXLAN functionality. VXLAN ingress replication lists are built from EVPN Route Type 3 updates.
 * Inter-VRF route leaking is supported only in combination with BGP EVPN
 * SR Linux does not support multi-topology IS-IS.
+* SR Linux does not support generic filtering (removal) of extended communities, only standard or large
 
 (caveats-sros)=
 ## Nokia SR OS

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -36,7 +36,7 @@ class SRLINUX(_Quirks):
         if 'extended' not in vals:
            log.error(
                       f'SR Linux on ({node.name}) does not support filtering out extended communities for BGP. {c}:{vals}\n',
-                      log.IncorrectType,
+                      Warning,
                       'quirks')
 
   def check_config_sw(self, node: Box, topology: Box) -> None:

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -31,5 +31,13 @@ class SRLINUX(_Quirks):
                     log.IncorrectType,
                     'quirks')
 
+    if 'bgp' in mods:
+      for c,vals in topology.get('bgp.community',[]).items():
+        if 'extended' not in vals:
+           log.error(
+                      f'SR Linux on ({node.name}) does not support filtering out extended communities for BGP. {c}:{vals}\n',
+                      log.IncorrectType,
+                      'quirks')
+
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'nokia.grpc')


### PR DESCRIPTION
Test case 05 filters extended communities from EBGP - SR Linux only supports filtering standard or large communities