### PR TITLE
Split processing of link prefix and gateway data

### DIFF
--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -1,0 +1,422 @@
+gateway:
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: true
+  vrrp:
+    group: 1
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+  switches:
+    device: eos
+    members:
+    - s1
+    - s2
+    module:
+    - gateway
+    - vlan
+input:
+- topology/input/vlan-vrrp.yml
+- package:topology-defaults.yml
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s1
+    vlan:
+      trunk:
+        red: {}
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s2
+    vlan:
+      trunk:
+        red: {}
+  linkindex: 1
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      red: {}
+- bridge: input_2
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: -2
+    ipv4: 172.16.0.254/24
+    protocol: vrrp
+    vrrp:
+      group: 1
+  interfaces:
+  - _vlan_mode: irb
+    gateway:
+      ipv4: 172.16.0.254/24
+    ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.1/24
+    node: s1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_3
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: -2
+    ipv4: 172.16.0.254/24
+    protocol: vrrp
+    vrrp:
+      group: 1
+  interfaces:
+  - _vlan_mode: irb
+    gateway:
+      ipv4: 172.16.0.254/24
+    ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.2/24
+    node: s2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+module:
+- vlan
+- gateway
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 3
+    interfaces:
+    - bridge: input_2
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: vrrp
+        vrrp:
+          group: 1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 2
+      name: h1 -> [s1,s2,h2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: s1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: vrrp
+          vrrp:
+            group: 1
+        ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 4
+    interfaces:
+    - bridge: input_3
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: vrrp
+        vrrp:
+          group: 1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      linkindex: 3
+      name: h2 -> [h1,s1,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: s1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: vrrp
+          vrrp:
+            group: 1
+        ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    name: h2
+    role: host
+  s1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      vrrp:
+        group: 1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s1 -> s2
+      neighbors:
+      - ifname: Ethernet1
+        node: s2
+      type: p2p
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: vrrp
+        vrrp:
+          group: 1
+      ifindex: 4
+      ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN red (1000) -> [h1,s2,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - gateway:
+          anycast:
+            mac: 0200.cafe.00ff
+            unicast: true
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: vrrp
+          vrrp:
+            group: 1
+        ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vlan
+    - gateway
+    name: s1
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway:
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: vrrp
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    gateway:
+      vrrp:
+        group: 1
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s2 -> s1
+      neighbors:
+      - ifname: Ethernet1
+        node: s1
+      type: p2p
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - bridge: input_3
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 3
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: vrrp
+        vrrp:
+          group: 1
+      ifindex: 4
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h1,s1,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - vlan
+    - gateway
+    name: s2
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        gateway:
+          id: -2
+          ipv4: 172.16.0.254/24
+          protocol: vrrp
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+provider: libvirt
+vlans:
+  red:
+    gateway:
+      id: -2
+      ipv4: 172.16.0.254/24
+      protocol: vrrp
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      node: s1
+    - gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
+        ipv4: 172.16.0.254/24
+        protocol: vrrp
+        vrrp:
+          group: 1
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: s2
+    - ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/vlan-vrrp.yml
+++ b/tests/topology/input/vlan-vrrp.yml
@@ -1,0 +1,29 @@
+#
+# VLAN-VRRP test case (regression test for #1344)
+#
+
+groups:
+  switches:
+    module: [ gateway, vlan ]
+    members: [ s1, s2 ]
+    device: eos
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+
+vlans:
+  red:
+    gateway.id: -2
+    gateway.protocol: vrrp
+    links: [ s1-h1, s2-h2 ]
+
+nodes:
+  s1:
+  s2:
+  h1:
+  h2:
+
+links:
+- s1:
+  s2:
+  vlan.trunk: [ red ]


### PR DESCRIPTION
The link prefix processing was also setting the link gateway ID which broke the creation of VLANs with specified gateway.id because the VLAN module assigns prefixes to VLANs before the nodes are attached to the virtual VLAN links.

This fix splits the prefix processing from the propagation of gateway IP, allowing the 'gateway.id' attribute to be specified on a VLAN.

Please note that while this fix works, it's still affected by #1351