### PR TITLE
SR Linux: Enable IS-IS IPv6 multi-topology

### DIFF
--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -36,7 +36,7 @@ The following table describes per-platform support of individual IS-IS features:
 | Cisco Nexus OS     | ✅  | ✅  | ✅  | ✅  |  ❌  |
 | FRR                | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Junos[^Junos]      | ✅  | ✅  | ✅  | ✅  |  ❌  |
-| Nokia SR Linux     | ✅  | ✅  |  ❌  | ✅  |  ❌  |
+| Nokia SR Linux     | ✅  | ✅  | ✅  | ✅  |  ❌  |
 | Nokia SR OS        | ✅  | ✅  | ✅  | ✅  |  ❌  |
 | VyOS               | ✅  | ✅  | ❌   |  ❌  |  ❌  |
 

--- a/netsim/ansible/templates/isis/srlinux.j2
+++ b/netsim/ansible/templates/isis/srlinux.j2
@@ -12,6 +12,8 @@ updates:
 {%    if clab.type in ['ixr6','ixr10','ixr6e','ixr10e'] %}
       multi-topology: {{ 'sr' not in module|default([]) }}
       _annotate_multi-topology: "Not supported in combination with SR"
+{%    else %}
+      multi-topology: True
 {%    endif %}
 {%   endif %}
 {% if ldp is defined and ldp.igp_sync|default(True) %}

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -25,10 +25,10 @@ class SRLINUX(_Quirks):
                 break
 
     if 'isis' in mods:
-      if node.get('isis.af.ipv6',False):
+      if node.get('isis.af.ipv6',False) and 'sr' in mods:
          log.error(
-            f'SR Linux on ({node.name}) does not support IS-IS multi-topology required for ipv6.\n',
-            log.IncorrectType,
+            f'SR Linux on ({node.name}) does not support IS-IS multi-topology for IPv6 in combination with segment routing',
+            Warning,
             'quirks')
 
     if 'bgp' in mods:


### PR DESCRIPTION
SR Linux 24.7 has IS-IS multi-topology for IPv6. It would be a shame not to use it ;)