### PR TITLE
Implement named prefixes for use in validation and prefix lists

### DIFF
--- a/docs/addressing.md
+++ b/docs/addressing.md
@@ -1,9 +1,10 @@
+(address-pools)=
 # Topology Address Pools
 
-Lab topology transformation code assigns IPv4 and IPv6 subnets (prefixes) to individual links and loopback interfaces from *address pools*. Node addresses are then assigned from the prefixes assigned to individual links.
+Lab topology transformation code assigns IPv4 and IPv6 subnets (prefixes) to individual links and loopback interfaces from *address pools*. Node addresses are then assigned from the prefixes assigned to individual links. Instead of address pools, you can define individual *named* prefixes in the **prefix** topology dictionary, and use the prefix names to number links and VLANs
 
 ```{tip}
-You can assign a static prefix to a link with **prefix** link attribute and static IP address to an interface with an **ipv4** or **ipv6** attribute of node-on-link data. For more details, see [static link addressing](links.md#static-link-addressing).
+You can assign a static prefix to a link with a **prefix** link attribute and a static IP address to an interface with an **ipv4** or **ipv6** attribute of node-on-link data. For more details, see [static link addressing](links.md#static-link-addressing).
 ```
 
 *netlab* use multiple predefined address pools:

--- a/docs/prefix.md
+++ b/docs/prefix.md
@@ -1,0 +1,80 @@
+(named-prefixes)=
+# Named IP Prefixes
+
+In most lab topologies, you probably don't care about the exact IP addresses and subnets. Defining IPv4 and IPv6 prefixes in [addressing pools](address pools) is good enough.
+
+If you want to tighten control over IP address allocation, use the **prefix** attribute on links or VLANS or the **ipv4**/**ipv6** attributes on node interfaces.
+
+However, there are scenarios in which you have to use the same prefix in multiple places, for example:
+
+* Using a link prefix in the lab validation code
+* Using a link prefix in a [prefix list](module-routing)
+* Using the same prefix on multiple links, for example, to implement a stretched subnet using a technology not supported by _netlab_.
+
+You can use *named IP prefixes* in all three scenarios. The named prefixes are defined in the top-level **prefix** dictionary. The dictionary keys are prefix names, the values are dictionaries defining individual prefixes. The prefix values can include **ipv4**, **ipv6**, **pool** and **[allocation](addr-allocation-sequential)** attributes.
+
+The **pool** attribute in a prefix can be used when you want a well-defined prefix but don't want to specify IPv4 and IPv6 subnets. The prefix will be allocated from the specified pool on first use.
+
+You can use the names of the *named prefixes* anywhere you would use an IPv4 or IPv6 prefix, for example, as a **links.prefix** value or as a **vlans._vlan_.prefix** value.
+
+## Example
+
+The following lab topology defines two prefixes. One of them has a static IPv4 and a static IPv6 subnet and uses the sequential IP address allocation method. The second prefix uses the **lan** pool:
+
+```yaml
+prefix:
+  s_pfx:
+    ipv4: 192.168.42.0/24
+    ipv6: 2001:db8:cafe:42::/64
+    allocation: sequential
+  d_pfx:
+    pool: lan
+```
+
+You can use the above prefixes to address individual links, for example:
+
+```yaml
+nodes: [ r1, r2 ]
+links:
+- r1:
+  prefix: s_pfx
+- r2:
+  prefix: d_pfx
+- r1-r2
+```
+
+_netlab_ generates the following link data from the above lab topology (the printout includes only the addressing portion of the link data):
+
+```
+- bridge: X_1
+  interfaces:
+  - ifindex: 1
+    ipv4: 192.168.42.1/24
+    ipv6: 2001:db8:cafe:42::1/64
+    node: r1
+  prefix:
+    _name: s_pfx
+    allocation: sequential
+    ipv4: 192.168.42.0/24
+    ipv6: 2001:db8:cafe:42::/64
+  type: stub
+- bridge: X_2
+  interfaces:
+  - ifindex: 1
+    ipv4: 172.16.0.2/24
+    node: r2
+  prefix:
+    _name: d_pfx
+    ipv4: 172.16.0.0/24
+  type: stub
+- interfaces:
+  - ifindex: 2
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 2
+    ipv4: 10.1.0.2/30
+    node: r2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+```

--- a/docs/topology-reference.md
+++ b/docs/topology-reference.md
@@ -16,6 +16,7 @@ Other topology elements include:
 * **groups** -- optional [groups of nodes](groups.md)
 * **module** -- default list of [modules](modules.md) used by this network topology. You can use device-level **module** attribute to override this setting for individual nodes.
 * **plugin** -- list of [plugins](plugins.md) used by this topology.
+* **prefix** -- [named IP prefixes](prefix.md) that can be used to address links and VLANs or in prefix lists or validation expressions.
 * **tools** -- dictionary of [external network management tools](extools.md) deployed after the lab has been started and configured.
 * **validate** -- lab [validation tests](topology/validate.md)
 
@@ -53,6 +54,7 @@ You'll find sample topology files in the [tutorials](tutorials.md).
    custom-config-templates.md
    extools.md
    plugins.md
+   prefix.md
    providers.md
    components.md
    defaults.md

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -371,7 +371,10 @@ def assign_link_prefix(
       nodes: Box,
       link_path: str = 'links') -> Box:
   if 'prefix' in link:                                    # User specified a static link prefix
-    pfx_list = addressing.parse_prefix(link.prefix)
+    pfx_list = addressing.parse_prefix(link.prefix,path=link_path)
+    if log.debug_active('addr'):                          # pragma: no cover (debugging printout)
+      print(f'link {link_path} got prefix {pfx_list} from {link.prefix}')
+    
     if isinstance(link.prefix,str):
       link.prefix = addressing.rebuild_prefix(pfx_list)   # convert str to prefix dictionary
 

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -702,6 +702,14 @@ def must_be_prefix_str(value: typing.Any) -> dict:
   return { '_valid': True, '_transform': transform_to_ipv6 }
 
 @type_test()
+def must_be_named_pfx(value: typing.Any) -> dict:
+  topology = global_vars.get_topology()
+  if isinstance(value,str) and topology is not None and value in topology.get('prefix',{}):
+    return { '_valid': True }
+  
+  return { '_type': 'named prefix' }
+
+@type_test()
 def must_be_mac(value: typing.Any) -> dict:
   if not isinstance(value,str):
     return {'_type': 'MAC address' }

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -12,6 +12,10 @@ global:
   plugin:
     type: list
     _subtype: str
+  prefix:
+    type: dict
+    _keytype: id
+    _subtype: _prefix
   provider: id
   tools:
     type: dict
@@ -37,7 +41,7 @@ link:
   name: str
   prefix:
     type: dict
-    _alt_types: [ bool, prefix_str ]
+    _alt_types: [ bool, prefix_str, named_pfx ]
   role: id
   pool: id
   type: { type: str, valid_values: [ lan, p2p, stub, loopback, tunnel, vlan_member ] }
@@ -108,6 +112,11 @@ group:
     true_value: {}
   device: device
   module: list
+_prefix:                   # Prefix entry
+  ipv4: { type: ipv4, use: prefix }
+  ipv6: { type: ipv6, use: prefix }
+  allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
+  pool: str
 _v_entry:                  # Validation entry
   _description: Single network validation test (an entry in the validate dictionary)
   description: str

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -1,8 +1,10 @@
 # Core _netlab_ attributes: global, link, interface, node, VLAN, VRF...
 #
 ---
-global:
-  addressing:
+global:                     # Common global attributes
+  addressing:               # We can do at least some baseline validation ;)
+    type: dict
+    _keytype: id
   defaults:
   groups:
   links:
@@ -27,14 +29,17 @@ global:
     _keytype: id
     _subtype: _v_entry
   version:
-internal:
+
+internal:                   # Internal attributes, not validated
   input:
   pools: dict
   Provider:
   Plugin:
   message: str
+
 can_be_false: [ link, interface ]
-link:
+
+link:                       # Global link attributes
   bandwidth: int
   bridge: id
   disable: bool
@@ -49,14 +54,16 @@ link:
   interfaces:
   mtu: { type: int, min_value: 64, max_value: 65535 }
   vlan_name: id
-link_internal:
+
+link_internal:              # Internal link attributes
   linkindex: int
   parentindex: int
 link_no_propagate: [ prefix, interfaces, gateway ]
 # Do not propagate VLAN attributes to node interfaces -- see #575
 # Also: do not propagate DHCP attributes from links to interfaces
 link_module_no_propagate: [ vlan, dhcp ]
-interface:
+
+interface:                  # Interface (node-to-link attachment) attributes
   node: node_id
   ipv4: { type: ipv4, use: interface }
   ipv6: { type: ipv6, use: interface }
@@ -87,7 +94,8 @@ node:
   cpu:
   memory: int
   unmanaged: bool
-pool:
+
+pool:                       # Address pool definition
   ipv4: { type: ipv4, use: prefix }
   ipv6: { type: ipv6, use: prefix }
   start: { type: int, min_value: 1 }
@@ -97,10 +105,12 @@ pool:
   mac: mac
   unnumbered: bool
 pool_no_copy: [ start, prefix, mac ]
-prefix:
+
+prefix:                     # Link prefix (called by link module directly)
   ipv4: { type: ipv4, use: prefix }
   ipv6: { type: ipv6, use: prefix }
   allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
+
 group:
   members:
     type: list
@@ -112,12 +122,16 @@ group:
     true_value: {}
   device: device
   module: list
-_prefix:                   # Prefix entry
+
+_prefix:                    # Generic named prefix entry
   ipv4: { type: ipv4, use: prefix }
   ipv6: { type: ipv6, use: prefix }
   allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
-  pool: str
-_v_entry:                  # Validation entry
+  pool:
+    type: str
+    _valid_with: [ allocation ]
+
+_v_entry:                   # Validation entry
   _description: Single network validation test (an entry in the validate dictionary)
   description: str
   fail: str

--- a/tests/errors/prefix-exclusive-attribute.log
+++ b/tests/errors/prefix-exclusive-attribute.log
@@ -1,0 +1,2 @@
+IncorrectAttr in topology: Attribute pool cannot be used with attributes ipv4 in topology.prefix.p1
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/prefix-exclusive-attribute.yml
+++ b/tests/errors/prefix-exclusive-attribute.yml
@@ -1,0 +1,11 @@
+# Test the "normalize and merge" routing policy processing
+#
+
+defaults.device: frr
+
+prefix:
+  p1:
+    pool: lan
+    ipv4: 192.168.24.0/24
+
+nodes: [ r1 ]

--- a/tests/topology/expected/addressing-prefix.yml
+++ b/tests/topology/expected/addressing-prefix.yml
@@ -1,0 +1,252 @@
+input:
+- topology/input/addressing-prefix.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.42/24
+    ipv6: 2001:db8:1::2a/64
+    node: r1
+  linkindex: 1
+  name: Prefix allocated from LAN pool
+  node_count: 1
+  prefix:
+    _name: p1
+    ipv4: 172.16.0.0/24
+    ipv6: 2001:db8:1::/64
+  type: stub
+- bridge: input_2
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.1.1/24
+    ipv6: 2001:db8:1:1::1/64
+    node: r1
+  linkindex: 2
+  name: Sequential prefix allocation from LAN pool
+  node_count: 1
+  prefix:
+    _name: p2
+    allocation: sequential
+    ipv4: 172.16.1.0/24
+    ipv6: 2001:db8:1:1::/64
+  type: stub
+- bridge: input_3
+  interfaces:
+  - ifindex: 3
+    ifname: eth3
+    ipv4: 10.1.0.1/30
+    node: r1
+  linkindex: 3
+  name: Prefix from P2P pool
+  node_count: 1
+  prefix:
+    _name: p3
+    ipv4: 10.1.0.0/30
+  type: stub
+- bridge: input_4
+  interfaces:
+  - ifindex: 4
+    ifname: eth4
+    ipv6: 2001:db8:2::2a/64
+    node: r1
+  linkindex: 4
+  name: Prefix from custom IPv6-only pool
+  node_count: 1
+  prefix:
+    _name: p4
+    ipv6: 2001:db8:2::/64
+  type: stub
+- bridge: input_5
+  interfaces:
+  - ifindex: 5
+    ifname: eth5
+    ipv4: 192.168.42.1/24
+    node: r1
+  linkindex: 5
+  name: Static prefix, P2P allocation
+  node_count: 1
+  prefix:
+    _name: s1
+    allocation: p2p
+    ipv4: 192.168.42.0/24
+  type: stub
+- bridge: input_6
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 6
+    ifname: eth6
+    ipv6: 2001:db8:cafe:1::2a/64
+    node: r1
+    vlan:
+      access: v1
+  linkindex: 6
+  name: VLAN prefix, static IPv6-only
+  node_count: 1
+  prefix:
+    _name: s2
+    allocation: id_based
+    ipv6: 2001:db8:cafe:1::/64
+  type: lan
+  vlan:
+    access: v1
+module:
+- vlan
+name: input
+nodes:
+  r1:
+    af:
+      ipv4: true
+      ipv6: true
+    box: none
+    device: none
+    id: 42
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.42/24
+      ipv6: 2001:db8:1::2a/64
+      linkindex: 1
+      name: Prefix allocated from LAN pool
+      neighbors: []
+      type: stub
+    - bridge: input_2
+      ifindex: 2
+      ifname: eth2
+      ipv4: 172.16.1.1/24
+      ipv6: 2001:db8:1:1::1/64
+      linkindex: 2
+      name: Sequential prefix allocation from LAN pool
+      neighbors: []
+      type: stub
+    - bridge: input_3
+      ifindex: 3
+      ifname: eth3
+      ipv4: 10.1.0.1/30
+      linkindex: 3
+      name: Prefix from P2P pool
+      neighbors: []
+      type: stub
+    - bridge: input_4
+      ifindex: 4
+      ifname: eth4
+      ipv6: 2001:db8:2::2a/64
+      linkindex: 4
+      name: Prefix from custom IPv6-only pool
+      neighbors: []
+      type: stub
+    - bridge: input_5
+      ifindex: 5
+      ifname: eth5
+      ipv4: 192.168.42.1/24
+      linkindex: 5
+      name: Static prefix, P2P allocation
+      neighbors: []
+      type: stub
+    - bridge: input_6
+      ifindex: 6
+      ifname: eth6
+      linkindex: 6
+      type: lan
+      vlan:
+        access: v1
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 7
+      ifname: Vlan1000
+      ipv6: 2001:db8:cafe:1::2a/64
+      name: VLAN v1 (1000)
+      neighbors: []
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.42/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.142
+      mac: 08:4f:a9:00:00:2a
+    module:
+    - vlan
+    name: r1
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      v1:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          _name: s2
+          allocation: id_based
+          ipv6: 2001:db8:cafe:1::/64
+prefix:
+  p1:
+    _name: p1
+    ipv4: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 2886729728
+      - 24
+      - 4
+    ipv6: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 42540766411283801782723599580828532736
+      - 64
+      - 6
+  p2:
+    _name: p2
+    allocation: sequential
+    ipv4: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 2886729984
+      - 24
+      - 4
+    ipv6: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 42540766411283801801170343654538084352
+      - 64
+      - 6
+  p3:
+    _name: p3
+    ipv4: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 167837696
+      - 30
+      - 4
+  p4:
+    _name: p4
+    ipv6: !!python/object/new:netaddr.ip.IPNetwork
+      state: !!python/tuple
+      - 42540766411285010708543214210003238912
+      - 64
+      - 6
+  s1:
+    _name: s1
+    allocation: p2p
+    ipv4: 192.168.42.0/24
+  s2:
+    _name: s2
+    ipv6: 2001:db8:cafe:1::/64
+provider: libvirt
+vlans:
+  v1:
+    host_count: 0
+    id: 1000
+    neighbors:
+    - ifname: Vlan1000
+      ipv6: 2001:db8:cafe:1::2a/64
+      node: r1
+    prefix:
+      _name: s2
+      allocation: id_based
+      ipv6: 2001:db8:cafe:1::/64

--- a/tests/topology/input/addressing-prefix.yml
+++ b/tests/topology/input/addressing-prefix.yml
@@ -1,0 +1,59 @@
+#
+# Test named prefixes
+#
+addressing:
+  lan:                              # Make LAN pool dual-stacked
+    ipv6: 2001:db8:1::/48
+  v6only:                           # Plus an IPv6-only pool
+    ipv6: 2001:db8:2::/48
+
+defaults.device: none
+module: [ vlan ]
+
+vlans:
+  v1:
+    prefix: s2
+
+# Create a few nodes with non-default IDs just for fun
+nodes:
+  r1:
+    id: 42
+
+# And now the real work starts
+prefix:
+  p1:                               # The first four prefixes are allocated from pools
+    pool: lan
+  p2:
+    pool: lan
+    allocation: sequential
+  p3:
+    pool: p2p
+  p4:
+    pool: v6only
+  s1:                               # Static prefix, allocation specified
+    ipv4: 192.168.42.0/24
+    allocation: p2p
+  s2:
+    ipv6: 2001:db8:cafe:1::/64      # Static IPv4-only prefix, no allocation
+
+# Now use prefixes on different links
+#
+links:
+- r1:
+  prefix: p1
+  name: Prefix allocated from LAN pool
+- r1:
+  prefix: p2
+  name: Sequential prefix allocation from LAN pool
+- r1:
+  prefix: p3
+  name: Prefix from P2P pool
+- r1:
+  prefix: p4
+  name: Prefix from custom IPv6-only pool
+- r1:                               # Static prefix
+  prefix: s1
+  name: Static prefix, P2P allocation
+- r1:                               # And another one used on a VLAN
+  vlan.access: v1
+  name: VLAN prefix, static IPv6-only


### PR DESCRIPTION
This PR implements 'named prefixes' -- a dictionary of prefixes that can be used in 'links.prefix', 'vlans.prefix', validation code, and (future) prefix lists.

The named prefixes can be static (ipv4 and/or ipv6 subnets, optionally with allocation mechanism) or allocation from one of the addressing pools, in which case the named prefix serves as a mechanism to prevent data duplication