### PR TITLE
Add linux-headers-generic to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,8 @@ RUN apt update && \
     tcpdump \
     iproute2 \
     dnsutils \
-    telnet && \
+    telnet \
+    linux-headers-generic && \
     netlab install --yes ubuntu ansible
 
 # add empty docker config files to avoid clab warnings for root user


### PR DESCRIPTION
Closes #1261 

Install the apt package `linux-headers-generic` in the devcontainer enabling to start the VyOS container "ghcr.io/sysoleg/vyos-container:latest"