### PR TITLE
Bug fix: Set IOSvL2 Vagrant box name to 'cisco/iosl2'

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -93,6 +93,7 @@ See also [Cisco IOSv](caveats-iosv) SSH, OSPF, RIPng, and BGP caveats.
 ## Cisco IOSv and IOSvL2
 
 * Cisco IOSv release 15.x does not support unnumbered interfaces. Use Cisco CSR 1000v.
+* Cisco IOSvL2 Vagrant box name is set to `cisco/iosl2` (not `cisco/iosvl2`) to avoid Vagrant generating bogus *never version of this box is available* messages ([more details](https://github.com/ipspace/netlab/issues/1313)).
 * BGP configuration is optimized for reasonable convergence times under lab conditions. Do not use the same settings in a production network.
 * Multiple OSPFv2 processes on Cisco IOS cannot have the same OSPF router ID. By default, _netlab_ generates the same router ID for global and VRF OSPF processes, resulting in non-fatal configuration errors that Ansible silently ignores.
 * It's impossible to configure RIPv2 on individual subnets on Cisco IOS. RIPv2 might be running on more interfaces than intended. _netlab_ configures those interfaces to be *passive*.

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -42,7 +42,7 @@ You have to use the following box names when installing or building the Vagrant 
 | Cisco Catalyst 8000v   | cisco/cat8000v              |
 | Cisco CRS 1000v        | cisco/csr1000v              |
 | Cisco IOSv             | cisco/iosv                  |
-| Cisco IOSvL2           | cisco/iosvl2                |
+| Cisco IOSvL2           | cisco/iosl2[^IOSL2]         |
 | Cisco IOS XR           | cisco/iosxr                 |
 | Cisco Nexus 9300v      | cisco/nexus9300v            |
 | Dell OS10              | dell/os10                   |
@@ -54,12 +54,14 @@ You have to use the following box names when installing or building the Vagrant 
 | Mikrotik RouterOS 7    | mikrotik/chr7               |
 | Sonic                  | netlab/sonic                |
 
+[^IOSL2]: We had to set the box name for Cisco IOSvL2 to `cisco/iosl2` to avoid Vagrant "*you should upgrade this box*" messages ([more details](https://github.com/ipspace/netlab/issues/1313)).
+
 The following Vagrant boxes are automatically downloaded from Vagrant Cloud when you're using them for the first time in your lab topology:
 
 | Virtual network device | Vagrant box name   |
 |------------------------|--------------------|
 | Cumulus VX             | CumulusCommunity/cumulus-vx:4.4.0 |
-| Cumulus VX 5.0 (NVUE)            | CumulusCommunity/cumulus-vx:5.0.1 |
+| Cumulus VX 5.0 (NVUE)  | CumulusCommunity/cumulus-vx:5.0.1 |
 | Generic Linux          | generic/ubuntu2004 |
 | VyOS                   | vyos/current       |
 

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -9,7 +9,7 @@ features:
     model: switch
     svi_interface_name: Vlan{vlan}
 libvirt:
-  image: cisco/iosvl2
+  image: cisco/iosl2
   build: https://netlab.tools/labs/iosvl2/
   create_template: iosv.xml.j2
 node:


### PR DESCRIPTION
Vagrant seems to consider boxes that start with the current box name when checking for upgrades.
This fix changes the Cisco IOSvL2 box name to `cisco/iosl2` to prevent overlaps with `cisco/iosv` box.