### PR TITLE
Updated lag module changes

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -1,0 +1,42 @@
+# Link Aggregation Group (LAG) Configuration Module
+
+This configuration module configures link bonding parameters, for LAGs between 2 devices (i.e. not MC-LAG)
+
+(lag-platform)=
+LAG is currently supported on these platforms:
+
+| Operating system      |   lag     |  LACP off  |  LACP passive
+| --------------------- | :-------: | :--------: |  :----------: 
+| Cumulus Linux         |    ✅     |     ✅     |      ❌
+| FRR                   |    ✅     |     ✅     |      ❌
+
+## Parameters
+
+The following parameters can be set globally or per node/link/interface:
+
+* **lacp**: LACP protocol interval: "fast", "slow" or "off"
+
+  Note that 'link down' is not easily detectable in a virtual environment with veth pairs, therefore it is strongly recommended
+  to enable LACP whenever possible
+
+* **lacp_mode**: "active" or "passive"
+
+The **lag.id** parameter can only be set at the link level; all links with the same lag.id value form a Link Aggregation Group.
+
+## Example
+
+To create a LAG consisting of 2 links between 2 devices:
+
+```
+module: [ lag ]
+
+nodes: [ r1, r2 ]
+
+links:
+- r1:
+  r2:
+  lag.id: 1
+- r1:
+  r2:
+  lag.id: 1
+```

--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -6,7 +6,7 @@ This configuration module configures link bonding parameters, for LAGs between 2
 LAG is currently supported on these platforms:
 
 | Operating system      |   lag     |  LACP off  |  LACP passive
-| --------------------- | :-------: | :--------: |  :----------: 
+| --------------------- | :-------: | :--------: |  :----------:
 | Cumulus Linux         |    ✅     |     ✅     |      ❌
 | FRR                   |    ✅     |     ✅     |      ❌
 
@@ -21,7 +21,7 @@ The following parameters can be set globally or per node/link/interface:
 
 * **lacp_mode**: "active" or "passive"
 
-The **lag.id** parameter can only be set at the link level; all links with the same lag.id value form a Link Aggregation Group.
+By setting the **lag.id** parameter at the link level and defining **lag.members**, a *lag* type link is created with the given list or count of member links.
 
 ## Example
 
@@ -36,7 +36,25 @@ links:
 - r1:
   r2:
   lag.id: 1
+  lag.members: 2
+```
+Additional parameters such as vlan trunks, OSPF cost, etc. can be applied to such *lag* type links. 
+
+In case additional attributes are required for the member links, the following syntax can also be used
+```
+links:
 - r1:
   r2:
-  lag.id: 1
+  lag:
+   id: 1
+   members:
+   - r1:
+       ifindex: 49  # Use 100G links 1/1/49 and 1/1/50
+     r2:
+       ifindex: 49
+   - r1:
+       ifindex: 50
+     r2:
+       ifindex: 50
 ```
+Naturally, the links in lag.members can only use nodes associated with the lag link

--- a/netsim/ansible/tasks/frr/initial-clab.yml
+++ b/netsim/ansible/tasks/frr/initial-clab.yml
@@ -5,6 +5,7 @@
     modprobe vrf || echo "FAILED"
   become: true
   delegate_to: localhost
+  run_once: true
   tags: [ print_action, always ]
   register: modprobe_result
   ignore_errors: True
@@ -13,6 +14,15 @@
   when: modprobe_result.stdout|default('') is search("FAILED")
   set_fact:
     netlab_mgmt_vrf: False
+
+- name: Load bonding kernel module
+  when: "'lag' in module|default([])"
+  shell: |
+    modprobe bonding
+  become: true
+  delegate_to: localhost
+  run_once: true
+  tags: [ print_action, always ]
 
 - include_tasks: deploy-config.yml
   tags: [ print_action, always ]

--- a/netsim/ansible/tasks/frr/initial-clab.yml
+++ b/netsim/ansible/tasks/frr/initial-clab.yml
@@ -15,14 +15,5 @@
   set_fact:
     netlab_mgmt_vrf: False
 
-- name: Load bonding kernel module
-  when: "'lag' in module|default([])"
-  shell: |
-    modprobe bonding
-  become: true
-  delegate_to: localhost
-  run_once: true
-  tags: [ print_action, always ]
-
 - include_tasks: deploy-config.yml
   tags: [ print_action, always ]

--- a/netsim/ansible/templates/dhcp/cumulus.j2
+++ b/netsim/ansible/templates/dhcp/cumulus.j2
@@ -2,7 +2,7 @@
 #
 # Disable IPv6 RA on DHCPv6 client interfaces
 #
-{% for l in interfaces if l.type in ['lan','p2p','stub'] and l.dhcp.client.ipv6 is defined %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] and l.dhcp.client.ipv6 is defined %}
 {%   if loop.first %}
 echo "Disable IPv6 RA"
 cat >/tmp/config <<CONFIG
@@ -21,7 +21,7 @@ vtysh -f /tmp/config
 #
 set -e
 #
-{% for l in interfaces if l.type in ['lan','p2p','stub'] and l.dhcp.client is defined %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] and l.dhcp.client is defined %}
 {%   if loop.first %}
 echo "DHCP: set IP addresses on interfaces"
 cat >/etc/network/interfaces.d/12-dhcp.intf <<CONFIG
@@ -43,7 +43,7 @@ CONFIG
 {%   endif %}
 {% endfor %}
 #
-{% for l in interfaces if l.type in ['lan','p2p','stub'] and l.dhcp.client is defined %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] and l.dhcp.client is defined %}
 {%   if loop.first %}
 echo "DHCP: executing ifup"
 nohup bash -c 'ifreload -a || ifreload -a' &

--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -63,7 +63,7 @@ done
 #
 echo "INIT: creating other interface"
 cat >/etc/network/interfaces.d/11-physical.intf <<CONFIG
-{% for l in interfaces if l.type in ['lan','p2p','stub'] %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] %}
 auto {{ l.ifname }}
 {%   if l.ipv4 is defined %}
 
@@ -99,6 +99,7 @@ iface {{ l.ifname }} inet6 static
 iface {{ l.ifname }}
   mtu {{ l.mtu }}
 {%     endif %}
+
 {% endfor %}
 CONFIG
 #
@@ -109,7 +110,7 @@ done
 #
 # For whatever crazy reason, I had to enable IPv6 in containers
 #
-{% for l in interfaces if l.type in ['lan','p2p','stub'] and (l.ipv6 is defined or 'external' in l.role|default('')) %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] and (l.ipv6 is defined or 'external' in l.role|default('')) %}
 sysctl -qw net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
 {% endfor %}
 #

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -102,6 +102,7 @@ echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 {% for l in interfaces if l.mtu is defined %}
 ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% endfor %}
+
 #
 # Rest of initial configuration done through VTYSH
 #

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -99,7 +99,7 @@ ip link set {{ l.ifname }} up
 echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 #
 # Set Ethernet interface MTU
-{% for l in interfaces if l.mtu is defined %}
+{% for l in interfaces if l.mtu is defined and l.get('type',"")!='lag' %}
 ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% endfor %}
 

--- a/netsim/ansible/templates/lag/cumulus.j2
+++ b/netsim/ansible/templates/lag/cumulus.j2
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+set -e
+
+echo "LAG: creating bond interface(s)"
+#
+# Create bond interface entry
+#
+{%- macro bond_interface(data) %}
+auto {{ data.ifname }}
+iface {{ data.ifname }}
+  pre-up ip link add {{ data.ifname }} type bond
+  bond-slaves {%- for i in interfaces if 'lag' in i and i.type=='p2p' and i.lag.id==data.lag.id %} {{ i.ifname }}{%- endfor %}
+{%    set _lacp = data.lag.lacp|default(lag.lacp) %}
+{%    if _lacp=='slow' %}
+  bond-lacp-rate slow
+{%    elif _lacp=='off' %}
+  bond-mode balance-xor
+{%    endif %}
+{% endmacro %}
+
+cat >/etc/network/interfaces.d/20-bond.intf <<CONFIG
+{% for l in interfaces if l.type == 'lag' %}
+{{ bond_interface(l) }}
+{% endfor %}
+CONFIG
+
+#
+echo "LAG: executing ifreload"
+#
+until ifreload -a; do
+  sleep 1
+done

--- a/netsim/ansible/templates/lag/frr.j2
+++ b/netsim/ansible/templates/lag/frr.j2
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+set -e # Exit immediately when any command fails
+#
+
+#
+# Create bonds for LAGs, if any. Requires kernel bonding module loaded
+#
+{% for l in interfaces if 'lag' in l %}
+{%  if l.type=='lag' %}
+{%   set _lacp = l.lag.lacp|default(lag.lacp) %}
+{%   set lacp_act = 'off' if _lacp=='off' else 'on' %}
+{%   set lacp_rate = ('lacp_rate ' + _lacp) if _lacp!='off' else '' %}
+{%   set _p = "balance-xor" if _lacp=='off' else "802.3ad" %}
+{%   set mode = "mode " + _p + " xmit_hash_policy encap3+4" %}
+ip link add dev {{l.ifname}} type bond {{mode}} lacp_active {{lacp_act}} {{lacp_rate}} || true
+ip link set dev {{l.ifname}} down
+{%  else %}
+ip link set dev {{ l.ifname }} down
+{%  endif %}
+{% endfor %}
+
+{% for l in interfaces if 'lag' in l %}
+{%  if l.type=='lag' %}
+ip link set dev {{l.ifname}} up
+{%  else %}
+ip link set dev {{ l.ifname }} master {% for i in interfaces if i.type=='lag' and i.lag.id==l.lag.id %}{{ i.ifname }}
+{% endfor %}
+ip link set dev {{ l.ifname }} up
+{%  endif %}
+{% endfor %}
+
+exit 0

--- a/netsim/ansible/templates/vlan/cumulus.j2
+++ b/netsim/ansible/templates/vlan/cumulus.j2
@@ -18,11 +18,10 @@ auto bridge
 iface bridge
     bridge-vlan-aware yes
 {% if vlans is defined %}
-{%   for vdata in vlans.values() %}
-    bridge-vids {{ vdata.id }}
-{%   endfor %}
+{%  set vids = vlans.values() | map(attribute='id') | sort | map('string') %}
+    bridge-vids {{ ",".join(vids) }}
 {%  endif %}
-{% for ifdata in interfaces if ifdata.virtual_interface is not defined and ifdata.vlan is defined %}
+{% for ifdata in interfaces if ifdata.vlan is defined and ifdata.type!="svi" %}
     bridge-ports {{ ifdata.ifname }}
 {% endfor %}
 CONFIG
@@ -35,7 +34,7 @@ cat >/etc/network/interfaces.d/51-bridge-interfaces.intf <<CONFIG
 auto {{ ifdata.ifname }}
 {%   endif %}
 iface {{ ifdata.ifname }}
-{%   if ifdata.vlan.trunk_id is defined %}
+{%   if ifdata.vlan.trunk_id is defined and ifdata.type == "svi" %}
     bridge-vids {{ ifdata.vlan.trunk_id|sort|join(",") }}
 {%     if ifdata.vlan.native is defined %}
     bridge-pvid {{ ifdata.vlan.access_id }}

--- a/netsim/ansible/templates/vlan/cumulus.j2
+++ b/netsim/ansible/templates/vlan/cumulus.j2
@@ -34,7 +34,7 @@ cat >/etc/network/interfaces.d/51-bridge-interfaces.intf <<CONFIG
 auto {{ ifdata.ifname }}
 {%   endif %}
 iface {{ ifdata.ifname }}
-{%   if ifdata.vlan.trunk_id is defined and ifdata.type == "svi" %}
+{%   if ifdata.vlan.trunk_id is defined and ifdata.type != "lag" %}
     bridge-vids {{ ifdata.vlan.trunk_id|sort|join(",") }}
 {%     if ifdata.vlan.native is defined %}
     bridge-pvid {{ ifdata.vlan.access_id }}

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -15,7 +15,7 @@ from ..data.types import must_be_string,must_be_list,must_be_dict,must_be_id
 from . import devices,addressing
 
 VIRTUAL_INTERFACE_TYPES: typing.Final[typing.List[str]] = [
-  'loopback', 'tunnel' ]
+  'loopback', 'tunnel', 'lag' ]
 
 def adjust_interface_list(iflist: list, link: Box, nodes: Box) -> list:
   link_intf = []
@@ -298,8 +298,8 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
       if sys_mtu and node.mtu == ifdata.mtu:    # .. is it equal to node MTU?
         ifdata.pop('mtu',None)                  # .... remove interface MTU on devices that support system MTU
     else:                                       # Node MTU is defined, interface MTU is not
-      if not sys_mtu:                           # .. does the device support system MTU?
-        ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU
+      if not sys_mtu and ifdata.get('type',None)!='lag':  # .. does the device support system MTU?
+        ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU unless it's a LAG
 
   node.interfaces.append(ifdata)
 
@@ -387,6 +387,11 @@ def assign_link_prefix(
       addr_pools: Box,
       nodes: Box,
       link_path: str = 'links') -> Box:
+  
+  # Don't assign a prefix to physical links that are part of a lag
+  if 'lag' in link and link.get("type","")!="lag":
+    return data.get_empty_box()
+
   if 'prefix' in link:                                    # User specified a static link prefix
     pfx_list = addressing.parse_prefix(link.prefix,path=link_path)
     if log.debug_active('addr'):                          # pragma: no cover (debugging printout)
@@ -857,7 +862,7 @@ def check_link_type(data: Box) -> bool:
 
   if link_type == 'loopback' and node_cnt != 1:
     log.error(
-      f'Looopback link {data._linkname} can have a single node attached\n... {data}',
+      f'Loopback link {data._linkname} can have a single node attached\n... {data}',
       log.IncorrectValue,
       'links')
     return False
@@ -1050,7 +1055,7 @@ def transform(link_list: typing.Optional[Box], defaults: Box, nodes: Box, pools:
       continue
 
     set_link_bridge_name(link,defaults)
-    link_default_pools = ['p2p','lan'] if link.type == 'p2p' else ['lan']
+    link_default_pools = ['p2p','lan'] if link.type in ['p2p','lag'] else ['lan']
     assign_link_prefix(link,link_default_pools,pools,nodes,link._linkname)
     assign_interface_addresses(link,pools,nodes,defaults)
     create_node_interfaces(link,pools,nodes,defaults=defaults)

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -298,8 +298,8 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
       if sys_mtu and node.mtu == ifdata.mtu:    # .. is it equal to node MTU?
         ifdata.pop('mtu',None)                  # .... remove interface MTU on devices that support system MTU
     else:                                       # Node MTU is defined, interface MTU is not
-      if not sys_mtu and ifdata.get('type',None)!='lag':  # .. does the device support system MTU?
-        ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU unless it's a LAG
+      if not sys_mtu:                           # .. does the device support system MTU?
+        ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU
 
   node.interfaces.append(ifdata)
 
@@ -387,10 +387,6 @@ def assign_link_prefix(
       addr_pools: Box,
       nodes: Box,
       link_path: str = 'links') -> Box:
-  
-  # Don't assign a prefix to physical links that are part of a lag
-  if 'lag' in link and link.get("type","")!="lag":
-    return data.get_empty_box()
 
   if 'prefix' in link:                                    # User specified a static link prefix
     pfx_list = addressing.parse_prefix(link.prefix,path=link_path)

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -27,7 +27,7 @@ def parser_add_debug(parser: argparse.ArgumentParser) -> None:
                   choices=sorted([
                     'all','addr','cli','links','libvirt','clab','modules','plugin','template',
                     'vlan','vrf','quirks','validate','addressing','groups','status',
-                    'external','defaults']),
+                    'external','defaults','lag']),
                   help=argparse.SUPPRESS)
   parser.add_argument('--test', dest='test', action='store',nargs='*',
                   choices=['errors'],

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -49,7 +49,7 @@ link:                       # Global link attributes
     _alt_types: [ bool, prefix_str, named_pfx ]
   role: id
   pool: id
-  type: { type: str, valid_values: [ lan, p2p, stub, loopback, tunnel, vlan_member ] }
+  type: { type: str, valid_values: [ lan, p2p, stub, loopback, tunnel, vlan_member, lag ] }
   unnumbered: bool
   interfaces:
   mtu: { type: int, min_value: 64, max_value: 65535 }

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -3,6 +3,7 @@ description: Cumulus VX 4.x or 5.x configured without NVUE
 interface_name: swp{ifindex}
 loopback_interface_name: lo{ifindex if ifindex else ""}
 tunnel_interface_name: "tun{ifindex}"
+lag_interface_name: "bond{ifindex}"
 mgmt_if: eth0
 libvirt:
   image: CumulusCommunity/cumulus-vx:4.4.5
@@ -63,6 +64,8 @@ features:
     asymmetrical_irb: True
   gateway:
     protocol: [ anycast, vrrp ]
+  lag:
+    passive: False
   ospf:
     unnumbered: True
     import: [ bgp, ripv2, connected, vrf ]

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -4,6 +4,7 @@ interface_name: eth{ifindex}
 mgmt_if: eth0
 loopback_interface_name: lo{ifindex if ifindex else ""}
 tunnel_interface_name: "tun{ifindex}"
+lag_interface_name: "bond{ifindex}"
 routing:
   _rm_per_af: True
 group_vars:
@@ -71,6 +72,8 @@ features:
       ipv4: true
       ipv6: true
       network: true
+  lag:
+    passive: False
   mpls:
     ldp: true
     vpn:

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -7,6 +7,15 @@ from .. import data
 from ..utils import log
 from ..augment import devices
 
+#
+# Checks if 2 lists have the same elements, independent of order
+#
+def same_list(l1,l2):
+  for l in l1:
+    if l not in l2:
+      return False
+  return len(l1)==len(l2)
+
 class LAG(_Module):
 
   """
@@ -20,7 +29,8 @@ class LAG(_Module):
       # Lookup virtual LAG link with same id between same pair of nodes, create if not existing
       vlag = None
       for l in topology.links:
-        if 'lag' in l and l.get('type',"")=="lag" and l.lag.id == link.lag.id and l.interfaces==link.interfaces:
+        if 'lag' in l and l.get('type',"")=="lag" and l.lag.id == link.lag.id \
+            and same_list(l.interfaces,link.interfaces):
           vlag = l
           break
       

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -1,0 +1,65 @@
+import typing
+import netaddr
+
+from box import Box
+from . import _Module
+from .. import data
+from ..utils import log
+from ..augment import devices
+
+class LAG(_Module):
+
+  """
+  link_pre_transform: Create virtual LAG links
+  """
+  def link_pre_transform(self, link: Box, topology: Box) -> None:
+    if log.debug_active('vlan'):
+      print(f'LAG link_pre_transform for {link}')
+    if 'lag' in link and link.get('type',"")!="lag":
+
+      # Lookup virtual LAG link with same id between same pair of nodes, create if not existing
+      vlag = None
+      for l in topology.links:
+        if 'lag' in l and l.get('type',"")=="lag" and l.lag.id == link.lag.id and l.interfaces==link.interfaces:
+          vlag = l
+          break
+      
+      if vlag is None:
+        vlag = data.get_box(link)
+        vlag.type = "lag"
+        vlag.linkindex = len(topology.links) + 1
+        vlag._linkname = f"links[{vlag.linkindex}]"
+        vlag.interfaces = [ i for i in link.interfaces ] # Make a deep copy
+        vlag.pop('mtu',None)                             # Remove any MTU attribute
+        topology.links.append(vlag)
+
+        if log.debug_active('vlan'):
+          print(f'LAG link_pre_transform created virtual link: {vlag}')
+
+        # remove any VLAN attributes from original link
+        link.pop('vlan',None)
+
+  """
+  node_post_transform: Check for correct supported configuration of LAG
+  """
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+    features = devices.get_device_features(node,topology.defaults)
+    for i in node.interfaces:
+      # 1. Check if the interface is part of a LAG
+      if 'lag' in i:
+        if 'lag' not in features:
+          log.error(
+              f'Node {node.name} does not support LAG configured on {i.ifname}',
+              category=log.IncorrectAttr,
+              module='lag',
+              hint='lag')
+
+        _type = i.get("type")
+        if _type=="lag":
+          continue
+        elif _type!="p2p":
+          log.error(
+              f'Node {node.name} has a LAG configured on {i.ifname} which is not a p2p link ({_type})',
+              category=log.IncorrectAttr,
+              module='lag',
+              hint='lag')

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -1,7 +1,7 @@
 import typing
 import netaddr
 
-from box import Box
+from box import Box, BoxList
 from . import _Module
 from .. import data
 from ..utils import log
@@ -10,7 +10,7 @@ from ..augment import devices
 #
 # Checks if 2 lists have the same elements, independent of order
 #
-def same_list(l1,l2):
+def same_list(l1:BoxList,l2:BoxList) -> bool:
   for l in l1:
     if l not in l2:
       return False
@@ -39,7 +39,7 @@ class LAG(_Module):
         vlag.type = "lag"
         vlag.linkindex = len(topology.links) + 1
         vlag._linkname = f"links[{vlag.linkindex}]"
-        vlag.interfaces = [ i for i in link.interfaces ] # Make a deep copy
+        vlag.interfaces = [ i for i in link.interfaces ] # Make a deep copy, could use a set?
         vlag.pop('mtu',None)                             # Remove any MTU attribute
         topology.links.append(vlag)
 

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -42,6 +42,14 @@ class LAG(_Module):
               category=log.IncorrectAttr,
               module='lag',
               hint='lag')
+        ATT = 'lag.lacp_mode'
+        lacp_mode = i.get(ATT) or link.get(ATT) or n.get(ATT) or topology.defaults.get(ATT)
+        if lacp_mode=='passive' and not features.lag.get('passive',False):
+          log.error(
+              f'Node {n.name} does not support passive LACP configured on link {link._linkname}',
+              category=log.IncorrectAttr,
+              module='lag',
+              hint='lag')
 
       if isinstance(link.lag.members,int):
         count = link.lag.members

--- a/netsim/modules/lag.yml
+++ b/netsim/modules/lag.yml
@@ -11,9 +11,9 @@ attributes:
     lacp:
     lacp_mode:
   link: # Most should be consistent across both interfaces on the link
-    id: { type: int, _required: True }
     lacp:
     lacp_mode:
     members:
+    ifindex: int  # Optional, to control naming of the bonding interface
   interface:
     lacp_mode:

--- a/netsim/modules/lag.yml
+++ b/netsim/modules/lag.yml
@@ -1,0 +1,18 @@
+# LAG default settings and attributes
+#
+lacp: "fast"                    # Link Aggregation Control Protocol, standby signalling through link down not working
+lacp_mode: "active"             # At least 1 side must be active
+
+attributes:
+  global:
+    lacp: { type: str, valid_values: [ "off", "slow", "fast" ] }
+    lacp_mode: { type: str, valid_values: [ "passive", "active" ] }
+  node:
+    lacp:
+    lacp_mode:
+  link: # Most should be consistent across both interfaces on the link
+    id: { type: int, _required: True }
+    lacp:
+    lacp_mode:
+  interface:
+    lacp_mode:

--- a/netsim/modules/lag.yml
+++ b/netsim/modules/lag.yml
@@ -14,5 +14,6 @@ attributes:
     id: { type: int, _required: True }
     lacp:
     lacp_mode:
+    members:
   interface:
     lacp_mode:

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -512,7 +512,7 @@ def create_vlan_link_data(init: typing.Union[Box,dict],vname: str, parent: typin
   return link_data
 
 """
-create_vlan_member_interface: Create interface data for a VLAN mamber link
+create_vlan_member_interface: Create interface data for a VLAN member link
 
 Used by create_vlan_links and create_loopback_vlan_links
 """

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -1,5 +1,6 @@
 # VLAN default settings and attributes
 #
+transform_after: [ lag ]
 no_propagate: [ start_vlan_id, mode ]
 start_vlan_id: 1000
 mode: irb

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -20,6 +20,7 @@ cleanup: [ clab.yml, clab_files ]
 bridge_type: bridge # Use 'ovs-bridge' to create Openvswitch bridges
 runtime: docker     # Default runtime, see Containerlab documentation
 kmods:
+  lag: [ bonding ]
   mpls: [ mpls-router, mpls-iptunnel ]
   sr:  [ mpls-router, mpls-iptunnel ]
   vxlan: [ vxlan, udp_tunnel, ip6_udp_tunnel ]

--- a/tests/errors/invalid-module.log
+++ b/tests/errors/invalid-module.log
@@ -1,5 +1,5 @@
 IncorrectValue in topology: attribute nodes.r2.module has invalid value(s): whatever
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
 IncorrectValue in topology: attribute module has invalid value(s): provider
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/link-invalid-type.log
+++ b/tests/errors/link-invalid-type.log
@@ -1,4 +1,4 @@
 IncorrectValue in links: attribute links[1].type has invalid value(s): wtf
-... valid values are: lan,p2p,stub,loopback,tunnel,vlan_member
+... valid values are: lan,p2p,stub,loopback,tunnel,vlan_member,lag
 ... use 'netlab show attributes link' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/module-missing-prerequisite.log
+++ b/tests/errors/module-missing-prerequisite.log
@@ -1,3 +1,3 @@
 IncorrectValue in topology: attribute nodes.r1.module has invalid value(s): mody
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,modx,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,modx,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/validate-list.log
+++ b/tests/errors/validate-list.log
@@ -1,5 +1,5 @@
 IncorrectValue in groups: attribute groups.g1.module has invalid value(s): a
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
 ... use 'netlab show attributes group' to display valid attributes
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary

--- a/tests/integration/lag/01-l3-lag-with-vlans.yml
+++ b/tests/integration/lag/01-l3-lag-with-vlans.yml
@@ -1,0 +1,50 @@
+---
+message: |
+  The devices under test are a pair of routers with a L3 LAG link with a trunk of VLANs between them
+  h1 and h2 should be able to ping each other, same applies for h3 and h4
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ r1,r2 ]
+    module: [lag,vlan]
+
+vlans:
+ v1:
+ v2:
+
+links:
+- r1:
+  r2:
+  lag.id: 1
+  vlan.trunk: [ v1, v2 ]
+- r1:
+  r2:
+  lag.id: 1
+- r1:
+   vlan.access: v1
+  h1:
+- r2:
+   vlan.access: v1
+  h2:
+- r1:
+   vlan.access: v2
+  h3:
+- r2:
+   vlan.access: v2
+  h4:
+
+validate:
+  ping12:
+    description: Pinging H2 from H1 on VLAN 1
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping34:
+    description: Pinging H4 from H3 on VLAN 2
+    nodes: [ h3 ]
+    plugin: ping('h4')

--- a/tests/integration/lag/01-l3-lag-with-vlans.yml
+++ b/tests/integration/lag/01-l3-lag-with-vlans.yml
@@ -20,7 +20,7 @@ links:
 - r1:
   r2:
   lag.id: 1
-  vlan.trunk: [ v1, v2 ]
+  vlan.trunk: [ v1, v2 ]  # Note that any trunk MUST be declared on the first link in the LAG
 - r1:
   r2:
   lag.id: 1

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -1,0 +1,31 @@
+---
+message: |
+  The devices under test are a pair of routers with a L3 LAG link between them
+  h1 and h2 should be able to ping each other
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ r1,r2 ]
+    module: [lag,ospf]
+
+links:
+- r1:
+  r2:
+  lag.id: 1
+- r1:
+  r2:
+  lag.id: 1
+- h1-r1
+- r2-h2
+
+validate:
+  ping:
+    description: Pinging H2 from H1
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -16,8 +16,8 @@ links:
 - r1:
   r2:
   lag.id: 1
-- r1:
-  r2:
+- r2:
+  r1:
   lag.id: 1
 - h1-r1
 - r2-h2

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -9,16 +9,18 @@ groups:
     device: linux
     provider: clab
   switches:
-    members: [ r1,r2 ]
+    members: [ r1,r2,r3 ]
     module: [ lag, ospf ]
 
 links:
 - r1:  # Need valid nodes on the link
   r2:
-  lag.id: 1
+  lag.members: 2
+- r2:  # Need valid nodes on the link
+  r3:
   lag.members: 2
 - h1-r1
-- r2-h2
+- r3-h2
 
 validate:
   ping:

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -10,15 +10,13 @@ groups:
     provider: clab
   switches:
     members: [ r1,r2 ]
-    module: [lag,ospf]
+    module: [ lag, ospf ]
 
 links:
-- r1:
+- r1:  # Need valid nodes on the link
   r2:
   lag.id: 1
-- r2:
-  r1:
-  lag.id: 1
+  lag.members: 2
 - h1-r1
 - r2-h2
 

--- a/tests/integration/lag/02-l3-lag-with-vlans.yml
+++ b/tests/integration/lag/02-l3-lag-with-vlans.yml
@@ -20,10 +20,10 @@ links:
 - r1:
   r2:
   lag.id: 1
-  vlan.trunk: [ v1, v2 ]  # Note that any trunk MUST be declared on the first link in the LAG
-- r1:
-  r2:
-  lag.id: 1
+  vlan.trunk: [ v1, v2 ]
+  lag.members:
+  - r1-r2
+  - r1-r2
 - r1:
    vlan.access: v1
   h1:

--- a/tests/topology/expected/lag-l3-vlan-trunk.yml
+++ b/tests/topology/expected/lag-l3-vlan-trunk.yml
@@ -5,31 +5,7 @@ lag:
   lacp: fast
   lacp_mode: active
 links:
-- interfaces:
-  - ifindex: 1
-    ifname: eth1
-    node: r1
-  - ifindex: 1
-    ifname: eth1
-    node: r2
-  lag:
-    id: 1
-  linkindex: 1
-  node_count: 2
-  type: p2p
-- interfaces:
-  - ifindex: 2
-    ifname: eth2
-    node: r1
-  - ifindex: 2
-    ifname: eth2
-    node: r2
-  lag:
-    id: 1
-  linkindex: 2
-  node_count: 2
-  type: p2p
-- bridge: input_3
+- bridge: input_1
   interfaces:
   - ifindex: 30000
     ifname: bond0
@@ -47,7 +23,47 @@ links:
         v2: {}
   lag:
     id: 1
-  linkindex: 3
+    members:
+    - _linkname: lag1.link[1]
+      interfaces:
+      - ifindex: 1
+        ifname: eth1
+        node: r1
+      - ifindex: 1
+        ifname: eth1
+        node: r2
+      lag:
+        id: 1
+      linkindex: 2
+      prefix: false
+      type: p2p
+    - _linkname: lag1.link[2]
+      interfaces:
+      - ifindex: 2
+        ifname: eth2
+        node: r1
+      - ifindex: 2
+        ifname: eth2
+        node: r2
+      lag:
+        id: 1
+      linkindex: 3
+      prefix: false
+      type: p2p
+    - _linkname: lag1.link[3]
+      interfaces:
+      - ifindex: 3
+        ifname: eth3
+        node: r1
+      - ifindex: 3
+        ifname: eth3
+        node: r2
+      lag:
+        id: 1
+      linkindex: 4
+      prefix: false
+      type: p2p
+  linkindex: 1
   node_count: 2
   prefix: {}
   type: lag
@@ -55,6 +71,45 @@ links:
     trunk:
       v1: {}
       v2: {}
+- interfaces:
+  - ifindex: 1
+    ifname: eth1
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    node: r2
+  lag:
+    id: 1
+  linkindex: 2
+  node_count: 2
+  prefix: false
+  type: p2p
+- interfaces:
+  - ifindex: 2
+    ifname: eth2
+    node: r1
+  - ifindex: 2
+    ifname: eth2
+    node: r2
+  lag:
+    id: 1
+  linkindex: 3
+  node_count: 2
+  prefix: false
+  type: p2p
+- interfaces:
+  - ifindex: 3
+    ifname: eth3
+    node: r1
+  - ifindex: 3
+    ifname: eth3
+    node: r2
+  lag:
+    id: 1
+  linkindex: 4
+  node_count: 2
+  prefix: false
+  type: p2p
 module:
 - lag
 - vlan
@@ -76,11 +131,106 @@ nodes:
     hostname: clab-input-r1
     id: 1
     interfaces:
+    - ifindex: 30000
+      ifname: bond0
+      lag:
+        id: 1
+        members:
+        - _linkname: lag1.link[1]
+          interfaces:
+          - ifindex: 1
+            ifname: eth1
+            node: r1
+          - ifindex: 1
+            ifname: eth1
+            node: r2
+          lag:
+            id: 1
+          linkindex: 2
+          prefix: false
+          type: p2p
+        - _linkname: lag1.link[2]
+          interfaces:
+          - ifindex: 2
+            ifname: eth2
+            node: r1
+          - ifindex: 2
+            ifname: eth2
+            node: r2
+          lag:
+            id: 1
+          linkindex: 3
+          prefix: false
+          type: p2p
+        - _linkname: lag1.link[3]
+          interfaces:
+          - ifindex: 3
+            ifname: eth3
+            node: r1
+          - ifindex: 3
+            ifname: eth3
+            node: r2
+          lag:
+            id: 1
+          linkindex: 4
+          prefix: false
+          type: p2p
+      linkindex: 1
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: bond0
+        lag:
+          id: 1
+          members:
+          - _linkname: lag1.link[1]
+            interfaces:
+            - ifindex: 1
+              ifname: eth1
+              node: r1
+            - ifindex: 1
+              ifname: eth1
+              node: r2
+            lag:
+              id: 1
+            linkindex: 2
+            prefix: false
+            type: p2p
+          - _linkname: lag1.link[2]
+            interfaces:
+            - ifindex: 2
+              ifname: eth2
+              node: r1
+            - ifindex: 2
+              ifname: eth2
+              node: r2
+            lag:
+              id: 1
+            linkindex: 3
+            prefix: false
+            type: p2p
+          - _linkname: lag1.link[3]
+            interfaces:
+            - ifindex: 3
+              ifname: eth3
+              node: r1
+            - ifindex: 3
+              ifname: eth3
+              node: r2
+            lag:
+              id: 1
+            linkindex: 4
+            prefix: false
+            type: p2p
+        node: r2
+      subif_index: 2
+      type: lag
+      virtual_interface: true
     - ifindex: 1
       ifname: eth1
       lag:
         id: 1
-      linkindex: 1
+      linkindex: 2
       mtu: 1500
       name: r1 -> r2
       neighbors:
@@ -93,7 +243,7 @@ nodes:
       ifname: eth2
       lag:
         id: 1
-      linkindex: 2
+      linkindex: 3
       mtu: 1500
       name: r1 -> r2
       neighbors:
@@ -102,21 +252,20 @@ nodes:
           id: 1
         node: r2
       type: p2p
-    - ifindex: 30000
-      ifname: bond0
+    - ifindex: 3
+      ifname: eth3
       lag:
         id: 1
-      linkindex: 3
+      linkindex: 4
+      mtu: 1500
       name: r1 -> r2
       neighbors:
-      - ifname: bond0
+      - ifname: eth3
         lag:
           id: 1
         node: r2
-      subif_index: 2
-      type: lag
-      virtual_interface: true
-    - ifindex: 3
+      type: p2p
+    - ifindex: 4
       ifname: bond0.1000
       parent_ifindex: 30000
       parent_ifname: bond0
@@ -125,7 +274,7 @@ nodes:
       vlan:
         access: v1
         access_id: 1000
-    - ifindex: 4
+    - ifindex: 5
       ifname: bond0.1001
       parent_ifindex: 30000
       parent_ifname: bond0
@@ -135,7 +284,7 @@ nodes:
         access: v2
         access_id: 1001
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 6
       ifname: vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN v1 (1000) -> [r2]
@@ -148,7 +297,7 @@ nodes:
       vlan:
         mode: irb
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 7
       ifname: vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN v2 (1001) -> [r2]
@@ -212,11 +361,106 @@ nodes:
     hostname: clab-input-r2
     id: 2
     interfaces:
+    - ifindex: 30000
+      ifname: bond0
+      lag:
+        id: 1
+        members:
+        - _linkname: lag1.link[1]
+          interfaces:
+          - ifindex: 1
+            ifname: eth1
+            node: r1
+          - ifindex: 1
+            ifname: eth1
+            node: r2
+          lag:
+            id: 1
+          linkindex: 2
+          prefix: false
+          type: p2p
+        - _linkname: lag1.link[2]
+          interfaces:
+          - ifindex: 2
+            ifname: eth2
+            node: r1
+          - ifindex: 2
+            ifname: eth2
+            node: r2
+          lag:
+            id: 1
+          linkindex: 3
+          prefix: false
+          type: p2p
+        - _linkname: lag1.link[3]
+          interfaces:
+          - ifindex: 3
+            ifname: eth3
+            node: r1
+          - ifindex: 3
+            ifname: eth3
+            node: r2
+          lag:
+            id: 1
+          linkindex: 4
+          prefix: false
+          type: p2p
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: bond0
+        lag:
+          id: 1
+          members:
+          - _linkname: lag1.link[1]
+            interfaces:
+            - ifindex: 1
+              ifname: eth1
+              node: r1
+            - ifindex: 1
+              ifname: eth1
+              node: r2
+            lag:
+              id: 1
+            linkindex: 2
+            prefix: false
+            type: p2p
+          - _linkname: lag1.link[2]
+            interfaces:
+            - ifindex: 2
+              ifname: eth2
+              node: r1
+            - ifindex: 2
+              ifname: eth2
+              node: r2
+            lag:
+              id: 1
+            linkindex: 3
+            prefix: false
+            type: p2p
+          - _linkname: lag1.link[3]
+            interfaces:
+            - ifindex: 3
+              ifname: eth3
+              node: r1
+            - ifindex: 3
+              ifname: eth3
+              node: r2
+            lag:
+              id: 1
+            linkindex: 4
+            prefix: false
+            type: p2p
+        node: r1
+      subif_index: 2
+      type: lag
+      virtual_interface: true
     - ifindex: 1
       ifname: eth1
       lag:
         id: 1
-      linkindex: 1
+      linkindex: 2
       mtu: 1500
       name: r2 -> r1
       neighbors:
@@ -229,7 +473,7 @@ nodes:
       ifname: eth2
       lag:
         id: 1
-      linkindex: 2
+      linkindex: 3
       mtu: 1500
       name: r2 -> r1
       neighbors:
@@ -238,21 +482,20 @@ nodes:
           id: 1
         node: r1
       type: p2p
-    - ifindex: 30000
-      ifname: bond0
+    - ifindex: 3
+      ifname: eth3
       lag:
         id: 1
-      linkindex: 3
+      linkindex: 4
+      mtu: 1500
       name: r2 -> r1
       neighbors:
-      - ifname: bond0
+      - ifname: eth3
         lag:
           id: 1
         node: r1
-      subif_index: 2
-      type: lag
-      virtual_interface: true
-    - ifindex: 3
+      type: p2p
+    - ifindex: 4
       ifname: bond0.1000
       parent_ifindex: 30000
       parent_ifname: bond0
@@ -261,7 +504,7 @@ nodes:
       vlan:
         access: v1
         access_id: 1000
-    - ifindex: 4
+    - ifindex: 5
       ifname: bond0.1001
       parent_ifindex: 30000
       parent_ifname: bond0
@@ -271,7 +514,7 @@ nodes:
         access: v2
         access_id: 1001
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 6
       ifname: vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN v1 (1000) -> [r1]
@@ -284,7 +527,7 @@ nodes:
       vlan:
         mode: irb
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 7
       ifname: vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN v2 (1001) -> [r1]

--- a/tests/topology/expected/lag-l3-vlan-trunk.yml
+++ b/tests/topology/expected/lag-l3-vlan-trunk.yml
@@ -1,0 +1,362 @@
+input:
+- topology/input/lag-l3-vlan-trunk.yml
+- package:topology-defaults.yml
+lag:
+  lacp: fast
+  lacp_mode: active
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: eth1
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    node: r2
+  lag:
+    id: 1
+  linkindex: 1
+  node_count: 2
+  type: p2p
+- interfaces:
+  - ifindex: 2
+    ifname: eth2
+    node: r1
+  - ifindex: 2
+    ifname: eth2
+    node: r2
+  lag:
+    id: 1
+  linkindex: 2
+  node_count: 2
+  type: p2p
+- bridge: input_3
+  interfaces:
+  - ifindex: 30000
+    ifname: bond0
+    node: r1
+    vlan:
+      trunk:
+        v1: {}
+        v2: {}
+  - ifindex: 30000
+    ifname: bond0
+    node: r2
+    vlan:
+      trunk:
+        v1: {}
+        v2: {}
+  lag:
+    id: 1
+  linkindex: 3
+  node_count: 2
+  prefix: {}
+  type: lag
+  vlan:
+    trunk:
+      v1: {}
+      v2: {}
+module:
+- lag
+- vlan
+name: input
+nodes:
+  r1:
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/r1/daemons:/etc/frr/daemons
+      - clab_files/r1/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-r1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      lag:
+        id: 1
+      linkindex: 1
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth1
+        lag:
+          id: 1
+        node: r2
+      type: p2p
+    - ifindex: 2
+      ifname: eth2
+      lag:
+        id: 1
+      linkindex: 2
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth2
+        lag:
+          id: 1
+        node: r2
+      type: p2p
+    - ifindex: 30000
+      ifname: bond0
+      lag:
+        id: 1
+      linkindex: 3
+      name: r1 -> r2
+      neighbors:
+      - ifname: bond0
+        lag:
+          id: 1
+        node: r2
+      subif_index: 2
+      type: lag
+      virtual_interface: true
+    - ifindex: 3
+      ifname: bond0.1000
+      parent_ifindex: 30000
+      parent_ifname: bond0
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: v1
+        access_id: 1000
+    - ifindex: 4
+      ifname: bond0.1001
+      parent_ifindex: 30000
+      parent_ifname: bond0
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: v2
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN v1 (1000) -> [r2]
+      neighbors:
+      - ifname: vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      ipv4: 172.16.1.1/24
+      name: VLAN v2 (1001) -> [r2]
+      neighbors:
+      - ifname: vlan1001
+        ipv4: 172.16.1.2/24
+        node: r2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    lag:
+      lacp: fast
+      lacp_mode: active
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - lag
+    - vlan
+    mtu: 1500
+    name: r1
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      v1:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+      v2:
+        bridge_group: 2
+        id: 1001
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+  r2:
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/r2/daemons:/etc/frr/daemons
+      - clab_files/r2/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      lag:
+        id: 1
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth1
+        lag:
+          id: 1
+        node: r1
+      type: p2p
+    - ifindex: 2
+      ifname: eth2
+      lag:
+        id: 1
+      linkindex: 2
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth2
+        lag:
+          id: 1
+        node: r1
+      type: p2p
+    - ifindex: 30000
+      ifname: bond0
+      lag:
+        id: 1
+      linkindex: 3
+      name: r2 -> r1
+      neighbors:
+      - ifname: bond0
+        lag:
+          id: 1
+        node: r1
+      subif_index: 2
+      type: lag
+      virtual_interface: true
+    - ifindex: 3
+      ifname: bond0.1000
+      parent_ifindex: 30000
+      parent_ifname: bond0
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: v1
+        access_id: 1000
+    - ifindex: 4
+      ifname: bond0.1001
+      parent_ifindex: 30000
+      parent_ifname: bond0
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access: v2
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN v1 (1000) -> [r1]
+      neighbors:
+      - ifname: vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      ipv4: 172.16.1.2/24
+      name: VLAN v2 (1001) -> [r1]
+      neighbors:
+      - ifname: vlan1001
+        ipv4: 172.16.1.1/24
+        node: r1
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    lag:
+      lacp: fast
+      lacp_mode: active
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - lag
+    - vlan
+    mtu: 1500
+    name: r2
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      v1:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+      v2:
+        bridge_group: 2
+        id: 1001
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+provider: clab
+vlans:
+  v1:
+    host_count: 0
+    id: 1000
+    neighbors:
+    - ifname: vlan1000
+      ipv4: 172.16.0.2/24
+      node: r2
+    - ifname: vlan1000
+      ipv4: 172.16.0.1/24
+      node: r1
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24
+  v2:
+    host_count: 0
+    id: 1001
+    neighbors:
+    - ifname: vlan1001
+      ipv4: 172.16.1.2/24
+      node: r2
+    - ifname: vlan1001
+      ipv4: 172.16.1.1/24
+      node: r1
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.1.0/24

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -21,10 +21,10 @@ links:
 - interfaces:
   - ifindex: 2
     ifname: eth2
-    node: r1
+    node: r2
   - ifindex: 2
     ifname: eth2
-    node: r2
+    node: r1
   lag:
     id: 1
   linkindex: 2

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -5,32 +5,7 @@ lag:
   lacp: fast
   lacp_mode: active
 links:
-- interfaces:
-  - ifindex: 1
-    ifname: eth1
-    node: r1
-  - ifindex: 1
-    ifname: eth1
-    node: r2
-  lag:
-    id: 1
-  linkindex: 1
-  mtu: 1600
-  node_count: 2
-  type: p2p
-- interfaces:
-  - ifindex: 2
-    ifname: eth2
-    node: r2
-  - ifindex: 2
-    ifname: eth2
-    node: r1
-  lag:
-    id: 1
-  linkindex: 2
-  node_count: 2
-  type: p2p
-- bridge: input_3
+- bridge: input_1
   interfaces:
   - ifindex: 30000
     ifname: bond0
@@ -42,11 +17,41 @@ links:
     node: r2
   lag:
     id: 1
-  linkindex: 3
+    members:
+    - _linkname: lag1.link[1]
+      interfaces:
+      - ifindex: 1
+        ifname: eth1
+        node: r1
+      - ifindex: 1
+        ifname: eth1
+        node: r2
+      lag:
+        id: 1
+      linkindex: 2
+      mtu: 1600
+      prefix: false
+      type: p2p
+  linkindex: 1
+  mtu: 1600
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
   type: lag
+- interfaces:
+  - ifindex: 1
+    ifname: eth1
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    node: r2
+  lag:
+    id: 1
+  linkindex: 2
+  mtu: 1600
+  node_count: 2
+  prefix: false
+  type: p2p
 module:
 - lag
 name: input
@@ -67,11 +72,57 @@ nodes:
     hostname: clab-input-r1
     id: 1
     interfaces:
+    - ifindex: 30000
+      ifname: bond0
+      ipv4: 10.1.0.1/30
+      lag:
+        id: 1
+        members:
+        - _linkname: lag1.link[1]
+          interfaces:
+          - ifindex: 1
+            ifname: eth1
+            node: r1
+          - ifindex: 1
+            ifname: eth1
+            node: r2
+          lag:
+            id: 1
+          linkindex: 2
+          mtu: 1600
+          prefix: false
+          type: p2p
+      linkindex: 1
+      mtu: 1600
+      name: r1 -> r2
+      neighbors:
+      - ifname: bond0
+        ipv4: 10.1.0.2/30
+        lag:
+          id: 1
+          members:
+          - _linkname: lag1.link[1]
+            interfaces:
+            - ifindex: 1
+              ifname: eth1
+              node: r1
+            - ifindex: 1
+              ifname: eth1
+              node: r2
+            lag:
+              id: 1
+            linkindex: 2
+            mtu: 1600
+            prefix: false
+            type: p2p
+        node: r2
+      type: lag
+      virtual_interface: true
     - ifindex: 1
       ifname: eth1
       lag:
         id: 1
-      linkindex: 1
+      linkindex: 2
       mtu: 1600
       name: r1 -> r2
       neighbors:
@@ -80,34 +131,6 @@ nodes:
           id: 1
         node: r2
       type: p2p
-    - ifindex: 2
-      ifname: eth2
-      lag:
-        id: 1
-      linkindex: 2
-      mtu: 1500
-      name: r1 -> r2
-      neighbors:
-      - ifname: eth2
-        lag:
-          id: 1
-        node: r2
-      type: p2p
-    - ifindex: 30000
-      ifname: bond0
-      ipv4: 10.1.0.1/30
-      lag:
-        id: 1
-      linkindex: 3
-      name: r1 -> r2
-      neighbors:
-      - ifname: bond0
-        ipv4: 10.1.0.2/30
-        lag:
-          id: 1
-        node: r2
-      type: lag
-      virtual_interface: true
     lag:
       lacp: fast
       lacp_mode: active
@@ -142,11 +165,57 @@ nodes:
     hostname: clab-input-r2
     id: 2
     interfaces:
+    - ifindex: 30000
+      ifname: bond0
+      ipv4: 10.1.0.2/30
+      lag:
+        id: 1
+        members:
+        - _linkname: lag1.link[1]
+          interfaces:
+          - ifindex: 1
+            ifname: eth1
+            node: r1
+          - ifindex: 1
+            ifname: eth1
+            node: r2
+          lag:
+            id: 1
+          linkindex: 2
+          mtu: 1600
+          prefix: false
+          type: p2p
+      linkindex: 1
+      mtu: 1600
+      name: r2 -> r1
+      neighbors:
+      - ifname: bond0
+        ipv4: 10.1.0.1/30
+        lag:
+          id: 1
+          members:
+          - _linkname: lag1.link[1]
+            interfaces:
+            - ifindex: 1
+              ifname: eth1
+              node: r1
+            - ifindex: 1
+              ifname: eth1
+              node: r2
+            lag:
+              id: 1
+            linkindex: 2
+            mtu: 1600
+            prefix: false
+            type: p2p
+        node: r1
+      type: lag
+      virtual_interface: true
     - ifindex: 1
       ifname: eth1
       lag:
         id: 1
-      linkindex: 1
+      linkindex: 2
       mtu: 1600
       name: r2 -> r1
       neighbors:
@@ -155,34 +224,6 @@ nodes:
           id: 1
         node: r1
       type: p2p
-    - ifindex: 2
-      ifname: eth2
-      lag:
-        id: 1
-      linkindex: 2
-      mtu: 1500
-      name: r2 -> r1
-      neighbors:
-      - ifname: eth2
-        lag:
-          id: 1
-        node: r1
-      type: p2p
-    - ifindex: 30000
-      ifname: bond0
-      ipv4: 10.1.0.2/30
-      lag:
-        id: 1
-      linkindex: 3
-      name: r2 -> r1
-      neighbors:
-      - ifname: bond0
-        ipv4: 10.1.0.1/30
-        lag:
-          id: 1
-        node: r1
-      type: lag
-      virtual_interface: true
     lag:
       lacp: fast
       lacp_mode: active

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -1,0 +1,204 @@
+input:
+- topology/input/lag-l3.yml
+- package:topology-defaults.yml
+lag:
+  lacp: fast
+  lacp_mode: active
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: eth1
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    node: r2
+  lag:
+    id: 1
+  linkindex: 1
+  mtu: 1600
+  node_count: 2
+  type: p2p
+- interfaces:
+  - ifindex: 2
+    ifname: eth2
+    node: r1
+  - ifindex: 2
+    ifname: eth2
+    node: r2
+  lag:
+    id: 1
+  linkindex: 2
+  node_count: 2
+  type: p2p
+- bridge: input_3
+  interfaces:
+  - ifindex: 30000
+    ifname: bond0
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 30000
+    ifname: bond0
+    ipv4: 10.1.0.2/30
+    node: r2
+  lag:
+    id: 1
+  linkindex: 3
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: lag
+module:
+- lag
+name: input
+nodes:
+  r1:
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/r1/daemons:/etc/frr/daemons
+      - clab_files/r1/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-r1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      lag:
+        id: 1
+      linkindex: 1
+      mtu: 1600
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth1
+        lag:
+          id: 1
+        node: r2
+      type: p2p
+    - ifindex: 2
+      ifname: eth2
+      lag:
+        id: 1
+      linkindex: 2
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth2
+        lag:
+          id: 1
+        node: r2
+      type: p2p
+    - ifindex: 30000
+      ifname: bond0
+      ipv4: 10.1.0.1/30
+      lag:
+        id: 1
+      linkindex: 3
+      name: r1 -> r2
+      neighbors:
+      - ifname: bond0
+        ipv4: 10.1.0.2/30
+        lag:
+          id: 1
+        node: r2
+      type: lag
+      virtual_interface: true
+    lag:
+      lacp: fast
+      lacp_mode: active
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - lag
+    mtu: 1500
+    name: r1
+  r2:
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/r2/daemons:/etc/frr/daemons
+      - clab_files/r2/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      lag:
+        id: 1
+      linkindex: 1
+      mtu: 1600
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth1
+        lag:
+          id: 1
+        node: r1
+      type: p2p
+    - ifindex: 2
+      ifname: eth2
+      lag:
+        id: 1
+      linkindex: 2
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth2
+        lag:
+          id: 1
+        node: r1
+      type: p2p
+    - ifindex: 30000
+      ifname: bond0
+      ipv4: 10.1.0.2/30
+      lag:
+        id: 1
+      linkindex: 3
+      name: r2 -> r1
+      neighbors:
+      - ifname: bond0
+        ipv4: 10.1.0.1/30
+        lag:
+          id: 1
+        node: r1
+      type: lag
+      virtual_interface: true
+    lag:
+      lacp: fast
+      lacp_mode: active
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - lag
+    mtu: 1500
+    name: r2
+provider: clab

--- a/tests/topology/input/lag-l3-vlan-trunk.yml
+++ b/tests/topology/input/lag-l3-vlan-trunk.yml
@@ -1,0 +1,24 @@
+#
+# Basic L3 LAG with VLANs example - ensure virtual 'lag' interfaces get created with L3 attributes moved from first physical link,
+# and VLAN interfaces are associated with the correct elements
+#
+
+defaults:
+ provider: clab
+ device: frr
+
+module: [ lag,vlan ]
+
+vlans:
+ v1:
+ v2:
+
+nodes: [ r1, r2 ]
+links:
+- r1:
+  r2:
+  lag.id: 1
+  vlan.trunk: [v1,v2]
+- r1:
+  r2:
+  lag.id: 1

--- a/tests/topology/input/lag-l3-vlan-trunk.yml
+++ b/tests/topology/input/lag-l3-vlan-trunk.yml
@@ -1,6 +1,5 @@
 #
-# Basic L3 LAG with VLANs example - ensure virtual 'lag' interfaces get created with L3 attributes moved from first physical link,
-# and VLAN interfaces are associated with the correct elements
+# Basic L3 LAG with VLANs example - 3 member links spelled out
 #
 
 defaults:
@@ -17,8 +16,7 @@ nodes: [ r1, r2 ]
 links:
 - r1:
   r2:
-  lag.id: 1
   vlan.trunk: [v1,v2]
-- r1:
-  r2:
-  lag.id: 1
+  lag:
+   id : 1
+   members: [ r1-r2, r1-r2, r1-r2 ]

--- a/tests/topology/input/lag-l3.yml
+++ b/tests/topology/input/lag-l3.yml
@@ -13,6 +13,6 @@ links:
   r2:
   lag.id: 1
   mtu: 1600  # Test that mtu attribute is not applied to LAG interface
-- r1:
-  r2:
+- r2:        # Test that the order of declaration of nodes doesn't affect the outcome
+  r1:
   lag.id: 1

--- a/tests/topology/input/lag-l3.yml
+++ b/tests/topology/input/lag-l3.yml
@@ -1,5 +1,5 @@
 #
-# Basic L3 LAG example - ensure virtual 'lag' interfaces get created with L3 attributes moved from first physical link
+# Basic L3 LAG example - single lag with 2 member links and custom MTU setting
 #
 
 defaults:
@@ -12,7 +12,5 @@ links:
 - r1:
   r2:
   lag.id: 1
-  mtu: 1600  # Test that mtu attribute is not applied to LAG interface
-- r2:        # Test that the order of declaration of nodes doesn't affect the outcome
-  r1:
-  lag.id: 1
+  lag.members: 2
+  mtu: 1600  # Test that MTU is copied to member links

--- a/tests/topology/input/lag-l3.yml
+++ b/tests/topology/input/lag-l3.yml
@@ -1,0 +1,18 @@
+#
+# Basic L3 LAG example - ensure virtual 'lag' interfaces get created with L3 attributes moved from first physical link
+#
+
+defaults:
+ provider: clab
+ device: frr
+
+module: [ lag ]
+nodes: [ r1, r2 ]
+links:
+- r1:
+  r2:
+  lag.id: 1
+  mtu: 1600  # Test that mtu attribute is not applied to LAG interface
+- r1:
+  r2:
+  lag.id: 1


### PR DESCRIPTION
(reworking to remove manual ```lag.id``` assignment by users)

This PR introduces a new virtual link type 'lag' which represents a collection of one or more physical links to be bonded.
Support is included for FRR and Cumulus, with both plain and VLAN use cases validated

Sample config:
```
links:
- r1:
  r2:
  lag.members: 2
```
If desired, users can also define member links explicitly:
```
lag.members: [ r1-r2, r1-r2 ]
```
or
```
lag.members:
- r1:
    ifindex: 49 # To use a particular pair of ports
  r2:
    ifindex: 49
- r1:
    ifindex: 50
  r2:
    ifindex: 50
```

Unlike previous attempts, in this module the ```lag.id``` parameter is auto-generated internally, like VLAN ids. The naming convention for corresponding bond interfaces uses the existing logic for loopbacks and other virtual interfaces; note that a LAG with id 1 may or may not become "bond1", for example.

Future extensions towards MC-LAG may be considered at some point in the future - for example:
```
links:
- r1:
  r2:
  r3:
  lag.members: [ r1-r2, r1-r3 ]
```