### PR TITLE
SR Linux: Check for the license needed to run IXR6/IXR10 containers

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -297,10 +297,9 @@ See also [](caveats-junos).
 * Only supported on top of *Containerlab*
 * Supports SR Linux release 24.7.1 or later (due to YANG model changes)
 * Requires `nokia.srlinux` Ansible Galaxy collection (minimum version 0.5.0). Use **ansible-galaxy collection install nokia.srlinux** command to install it.
-* MPLS and LDP are only supported on 7250 IXR (clab.type in ['ixr6','ixr6e','ixr10','ixr10e'])
+* MPLS and LDP are only supported on 7250 IXR (clab.type in ['ixr6','ixr6e','ixr10','ixr10e']). You need a license to run these containers.
 * Nokia SR Linux needs an EVPN control plane to enable VXLAN functionality. VXLAN ingress replication lists are built from EVPN Route Type 3 updates.
 * Inter-VRF route leaking is supported only in combination with BGP EVPN
-* SR Linux does not support multi-topology IS-IS.
 * SR Linux does not support configurable propagation of extended BGP communities.
 
 (caveats-sros)=

--- a/docs/module/sr-mpls.md
+++ b/docs/module/sr-mpls.md
@@ -33,7 +33,7 @@ SR-MPLS is implemented on the following platforms:
 | Juniper vMX           |   ✅  |  ✅  |  ✅   |  ❌   |
 | Juniper vPTX          |   ✅  |  ✅  |  ✅   |  ❌   |
 | Juniper vSRX          |   ✅  |  ✅  |  ✅   |  ❌   |
-| Nokia SR Linux        |   ✅  |  ✅  |  ✅   |  ❌   |
+| Nokia SR Linux [❗](caveats-srlinux) |   ✅  |  ✅  |  ✅   |  ❌   |
 | Nokia SR OS           |   ✅  |  ✅  |  ✅   |  ❌   |
 
 ## Parameters

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -42,7 +42,7 @@ libvirt:
   build: https://netlab.tools/labs/dellos10/
   create:
     virt-install --connect=qemu:///system --name=vm_box --arch=x86_64 --cpu host --vcpus=2 --hvm
-      --ram=2048 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+      --ram=4096 --network=network:vagrant-libvirt,model=virtio --graphics none --import
       --disk path=vm.qcow2,format=qcow2,bus=sata
       --disk path=hdb_OS10-installer.qcow2,format=qcow2,bus=virtio
       --disk path=hdc_OS10-platform.qcow2,format=qcow2,bus=virtio

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -13,6 +13,13 @@ class SRLINUX(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
+    dt = node.clab.type
+    if dt in ['ixr6','ixr10','ixr6e','ixr10e'] and not node.clab.get('license',None):
+      log.error(
+        f'You need a valid SR Linux license to run {dt} container on node {node.name}',
+        log.MissingValue,
+        'quirks')
+
     mods = node.get('module',[])
     if 'vrf' in mods:
         for _,vrf in node.get('vrfs', {}).items():
@@ -40,7 +47,6 @@ class SRLINUX(_Quirks):
               'quirks')
 
     if 'mpls' in mods or 'sr' in mods:
-      dt = node.clab.type
       if dt not in ['ixr6','ixr10','ixr6e','ixr10e']:
         log.error(
           f'SR Linux device type must be set to ixr6/ixr10 for MPLS to work (node {node.name})',

--- a/netsim/templates/provider/libvirt/dellos10-domain.j2
+++ b/netsim/templates/provider/libvirt/dellos10-domain.j2
@@ -7,7 +7,7 @@
     {{ name }}.vm.provider :libvirt do |domain|
       domain.disk_bus = 'ide'
       domain.cpus = 2
-      domain.memory = 2048
+      domain.memory = 4096
       domain.nic_model_type = "e1000"
       domain.driver = "kvm"
     end


### PR DESCRIPTION
Trying to implement the "Principle of Least Astonishment", netlab checks whether you have the necessary license to
run IXR6/IXR10 containers. 

https://containerlab.dev/manual/kinds/srl/#types

Figuring out why those containers are crashing is an experience I wouldn't recommend to anyone.