### PR TITLE
Netlab exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ If you encounter bugs using release 1.7.x, please downgrade to [1.6.4](https://g
 **netlab connect**
 : Use SSH or **docker exec** to [connect to a lab device](https://netlab.tools/netlab/connect/) using device names, management network IP addresses (**ansible_host**), SSH port, and username/passwords specified in lab topology or *netlab* device defaults.
 
+**netlab exec**
+: Use SSH or **docker exec** to [execute a command on one or more network devices](https://netlab.tools/netlab/exec/) using device names, management network IP addresses (**ansible_host**), SSH port, and username/passwords specified in lab topology or *netlab* device defaults.
+
 **netlab capture**
 : [Perform packet capture](https://netlab.tools/netlab/capture/) on VM- and container interfaces
 

--- a/docs/cli-overview.md
+++ b/docs/cli-overview.md
@@ -28,3 +28,6 @@ The following programs, scripts and Ansible playbooks are included with *netlab*
 
 **netlab collect**
 : Using Ansible fact gathering or other device-specific Ansible modules, collects device configurations and saves them in specified directory. [More details...](netlab/collect.md)
+
+**netlab exec**
+: Use Ansible inventory to connect to one or more lab devices using the inventory names and executes an arbitrary command on them. Device IP address (**ansible_host**) and username/passwords are retrieved from Ansible inventory. Ideal when you use centralized Vagrant or Clab environments and want to execute commands on the devices. [More details...](netlab/exec.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ When the lab is fully configured, you can use the:
 * **[netlab connect](netlab-connect)** command to connect to network devices via SSH or **docker exec**
 * **[netlab config](netlab-config)** command to deploy custom configuration snippets
 * **[netlab capture](netlab-capture)** command to capture packets on VM- or container interfaces
-
+* **[netlab exec](netlab-exec)** command to execute arbitrary commands on one or more network devices
 Before shutting down your lab with the **[netlab down](netlab/down.md)** command, you might want to run the **[netlab collect](netlab/collect.md)** command to save the configuration changes you made.
 
 ## Getting Started

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ When the lab is fully configured, you can use the:
 * **[netlab config](netlab-config)** command to deploy custom configuration snippets
 * **[netlab capture](netlab-capture)** command to capture packets on VM- or container interfaces
 * **[netlab exec](netlab-exec)** command to execute arbitrary commands on one or more network devices
+
 Before shutting down your lab with the **[netlab down](netlab/down.md)** command, you might want to run the **[netlab collect](netlab/collect.md)** command to save the configuration changes you made.
 
 ## Getting Started

--- a/docs/netlab/cli.md
+++ b/docs/netlab/cli.md
@@ -22,6 +22,7 @@ The **netlab** command is the *netlab* CLI interface. It includes data model tra
 * **[netlab collect](collect.md)** uses Ansible device facts (or equivalent functionality implemented with Ansible modules) to collect device configurations and store them in the specified directory.
 * **‌[netlab validate](validate.md)** executes tests defined in the lab topology on the lab devices
 * **[netlab down](down.md)** destroys the virtual lab.
+* **[netlab exec](exec.md)** executes a command on one or more network devices.
 
 ## Reports and Graphs
 
@@ -60,6 +61,7 @@ The **netlab** command is the *netlab* CLI interface. It includes data model tra
    netlab connect <connect.md>
    netlab create <create.md>
    netlab down <down.md>
+   netlab exec <exec.md>
    netlab graph <graph.md>
    netlab initial <initial.md>
    netlab inspect <inspect.md>

--- a/docs/netlab/exec.md
+++ b/docs/netlab/exec.md
@@ -1,7 +1,7 @@
 (netlab-exec)=
-# Executing Commands ono Lab Devices
+# Executing Commands on Lab Devices
 
-**netlab exec** command uses information stored in the _netlab_ snapshot file and reported with the **[`netlab inspect --node`](inspect.md)** command toexec to a lab device or tool using SSH or **docker exec**.
+**netlab exec** command uses information stored in the _netlab_ snapshot file and reported with the **[`netlab inspect --node`](inspect.md)** command to execute a command on one or more lab devices using SSH or **docker exec**.
 
 ## Usage
 

--- a/docs/netlab/exec.md
+++ b/docs/netlab/exec.md
@@ -1,0 +1,30 @@
+(netlab-exec)=
+# Executing Commands ono Lab Devices
+
+**netlab exec** command uses information stored in the _netlab_ snapshot file and reported with the **[`netlab inspect --node`](inspect.md)** command toexec to a lab device or tool using SSH or **docker exec**.
+
+## Usage
+
+```text
+usage: netlab exec [-h] [-v] [-q] [--dry-run] [--snapshot [SNAPSHOT]]                      
+                      node
+
+Executes a command on one or more network devices
+
+positional arguments:
+  node                  Device(s) to execute the command on
+
+options:
+  -h, --help            show this help message and exit
+  -v, --verbose         Verbose logging
+  -q, --quiet           No logging
+  --dry-run             Print the commands that would be executed, but do not execute them
+  --snapshot [SNAPSHOT]
+                        Transformed topology snapshot file
+
+The rest of the arguments are passed to SSH or docker exec command
+```
+
+```{warning}
+Do not use **netlab exec** in a production environment.
+```

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -242,7 +242,7 @@ def run(cli_args: typing.List[str]) -> None:
   host = args.host
 
   if host in topology.nodes:
-    connect_to_node(args,rest,topology,host,log_level)
+    connect_to_node(node=host,args=args,rest=rest,topology=topology,log_level=log_level)
   elif host in topology.tools:
     connect_to_tool(host,rest,topology,log_level)
   else:

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -164,17 +164,17 @@ def create_command_list(host: Box, args: argparse.Namespace, rest: list) -> list
     return rest
 
 def connect_to_node(      
+      node: str, 
       args: argparse.Namespace,
       rest: list,
       topology: Box,
-      node: typing.Optional[str] = None, 
       log_level: LogLevel = LogLevel.INFO) -> typing.Union[bool,int,str]:
   
   host_data = outputs_common.adjust_inventory_host(
                 node=topology.nodes[node],
                 defaults=topology.defaults,
                 group_vars=True)
-  host_data.host = node or args.host
+  host_data.host = node
   connection = host_data.netlab_console_connection or host_data.ansible_connection
 
   rest = create_command_list(host_data,args,rest)

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -167,8 +167,9 @@ def connect_to_node(
       args: argparse.Namespace,
       rest: list,
       topology: Box,
+      node: str,
       log_level: LogLevel = LogLevel.INFO) -> typing.Union[bool,int,str]:
-  node = args.host
+  
   host_data = outputs_common.adjust_inventory_host(
                 node=topology.nodes[node],
                 defaults=topology.defaults,
@@ -241,7 +242,7 @@ def run(cli_args: typing.List[str]) -> None:
   host = args.host
 
   if host in topology.nodes:
-    connect_to_node(args,rest,topology,log_level)
+    connect_to_node(args,rest,topology,host,log_level)
   elif host in topology.tools:
     connect_to_tool(host,rest,topology,log_level)
   else:

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -163,18 +163,18 @@ def create_command_list(host: Box, args: argparse.Namespace, rest: list) -> list
   else:
     return rest
 
-def connect_to_node(
+def connect_to_node(      
       args: argparse.Namespace,
       rest: list,
       topology: Box,
-      node: str,
+      node: typing.Optional[str] = None, 
       log_level: LogLevel = LogLevel.INFO) -> typing.Union[bool,int,str]:
   
   host_data = outputs_common.adjust_inventory_host(
                 node=topology.nodes[node],
                 defaults=topology.defaults,
                 group_vars=True)
-  host_data.host = node
+  host_data.host = node or args.host
   connection = host_data.netlab_console_connection or host_data.ansible_connection
 
   rest = create_command_list(host_data,args,rest)

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -24,7 +24,7 @@ from ..augment.groups import group_members
 #
 # CLI parser for 'netlab ' command
 #
-def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
+def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]::
   parser = argparse.ArgumentParser(
       prog="netlab exec",
       description='Run a command on one or more network devices',
@@ -61,16 +61,16 @@ def run(cli_args: typing.List[str]) -> None:
   topology = load_snapshot(args)
   selector = args.node
   args = argparse.Namespace(show=None,verbose=False, quiet=True,Output=True) 
-  if selector in topology.nodes:   
-    connect_to_node(args,rest,topology,selector,log_level)
+  if selector in topology.nodes:
+    connect_to_node(node=selector,args=args,rest=rest,topology=topology,log_level=log_level)
   elif selector in topology.groups:
     node_list = group_members(topology,selector)
     for node in node_list:           
-        connect_to_node(args,rest,topology,node,log_level)   
+        connect_to_node(node=node,args=args,rest=rest,topology=topology,log_level=log_level)   
   else:  
     node_list = _nodeset.parse_nodeset(selector,topology)
     for node in node_list:
-        connect_to_node(args,rest,topology,node,log_level)
+        connect_to_node(node=node,args=args,rest=rest,topology=topology,log_level=log_level)
   
  
 

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -24,7 +24,7 @@ from ..augment.groups import group_members
 #
 # CLI parser for 'netlab ' command
 #
-def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]::
+def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
   parser = argparse.ArgumentParser(
       prog="netlab exec",
       description='Run a command on one or more network devices',

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -24,7 +24,7 @@ from ..augment.groups import group_members
 #
 # CLI parser for 'netlab ' command
 #
-def exec_parse(args: typing.List[str]) -> argparse.Namespace:
+def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
   parser = argparse.ArgumentParser(
       prog="netlab exec",
       description='Run a command on one or more network devices',

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -14,12 +14,11 @@ from box import Box
 
 from . import external_commands, set_dry_run
 from . import load_snapshot, _nodeset, parser_add_verbose
+from .connect import quote_list, docker_connect, ssh_connect, LogLevel, get_log_level
+
 from ..outputs import common as outputs_common
 from ..utils import strings, log
 from ..augment.groups import group_members
-from .connect import quote_list, docker_connect, ssh_connect, LogLevel, get_log_level
-
-
 
 #
 # CLI parser for 'netlab ' command
@@ -47,8 +46,7 @@ def connect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
       dest='node', action='store',
       help='Node(s) to run command on')
   return parser.parse_known_args(args)
-
-       
+      
 def exec_on_node(
       args: argparse.Namespace,
       rest: list,
@@ -71,7 +69,6 @@ def exec_on_node(
     return ssh_connect(host_data,args,rest,log_level)
   else:
     log.fatal(f'Unknown connection method {connection} for host {node}',module='connect')
-
 
 def run(cli_args: typing.List[str]) -> None:
   (args, rest) = connect_parse(cli_args)

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -103,8 +103,7 @@ def run(cli_args: typing.List[str]) -> None:
   selector = args.node
 
   if selector in topology.nodes:
-    
-    exec_on_node_node(args,rest,topology,selector,log_level)
+    exec_on_node(args,rest,topology,selector,log_level)
   elif selector in topology.groups:
     node_list= topology.groups.get(selector, {}).get('members', [])
     for node in node_list:

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -16,7 +16,7 @@ from . import external_commands, set_dry_run
 from . import load_snapshot, _nodeset, parser_add_verbose
 from ..outputs import common as outputs_common
 from ..utils import strings, log
-
+from ..augment.groups import group_members
 from .connect import quote_list, docker_connect, ssh_connect, LogLevel, get_log_level
 
 
@@ -89,7 +89,7 @@ def run(cli_args: typing.List[str]) -> None:
   if selector in topology.nodes:
     exec_on_node(args,rest,topology,selector,log_level)
   elif selector in topology.groups:
-    node_list= topology.groups.get(selector, {}).get('members', [])
+    node_list = group_members(topology,selector)
     for node in node_list:
         exec_on_node(args,rest,topology,node,log_level)   
   else:  

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -1,0 +1,121 @@
+#
+# netlab exec command
+#
+# run a command on one or more lab devices
+#
+import typing
+import os
+import sys
+import argparse
+import subprocess
+from enum import IntEnum
+
+from box import Box
+
+from . import external_commands, set_dry_run
+from . import load_snapshot, _nodeset, parser_add_verbose
+from ..outputs import common as outputs_common
+from ..utils import strings, log
+
+from .connect import quote_list, docker_connect, ssh_connect
+
+
+class LogLevel(IntEnum):
+  NONE = 0
+  INFO = 1
+  ARGS = 2
+  DRY_RUN = 3
+
+
+#
+# CLI parser for 'netlab ' command
+#
+def connect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
+  parser = argparse.ArgumentParser(
+      prog="netlab exec",
+      description='Run a command on one or more network devices',
+      epilog='The rest of the arguments are passed to SSH or docker exec command')
+  parser_add_verbose(parser)
+  parser.add_argument(
+      '--dry-run',
+      dest='dry_run',
+      action='store_true',
+      help='Print the hosts and the commands that would be executed on them, but do not execute them')
+  parser.add_argument(
+      '--snapshot',
+      dest='snapshot',
+      action='store',
+      nargs='?',
+      default='netlab.snapshot.yml',
+      const='netlab.snapshot.yml',
+      help='Transformed topology snapshot file')
+  parser.add_argument(
+      dest='node', action='store',
+      help='Node(s) to run command on')
+  return parser.parse_known_args(args)
+
+
+def get_log_level(args: argparse.Namespace) -> LogLevel:
+    if args.dry_run:
+        return LogLevel.DRY_RUN
+    elif args.quiet:
+        return LogLevel.NONE
+    elif args.verbose:
+        return LogLevel.ARGS
+    else:
+        return LogLevel.INFO
+       
+def exec_on_node(
+      args: argparse.Namespace,
+      rest: list,
+      topology: Box,
+      node: str,
+      log_level: LogLevel = LogLevel.INFO) -> typing.Union[bool,int,str]:
+  
+  host_data = outputs_common.adjust_inventory_host(
+                node=topology.nodes[node],
+                defaults=topology.defaults,
+                group_vars=True)
+  host_data.host = node
+  connection = host_data.netlab_console_connection or host_data.ansible_connection
+
+  if connection == 'docker':
+    return docker_connect(host_data,args,rest,log_level)
+  elif connection in ['paramiko','ssh','network_cli','netconf','httpapi'] or not connection:
+    if connection in ['netconf','httpapi']:
+      print(f"Using SSH to connect to a device configured with {connection} connection")
+    return ssh_connect(host_data,args,rest,log_level)
+  else:
+    log.fatal(f'Unknown connection method {connection} for host {node}',module='connect')
+
+
+def run(cli_args: typing.List[str]) -> None:
+  (args, rest) = connect_parse(cli_args)
+  log.set_logging_flags(args)
+  log_level = get_log_level(args)
+  set_dry_run(args)
+
+  if not rest:
+    log.fatal("No command to execute on node(s) was specified. Aborting.")
+
+  rest = quote_list(rest)    
+  topology = load_snapshot(args)
+  selector = args.node
+
+  if selector in topology.nodes:
+    
+    exec_on_node_node(args,rest,topology,selector,log_level)
+  elif selector in topology.groups:
+    node_list= topology.groups.get(selector, {}).get('members', [])
+    for node in node_list:
+        exec_on_node(args,rest,topology,node,log_level)   
+  else:  
+    node_list = _nodeset.parse_nodeset(selector,topology)
+    for node in node_list:
+        exec_on_node(args,rest,topology,node,log_level)
+  
+ 
+
+    
+
+

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -17,14 +17,8 @@ from . import load_snapshot, _nodeset, parser_add_verbose
 from ..outputs import common as outputs_common
 from ..utils import strings, log
 
-from .connect import quote_list, docker_connect, ssh_connect
+from .connect import quote_list, docker_connect, ssh_connect, LogLevel, get_log_level
 
-
-class LogLevel(IntEnum):
-  NONE = 0
-  INFO = 1
-  ARGS = 2
-  DRY_RUN = 3
 
 
 #
@@ -54,16 +48,6 @@ def connect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
       help='Node(s) to run command on')
   return parser.parse_known_args(args)
 
-
-def get_log_level(args: argparse.Namespace) -> LogLevel:
-    if args.dry_run:
-        return LogLevel.DRY_RUN
-    elif args.quiet:
-        return LogLevel.NONE
-    elif args.verbose:
-        return LogLevel.ARGS
-    else:
-        return LogLevel.INFO
        
 def exec_on_node(
       args: argparse.Namespace,

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -497,7 +497,7 @@ def get_parsed_result(v_entry: Box, n_name: str, topology: Box, verbosity: int) 
 
   # Set up arguments for the 'netlab connect' command and execute it
   #
-  args = argparse.Namespace(quiet=True,host=n_name,output=True,show=v_cmd,verbose=False)
+  args = argparse.Namespace(quiet=True,output=True,show=v_cmd,verbose=False)
   result = connect_to_node(args=args,rest=[],topology=topology,node=n_name,log_level=LogLevel.NONE)
 
   if verbosity >= 3:                                        # Extra-verbose: print the results we got
@@ -546,7 +546,7 @@ def get_result_string(
 
   # Set up arguments for the 'netlab connect' command and execute it
   #
-  args = argparse.Namespace(quiet=True,host=n_name,output=True,show=None,verbose=False)
+  args = argparse.Namespace(quiet=True,output=True,show=None,verbose=False)
   result = connect_to_node(args=args,rest=v_cmd,topology=topology,node=n_name,log_level=LogLevel.NONE)
 
   if result is False:                                       # Report an error if 'netlab connect' failed

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -498,7 +498,7 @@ def get_parsed_result(v_entry: Box, n_name: str, topology: Box, verbosity: int) 
   # Set up arguments for the 'netlab connect' command and execute it
   #
   args = argparse.Namespace(quiet=True,host=n_name,output=True,show=v_cmd,verbose=False)
-  result = connect_to_node(args=args,rest=[],topology=topology,log_level=LogLevel.NONE)
+  result = connect_to_node(args=args,rest=[],topology=topology,node=n_name,log_level=LogLevel.NONE)
 
   if verbosity >= 3:                                        # Extra-verbose: print the results we got
     print(f'Executed {v_cmd} got {result}')
@@ -547,7 +547,7 @@ def get_result_string(
   # Set up arguments for the 'netlab connect' command and execute it
   #
   args = argparse.Namespace(quiet=True,host=n_name,output=True,show=None,verbose=False)
-  result = connect_to_node(args=args,rest=v_cmd,topology=topology,log_level=LogLevel.NONE)
+  result = connect_to_node(args=args,rest=v_cmd,topology=topology,node=n_name,log_level=LogLevel.NONE)
 
   if result is False:                                       # Report an error if 'netlab connect' failed
     if report_error:

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -498,7 +498,7 @@ def get_parsed_result(v_entry: Box, n_name: str, topology: Box, verbosity: int) 
   # Set up arguments for the 'netlab connect' command and execute it
   #
   args = argparse.Namespace(quiet=True,output=True,show=v_cmd,verbose=False)
-  result = connect_to_node(args=args,rest=[],topology=topology,node=n_name,log_level=LogLevel.NONE)
+  result = connect_to_node(node=n_name,args=args,rest=[],topology=topology,log_level=LogLevel.NONE)
 
   if verbosity >= 3:                                        # Extra-verbose: print the results we got
     print(f'Executed {v_cmd} got {result}')
@@ -547,7 +547,7 @@ def get_result_string(
   # Set up arguments for the 'netlab connect' command and execute it
   #
   args = argparse.Namespace(quiet=True,output=True,show=None,verbose=False)
-  result = connect_to_node(args=args,rest=v_cmd,topology=topology,node=n_name,log_level=LogLevel.NONE)
+  result = connect_to_node(node=n_name,args=args,rest=v_cmd,topology=topology,log_level=LogLevel.NONE)
 
   if result is False:                                       # Report an error if 'netlab connect' failed
     if report_error:


### PR DESCRIPTION
Synposis:
	netlab exec [-h] [-v] [-q] [--dry-run] [--snapshot [SNAPSHOT]]
	node

The rest of the arguments are passed to SSH or docker exec command.
Let my people go execing!

This is a draft pull request. It misses cosmetics and documentation.
It is also the first line of python I wrote in my life. So more merciless your review is it,  the better for me to learn this language.
I choose to duplicate ~24 lines of code. In the end is 0 maintenance burden.  It could have been refactored, but it works this way.
Error reporting is no better or worse than other part of netlab. It may be improved. 
Please use it. Break it. 

