### PR TITLE
Routing import for AOS-CX and VyOS

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -77,7 +77,7 @@ The following features are only supported on a subset of platforms:
 | Operating system      | EBGP<br>local AS | IBGP<br>local AS | Route<br>import | VRF route<br>import |
 | --------------------- | :-: | :-: | :-: | :-: |
 | Arista EOS            |  ✅ |  ✅ |  ✅ |  ✅ |
-| Aruba AOS-CX          |  ✅ |  ✅ |  ❌  |  ❌  |
+| Aruba AOS-CX          |  ✅ |  ✅ |  ✅ |  ✅ |
 | BIRD                  |  ✅ |  ✅ |  ❌  |  ❌  |
 | Cisco IOS/IOS XE[^18v]|  ✅ |  ✅ |  ✅ |  ✅ |
 | Cumulus Linux 4.x     |  ✅ |  ✅ |  ✅ |  ✅ |
@@ -86,7 +86,7 @@ The following features are only supported on a subset of platforms:
 | Nokia SR Linux        |  ✅ |  ✅ |  ❌  |  ❌  |
 | Nokia SR OS           |  ✅ |  ✅ |  ❌  |  ❌  |
 | Sonic                 |  ✅ |  ✅ |  ❌  |  ❌  |
-| VyOS                  |  ✅ |  ❌  |  ❌  |  ❌  |
+| VyOS                  |  ✅ |  ❌  |  ✅ |  ✅ |
 
 ```{tip}
 See [BGP Integration Tests Results](https://release.netlab.tools/_html/coverage.bgp) for more details.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -49,7 +49,7 @@ The following table describes per-platform support of individual router-level OS
 | Operating system         | Areas | Reference<br/>bandwidth | OSPFv3 | Route<br>import | Default<br>route |
 | ------------------------ | :---: | :---------------------: | :----: | :--: | :-------------: |
 | Arista EOS               |   ✅  |            ✅           |   ✅   |  ✅  |       ❌          |
-| Aruba AOS-CX             |   ✅  |            ✅           |   ✅   |  ❌   |       ❌          |
+| Aruba AOS-CX             |   ✅  |            ✅           |   ✅   |  ✅  |       ❌          |
 | Cisco IOS                |   ✅  |            ✅           |   ✅   |  ✅  |       ❌          |
 | Cisco IOS XRv            |   ✅  |            ✅           |   ✅   |  ❌   |       ❌          |
 | Cisco IOS XE[^18v]       |   ✅  |            ✅           |   ✅   |  ✅  |       ❌          |
@@ -64,7 +64,7 @@ The following table describes per-platform support of individual router-level OS
 | Mikrotik RouterOS 7      |   ✅  |            ❌           |   ✅   |  ❌  |       ❌          |
 | Nokia SR Linux           |   ✅  |            ✅           |   ✅   |  ❌   |       ❌          |
 | Nokia SR OS              |   ✅  |            ✅           |   ✅   |  ❌   |       ❌          |
-| VyOS                     |   ✅  |            ✅           |   ✅   |  ❌   |       ❌          |
+| VyOS                     |   ✅  |            ✅           |   ✅   |  ✅  |       ❌          |
 
 **Notes:**
 * Dell OS10 does not support OSPF on the so-called *Virtual Network* interface, the VLAN implementation model currently used in our templates.

--- a/netsim/ansible/templates/bgp/arubacx.j2
+++ b/netsim/ansible/templates/bgp/arubacx.j2
@@ -23,6 +23,14 @@ router bgp {{ bgp.as }}
 {% for af in ['ipv4','ipv6'] if bgp[af] is defined %}
   address-family {{ af }} unicast
 !
+{% if bgp.import is defined %}
+{%   for s_proto,s_data in bgp.import.items() %}
+  redistribute {{ s_proto }}{%
+    if s_proto == 'ospf' and af == 'ipv6' %}v3{% endif %}{%
+    if 'policy' in s_data %} route-map {{ s_data.policy }}-{{ af }}{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {%   if loopback[af] is defined and bgp.advertise_loopback %}
 {{     bgpcfg.bgp_network(af,loopback[af]) }}
 {%   endif %}

--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -31,6 +31,14 @@ set protocols bgp parameters cluster-id {{ bgp.rr_cluster_id }}
 
 # Work on Family {{ af }}
 
+{% if bgp.import is defined %}
+{%   for s_proto,s_data in bgp.import.items() %}
+set protocols bgp address-family {{ af }}-unicast redistribute {{ s_proto }}{%
+    if s_proto == 'ospf' and af == 'ipv6' %}v3{% endif %}{%
+    if 'policy' in s_data %} route-map {{ s_data.policy }}-{{ af }}{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {%     if loopback[af] is defined and bgp.advertise_loopback %}
 {{       bgpcfg.bgp_network(af,loopback[af]) }}
 {%     endif %}

--- a/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
@@ -1,8 +1,14 @@
-
 router ospf {{ pid }}
 {% if ospf.router_id|ipv4 %}
     router-id {{ ospf.router_id }}
 {% endif %}
+
+{% if ospf.import is defined %}
+{%   for s_proto,s_data in ospf.import.items() %}
+ redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv4{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {% if ospf.reference_bandwidth is defined %}
     reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}

--- a/netsim/ansible/templates/ospf/arubacx.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv3.j2
@@ -4,6 +4,12 @@ router ospfv3 {{ pid }}
     reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
 
+{% if ospf.import is defined %}
+{%   for s_proto,s_data in ospf.import.items() %}
+ redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv6{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {# need to define all areas in advance #}
     area {{ ospf.area }}
 {% for l in interfaces|default([]) if 'ospf' in l and 'ipv6' in l %}

--- a/netsim/ansible/templates/ospf/vyos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv2.j2
@@ -26,4 +26,10 @@ set protocols ospf interface {{ l.ifname }} cost {{ l.ospf.cost }}
 set protocols ospf interface {{ l.ifname }} bfd profile netsim
 {%   endif %}
 
+{% if ospf.import is defined %}
+{%   for s_proto,s_data in ospf.import.items() %}
+set protocols ospf redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv4{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {% endfor %}

--- a/netsim/ansible/templates/ospf/vyos.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv3.j2
@@ -23,4 +23,10 @@ set protocols ospfv3 interface {{ l.ifname }} cost {{ l.ospf.cost }}
 set protocols ospfv3 interface {{ l.ifname }} bfd profile netsim
 {%   endif %}
 
+{% if ospf.import is defined %}
+{%   for s_proto,s_data in ospf.import.items() %}
+set protocols ospfv3 redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv6{% endif +%}
+{%   endfor %}
+{% endif %}
+
 {% endfor %}

--- a/netsim/ansible/templates/vrf/arubacx.bgp.j2
+++ b/netsim/ansible/templates/vrf/arubacx.bgp.j2
@@ -13,11 +13,14 @@ router bgp {{ bgp.as }}
 
 {%   for af in ('ipv4','ipv6') if af in vdata.af|default({}) %}
  address-family {{ af }} unicast
-  redistribute connected
   redistribute local loopback
-{%     if 'ospf' in vdata %}
-  redistribute ospf{{ '' if af == 'ipv4' else 'v3' }} {{ vdata.ospfidx }}
-{%     endif %}
+{% if vdata.bgp.import is defined %}
+{%   for s_proto,s_data in vdata.bgp.import.items() %}
+  redistribute {{ s_proto }}{%
+    if s_proto == 'ospf' and af == 'ipv6' %}v3{% endif %}{%
+    if 'policy' in s_data %} route-map {{ s_data.policy }}-{{ af }}{% endif +%}
+{%   endfor %}
+{% endif %}
 !
 {%     for n in vdata.networks|default([]) if af in n %}
 {{       bgpcfg.bgp_network(af,n[af]) }}

--- a/netsim/ansible/templates/vrf/vyos.bgp.j2
+++ b/netsim/ansible/templates/vrf/vyos.bgp.j2
@@ -18,10 +18,14 @@ set protocols bgp address-family {{ af }}-unicast label vpn export auto
 
 
 {% for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}
-set protocols bgp address-family {{ af }}-unicast redistribute connected
-{%   if vdata.ospf is defined %}
-set protocols bgp address-family {{ af }}-unicast redistribute ospf
-{%   endif %}
+
+{% if vdata.bgp.import is defined %}
+{%   for s_proto,s_data in vdata.bgp.import.items() %}
+set protocols bgp address-family {{ af }}-unicast redistribute {{ s_proto }}{%
+    if s_proto == 'ospf' and af == 'ipv6' %}v3{% endif %}{%
+    if 'policy' in s_data %} route-map {{ s_data.policy }}-{{ af }}{% endif +%}
+{%   endfor %}
+{% endif %}
 
 # Define networks for VRF Loopback
 {%   for n in vdata.networks|default([]) if af in n %}

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -37,6 +37,7 @@ features:
     local_as: true
     local_as_ibgp: false
     vrf_local_as: true
+    import: [ ospf, connected, vrf ]
   evpn:
     asymmetrical_irb: true
     irb: true
@@ -45,7 +46,8 @@ features:
   mpls:
     ldp: true
     vpn: true
-  ospf: true
+  ospf:
+    import: [ bgp, connected, vrf ]
   routing:
     policy:
       set:

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -24,6 +24,7 @@ features:
     local_as: true
     rfc8950: true
     vrf_local_as: true
+    import: [ ospf, ripv2, connected, vrf ]
   evpn:
     asymmetrical_irb: true
     irb: true
@@ -35,6 +36,7 @@ features:
     vpn: true
   ospf:
     unnumbered: true
+    import: [ bgp, ripv2, connected, vrf ]
   ripv2:
     ipv4: true
     ipv6: true

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -13,6 +13,7 @@ no_propagate:
   rr_list:
   as_list:
 transform_after: [ vlan ]
+config_after: [ routing ]
 next_hop_self: true
 attributes:
   global:

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -3,7 +3,7 @@
 ---
 area: 0.0.0.0
 transform_after: [ vlan, vrf ]
-config_after: [ vlan, dhcp ]
+config_after: [ vlan, dhcp, routing ]
 attributes:
   global:
     af:

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -42,8 +42,8 @@ links:
   role: external
   type: p2p
 module:
-- bgp
 - routing
+- bgp
 name: input
 nodes:
   r1:
@@ -114,8 +114,8 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:00:00:01
     module:
-    - bgp
     - routing
+    - bgp
     name: r1
     routing:
       _numobj:
@@ -203,8 +203,8 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:00:00:02
     module:
-    - bgp
     - routing
+    - bgp
     name: r2
     routing:
       _numobj:


### PR DESCRIPTION
includes forced config order, for configuring routing before bgp and ospf

testing:

**Aruba CX**

- [x] ospfv2/10
- [x] ospfv2/11
- [x] ospfv3/10
- [x] ospfv3/11
- [x] bgp/30
- [x] bgp/31
- [x] vrf/11
- [x] vrf/15
- [x] vrf/33
- [x] vrf/34

**VyOS**

- [x] ospfv2/10
- [x] ospfv2/11
- [x] ospfv3/10
- [x] ospfv3/11
- [x] bgp/30
- [x] bgp/31
- [x] vrf/11
- [x] vrf/15
- [x] vrf/33
- [x] vrf/34
