### PR TITLE
FRR: Load VRF kernel module upon initial startup, disable use of vrfs when not available

### DIFF
--- a/netsim/ansible/tasks/frr/initial-clab.yml
+++ b/netsim/ansible/tasks/frr/initial-clab.yml
@@ -1,0 +1,17 @@
+- name: Attempt to load VRF kernel module 
+  block:
+    - name: "Load VRF kernel module"
+      when: netlab_mgmt_vrf|default(False) or 'vrf' in module
+      shell: |
+        modprobe vrf
+      become: true
+      delegate_to: localhost
+      run_once: true
+      tags: [ print_action, always ]
+  rescue:
+    - name: Unable to load vrf kernel module - disable use of VRFs
+      set_fact: 
+        netlab_mgmt_vrf: False
+
+- include_tasks: deploy-config.yml
+  tags: [ print_action, always ]

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -124,7 +124,7 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
-{% if clab is defined %}
+{% if clab is defined and netlab_mgmt_vrf|default(False) %}
 vrf mgmt
  exit-vrf
 !


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1209