### PR TITLE
Fix Cumulus mgmt ip prefix

### DIFF
--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -163,7 +163,9 @@ class _Provider(Callback):
       file_name = file.replace(out_folder+"/","")
       template_name = self.find_extra_template(node,file_name,topology)
       if template_name:
-        node_data = node + { 'hostvars': topology.nodes, 'hosts': get_host_addresses(topology) }
+        node_data = node + { 'hostvars': topology.nodes, 
+                             'hosts': get_host_addresses(topology),
+                             'mgmtpool': topology.addressing.mgmt }  # Needed for subnet prefix
         if '/' in file_name:                      # Create subdirectory in out_folder if needed
           pathlib.Path(f"{out_folder}/{os.path.dirname(file_name)}").mkdir(parents=True,exist_ok=True)
         try:

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -165,7 +165,7 @@ class _Provider(Callback):
       if template_name:
         node_data = node + { 'hostvars': topology.nodes, 
                              'hosts': get_host_addresses(topology),
-                             'mgmtpool': topology.addressing.mgmt }  # Needed for subnet prefix
+                             'addressing': topology.addressing }  # Needed for subnet prefix
         if '/' in file_name:                      # Create subdirectory in out_folder if needed
           pathlib.Path(f"{out_folder}/{os.path.dirname(file_name)}").mkdir(parents=True,exist_ok=True)
         try:

--- a/netsim/templates/provider/clab/cumulus/interfaces.j2
+++ b/netsim/templates/provider/clab/cumulus/interfaces.j2
@@ -7,7 +7,7 @@ iface mgmt
 
 auto eth0
 iface eth0 inet static
-    address {{ mgmt.ipv4 }}
+    address {{ mgmt.ipv4 }}/{{ mgmtpool.prefix }}
     vrf mgmt
 
 source /etc/network/interfaces.d/*.intf

--- a/netsim/templates/provider/clab/cumulus/interfaces.j2
+++ b/netsim/templates/provider/clab/cumulus/interfaces.j2
@@ -7,7 +7,7 @@ iface mgmt
 
 auto eth0
 iface eth0 inet static
-    address {{ mgmt.ipv4 }}/{{ mgmtpool.prefix }}
+    address {{ mgmt.ipv4 }}/{{ addressing.mgmt.prefix }}
     vrf mgmt
 
 source /etc/network/interfaces.d/*.intf


### PR DESCRIPTION
ssh to Cumulus nodes is currently broken due to the implied /32 prefix

It might be more elegant to fix this by normalizing ```mgmt.ipv4``` to include the prefix, and then removing it everywhere else.

It could also be considered to condition the use of the mgmt vrf on ```netlab_mgmt_vrf``` like done for FRR