### PR TITLE
Build VLAN-aware DHCP pools (fixes #1358, #1343)

### DIFF
--- a/docs/module/dhcp.md
+++ b/docs/module/dhcp.md
@@ -66,6 +66,11 @@ You have to set **‌dhcp.vrf** to _False_ on a Cisco IOS XE DHCP server when yo
 
 You can enable the DHCP client on all non-relaying devices attached to a link with the boolean **dhcp.client.ipv4** link attribute and the DHCPv6 client with the boolean **dhcp.client.ipv6** attribute.
 
+```{warning}
+* While you can use the **‌dhcp.client** parameter to enable DHCP for all hosts attached to a VLAN segment ([see example](dhcp-vlan-example)), do not use DHCP on [routed VLANs](vlan-addressing-routed).
+* The Default router IP address is not set for the VLAN-serving DHCP pools unless you use the **‌gateway** module with anycast or VRRP default gateway on the VLAN.
+```
+
 ## Interface Parameters
 
 * To start a DHCP client on an interface, set the **ipv4** or **ipv6** address to **dhcp**. You can use the **dhcp.client.ipv4** or the **dhcp.client.ipv6** interface attribute only when the node already uses the DHCP module. 
@@ -147,6 +152,7 @@ links:
 - relay-server
 ```
 
+(dhcp-vlan-example)=
 The following example enables the DHCP client on all hosts attached to a VLAN and the DHCP relay on the access switch:
 
 ```

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -749,6 +749,7 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
       if vlan_subif:
         ifdata.vlan.mode = 'route'
         ifdata.vlan.access_id = vlan_data.id
+        ifdata.vlan.name = access_vlan
       else:
         ifdata._vlan_mode = 'route'                                         # Flags we need to clean up up the routed native VLAN mess
         if native_vlan:                                                     # ... we can't use the vlan.* attributes as they might get removed
@@ -775,6 +776,7 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
         { k:v for k,v in ifdata.items() if k in copy_attr })                # ... that will also give us IP/gateway addresses
       if vlan_mode:                                                         # Set VLAN forwarding mode for completness' sake
         vlan_ifdata.vlan.mode = vlan_mode
+      vlan_ifdata.vlan.name = access_vlan
       vlan_ifdata.ifindex = node.interfaces[-1].ifindex + 1                 # Fill in the rest of interface data:
       vlan_ifdata.ifname = svi_name.format(                                 # ... ifindex, ifname, description
                               vlan=vlan_data.id,

--- a/tests/topology/expected/addressing-prefix.yml
+++ b/tests/topology/expected/addressing-prefix.yml
@@ -175,6 +175,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: v1
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -562,6 +562,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -752,6 +753,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -165,6 +165,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 2
@@ -185,6 +186,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:
@@ -373,6 +375,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 3
@@ -393,6 +396,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     - bridge_group: 2
@@ -413,6 +417,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 3
@@ -433,6 +438,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:
@@ -604,6 +610,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 2
@@ -624,6 +631,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -1,0 +1,527 @@
+dhcp:
+  pools:
+  - clean_name: vlan_red
+    excluded:
+      ipv4:
+      - 172.16.0.2
+    ipv4: 172.16.0.0/24
+    name: vlan_red
+  - clean_name: vlan_blue
+    excluded:
+      ipv6:
+      - 2001:db8:cafe:1::2
+    gateway:
+      ipv6: 2001:db8:cafe:1::1
+    ipv6: 2001:db8:cafe:1::/64
+    name: vlan_blue
+gateway:
+  anycast:
+    mac: 0200.cafe.00ff
+    unicast: true
+  vrrp:
+    group: 1
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+input:
+- topology/input/dhcp-vlan.yml
+- package:topology-defaults.yml
+libvirt:
+  providers:
+    clab: true
+links:
+- bridge: input_1
+  gateway:
+    ipv4: 192.168.42.2/24
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 192.168.42.2/24
+    ipv6: 2001:db8:cafe:d001::2/64
+    node: s1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 192.168.42.6/24
+    ipv6: 2001:db8:cafe:d001::6/64
+    node: dhs
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 192.168.42.0/24
+    ipv6: 2001:db8:cafe:d001::/64
+  type: lan
+- bridge: input_2
+  dhcp:
+    subnet:
+      ipv6: true
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv6: 2001:db8:cafe:1::1/64
+    protocol: anycast
+    vrrp:
+      group: 1
+  interfaces:
+  - _vlan_mode: irb
+    dhcp:
+      server:
+      - dhs
+    gateway:
+      ipv6: 2001:db8:cafe:1::1/64
+    ifindex: 2
+    ifname: Ethernet2
+    ipv6: 2001:db8:cafe:1::2/64
+    node: s1
+    vlan:
+      access: blue
+  - dhcp:
+      client:
+        ipv6: true
+    ifindex: 1
+    ifname: eth1
+    ipv6: 2001:db8:cafe:1::5/64
+    node: h3
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv6: 2001:db8:cafe:1::/64
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_3
+  dhcp:
+    client:
+      ipv4: true
+    subnet:
+      ipv4: true
+  interfaces:
+  - _vlan_mode: irb
+    dhcp:
+      client:
+        ipv4: true
+    ifindex: 3
+    ifname: Ethernet3
+    ipv4: 172.16.0.2/24
+    node: s1
+    vlan:
+      access: red
+  - dhcp:
+      client:
+        ipv4: true
+    ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_4
+  dhcp:
+    client:
+      ipv4: true
+    subnet:
+      ipv4: true
+  interfaces:
+  - _vlan_mode: irb
+    dhcp:
+      client:
+        ipv4: true
+    ifindex: 4
+    ifname: Ethernet4
+    ipv4: 172.16.0.2/24
+    node: s1
+    vlan:
+      access: red
+  - dhcp:
+      client:
+        ipv4: true
+    ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  linkindex: 4
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+module:
+- vlan
+- dhcp
+- gateway
+name: input
+nodes:
+  dhs:
+    _daemon: true
+    _daemon_config:
+      dhcp: /etc/dhcp.ignore
+      dnsmasq: /etc/dnsmasq.conf
+    _daemon_parent: linux
+    af:
+      ipv4: true
+      ipv6: true
+    box: netlab/dnsmasq:latest
+    clab:
+      binds:
+      - clab_files/dhs/hosts:/etc/hosts
+      - clab_files/dhs/dnsmasq:/etc/dnsmasq.conf
+      - clab_files/dhs/dhcp:/etc/dhcp.ignore
+      config_templates:
+      - hosts:/etc/hosts
+      - dnsmasq:/etc/dnsmasq.conf
+      - dhcp:/etc/dhcp.ignore
+      kind: linux
+    device: dnsmasq
+    dhcp:
+      pools:
+      - clean_name: vlan_red
+        excluded:
+          ipv4:
+          - 172.16.0.2
+        ipv4: 172.16.0.0/24
+        name: vlan_red
+      - clean_name: vlan_blue
+        excluded:
+          ipv6:
+          - 2001:db8:cafe:1::2
+        gateway:
+          ipv6: 2001:db8:cafe:1::1
+        ipv6: 2001:db8:cafe:1::/64
+        name: vlan_blue
+      server: true
+    hostname: clab-input-dhs
+    id: 6
+    interfaces:
+    - bridge: input_1
+      gateway:
+        ipv4: 192.168.42.2/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 192.168.42.6/24
+      ipv6: 2001:db8:cafe:d001::6/64
+      linkindex: 1
+      mtu: 1500
+      name: dhs -> s1
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 192.168.42.2/24
+        ipv6: 2001:db8:cafe:d001::2/64
+        node: s1
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.106
+      mac: 08:4f:a9:00:00:06
+    module:
+    - dhcp
+    mtu: 1500
+    name: dhs
+    provider: clab
+    role: host
+  h1:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 3
+    interfaces:
+    - bridge: input_3
+      dhcp:
+        client:
+          ipv4: true
+      gateway:
+        ipv4: 172.16.0.2/24
+      ifindex: 1
+      ifname: eth1
+      linkindex: 3
+      name: h1 -> [s1,h2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s1
+      - dhcp:
+          client:
+            ipv4: true
+        ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    module:
+    - dhcp
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 4
+    interfaces:
+    - bridge: input_4
+      dhcp:
+        client:
+          ipv4: true
+      gateway:
+        ipv4: 172.16.0.2/24
+      ifindex: 1
+      ifname: eth1
+      linkindex: 4
+      name: h2 -> [h1,s1]
+      neighbors:
+      - dhcp:
+          client:
+            ipv4: true
+        ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: s1
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    module:
+    - dhcp
+    name: h2
+    role: host
+  h3:
+    af:
+      ipv6: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 5
+    interfaces:
+    - bridge: input_2
+      dhcp:
+        client:
+          ipv6: true
+      ifindex: 1
+      ifname: eth1
+      linkindex: 2
+      name: h3 -> [s1]
+      neighbors:
+      - ifname: Vlan1001
+        ipv6: 2001:db8:cafe:1::2/64
+        node: s1
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
+    module:
+    - dhcp
+    name: h3
+    role: host
+  s1:
+    af:
+      ipv4: true
+      ipv6: true
+    box: arista/veos
+    device: eos
+    dhcp:
+      relay: true
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+    id: 2
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1
+      ipv4: 192.168.42.2/24
+      ipv6: 2001:db8:cafe:d001::2/64
+      linkindex: 1
+      name: s1 -> dhs
+      neighbors:
+      - ifname: eth1
+        ipv4: 192.168.42.6/24
+        ipv6: 2001:db8:cafe:d001::6/64
+        node: dhs
+      type: lan
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_3
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 3
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 4
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv6: 2001:db8:cafe:1::1/64
+        protocol: anycast
+      ifindex: 5
+      ifname: Vlan1001
+      ipv6: 2001:db8:cafe:1::2/64
+      name: VLAN blue (1001) -> [h3]
+      neighbors:
+      - dhcp:
+          client:
+            ipv6: true
+        ifname: eth1
+        ipv6: 2001:db8:cafe:1::5/64
+        node: h3
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: blue
+    - bridge_group: 2
+      dhcp:
+        relay:
+          ipv4:
+          - 192.168.42.6
+        server:
+        - dhs
+      ifindex: 6
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h1,h2]
+      neighbors:
+      - dhcp:
+          client:
+            ipv4: true
+        ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - dhcp:
+          client:
+            ipv4: true
+        ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - vlan
+    - dhcp
+    - gateway
+    name: s1
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 1
+        id: 1001
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv6: 2001:db8:cafe:1::/64
+      red:
+        bridge_group: 2
+        dhcp:
+          client:
+            ipv4: true
+          server:
+          - dhs
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+provider: libvirt
+vlans:
+  blue:
+    host_count: 1
+    id: 1001
+    neighbors:
+    - dhcp:
+        client:
+          ipv6: true
+      ifname: eth1
+      ipv6: 2001:db8:cafe:1::5/64
+      node: h3
+    - ifname: Vlan1001
+      ipv6: 2001:db8:cafe:1::2/64
+      node: s1
+    prefix:
+      allocation: id_based
+      ipv6: 2001:db8:cafe:1::/64
+  red:
+    dhcp:
+      client:
+        ipv4: true
+    host_count: 2
+    id: 1000
+    neighbors:
+    - dhcp:
+        client:
+          ipv4: true
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: s1
+    - dhcp:
+        client:
+          ipv4: true
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -367,6 +367,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
       vrf: tenant
     - bgp:
         advertise: true
@@ -384,6 +385,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
       vrf: tenant
     - bridge_group: 3
       ifindex: 7
@@ -401,6 +403,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
       vrf: tenant
     loopback:
       ifindex: 0
@@ -522,6 +525,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: red
             vrf: tenant
           - bgp:
               advertise: true
@@ -543,6 +547,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: green
             vrf: tenant
           - bridge_group: 3
             ifindex: 7
@@ -563,6 +568,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: blue
             vrf: tenant
           router_id: 10.0.0.1
         rd: '65000:1'
@@ -669,6 +675,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
       vrf: tenant
     - bgp:
         advertise: true
@@ -686,6 +693,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: purple
       vrf: tenant
     - bridge_group: 3
       ifindex: 7
@@ -703,6 +711,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
       vrf: tenant
     loopback:
       ifindex: 0
@@ -824,6 +833,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: blue
             vrf: tenant
           - bgp:
               advertise: true
@@ -845,6 +855,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: purple
             vrf: tenant
           - bridge_group: 3
             ifindex: 7
@@ -865,6 +876,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: red
             vrf: tenant
           router_id: 10.0.0.2
         rd: '65000:1'

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -101,6 +101,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
       vrf: tenant
     loopback:
       ifindex: 0

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -95,6 +95,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -347,6 +347,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 4
       ifname: Vlan1001
@@ -369,6 +370,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -517,6 +519,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -649,6 +652,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -128,6 +128,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 9
       ifname: Vlan1001
@@ -148,6 +149,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 3
       ifindex: 10
       ifname: Vlan1002
@@ -166,6 +168,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -261,6 +264,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 6
       ifname: Vlan1001
@@ -281,6 +285,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 3
       ifindex: 7
       ifname: Vlan1002
@@ -299,6 +304,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -393,6 +399,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1001
@@ -412,6 +419,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -189,6 +189,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -260,6 +261,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -382,6 +382,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
     - bridge_group: 3
       ifindex: 13
@@ -399,6 +400,7 @@ nodes:
       vlan:
         access_id: 1002
         mode: route
+        name: green
         routed_link: true
     - bridge_group: 1
       ifindex: 14
@@ -416,6 +418,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
     - ifindex: 15
       ifname: eth6.1001
@@ -488,6 +491,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 22
       ifname: vlan1001
@@ -501,6 +505,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     - bridge_group: 3
       ifindex: 23
       ifname: vlan1002
@@ -516,6 +521,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: green
     loopback:
       ifindex: 0
       ifname: lo
@@ -703,6 +709,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
     - bridge_group: 2
       ifindex: 7
       ifname: vlan1001
@@ -716,6 +723,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     - bridge_group: 3
       ifindex: 8
       ifname: vlan1002
@@ -731,6 +739,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: lo
@@ -877,6 +886,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
     - bridge_group: 3
       ifindex: 11
@@ -894,6 +904,7 @@ nodes:
       vlan:
         access_id: 1002
         mode: route
+        name: green
         routed_link: true
     - bridge_group: 1
       ifindex: 12
@@ -911,6 +922,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
     - ifindex: 13
       ifname: eth6.1001
@@ -956,6 +968,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 17
       ifname: vlan1001
@@ -969,6 +982,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     - bridge_group: 3
       ifindex: 18
       ifname: vlan1002
@@ -984,6 +998,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: lo

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -87,6 +87,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -161,6 +162,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 4
       ifname: Vlan1001
@@ -174,6 +176,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -147,6 +147,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -82,6 +82,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: vxlan
     loopback:
       ifindex: 0
       ifname: lo
@@ -161,6 +162,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: vxlan
     loopback:
       ifindex: 0
       ifname: lo

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -76,6 +76,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1000
@@ -89,6 +90,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -158,6 +160,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1000
@@ -171,6 +174,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -240,6 +244,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1002
@@ -253,6 +258,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -222,6 +222,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -312,6 +313,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -258,6 +258,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -179,6 +179,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -243,6 +244,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -262,6 +262,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -355,6 +356,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -434,6 +436,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -282,6 +282,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 7
       ifname: Vlan1001
@@ -299,6 +300,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -385,6 +387,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 7
       ifname: Vlan1001
@@ -402,6 +405,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -231,6 +231,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -315,6 +316,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 6
       ifname: BVI2
@@ -328,6 +330,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -160,6 +160,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: vl_irb
+        name: red
     - bridge_group: 2
       ifindex: 9
       ifname: vlan1001
@@ -173,6 +174,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: g_irb
+        name: blue
     - bridge_group: 3
       ifindex: 10
       ifname: vlan1002
@@ -185,6 +187,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: vl_irb
+        name: green
     - bridge_group: 4
       ifindex: 11
       ifname: vlan1003
@@ -198,6 +201,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: g_irb
+        name: orange
     loopback:
       ifindex: 0
       ifname: lo
@@ -319,6 +323,7 @@ nodes:
       vlan:
         access_id: 1003
         mode: route
+        name: orange
     - bridge_group: 1
       ifindex: 8
       ifname: vlan1000
@@ -332,6 +337,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: n_irb
+        name: red
     - bridge_group: 2
       ifindex: 9
       ifname: vlan1001
@@ -345,6 +351,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: n_irb
+        name: blue
     - bridge_group: 3
       ifindex: 10
       ifname: vlan1002
@@ -357,6 +364,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: green
     loopback:
       ifindex: 0
       ifname: lo

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -137,6 +137,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 3
       ifindex: 5
       ifname: BVI3
@@ -150,6 +151,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -245,6 +247,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 3
       ifindex: 5
       ifname: BVI3
@@ -258,6 +261,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -242,6 +242,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -69,6 +69,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
@@ -85,6 +86,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -175,6 +177,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 5
       ifname: vlan1000
@@ -188,6 +191,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: lo

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -370,6 +370,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
       vrf: blue
     - _parent_intf: lo
       _parent_ipv4: 10.0.0.1/32
@@ -401,6 +402,7 @@ nodes:
       vlan:
         access_id: 1002
         mode: route
+        name: green
       vrf: green
     - bridge_group: 3
       ifindex: 4
@@ -427,6 +429,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
       vrf: red
     loopback:
       ifindex: 0
@@ -561,6 +564,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
       vrf: blue
     - _parent_intf: lo
       _parent_ipv4: 10.0.0.2/32
@@ -592,6 +596,7 @@ nodes:
       vlan:
         access_id: 1002
         mode: route
+        name: green
       vrf: green
     - bridge_group: 3
       ifindex: 4
@@ -618,6 +623,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
       vrf: red
     loopback:
       ifindex: 0
@@ -782,6 +788,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
       vrf: red
     - bridge_group: 2
       ifindex: 11
@@ -805,6 +812,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
       vrf: blue
     - bridge_group: 3
       ifindex: 12
@@ -831,6 +839,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: green
       vrf: green
     loopback:
       ifindex: 0
@@ -1036,6 +1045,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
       vrf: blue
     - bridge_group: 2
       ifindex: 12
@@ -1061,6 +1071,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: green
       vrf: green
     - bridge_group: 3
       ifindex: 13
@@ -1083,6 +1094,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
       vrf: red
     loopback:
       ifindex: 0

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -244,6 +244,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
@@ -269,6 +270,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -369,6 +371,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 7
       ifname: Vlan1001
@@ -387,6 +390,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -474,6 +478,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 2
       ifindex: 8
       ifname: Vlan1000
@@ -492,6 +497,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -484,6 +484,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 10
       ifname: BVI2
@@ -506,6 +507,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 3
       ifindex: 11
       ifname: BVI3
@@ -528,6 +530,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -662,6 +665,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 11
       ifname: Vlan1001
@@ -684,6 +688,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     - bridge_group: 3
       ifindex: 12
       ifname: Vlan1002
@@ -706,6 +711,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -414,6 +414,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 1
@@ -433,6 +434,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:
@@ -533,6 +535,7 @@ nodes:
             vlan:
               access_id: 1001
               mode: route
+              name: blue
               routed_link: true
             vrf: blue
           router_id: 10.0.0.1
@@ -614,6 +617,7 @@ nodes:
             vlan:
               access_id: 1000
               mode: route
+              name: red
               routed_link: true
             vrf: red
           router_id: 10.0.0.1
@@ -694,6 +698,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 1
@@ -713,6 +718,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     - bridge_group: 2
@@ -732,6 +738,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 1
@@ -751,6 +758,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:
@@ -851,6 +859,7 @@ nodes:
             vlan:
               access_id: 1001
               mode: route
+              name: blue
               routed_link: true
             vrf: blue
           - bridge_group: 2
@@ -874,6 +883,7 @@ nodes:
             vlan:
               access_id: 1001
               mode: route
+              name: blue
               routed_link: true
             vrf: blue
           router_id: 10.0.0.2
@@ -937,6 +947,7 @@ nodes:
             vlan:
               access_id: 1000
               mode: route
+              name: red
               routed_link: true
             vrf: red
           - bridge_group: 1
@@ -960,6 +971,7 @@ nodes:
             vlan:
               access_id: 1000
               mode: route
+              name: red
               routed_link: true
             vrf: red
           router_id: 10.0.0.2
@@ -999,6 +1011,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: blue
         routed_link: true
       vrf: blue
     - bridge_group: 2
@@ -1018,6 +1031,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: red
         routed_link: true
       vrf: red
     loopback:
@@ -1098,6 +1112,7 @@ nodes:
             vlan:
               access_id: 1001
               mode: route
+              name: blue
               routed_link: true
             vrf: blue
           router_id: 10.0.0.3
@@ -1141,6 +1156,7 @@ nodes:
             vlan:
               access_id: 1000
               mode: route
+              name: red
               routed_link: true
             vrf: red
           router_id: 10.0.0.3

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -273,6 +273,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -361,6 +362,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -90,6 +90,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: leak-customer1
         routed_link: true
       vrf: global
     - bridge_group: 1
@@ -109,6 +110,7 @@ nodes:
       vlan:
         access_id: 1000
         mode: route
+        name: leak-customer1
         routed_link: true
       vrf: customer1
     - bridge_group: 2
@@ -128,6 +130,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: leak-customer2
         routed_link: true
       vrf: global
     - bridge_group: 2
@@ -147,6 +150,7 @@ nodes:
       vlan:
         access_id: 1001
         mode: route
+        name: leak-customer2
         routed_link: true
       vrf: customer2
     loopback:

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -112,6 +112,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1001
@@ -129,6 +130,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -226,6 +228,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red
     - bridge_group: 2
       ifindex: 5
       ifname: vlan1001
@@ -244,6 +247,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue
     loopback:
       ifindex: 0
       ifname: lo
@@ -343,6 +347,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1000
@@ -360,6 +365,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -465,6 +471,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     - bridge_group: 2
       ifindex: 7
       ifname: Vlan1000
@@ -482,6 +489,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -299,6 +299,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1001
@@ -316,6 +317,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -429,6 +431,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: red
     - bridge_group: 2
       ifindex: 5
       ifname: Vlan1001
@@ -446,6 +449,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: bridge
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -469,6 +469,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red_transport
       vrf: red
     - bridge_group: 2
       ifindex: 7
@@ -483,6 +484,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue_transport
       vrf: blue
     loopback:
       ifindex: 0
@@ -588,6 +590,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: blue_transport
             vrf: blue
           router_id: 10.0.0.6
         rd: '65000:2'
@@ -645,6 +648,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: red_transport
             vrf: red
           router_id: 10.0.0.6
         rd: '65000:1'
@@ -724,6 +728,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red_transport
       vrf: red
     - bridge_group: 2
       ifindex: 7
@@ -738,6 +743,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: blue_transport
       vrf: blue
     loopback:
       ifindex: 0
@@ -843,6 +849,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: blue_transport
             vrf: blue
           router_id: 10.0.0.7
         rd: '65000:2'
@@ -900,6 +907,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: red_transport
             vrf: red
           router_id: 10.0.0.7
         rd: '65000:1'
@@ -966,6 +974,7 @@ nodes:
       virtual_interface: true
       vlan:
         mode: irb
+        name: red_transport
       vrf: red
     loopback:
       ifindex: 0
@@ -1062,6 +1071,7 @@ nodes:
             virtual_interface: true
             vlan:
               mode: irb
+              name: red_transport
             vrf: red
           router_id: 10.0.0.8
         rd: '65000:1'

--- a/tests/topology/input/dhcp-vlan.yml
+++ b/tests/topology/input/dhcp-vlan.yml
@@ -1,0 +1,48 @@
+#
+# VLAN-DHCP test case
+#
+
+provider: libvirt
+
+module: [ dhcp, vlan, gateway ]
+
+groups:
+  hosts:
+    device: linux
+    members: [ h1, h2, h3 ]
+
+vlans:
+  red:
+    dhcp.client.ipv4: True
+    links: [ s1-h1, s1-h2 ]
+  blue:
+    prefix.ipv6: 2001:db8:cafe:1::/64
+
+nodes:
+  s1:
+    device: eos
+    vlans:
+      red:
+        dhcp.server: dhs
+  h1:
+    device: linux
+  h2:
+    device: linux
+  h3:
+  dhs:
+    device: dnsmasq
+    provider: clab
+
+links:
+- s1:
+  dhs:
+  prefix:
+    ipv4: 192.168.42.0/24
+    ipv6: 2001:db8:cafe:d001::/64
+- s1:
+    dhcp.server: dhs
+  h3:
+    ipv6: dhcp
+  vlan.access: blue
+  gateway.id: 1
+  gateway.protocol: anycast


### PR DESCRIPTION
The simplistic 'build DHCP pools from links' algorithm has been heavily modified to cope with VLANs where a single subnet can be stretched across multiple links:

* In the first phase, the algorithm collects VLAN prefixes, using the VLAN name as the pool ID
* In the second phase, it scans all node interfaces, extracts IP addresses from SVI/subinterfaces and adds them to the VLAN 'excluded addresses' lists
* Finally, it scans the links for DHCP clients, creates new pools for classic links, and marks a pool/prefix active.

The collected data is then transformed into the topology.dhcp.pools list compatible with existing configuration templates

There's another outstanding bug (#1359), but that one might be applicable to non-VLAN segments as well.