### PR TITLE
Fix: Reserve gateway.id parameters specified on links and global VLANs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
 
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+##    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 else:
     html_theme = "default"
 

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -1,6 +1,6 @@
 # First-Hop Gateway Configuration Module
 
-First-hop Gateway configuration module implements mechanisms used to implement a shared router IPv4 address on a stub access network.
+The first-hop Gateway configuration module implements mechanisms used to implement a shared router IPv4 address on a stub access network.
 
 The module supports statically configured anycast gateway IPv4 address and VRRPv3 for IPv4 and IPv6.
 
@@ -35,33 +35,43 @@ The module is supported on these platforms:
 The module supports the following global parameters:
 
 * **gateway.protocol** (default: *anycast*) -- the first-hop gateway resolution protocol. The supported values are *anycast* and *vrrp*.
-* **gateway.id** (default: -1) -- the IP address within the subnet used for the gateway IP address
+* **gateway.id** (default: -2) -- the IP address within the subnet used for the gateway IP address. The **gateway.id** could be a positive number (a fixed IP address within a subnet using the *gateway* module) or a negative number specifying the offset from the end of the subnet. The default value specifies a subnet's last valid IP address (-1 is the broadcast address).
 
 ## Link Parameters
 
-Gateway configuration module is enabled on all links that have **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on per-link basis.
+The Gateway configuration module is enabled on all links that have the **gateway** attribute set to *True* or to a dictionary of valid parameters. You can change most global parameters on a per-link basis.
+
+## Reserved IP Addresses
+
+A positive **gateway.id** value could generate IP addresses that overlap with node interface addresses on subnets using [ID-based address allocation](addr-allocation).
+
+The *gateway* module tries to prevent that and reserves the node ID values specified in the global, link, or global VLAN **gateway.id** values.
+
+```{tip}
+If you want to use one of the first IP addresses in the high-availability subnets as the gateway IP address, set the global value of the **‌gateway.id** parameter unless you have an excellent reason to do something else.
+```
 
 ## Anycast Gateway
 
-The *gateway* configuration module supports IPv4 anycast gateways -- MAC and IPv4 addresses shared between multiple nodes attached to the same segment.
+The *gateway* configuration module supports IPv4 anycast gateways, which use MAC and IPv4 addresses shared between multiple nodes attached to the same segment.
 
 ### Implementation Notes
 
 * The default *netlab* shared MAC address is 0200.cafe.00ff.
 * The gateway IP is configured to respond to ping requests
 * Vendors use different names for anycast gateways: VARP (Arista), VRR (Cumulus), passive VRRP (Nokia)
-* Arista EOS uses the same shared MAC address on all interfaces. Do not set link-level **gateway.anycast.mac** parameter in topologies using Arista EOS.
+* Arista EOS uses the same shared MAC address on all interfaces. Do not set the link-level **gateway.anycast.mac** parameter in topologies using Arista EOS.
 * Arista vEOS cannot use VRRP MAC address as a shared MAC address (default recommended by Cumulus Linux)
 
 ### Anycast Parameters
 
 Anycast implementation of shared first-hop IPv4 address supports these parameters that can be specified globally or on individual links or interfaces.
 
-* **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses together with anycast IP address.
+* **gateway.anycast.unicast** (default: True) -- configure node-specific unicast IP addresses even when using the anycast IP address.
 * **gateway.anycast.mac** -- Static MAC address used for the anycast IPv4 address
 
 ```{tip}
-Many implementations require unique unicast IPv4 addresses configured on the interfaces that have anycast IPv4 address. Set **gateway.anycast.unicast** to *False* only when absolutely necessary.
+Many implementations require unique unicast IPv4 addresses configured on interfaces with anycast IPv4 address. Set **gateway.anycast.unicast** to *False* only when absolutely necessary.
 ```
 
 ## Virtual Router Redundancy Protocol (VRRP)
@@ -69,12 +79,12 @@ Many implementations require unique unicast IPv4 addresses configured on the int
 *netlab* supports a single VRRPv3 instance per subnet/interface. The VRRPv3 instance can provide shared IPv4 and IPv6 addresses.
 
 ```{tip}
-More complex topologies like multiple VRRPv3 instances *on the same subnet* could be deployed with a judicious application of interface parameters[^VNS], but you won't be able to model multiple VRRPv3 instances *per interface*[^VDM].
+More complex topologies, such as multiple VRRPv3 instances *on the same subnet*, could be deployed with a judicious application of interface parameters[^VNS], but you won't be able to model multiple VRRPv3 instances *per interface*[^VDM].
 ```
 
-[^VNS]: These topologies are not supported and will not be integrated into *netlab* core. If you want to have an easier way of configuring them in a lab topology, please feel free to create a plugin.
+[^VNS]: These topologies are unsupported and will not be integrated into the *netlab* core. If you want an easier way of configuring them in a lab topology, please feel free to create a plugin.
 
-[^VDM]: That would require a completely different data model. You'll have to use custom configuration templates if you want to implement something along those lines.
+[^VDM]: That would require a completely different data model. You'll have to use custom configuration templates to implement something along those lines.
 
 ### VRRP Parameters
 
@@ -84,4 +94,4 @@ More complex topologies like multiple VRRPv3 instances *on the same subnet* coul
 * **vrrp.priority** (interface parameter, integer)
 * **vrrp.preempt** (interface parameter, boolean)
 
-No other aspect of VRRP (VRRP version, timers...) is manageable through *netlab* parameters, if you want to configured them create a plugin to implement additional VRRP functionality.
+No other aspect of VRRP (VRRP version, timers...) is manageable through *netlab* parameters; if you want to configure them, create a plugin to implement additional VRRP functionality.

--- a/tests/errors/anycast-params.log
+++ b/tests/errors/anycast-params.log
@@ -1,4 +1,2 @@
-IncorrectType in gateway: attribute 'links[1].gateway.protocol' must be a string, found bool
-... use 'netlab show attributes --module gateway link' to display valid attributes
-IncorrectType in gateway: attribute 'links[2].gateway.id' must be an integer, found str
+IncorrectValue in gateway: Link links[2] gateway.id parameter is not integer
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/anycast-prefix.log
+++ b/tests/errors/anycast-prefix.log
@@ -1,3 +1,10 @@
+IncorrectValue in links: Cannot use ipv4 prefix 10.1.0.0/30 to address 2 nodes plus first-hop gateway on links[1]
+... link data: {'_linkname': 'links[1]', 'gateway': {'id': 1, 'protocol': 'anycast',
+... 'anycast': {'mac': '0200.cafe.00ff', 'unicast': True}, 'vrrp': {'group': 1},
+... 'ipv4': '10.1.0.1/30'}, 'interfaces': [{'node': 'r1', 'gateway': {'ipv4':
+... '10.1.0.1/30'}}, {'node': 'r2', 'gateway': {'ipv4': '10.1.0.1/30'}}],
+... 'linkindex': 1, 'node_count': 2, 'type': 'p2p', 'prefix': {'ipv4':
+... '10.1.0.0/30'}}
 IncorrectValue in links: Cannot use ipv4 prefix 192.168.0.8/29 to address 4 nodes plus first-hop gateway on links[2]
 ... link data: {'_linkname': 'links[2]', 'prefix': {'ipv4': '192.168.0.8/29'},
 ... 'gateway': {'id': -4, 'protocol': 'anycast', 'anycast': {'mac':

--- a/tests/errors/gateway-global-params.log
+++ b/tests/errors/gateway-global-params.log
@@ -1,3 +1,3 @@
 IncorrectType in gateway: attribute 'gateway.protocol' must be a string, found bool
-IncorrectType in gateway: Global/default gateway.id parameter is missing or not integer
+IncorrectValue in gateway: Global/default gateway.id parameter is not integer
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -47,24 +47,24 @@ links:
     anycast:
       mac: 0200.cafe.00ff
       unicast: true
-    id: -2
-    ipv4: 172.16.0.254/24
+    id: 1
+    ipv4: 172.16.0.1/24
     protocol: vrrp
     vrrp:
       group: 1
   interfaces:
   - _vlan_mode: irb
     gateway:
-      ipv4: 172.16.0.254/24
+      ipv4: 172.16.0.1/24
     ifindex: 2
     ifname: Ethernet2
-    ipv4: 172.16.0.1/24
+    ipv4: 172.16.0.2/24
     node: s1
     vlan:
       access: red
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.3/24
+    ipv4: 172.16.0.4/24
     node: h1
   linkindex: 2
   node_count: 2
@@ -79,24 +79,24 @@ links:
     anycast:
       mac: 0200.cafe.00ff
       unicast: true
-    id: -2
-    ipv4: 172.16.0.254/24
+    id: 1
+    ipv4: 172.16.0.1/24
     protocol: vrrp
     vrrp:
       group: 1
   interfaces:
   - _vlan_mode: irb
     gateway:
-      ipv4: 172.16.0.254/24
+      ipv4: 172.16.0.1/24
     ifindex: 2
     ifname: Ethernet2
-    ipv4: 172.16.0.2/24
+    ipv4: 172.16.0.3/24
     node: s2
     vlan:
       access: red
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.4/24
+    ipv4: 172.16.0.5/24
     node: h2
   linkindex: 3
   node_count: 2
@@ -116,47 +116,47 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 3
+    id: 4
     interfaces:
     - bridge: input_2
       gateway:
         anycast:
           mac: 0200.cafe.00ff
           unicast: true
-        id: -2
-        ipv4: 172.16.0.254/24
+        id: 1
+        ipv4: 172.16.0.1/24
         protocol: vrrp
         vrrp:
           group: 1
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.3/24
+      ipv4: 172.16.0.4/24
       linkindex: 2
       name: h1 -> [s1,s2,h2]
       neighbors:
       - ifname: Vlan1000
-        ipv4: 172.16.0.1/24
+        ipv4: 172.16.0.2/24
         node: s1
       - gateway:
           anycast:
             mac: 0200.cafe.00ff
             unicast: true
-          id: -2
-          ipv4: 172.16.0.254/24
+          id: 1
+          ipv4: 172.16.0.1/24
           protocol: vrrp
           vrrp:
             group: 1
         ifname: Vlan1000
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.5/24
         node: h2
       type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.103
-      mac: 08:4f:a9:00:00:03
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
     name: h1
     role: host
   h2:
@@ -164,47 +164,47 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 4
+    id: 5
     interfaces:
     - bridge: input_3
       gateway:
         anycast:
           mac: 0200.cafe.00ff
           unicast: true
-        id: -2
-        ipv4: 172.16.0.254/24
+        id: 1
+        ipv4: 172.16.0.1/24
         protocol: vrrp
         vrrp:
           group: 1
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.4/24
+      ipv4: 172.16.0.5/24
       linkindex: 3
       name: h2 -> [h1,s1,s2]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.4/24
         node: h1
       - ifname: Vlan1000
-        ipv4: 172.16.0.1/24
+        ipv4: 172.16.0.2/24
         node: s1
       - gateway:
           anycast:
             mac: 0200.cafe.00ff
             unicast: true
-          id: -2
-          ipv4: 172.16.0.254/24
+          id: 1
+          ipv4: 172.16.0.1/24
           protocol: vrrp
           vrrp:
             group: 1
         ifname: Vlan1000
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.0.3/24
         node: s2
       type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.104
-      mac: 08:4f:a9:00:00:04
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
     name: h2
     role: host
   s1:
@@ -215,7 +215,7 @@ nodes:
     gateway:
       vrrp:
         group: 1
-    id: 1
+    id: 2
     interfaces:
     - ifindex: 1
       ifname: Ethernet1
@@ -240,34 +240,34 @@ nodes:
         access_id: 1000
     - bridge_group: 1
       gateway:
-        id: -2
-        ipv4: 172.16.0.254/24
+        id: 1
+        ipv4: 172.16.0.1/24
         protocol: vrrp
         vrrp:
           group: 1
           priority: 100
       ifindex: 4
       ifname: Vlan1000
-      ipv4: 172.16.0.1/24
+      ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s2,h2]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.4/24
         node: h1
       - gateway:
           anycast:
             mac: 0200.cafe.00ff
             unicast: true
-          id: -2
-          ipv4: 172.16.0.254/24
+          id: 1
+          ipv4: 172.16.0.1/24
           protocol: vrrp
           vrrp:
             group: 1
         ifname: Vlan1000
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.0.3/24
         node: s2
       - ifname: eth1
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.5/24
         node: h2
       type: svi
       virtual_interface: true
@@ -276,14 +276,14 @@ nodes:
     loopback:
       ifindex: 0
       ifname: Loopback0
-      ipv4: 10.0.0.1/32
+      ipv4: 10.0.0.2/32
       neighbors: []
       type: loopback
       virtual_interface: true
     mgmt:
       ifname: Management1
-      ipv4: 192.168.121.101
-      mac: 08:4f:a9:00:00:01
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
     module:
     - vlan
     - gateway
@@ -294,8 +294,8 @@ nodes:
       red:
         bridge_group: 1
         gateway:
-          id: -2
-          ipv4: 172.16.0.254/24
+          id: 1
+          ipv4: 172.16.0.1/24
           protocol: vrrp
           vrrp:
             priority: 100
@@ -312,7 +312,7 @@ nodes:
     gateway:
       vrrp:
         group: 1
-    id: 2
+    id: 3
     interfaces:
     - ifindex: 1
       ifname: Ethernet1
@@ -337,25 +337,25 @@ nodes:
         access_id: 1000
     - bridge_group: 1
       gateway:
-        id: -2
-        ipv4: 172.16.0.254/24
+        id: 1
+        ipv4: 172.16.0.1/24
         protocol: vrrp
         vrrp:
           group: 1
           priority: 200
       ifindex: 4
       ifname: Vlan1000
-      ipv4: 172.16.0.2/24
+      ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h1,s1,h2]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.4/24
         node: h1
       - ifname: Vlan1000
-        ipv4: 172.16.0.1/24
+        ipv4: 172.16.0.2/24
         node: s1
       - ifname: eth1
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.5/24
         node: h2
       type: svi
       virtual_interface: true
@@ -364,14 +364,14 @@ nodes:
     loopback:
       ifindex: 0
       ifname: Loopback0
-      ipv4: 10.0.0.2/32
+      ipv4: 10.0.0.3/32
       neighbors: []
       type: loopback
       virtual_interface: true
     mgmt:
       ifname: Management1
-      ipv4: 192.168.121.102
-      mac: 08:4f:a9:00:00:02
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
     module:
     - vlan
     - gateway
@@ -382,8 +382,8 @@ nodes:
       red:
         bridge_group: 1
         gateway:
-          id: -2
-          ipv4: 172.16.0.254/24
+          id: 1
+          ipv4: 172.16.0.1/24
           protocol: vrrp
           vrrp:
             priority: 200
@@ -396,32 +396,32 @@ provider: libvirt
 vlans:
   red:
     gateway:
-      id: -2
-      ipv4: 172.16.0.254/24
+      id: 1
+      ipv4: 172.16.0.1/24
       protocol: vrrp
     host_count: 2
     id: 1000
     neighbors:
     - ifname: eth1
-      ipv4: 172.16.0.3/24
+      ipv4: 172.16.0.4/24
       node: h1
     - ifname: Vlan1000
-      ipv4: 172.16.0.1/24
+      ipv4: 172.16.0.2/24
       node: s1
     - gateway:
         anycast:
           mac: 0200.cafe.00ff
           unicast: true
-        id: -2
-        ipv4: 172.16.0.254/24
+        id: 1
+        ipv4: 172.16.0.1/24
         protocol: vrrp
         vrrp:
           group: 1
       ifname: Vlan1000
-      ipv4: 172.16.0.2/24
+      ipv4: 172.16.0.3/24
       node: s2
     - ifname: eth1
-      ipv4: 172.16.0.4/24
+      ipv4: 172.16.0.5/24
       node: h2
     prefix:
       allocation: id_based

--- a/tests/topology/input/vlan-vrrp.yml
+++ b/tests/topology/input/vlan-vrrp.yml
@@ -13,7 +13,7 @@ groups:
 
 vlans:
   red:
-    gateway.id: -2
+    gateway.id: 1
     gateway.protocol: vrrp
     links: [ s1-h1, s2-h2 ]
 


### PR DESCRIPTION
Fixes the easier part of #1351