### PR TITLE
AOS-CX+VYOS: route-map match as-path

### DIFF
--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -24,14 +24,14 @@ The following table describes high-level per-platform support of generic routing
 | Operating system      | Routing<br>policies | Prefix<br>filters| AS-path<br>filters | BGP<br>communities | Static<br>routes|
 | ------------------ | :-: | :-: | :-: |:-: | :-: |
 | Arista EOS          |  ✅  |  ✅  |  ✅  |
-| Aruba AOS-CX        |  ✅  |  ✅  |
+| Aruba AOS-CX        |  ✅  |  ✅  |  ✅  |
 | Cisco IOSv          |  ✅  |  ✅  |  ✅  |
 | Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |  ✅  |
 | Nokia SR Linux      |  ✅  |
 | Nokia SR OS         |  ✅  |
-| VyOS                |  ✅  |  ✅  |
+| VyOS                |  ✅  |  ✅  |  ✅  |
 
 ```{tip}
 See [Routing Integration Tests Results](https://release.netlab.tools/_html/coverage.routing) for more details.

--- a/netsim/ansible/templates/routing/_route_map_ios.j2
+++ b/netsim/ansible/templates/routing/_route_map_ios.j2
@@ -42,7 +42,11 @@ that use "industry standard" CLI (IOS, IOS-XE, FRR, Cumulus, Arista)
 {%       set acl_num = p_entry.match.aspath
            if ansible_network_os != 'ios'
            else routing._numobj.aspath[p_entry.match.aspath] %}
-  match as-path {{ acl_num }}
+{# Different vendors following similar syntax may differ for some specific keyword.
+    Defining here a default one for 'as-path', and then specific overrides #}
+{% set aspath_kw = 'as-path' %}
+{% set aspath_kw = 'aspath-list' if netlab_device_type == 'arubacx' else aspath_kw %}
+  match {{ aspath_kw }} {{ acl_num }}
 {%     endif %}
 {%     if 'nexthop' in p_entry.match %}
   match {{ ipkwd }} next-hop prefix-list {{ p_entry.match.nexthop }}

--- a/netsim/ansible/templates/routing/_route_policy_vyos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_vyos.j2
@@ -31,6 +31,9 @@ set match {{ ipkwd }} address prefix-list {{ p_entry.match.prefix }}-{{ match_af
 {%     if 'nexthop' in p_entry.match %}
 set match {{ ipkwd }} nexthop prefix-list {{ p_entry.match.nexthop }}
 {%     endif %}
+{%     if 'aspath' in p_entry.match %}
+set match as-path {{ p_entry.match.aspath }}
+{%     endif %}
 {%   endif %}
 {%- endmacro %}
 

--- a/netsim/ansible/templates/routing/arubacx.j2
+++ b/netsim/ansible/templates/routing/arubacx.j2
@@ -3,6 +3,14 @@
 {%   include '_prefix_list_ios.j2' %}
 {% endif %}
 !
+{% if routing.aspath|default({}) %}
+{%   for asp_name,asp_list in routing.aspath.items() %}
+{%     for asp_line in asp_list %}
+ip aspath-list {{ asp_name }} {{ asp_line.action }} {{ asp_line.path }}
+{%     endfor %}
+{%   endfor %}
+{% endif %}
+!
 {% import '_route_map_ios.j2' as routemap with context %}
 !
 {% if routing.policy|default({}) %}

--- a/netsim/ansible/templates/routing/vyos.j2
+++ b/netsim/ansible/templates/routing/vyos.j2
@@ -13,6 +13,15 @@ configure
 {%   include '_prefix_list_vyos.j2' %}
 {% endif %}
 
+{% if routing.aspath|default({}) %}
+{%   for asp_name,asp_list in routing.aspath.items() %}
+{%     for asp_line in asp_list %}
+set policy as-path-list {{ asp_name }} rule {{ asp_line.sequence }} action {{ asp_line.action }}
+set policy as-path-list {{ asp_name }} rule {{ asp_line.sequence }} regex "{{ asp_line.path }}"
+{%     endfor %}
+{%   endfor %}
+{% endif %}
+
 {% if routing.policy|default({}) %}
 {%   import '_route_policy_vyos.j2' as routemap with context %}
 {{   routemap.create_route_maps(routing.policy) }}

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -49,8 +49,9 @@ features:
   routing:
     policy:
       set: [ locpref, med, weight, prepend ]
-      match: [ prefix, nexthop ]
+      match: [ prefix, nexthop, aspath ]
     prefix: True
+    aspath: True
   vlan:
     # model: l3-switch
     model: switch

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -42,8 +42,9 @@ features:
   routing:
     policy:
       set: [ locpref, med, prepend ]
-      match: [ prefix, nexthop ]
+      match: [ prefix, nexthop, aspath ]
     prefix: True
+    aspath: True
   vlan:
     model: l3-switch
     svi_interface_name: "br0.{vlan}"


### PR DESCRIPTION
(Tested backward compat for the `as-path keyword` with FRR)