### PR TITLE
ArubaCX + VyOS OSPF/v3 default originate + bonus

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -352,3 +352,4 @@ Other VyOS caveats:
 * VRF and VXLAN kernel modules are usually bundled with a Linux distribution. If your Ubuntu distribution does not include the MPLS drivers, try installing them with `sudo apt install linux-generic`.
 * You cannot load kernel modules in GitHub Codespaces and thus cannot use _vrf_, _mpls_, or _vxlan_ modules on VyOS nodes in that environment.
 * While VyOS itself supports IPv6 transport for VXLAN, using static flooding with the **vxlan** module, this seems not to work with EVPN, where an IPv4 VTEP is always announced by **frr**.
+* VyOS does not have a simple way to handle a management VRF on containerlab, so it will always have a default IPv4 route (`0.0.0.0/0`) on the default routing table. This can cause some problems if you want to originate a default only if received by other routers.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -50,7 +50,7 @@ The following table describes per-platform support of individual router-level OS
 | Operating system         | Areas | Reference<br/>bandwidth | OSPFv3 | Route<br>import | Default<br>route |
 | ------------------------ |:-:|:-:|:-:|:-:|:-:|
 | Arista EOS               | ✅| ✅| ✅| ✅| ✅|
-| Aruba AOS-CX             | ✅| ✅| ✅| ✅| ❌ |
+| Aruba AOS-CX             | ✅| ✅| ✅| ✅| ✅|
 | Cisco IOS                | ✅| ✅| ✅| ✅| ✅|
 | Cisco IOS XRv            | ✅| ✅| ✅| ❌ | ❌ |
 | Cisco IOS XE[^18v]       | ✅| ✅| ✅| ✅| ✅|
@@ -65,7 +65,7 @@ The following table describes per-platform support of individual router-level OS
 | Mikrotik RouterOS 7      | ✅| ❌ | ✅| ❌ | ❌ |
 | Nokia SR Linux           | ✅| ✅| ✅| ❌ | ❌ |
 | Nokia SR OS              | ✅| ✅| ✅| ❌ | ❌ |
-| VyOS                     | ✅| ✅| ✅| ✅| ❌ |
+| VyOS                     | ✅| ✅| ✅| ✅| ✅|
 
 **Notes:**
 * Dell OS10 does not support OSPF on the so-called *Virtual Network* interface, the VLAN implementation model currently used in our templates.

--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -52,7 +52,7 @@ These platforms support routing protocols in VRFs:
 | Mikrotik RouterOS 6   | ✅  [❗](caveats-routeros6) |  ❌  | ✅  |
 | Mikrotik RouterOS 7   | ✅  |  ❌  | ✅  |
 | SR Linux              | ✅  |  ❌  | ✅  |
-| VyOS                  | ✅  |  ❌  | ✅  |
+| VyOS                  | ✅  | ✅  | ✅  |
 
 ```{note}
 * IS-IS and EIGRP cannot be run within a VRF, but both configuration modules are VRF-aware -- they will not try to configure IS-IS or EIGRP routing on VRF interfaces

--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -12,9 +12,9 @@ configure
 It seems VyOS has some problems in handling hostnames with only one letter in it.
 #}
 {% if inventory_hostname|length > 1 %}
-set system host-name '{{ inventory_hostname }}'
+set system host-name '{{ inventory_hostname | replace("_","-") }}'
 {% else %}
-set system host-name 'vyos-{{ inventory_hostname }}'
+set system host-name 'vyos-{{ inventory_hostname | replace("_","-") }}'
 {% endif %}
 
 {% if vrfs is defined %}

--- a/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
@@ -1,7 +1,11 @@
+{% import "ios.default.j2" as ospf_default %}
+
 router ospf {{ pid }}
 {% if ospf.router_id|ipv4 %}
     router-id {{ ospf.router_id }}
 {% endif %}
+
+{{ ospf_default.config(ospf,'ipv4') }}
 
 {% if ospf.import is defined %}
 {%   for s_proto,s_data in ospf.import.items() %}

--- a/netsim/ansible/templates/ospf/arubacx.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv3.j2
@@ -1,8 +1,12 @@
+{% import "ios.default.j2" as ospf_default %}
+
 router ospfv3 {{ pid }}
     router-id {{ ospf.router_id }}
 {% if ospf.reference_bandwidth is defined %}
     reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
+
+{{ ospf_default.config(ospf,'ipv6') }}
 
 {% if ospf.import is defined %}
 {%   for s_proto,s_data in ospf.import.items() %}

--- a/netsim/ansible/templates/ospf/vyos.default.j2
+++ b/netsim/ansible/templates/ospf/vyos.default.j2
@@ -1,0 +1,24 @@
+{% macro config(ospf_data,af='ipv4') %}
+{% if ospf_data.default is defined %}
+{%   set dfd = ospf_data.default %}
+
+set protocols ospf{% if af == 'ipv6' %}v3{% endif %} default-information originate
+
+{%   if dfd.always|default(False) %}
+set protocols ospf{% if af == 'ipv6' %}v3{% endif %} default-information originate always
+{%   endif %}
+
+{%   if dfd.type|default('') %}
+set protocols ospf{% if af == 'ipv6' %}v3{% endif %} default-information originate metric-type {{ dfd.type.replace('e','') }}
+{%   endif %}
+
+{%   if dfd.cost|default(0) %}
+set protocols ospf{% if af == 'ipv6' %}v3{% endif %} default-information originate metric {{ dfd.cost }}
+{%   endif %}
+
+{%   if dfd.policy|default(False) %}
+set protocols ospf{% if af == 'ipv6' %}v3{% endif %} default-information originate route-map {{ dfd.policy }}-{{ af }}
+{%   endif %}
+
+{% endif %}
+{% endmacro -%}

--- a/netsim/ansible/templates/ospf/vyos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv2.j2
@@ -1,6 +1,10 @@
+{% import "vyos.default.j2" as ospf_default %}
+
 {% if ospf.router_id|ipv4 %}
 set protocols ospf parameters router-id {{ ospf.router_id }}
 {% endif %}
+
+{{ ospf_default.config(ospf,'ipv4') }}
 
 {% if ospf.reference_bandwidth is defined %}
 set protocols ospf auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}

--- a/netsim/ansible/templates/ospf/vyos.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv3.j2
@@ -1,6 +1,10 @@
+{% import "vyos.default.j2" as ospf_default %}
+
 {% if ospf.router_id|ipv4 %}
 set protocols ospfv3 parameters router-id {{ ospf.router_id }}
 {% endif %}
+
+{{ ospf_default.config(ospf,'ipv6') }}
 
 {% for l in interfaces|default([]) if l.ospf.passive|default(False) %}
 set protocols ospfv3 interface {{ l.ifname }} passive

--- a/netsim/ansible/templates/vrf/arubacx.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/arubacx.ospfv2-vrf.j2
@@ -1,11 +1,15 @@
+{% import "ios.default.j2" as ospf_default %}
 !
 router ospf {{ vdata.ospfidx }} vrf {{ vname }}
     router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
 
-{% if bgp.as is defined %}
-    redistribute bgp
+{{ ospf_default.config(vdata.ospf,'ipv4') }}
+
+{% if vdata.ospf.import is defined %}
+{%   for s_proto,s_data in vdata.ospf.import.items() %}
+ redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv4{% endif +%}
+{%   endfor %}
 {% endif %}
-    redistribute connected
 
 {% if ospf.reference_bandwidth is defined %}
     reference-bandwidth {{ ospf.reference_bandwidth }}

--- a/netsim/ansible/templates/vrf/arubacx.ospfv3-vrf.j2
+++ b/netsim/ansible/templates/vrf/arubacx.ospfv3-vrf.j2
@@ -1,11 +1,15 @@
+{% import "ios.default.j2" as ospf_default %}
 !
 router ospfv3 {{ vdata.ospfidx }} vrf {{ vname }}
     router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
 
-{% if bgp.as is defined %}
-    redistribute bgp
+{{ ospf_default.config(vdata.ospf,'ipv6') }}
+
+{% if vdata.ospf.import is defined %}
+{%   for s_proto,s_data in vdata.ospf.import.items() %}
+ redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv6{% endif +%}
+{%   endfor %}
 {% endif %}
-    redistribute connected
 
 {% if ospf.reference_bandwidth is defined %}
     reference-bandwidth {{ ospf.reference_bandwidth }}

--- a/netsim/ansible/templates/vrf/vyos.default.j2
+++ b/netsim/ansible/templates/vrf/vyos.default.j2
@@ -1,0 +1,1 @@
+../ospf/vyos.default.j2

--- a/netsim/ansible/templates/vrf/vyos.j2
+++ b/netsim/ansible/templates/vrf/vyos.j2
@@ -22,7 +22,12 @@ edit vrf name {{ vname }}
 {% endif %}
 
 {% if 'ospf' in vdata %}
-{% include 'vyos.ospfv2-vrf.j2' %}
+{%   if vdata.af.ipv4|default(False) %}
+{%     include 'vyos.ospfv2-vrf.j2' %}
+{%   endif %}
+{%   if vdata.af.ipv6|default(False) %}
+{%     include 'vyos.ospfv3-vrf.j2' %}
+{%   endif %}
 {% endif %}
 
 # Back to root level

--- a/netsim/ansible/templates/vrf/vyos.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/vyos.ospfv2-vrf.j2
@@ -1,12 +1,16 @@
+{% import "vyos.default.j2" as ospf_default %}
 
 {% if vdata.ospf.router_id|ipv4 or ospf.router_id|ipv4 %}
 set protocols ospf parameters router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
 {% endif %}
 
-set protocols ospf redistribute connected
-{% if bgp.as is defined %}
-set protocols ospf redistribute bgp
+{% if vdata.ospf.import is defined %}
+{%   for s_proto,s_data in vdata.ospf.import.items() %}
+set protocols ospf redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv4{% endif +%}
+{%   endfor %}
 {% endif %}
+
+{{ ospf_default.config(vdata.ospf,'ipv4') }}
 
 {% if ospf.reference_bandwidth is defined %}
 set protocols ospf auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}

--- a/netsim/ansible/templates/vrf/vyos.ospfv3-vrf.j2
+++ b/netsim/ansible/templates/vrf/vyos.ospfv3-vrf.j2
@@ -1,0 +1,36 @@
+{% import "vyos.default.j2" as ospf_default %}
+
+{% if vdata.ospf.router_id|ipv4 or ospf.router_id|ipv4 %}
+set protocols ospfv3 parameters router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
+{% endif %}
+
+{% if vdata.ospf.import is defined %}
+{%   for s_proto,s_data in vdata.ospf.import.items() %}
+set protocols ospfv3 redistribute {{ s_proto }}{% if 'policy' in s_data %} route-map {{ s_data.policy }}-ipv6{% endif +%}
+{%   endfor %}
+{% endif %}
+
+{{ ospf_default.config(vdata.ospf,'ipv6') }}
+
+{% if ospf.reference_bandwidth is defined %}
+set protocols ospfv3 auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+{% endif %}
+
+{% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv6' in l %}
+
+set protocols ospfv3 interface {{ l.ifname }} area {{ l.ospf.area }}
+
+{%   if l.ospf.passive|default(False) %}
+set protocols ospfv3 interface {{ l.ifname }} passive
+{%   endif %}
+{%   if l.ospf.network_type is defined %}
+set protocols ospfv3 interface {{ l.ifname }} network {{ l.ospf.network_type }}
+{%   endif %}
+{%   if l.ospf.cost is defined %}
+set protocols ospfv3 interface {{ l.ifname }} cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+set protocols ospfv3 interface {{ l.ifname }} bfd
+{%   endif %}
+
+{% endfor %}

--- a/netsim/devices/arubacx.py
+++ b/netsim/devices/arubacx.py
@@ -16,6 +16,7 @@ class ARUBACX(_Quirks):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     mods = node.get('module',[])
+    # Checks for OSPF Process ID (index based)
     if 'ospf' in mods and 'vrf' in mods:
         ospfidx = 2
         for vrf in node.get('vrfs', {}).keys():
@@ -27,6 +28,18 @@ class ARUBACX(_Quirks):
                 return
             node.vrfs[vrf]['ospfidx'] = ospfidx
             ospfidx = ospfidx + 1
+    # Remove OSPF default originate route-type (not supported, yet)
+    if 'ospf' in mods:
+      if 'default' in node.get('ospf', {}) and 'type' in node.ospf.default:
+        del node.ospf.default['type']
+        log.info(f'OSPF default-information originate (on node {node.name}) does not support metric-type attribute (on default routing table)',
+                  'quirks')
+    if 'ospf' in mods and 'vrf' in mods:
+      for vname,vdata in node.get('vrfs', {}).items():
+        if 'default' in vdata.get('ospf', {}) and 'type' in vdata.ospf.default:
+          del vdata.ospf.default['type']
+          log.info(f'OSPF default-information originate (on node {node.name}) does not support metric-type attribute (on vrf {vname})',
+                    'quirks')
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'arubanetworks.aoscx')

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -48,6 +48,7 @@ features:
     vpn: true
   ospf:
     import: [ bgp, connected, vrf ]
+    default: true
   routing:
     policy:
       set:

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -37,6 +37,7 @@ features:
   ospf:
     unnumbered: true
     import: [ bgp, ripv2, connected, vrf ]
+    default: true
   ripv2:
     ipv4: true
     ipv6: true
@@ -65,6 +66,7 @@ features:
     native_routed: true
   vrf:
     ospfv2: True
+    ospfv3: True
     bgp: True
   vxlan:
     vtep6: true


### PR DESCRIPTION
ArubaCX + VyOS OSPF/v3 default originate

++ bonus: Support for OSPFv3 in VRF for VyOS

**Testing caveats for ospfv2/20-default.yml**

- ArubaCX allows to generate the default only as `E2` - the test is failing for the wrong metric received from `dut_c` --> created device quirk for removing `metric-type` from ospf struct
- VyOS does not have a management VRF; a default route is always present on the main routing table - hence, test is failing because the probe always receive the E1 route announced by `dut_c` (which shall announce the default only if present) --> documented in `caveats.md`

