### PR TITLE
Symlink Cisco iosvl2 quirks for ioll2 images. Update error message

### DIFF
--- a/netsim/devices/ioll2.py
+++ b/netsim/devices/ioll2.py
@@ -1,0 +1,1 @@
+iosvl2.py

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -13,7 +13,7 @@ def check_reserved_vlans(node: Box, topology: Box) -> None:
   for vname,vdata in node.get('vlans',{}).items():
     if vdata.id in range(1002,1006):
       log.error(
-        f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 for historic reasons',
+        f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 and IOLL2 for historic reasons',
         category=log.IncorrectValue,
         module='quirks')
 

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -13,7 +13,7 @@ def check_reserved_vlans(node: Box, topology: Box) -> None:
   for vname,vdata in node.get('vlans',{}).items():
     if vdata.id in range(1002,1006):
       log.error(
-        f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 and IOLL2 for historic reasons',
+        f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 or IOLL2 for historic reasons',
         category=log.IncorrectValue,
         module='quirks')
 


### PR DESCRIPTION
Symlink Cisco iosvl2 quirks as quirk module for ioll2 devices. Update error message to mention both devices. Even if vlan module is disabled for now on ioll2, do this change now so it is done and present for future development on ioll2.