### PR TITLE
clab: support for node parameter startup-delay

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -282,6 +282,7 @@ You can also change these *containerlab* parameters:
 * **clab.env** to set container environment (used to [set interface names for Arista cEOS](https://containerlab.dev/manual/kinds/ceos/#additional-interface-naming-considerations))
 * **clab.ports** to map container ports to host ports
 * **clab.cmd** to execute a command in a container.
+* **clab.startup-delay** to make certain node(s) to boot/start later than others (amount in seconds)
 
 ```{warning}
 String values (for example, the command to execute specified in **clab.cmd**) are put into single quotes when written into the `clab.yml` containerlab configuration file. Ensure you're not using single quotes in your command line.

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,7 +3,7 @@
 #
 description: containerlab with Docker
 config: clab.yml
-node_config_attributes: [ type, cmd, env, ports ]
+node_config_attributes: [ type, cmd, env, ports, startup-delay ]
 template: clab.j2
 # Preserve env to allow user to configure PATH
 start: sudo -E containerlab deploy -t clab.yml
@@ -40,6 +40,7 @@ attributes:
       srl-agents:
       license: str
       runtime: str
+      startup-delay: int
   interface:
     name: str
   link:


### PR DESCRIPTION
Redoing the pull request lost due to a stupid 'git push --force'