### PR TITLE
Split set_fhrp_gateway to avoid accessing link.interfaces before it is populated

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -358,7 +358,7 @@ def set_fhrp_gateway(link: Box, pfx_list: Box, nodes: Box, link_path: str) -> No
   if not fhrp_assigned:
     return
 
-  for intf in link.interfaces:                                        # Copy link gateway into interface attributes
+  for intf in link.get('interfaces',[]):                              # Copy link gateway into interface attributes
     if 'gateway' in nodes[intf.node].get('module',[]):                # ... but only for nodes using the gateway module
       for af in log.AF_LIST:
         if af in link.gateway:


### PR DESCRIPTION
Possibly points at wrong calling order for set_fhrp_gateway - called too early in process?

Hit this with following lab snippet:
```
vlans:
  v1:
    gateway:
      id: 1
      protocol: vrrp
```