### PR TITLE
SR Linux: Implement OSPF default route

### DIFF
--- a/netsim/ansible/templates/ospf/srlinux.macro.j2
+++ b/netsim/ansible/templates/ospf/srlinux.macro.j2
@@ -7,13 +7,43 @@
    Just to make it more fun, while one might be 'redistributing' or 'importing' routes into a routing
    protocol, SR Linux 'exports' them in the same routing protocol, so we have an 'export-policy'
 #}
-{% if ospf.import|default([]) %}
+{% if ospf.default|default(False) %}
+- path: /routing-policy/prefix-set[name=default_route]
+  value:
+    prefix:
+    - ip-prefix: "0.0.0.0/0"
+      mask-length-range: exact
+    - ip-prefix: "::/0"
+      mask-length-range: exact
+{%   if ospf.default.always|default(False) %}
+- path: /network-instance[name={{vrf}}]/next-hop-groups/group[name=blackhole]
+  value:
+    blackhole:
+      generate-icmp: True
+
+- path: /network-instance[name={{vrf}}]/static-routes
+  value:
+    route:
+    - prefix: {{ "0.0.0.0/0" if af == 'ipv4' else "::/0" }}
+      preference: 254
+      next-hop-group: blackhole
+{%   endif %}
+{% endif %}
+{% set ospf_import = ospf.import|default(False) or ospf.default|default(False) %}
+{% if ospf_import %}
 - path: /routing-policy/policy[name={{vrf}}_export_ospf]
   value:
     default-action:
       policy-result: reject
     statement:
-{%   for s_proto in ospf.import %}
+{%   if ospf.default|default(False) %}
+    - name: default
+      match:
+        prefix-set: default_route
+      action:
+        policy-result: accept
+{%   endif %}
+{%   for s_proto in ospf.import|default([]) %}
 {%     for srl_proto in netlab_match_protomap[s_proto] if srl_proto != 'bgp-evpn' or evpn_active %}
     - name: export_{{ srl_proto }}
       match:
@@ -43,7 +73,7 @@
 {%     if ospf.reference_bandwidth is defined %}
           reference-bandwidth: {{ ospf.reference_bandwidth * 1000 }} # in kbps
 {%     endif %}
-{%     if ospf.import|default([]) %}
+{%     if ospf_import %}
           asbr: {}
           export-policy: "{{vrf}}_export_ospf"
 {%     endif %}

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -61,6 +61,7 @@ features:
   ospf:
     unnumbered: True
     import: [ bgp, isis, connected, vrf ]
+    default: true
   routing:
     policy:
       set: [ locpref, med ]

--- a/tests/integration/ospf/ospfv2/20-default.yml
+++ b/tests/integration/ospf/ospfv2/20-default.yml
@@ -47,30 +47,33 @@ validate:
     wait_msg: Waiting for OSPF adjacency process to complete
     nodes: [ probe ]
     plugin: ospf_neighbor(nodes.dut_a.ospf.router_id)
+    stop_on_error: True
   adj_c:
     description: Check OSPF adjacencies with DUT_C
     wait: 30
     wait_msg: Waiting for OSPF adjacency process to complete
     nodes: [ probe ]
     plugin: ospf_neighbor(nodes.dut_c.ospf.router_id)
+    stop_on_error: True
   adj_x:
     description: Check EBGP sessions with DUT_C
     wait_msg: Wait for BGP sessions to be established
     wait: 30
     nodes: [ xf ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut_c')
-  df:
+    stop_on_error: True
+  df_a:
     description: Do we have at least some default route?
     wait_msg: Wait for SPF to complete
     wait: 10
     nodes: [ probe ]
     plugin: ospf_prefix('0.0.0.0/0')
-  df_a:
-    description: Check for the always-present default route
-    wait_msg: Wait for SPF to complete
-    wait: 10
+    stop_on_error: True
+  df_a_cost:
+    description: Check for the cost/metric of always-present default route
     nodes: [ probe ]
     plugin: ospf_prefix('0.0.0.0/0',cost=40,rt='N E2')
+    level: warning
   #
   # We have to shut down the link to DUT_A because Arista in its infinite wisdom
   # treats EBGP routes like IBGP routes (OSPFv2 is better) and so the BGP default route
@@ -91,7 +94,12 @@ validate:
     wait_msg: Wait for SPF to complete
     wait: 10
     nodes: [ probe ]
+    plugin: ospf_prefix('0.0.0.0/0')
+  df_c_cost:
+    description: Check for the cost/metric of the conditional default route
+    nodes: [ probe ]
     plugin: ospf_prefix('0.0.0.0/0',cost=30)
+    level: warning
   #
   # Making sure the test is idempotent, disable the BGP default route and reenable
   # the link with DUT_A
@@ -107,4 +115,4 @@ validate:
     description: Enable the link to DUT_A
     nodes: [ probe ]
     devices: [ frr ]
-    exec: ip link set {{ interfaces[0].ifname }} down
+    exec: ip link set {{ interfaces[0].ifname }} up

--- a/tests/integration/ospf/ospfv3/20-default.yml
+++ b/tests/integration/ospf/ospfv3/20-default.yml
@@ -59,17 +59,16 @@ validate:
     wait: 30
     nodes: [ xf ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut_c',af='ipv6')
-  df:
+  df_a:
     description: Do we have at least some default route?
     wait_msg: Wait for SPF to complete
     wait: 10
     nodes: [ probe ]
     plugin: ospf6_prefix('::/0')
-  df_a:
-    description: Check for the always-present default route
-    wait_msg: Wait for SPF to complete
-    wait: 10
+  df_a_cost:
+    description: Check the cost of the always-present default route
     nodes: [ probe ]
+    level: warning
     plugin: ospf6_prefix('::/0',cost=40,rt='External-2')
   #
   # We have to shut down the link to DUT_A because the stupid FRRouting fails to report
@@ -91,6 +90,11 @@ validate:
     wait_msg: Wait for SPF to complete
     wait: 10
     nodes: [ probe ]
+    plugin: ospf6_prefix('::/0')
+  df_c_cost:
+    description: Check for the cost of the conditional default route
+    nodes: [ probe ]
+    level: warning
     plugin: ospf6_prefix('::/0',cost=30)
   #
   # Making sure the test is idempotent, disable the BGP default route and reenable


### PR DESCRIPTION
Another feature not yet supported in SR Linux netlab templates: OSPF default route. Validation tests pass, although with warnings as it's impossible to set OSPF metric or OSPF metric type on SR Linux routes exported into OSPFv2/OSPFv3