### PR TITLE
Add python 3.13, remove end-of-support 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      max-parallel: 6
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 6
+      max-parallel: 5
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        # 3.8 went end-of-support on 2024-10-7 as 3.13 was released
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
   ],


### PR DESCRIPTION
Python 3.13 was released 3 days ago - include it in CI/CD testing, and remove the now-deprecated 3.8 version from testing