### PR TITLE
VyOS: enable SSH service when running in containerlab

### DIFF
--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -94,6 +94,11 @@ set service lldp interface {{ mgmt.ifname|default('eth0') }} disable
 set service router-advert interface {{ l.ifname }}
 {% endfor %}
 
+{# If running on containerlab, enable SSH service (disabled by default) #}
+{% if clab.kind is defined %}
+set service ssh
+{% endif %}
+
 # Commit, save and exit from subshell
 
 commit


### PR DESCRIPTION
... this will allow Graphite to log into it.

thanks to @ubaumann.