### PR TITLE
SR Linux: route import (redistribution) into OSPF and BGP

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -83,7 +83,7 @@ The following features are only supported on a subset of platforms:
 | Cumulus Linux 4.x     |  ✅ |  ✅ |  ✅ |  ✅ |
 | Dell OS10             |  ✅ |  ❌  |  ❌  |  ❌  |
 | FRR                   |  ✅ |  ✅ |  ✅ |  ✅ |
-| Nokia SR Linux        |  ✅ |  ✅ |  ❌  |  ❌  |
+| Nokia SR Linux        |  ✅ |  ✅ |  ✅ |  ✅ |
 | Nokia SR OS           |  ✅ |  ✅ |  ❌  |  ❌  |
 | Sonic                 |  ✅ |  ✅ |  ❌  |  ❌  |
 | VyOS                  |  ✅ |  ❌  |  ✅ |  ✅ |

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -63,7 +63,7 @@ The following table describes per-platform support of individual router-level OS
 | Junos[^Junos]            | ✅| ✅| ✅| ❌ | ❌ |
 | Mikrotik RouterOS 6      | ✅| ❌ | ❌ | ❌ | ❌ |
 | Mikrotik RouterOS 7      | ✅| ❌ | ✅| ❌ | ❌ |
-| Nokia SR Linux           | ✅| ✅| ✅| ❌ | ❌ |
+| Nokia SR Linux           | ✅| ✅| ✅| ✅| ❌ |
 | Nokia SR OS              | ✅| ✅| ✅| ❌ | ❌ |
 | VyOS                     | ✅| ✅| ✅| ✅| ✅|
 

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -6,7 +6,7 @@
       mask-length-range: exact
 {% endmacro %}
 
-{% macro bgp_export_policy(vrf,type,nh=None) %}
+{% macro bgp_export_policy(vrf,type,nh=None,import=[]) %}
 {%   if vrf == 'default' and type == 'bgp' %}
 - path: /routing-policy/prefix-set[name={{ vrf }}_bgp_advertise]
   value:
@@ -18,7 +18,7 @@
     default-action:
       policy-result: reject
     statement:
-{%   if vrf == 'default' %}
+{%   if 'connected' not in import %}
     - name: prefixes
       match:
         prefix-set: {{ vrf }}_bgp_advertise
@@ -48,30 +48,22 @@
       action:
         policy-result: accept
 {%   endif %}
-{%   if vrf != 'default' %}
-    - name: local
-      match:
-        protocol: local
-      action:
-        policy-result: accept
-    - name: ospfv2
-      match:
-        protocol: ospfv2
-      action:
-        policy-result: accept
-    - name: ospfv3
-      match:
-        protocol: ospfv3
-      action:
-        policy-result: accept
-{%     if 'evpn' in module %}
+{%   if 'evpn' in module and vrf != 'default' %}
     - name: bgp_evpn
       match:
         protocol: bgp-evpn
       action:
         policy-result: accept
-{%     endif %}
 {%   endif %}
+{%   for s_proto in import %}
+{%     for srl_proto in netlab_match_protomap[s_proto] %}
+    - name: export_{{ srl_proto }}
+      match:
+        protocol: {{ srl_proto }}
+      action:
+        policy-result: accept
+{%     endfor %}
+{%   endfor %}
 {% endmacro %}
 
 {% macro bgp_families(neighbor,ipv4=True,ipv6=True,import=None,export=None) %}
@@ -150,12 +142,12 @@
     for loops are there to ensure the AF-IBGP export policy is defined
     only once)
 #}
-{{ bgp_export_policy(vrf,'bgp') }}
+{{ bgp_export_policy(vrf,'bgp',import=vrf_bgp.import|default([])) }}
 {% if bgp.next_hop_self|default(False) %}
 {%   for afm in vrf_context.af %}
 {%     for n in vrf_bgp.neighbors|default([]) if afm in n and n.type == 'ibgp' %}
 {%       if loop.first %}
-{{         bgp_export_policy(vrf,'ibgp-'+afm,loopback[afm]|ipaddr('address')) }}
+{{         bgp_export_policy(vrf,'ibgp-'+afm,loopback[afm]|ipaddr('address'),import=vrf_bgp.import|default([])) }}
 {%       endif %}
 {%     endfor %}
 {%   endfor %}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -23,7 +23,7 @@
       match:
         prefix-set: {{ vrf }}_bgp_advertise
       action:
-        policy-result: accept
+        policy-result: next-policy
 {%   endif %}
 {%   if 'ibgp' in type and nh %}
     - name: rr-next-hop-unchanged
@@ -32,12 +32,12 @@
         bgp:
           community-set: ibgp-mark
       action:
-        policy-result: accept
+        policy-result: next-policy
     - name: ebgp-next-hop-self
       match:
         protocol: bgp
       action:
-        policy-result: "accept"
+        policy-result: next-policy
         bgp:
           next-hop:
             set: "{{ nh }}"
@@ -46,14 +46,14 @@
       match:
         protocol: bgp
       action:
-        policy-result: accept
+        policy-result: next-policy
 {%   endif %}
 {%   if 'evpn' in module and vrf != 'default' %}
     - name: bgp_evpn
       match:
         protocol: bgp-evpn
       action:
-        policy-result: accept
+        policy-result: next-policy
 {%   endif %}
 {%   for s_proto in import %}
 {%     for srl_proto in netlab_match_protomap[s_proto] %}
@@ -61,7 +61,7 @@
       match:
         protocol: {{ srl_proto }}
       action:
-        policy-result: accept
+        policy-result: next-policy
 {%     endfor %}
 {%   endfor %}
 {% endmacro %}
@@ -103,7 +103,7 @@
 {% set nh_self = bgp.next_hop_self|default(False) and type == 'ibgp' %}
 {% set nh_self_rr = nh_self and vrf_bgp.rr|default(False) %}
 {% set ep_name = (vrf + "_ibgp-" + af + "_export") if nh_self_rr else (vrf + "_bgp_export") %}
-{{ bgp_families(neighbor,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name ]) }}
+{{ bgp_families(neighbor,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name, 'accept_all' ]) }}
     timers:
       connect-retry: 10
       _annotate_connect-retry: "Reduce default 120s to 10s"

--- a/netsim/ansible/templates/ospf/srlinux.j2
+++ b/netsim/ansible/templates/ospf/srlinux.j2
@@ -1,5 +1,5 @@
 {% set pid = ospf.process|default(0) %}
-{% from "srlinux.macro.j2" import ospf_config %}
+{% from "srlinux.macro.j2" import ospf_config with context %}
 updates:
 {% if ospf.af.ipv4 is defined %}
 {{ ospf_config( pid,'ipv4','default',ospf,interfaces) }}

--- a/netsim/ansible/templates/ospf/srlinux.macro.j2
+++ b/netsim/ansible/templates/ospf/srlinux.macro.j2
@@ -3,29 +3,25 @@
 {%- endmacro %}
 
 {% macro ospf_config(pid,af,vrf,ospf,vrf_interfaces,evpn_active=False) %}
-{% if vrf != 'default' %}
+{#
+   Just to make it more fun, while one might be 'redistributing' or 'importing' routes into a routing
+   protocol, SR Linux 'exports' them in the same routing protocol, so we have an 'export-policy'
+#}
+{% if ospf.import|default([]) %}
 - path: /routing-policy/policy[name={{vrf}}_export_ospf]
   value:
     default-action:
       policy-result: reject
     statement:
-    - name: bgp
+{%   for s_proto in ospf.import %}
+{%     for srl_proto in netlab_match_protomap[s_proto] if srl_proto != 'bgp-evpn' or evpn_active %}
+    - name: export_{{ srl_proto }}
       match:
-        protocol: bgp
+        protocol: {{ srl_proto }}
       action:
         policy-result: accept
-    - name: local
-      match:
-        protocol: local
-      action:
-        policy-result: accept
-{% if evpn_active %}
-    - name: bgp_evpn
-      match:
-        protocol: bgp-evpn
-      action:
-        policy-result: accept
-{% endif %}
+{%     endfor %}
+{%   endfor %}
 {% endif %}
 
 - path: /network-instance[name={{ vrf|default('default') }}]
@@ -47,7 +43,7 @@
 {%     if ospf.reference_bandwidth is defined %}
           reference-bandwidth: {{ ospf.reference_bandwidth * 1000 }} # in kbps
 {%     endif %}
-{%     if vrf != 'default' %}
+{%     if ospf.import|default([]) %}
           asbr: {}
           export-policy: "{{vrf}}_export_ospf"
 {%     endif %}

--- a/netsim/ansible/templates/vrf/srlinux.j2
+++ b/netsim/ansible/templates/vrf/srlinux.j2
@@ -1,4 +1,4 @@
-{% from "templates/ospf/srlinux.macro.j2" import ospf_config %}
+{% from "templates/ospf/srlinux.macro.j2" import ospf_config with context %}
 {% from "templates/bgp/srlinux.macro.j2" import bgp_config with context %}
 
 updates:

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -45,7 +45,7 @@ features:
     activate_af: True
     ipv6_lla: True
     rfc8950: True
-###    import: [ ospf, isis, connected, vrf ]
+    import: [ ospf, isis, connected, vrf ]
   evpn:
     irb: True
     asymmetrical_irb: True

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -9,6 +9,11 @@ group_vars:
   ansible_network_os: srlinux # nokia.srlinux.srlinux
   ansible_connection: paramiko
   netlab_console_connection: ssh
+  netlab_match_protomap:
+    ospf: [ ospfv2, ospfv3 ]
+    bgp: [ bgp, bgp-evpn ]
+    connected: [ local ]
+    isis: [ isis ]
 sr:
   srgb_range_start: 500000
   srgb_range_size: 1000
@@ -40,6 +45,7 @@ features:
     activate_af: True
     ipv6_lla: True
     rfc8950: True
+###    import: [ ospf, isis, connected, vrf ]
   evpn:
     irb: True
     asymmetrical_irb: True
@@ -54,6 +60,7 @@ features:
     ldp: True                           # on 7250 IXR only
   ospf:
     unnumbered: True
+    import: [ bgp, isis, connected, vrf ]
   routing:
     policy:
       set: [ locpref, med ]

--- a/netsim/extra/bgp.policy/srlinux.j2
+++ b/netsim/extra/bgp.policy/srlinux.j2
@@ -7,7 +7,7 @@
 {%     else %}
 - path: /network-instance[name={{vrf}}]/protocols/bgp/neighbor[peer-address={{ n[af]|ipaddr('address') }}]/{{ p_path }}
 {% endif %}
-  value: [ {{ n.policy[direction] }} ]
+  value: [ {{ vrf }}_bgp_export, {{ n.policy[direction] }} ]
 {% endfor %}
 {%- endmacro %}
 

--- a/tests/integration/bgp.policy/31-med.yml
+++ b/tests/integration/bgp.policy/31-med.yml
@@ -47,11 +47,11 @@ validate:
     plugin: bgp_prefix(nodes.dut.loopback.ipv6,af='ipv6')
 
   med_v4:
-    description: Check for MED on DUT IPv4 X1 prefix
+    description: Check for MED on DUT IPv4 prefix
     nodes: [ probe ]
     plugin: bgp_prefix(nodes.dut.loopback.ipv4,med=42)
 
   med_v6:
-    description: Check for MED on DUT IPv6 X1 prefix
+    description: Check for MED on DUT IPv6 prefix
     nodes: [ probe ]
     plugin: bgp_prefix(nodes.dut.loopback.ipv6,af='ipv6',med=42)

--- a/tests/integration/bgp.session/04-default-originate.yml
+++ b/tests/integration/bgp.session/04-default-originate.yml
@@ -34,7 +34,7 @@ validate:
   session:
     description: Check EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 10
+    wait: 20
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
   def_ipv4:


### PR DESCRIPTION
Adds SR Linux support for unconditional route import into BGP and OSPF. Also, creates chains for BGP import/export policies so the per-neighbor routing policy works correctly (as opposed to dumping the whole RIB to the neighbor)