### PR TITLE
Add default route to mgmt

### DIFF
--- a/netsim/templates/provider/clab/cumulus/interfaces.j2
+++ b/netsim/templates/provider/clab/cumulus/interfaces.j2
@@ -8,6 +8,7 @@ iface mgmt
 auto eth0
 iface eth0 inet static
     address {{ mgmt.ipv4 }}/{{ addressing.mgmt.prefix }}
+    gateway {{ addressing.mgmt.ipv4 | ipv4(1) | ipaddr('address') }}
     vrf mgmt
 
 source /etc/network/interfaces.d/*.intf


### PR DESCRIPTION
This route is used for things like DNS and NTP