### PR TITLE
ArubaCX Fix: redistribute ospfv3 as well if present

### DIFF
--- a/netsim/ansible/templates/vrf/arubacx.bgp.j2
+++ b/netsim/ansible/templates/vrf/arubacx.bgp.j2
@@ -15,8 +15,8 @@ router bgp {{ bgp.as }}
  address-family {{ af }} unicast
   redistribute connected
   redistribute local loopback
-{%     if af == 'ipv4' and 'ospf' in vdata %}
-  redistribute ospf {{ vdata.ospfidx }}
+{%     if 'ospf' in vdata %}
+  redistribute ospf{{ '' if af == 'ipv4' else 'v3' }} {{ vdata.ospfidx }}
 {%     endif %}
 !
 {%     for n in vdata.networks|default([]) if af in n %}


### PR DESCRIPTION
tested with https://github.com/ipspace/netlab/blob/dev/tests/integration/vrf/23-multi-vrf-mixed-ipv6.yml

and also with https://github.com/ipspace/netlab/blob/dev/tests/integration/vrf/15-multi-vrf-mixed.yml for backward compatibility