### PR TITLE
SR Linux: Simplify the IBGP export policy with the new 'next-hop: self' action

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -6,7 +6,7 @@
       mask-length-range: exact
 {% endmacro %}
 
-{% macro bgp_export_policy(vrf,type,nh=None,import=[]) %}
+{% macro bgp_export_policy(vrf,type,nhs=False,import=[]) %}
 {%   if vrf == 'default' and type == 'bgp' %}
 - path: /routing-policy/prefix-set[name={{ vrf }}_bgp_advertise]
   value:
@@ -25,7 +25,7 @@
       action:
         policy-result: next-policy
 {%   endif %}
-{%   if 'ibgp' in type and nh %}
+{%   if 'ibgp' in type and nhs %}
     - name: rr-next-hop-unchanged
       match:
         protocol: bgp
@@ -33,6 +33,10 @@
           community-set: ibgp-mark
       action:
         policy-result: next-policy
+        bgp:
+          communities:
+            remove:
+              ibgp-mark
     - name: ebgp-next-hop-self
       match:
         protocol: bgp
@@ -40,7 +44,7 @@
         policy-result: next-policy
         bgp:
           next-hop:
-            set: "{{ nh }}"
+            set: self
 {%   else %}
     - name: bgp
       match:
@@ -102,7 +106,7 @@
     admin-state: enable
 {% set nh_self = bgp.next_hop_self|default(False) and type == 'ibgp' %}
 {% set nh_self_rr = nh_self and vrf_bgp.rr|default(False) %}
-{% set ep_name = (vrf + "_ibgp-" + af + "_export") if nh_self_rr else (vrf + "_bgp_export") %}
+{% set ep_name = (vrf + "_ibgp-nhs_export") if nh_self_rr else (vrf + "_bgp_export") %}
 {{ bgp_families(neighbor,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name, 'accept_all' ]) }}
     timers:
       connect-retry: 10
@@ -143,13 +147,11 @@
     only once)
 #}
 {{ bgp_export_policy(vrf,'bgp',import=vrf_bgp.import|default([])) }}
-{% if bgp.next_hop_self|default(False) %}
-{%   for afm in vrf_context.af %}
-{%     for n in vrf_bgp.neighbors|default([]) if afm in n and n.type == 'ibgp' %}
-{%       if loop.first %}
-{{         bgp_export_policy(vrf,'ibgp-'+afm,loopback[afm]|ipaddr('address'),import=vrf_bgp.import|default([])) }}
-{%       endif %}
-{%     endfor %}
+{% if bgp.next_hop_self|default(False) and bgp.rr|default(False) %}
+{%   for n in vrf_bgp.neighbors|default([]) if n.type == 'ibgp' %}
+{%     if loop.first %}
+{{       bgp_export_policy(vrf,'ibgp-nhs',nhs=true,import=vrf_bgp.import|default([])) }}
+{%     endif %}
 {%   endfor %}
 {% endif %}
 

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -51,6 +51,10 @@
         protocol: bgp
       action:
         policy-result: next-policy
+        bgp:
+          communities:
+            remove:
+              ibgp-mark
 {%   endif %}
 {%   if 'evpn' in module and vrf != 'default' %}
     - name: bgp_evpn

--- a/tests/integration/bgp/03-ibgp-rr.yml
+++ b/tests/integration/bgp/03-ibgp-rr.yml
@@ -75,11 +75,12 @@ validate:
     wait: 5
     nodes: [ r2 ]
     plugin: bgp_prefix('172.0.42.0/24',peer=nodes.dut.bgp.router_id)
-#  inact:
-#    description: Check route reflection of inactive routes on DUT
-#    wait: 5
-#    nodes: [ r2 ]
-#    plugin: bgp_prefix('10.0.0.10/32',peer=nodes.dut.bgp.router_id)
+  inact:
+    description: Check route reflection of inactive routes on DUT
+    wait: 2
+    nodes: [ r2 ]
+    level: warning
+    plugin: bgp_prefix('10.0.0.10/32',peer=nodes.dut.bgp.router_id)
   nhu:
     description: Check next-hop handling of reflected routes
     nodes: [ r2 ]


### PR DESCRIPTION
SR Linux needs an export to set next-hop to "self" on EBGP routes but not on reflected IBGP routes.
The original template created two per-AF export policies and set the BGP next hop to the IP address
of the loopback interface.

With the new "action.bgp.next-hop: self" option, we can simplify that into a single route map that does
not depend on IP addresses or address families.

Last but not least, we're removing the internal BGP communities used to mark IBGP routes.