### PR TITLE
Use node-level VLAN gateway data on SVI interfaces (fixes #1349)

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -785,7 +785,10 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
       vlan_ifdata.type = "svi"
       vlan_ifdata.neighbors = []                                            # No neighbors so far
                                                                             # Overwrite interface settings with VLAN settings
-      vlan_ifdata = vlan_ifdata + { k:v for k,v in vlan_data.items() if k not in svi_skipattr }
+      vlan_ifdata = vlan_ifdata + {
+                      k:v for k,v in vlan_data.items()
+                        if k not in svi_skipattr and
+                           (v is not True or k not in vlan_ifdata) }
       fix_vlan_mode_attribute(vlan_ifdata)
       node.interfaces.append(vlan_ifdata)                                   # ... and add SVI interface to list of node interfaces
       vlan_ifmap[access_vlan] = vlan_ifdata

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -30,8 +30,8 @@ attributes:
     evpn:
   #
   # Do not copy these VLAN attributes into SVI interfaces
-  vlan_svi_no_propagate:
-    gateway:
+  #vlan_svi_no_propagate:
+  #  gateway:
   #
   # Do not copy these attributes into SVI interfaces
   phy_ifattr:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -245,6 +245,7 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          priority: 100
       ifindex: 4
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
@@ -296,6 +297,8 @@ nodes:
           id: -2
           ipv4: 172.16.0.254/24
           protocol: vrrp
+          vrrp:
+            priority: 100
         id: 1000
         mode: irb
         prefix:
@@ -339,6 +342,7 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          priority: 200
       ifindex: 4
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
@@ -381,6 +385,8 @@ nodes:
           id: -2
           ipv4: 172.16.0.254/24
           protocol: vrrp
+          vrrp:
+            priority: 200
         id: 1000
         mode: irb
         prefix:

--- a/tests/topology/input/vlan-vrrp.yml
+++ b/tests/topology/input/vlan-vrrp.yml
@@ -1,5 +1,5 @@
 #
-# VLAN-VRRP test case (regression test for #1344)
+# VLAN-VRRP test case (regression test for #1344, #1349)
 #
 
 groups:
@@ -19,7 +19,11 @@ vlans:
 
 nodes:
   s1:
+    vlans.red:
+      gateway.vrrp.priority: 100
   s2:
+    vlans.red:
+      gateway.vrrp.priority: 200
   h1:
   h2:
 


### PR DESCRIPTION
The VLAN module did not copy gateway.* items specified in the global or node VLAN data to prevent 'gateway: true' overwriting the data computed through the gateway module transformation and subsequent link transformation.

With a perfect hindsight, that was wrong. This fix:

* Removes the 'do not copy gateway.* items' restriction
* Changes the 'merge interface data with node vlan data' logic to say 'if the VLAN data is True and the interface data exists, use the interface data'

The first change fixes the 'vlan-vrrp' test case. The second change keeps 'anycast-gateway' test case working.