### PR TITLE
STP module

### DIFF
--- a/docs/module-reference.md
+++ b/docs/module-reference.md
@@ -14,10 +14,12 @@ The following configuration modules are included in the **netlab** distribution:
    module/gateway.md
    module/routing.md
    module/isis.md
+   module/lag.md
    MPLS Configuration Module (LDP, BGP-LU, MPLS/VPN) <module/mpls.md>
    module/ospf.md
    module/ripv2.md
    module/sr-mpls.md
+   module/stp.md
    module/vrf.md
    module/vlan.md
    module/vxlan.md

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -20,7 +20,7 @@ The following table describes per-platform support of individual STP features:
 
 * **stp.enable** (bool) -- Enable STP. Optional, default: **True**.
 
-## Node Parameters
+## Node Parameters (global or per VLAN)
 
 * **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -9,8 +9,8 @@ The following table describes per-platform support of individual STP features:
 
 | Operating system   | STP | MSTP | RSTP | Per-VLAN RSTP (PVRST)
 | ------------------ | :-: | :--: | :--: | :------------------: |
-| Cumulus Linux      | ✅  |  ✅  |  ✅  |          ❌          ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |  ✅  |  ❌  |          ❌          ! Note: STP is disabled by default
+| Cumulus Linux      | ✅  |  ❌  |  ✅  |          ❌          ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |  ❌  |  ❌  |          ❌          ! Note: STP is disabled by default
 
 Note that in real networks MSTP ports fallback to regular STP upon receiving a plain STP BPDU; such a scenario cannot currently be replicated in Netlab, due to the single global default protocol being enforced.
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -7,10 +7,11 @@ Many platforms already support and enable STP by default; this module provides e
 
 The following table describes per-platform support of individual STP features:
 
-| Operating system   | STP | MSTP | RSTP | Per-VLAN RSTP (PVRST)
-| ------------------ | :-: | :--: | :--: | :------------------: |
-| Cumulus Linux      | ✅  |  ❌  |  ✅  |          ❌          ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |  ❌  |  ❌  |          ❌          ! Note: STP is disabled by default
+| Operating system   | STP | MSTP | RSTP | Per-VLAN RSTP | Enable per port
+| ------------------ | :-: | :--: | :--: | :-----------: | :--------------:
+| Arista EOS         | ✅  |  ✅  |  ✅  |      ✅       |       ✅        ! Note: STP is enabled by default, using MSTP
+| Cumulus Linux      | ✅  |  ❌  |  ✅  |      ❌       |       ❌        ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |  ❌  |  ❌  |      ❌       |       ✅        ! Note: STP is disabled by default
 
 Note that in real networks MSTP ports fallback to regular STP upon receiving a plain STP BPDU; such a scenario cannot currently be replicated in Netlab, due to the single global default protocol being enforced.
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -8,24 +8,34 @@ Many platforms already support and enable STP by default; this module provides e
 The following table describes per-platform support of individual STP features:
 
 | Operating system   | STP | MSTP | RSTP | Per-VLAN (R)STP | Enable per port
-| ------------------ | :-: | :--: | :--: | :-------------: | :--------------:
-| Arista EOS         | ✅  |  ✅  |  ✅  |       ✅        |       ✅      ! Note: STP is enabled by default, using MSTP
-| Cumulus Linux      | ✅  |  ❌  |  ✅  |       ❌        |       ✅      ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |  ❌  |  ❌  |       ✅        |       ❌      ! Note: STP is disabled by default
+| ------------------ |:---:|:---:|:---:|:---:|:---:|
+| Arista EOS[^EOS]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
+| Cumulus Linux[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
+| FRR[^FRR]          | ✅  |  ❌  |  ❌  |  ✅ | ❌   |
 
-Note that MSTP/RSTP ports fallback to regular STP upon receiving a plain STP BPDU.
+[^EOS]: MSTP is enabled by default
+[^CL]: STP is enabled by default
+[^FRR]: STP is disabled by default
+
+```{tip}
+MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
+```
 
 ## Global Parameters
 
 * **stp.protocol** (one of stp, mstp, rstp or pvrst) -- Global STP flavor to run on supporting nodes, default **stp**
 
-## Global, Node, Link and Interface Parameters
+## Global, Node, Link, Interface, and VLAN Parameters
 
-* **stp.enable** (bool) -- Enable STP. Optional, default: **True**. Set this to **False** explicitly to disable STP on platforms that enable it by default. Not responsible for loops created as a result...
+* **stp.enable** (bool) -- Enable STP. Optional, default: **True**. Set this to **False** explicitly to disable STP on platforms that enable it by default. We're not responsible for the loops you might get as a result.
+
+```{tip}
+You can set the **‌stp.enable** parameter in the **‌vlans** dictionary to enable per-VLAN STP.
+```
 
 ## Node Parameters (global or per VLAN)
 
-* **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
+* **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default, all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
 
 ## Interface Parameters
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -7,18 +7,20 @@ Many platforms already support and enable STP by default; this module provides e
 
 The following table describes per-platform support of individual STP features:
 
-| Operating system   | STP | Per-VLAN STP (PVRST)
-| ------------------ | :-: | :------------------: |
-| Cumulus Linux      | ✅  |         ❌           ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |         ✅           ! Note: STP is disabled by default
+| Operating system   | STP | MSTP | RSTP | Per-VLAN RSTP (PVRST)
+| ------------------ | :-: | :--: | :--: | :------------------: |
+| Cumulus Linux      | ✅  |  ✅  |  ✅  |          ❌          ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |  ✅  |  ❌  |          ❌          ! Note: STP is disabled by default
+
+Note that in real networks MSTP ports fallback to regular STP upon receiving a plain STP BPDU; such a scenario cannot currently be replicated in Netlab, due to the single global default protocol being enforced.
 
 ## Global Parameters
 
-* **stp.pvrst** (bool) -- Topology requires per-VLAN Rapid Spanning Tree Protocol, implies a feature check for all STP-enabled nodes
+* **stp.protocol** (one of stp, mstp, rstp or pvrst) -- Global STP flavor to run on supporting nodes, default **stp**
 
 ## Global, Node, Link and Interface Parameters
 
-* **stp.enable** (bool) -- Enable STP. Optional, default: **True**.
+* **stp.enable** (bool) -- Enable STP. Optional, default: **True**. Set this to **False** explicitly to disable STP on platforms that enable it by default. Not responsible for loops created as a result...
 
 ## Node Parameters (global or per VLAN)
 
@@ -26,6 +28,4 @@ The following table describes per-platform support of individual STP features:
 
 ## Interface Parameters
 
-* **stp.port_priority** (int 0..255, some platforms have lower max values) -- STP port priority for selecting between multiple ports; ports are blocked based on priority (lower value = higher priority)
-
-
+* **stp.port_priority** (int 0..255, some platforms have lower max values and/or require multiples of N) -- STP port priority for selecting between multiple ports; ports are blocked based on priority (lower value = higher priority). The priority is sent over the wire (4 bits) as the most significant part of the port ID; it is used by the node *receiving* it (!) to decide which port(s) to unblock.

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -1,0 +1,31 @@
+# STP Configuration Module
+
+This configuration module enables support for Spanning Tree Protocol (STP) to avoid loops by dynamically blocking ports.
+Many platforms already support and enable STP by default; this module provides explicit control over those settings
+
+## Platform Support
+
+The following table describes per-platform support of individual STP features:
+
+| Operating system   | STP | Per-VLAN STP (PVRST)
+| ------------------ | :-: | :------------------: |
+| Cumulus Linux      | ✅  |         ❌           ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |         ✅           ! Note: STP is disabled by default
+
+## Global Parameters
+
+* **stp.pvrst** (bool) -- Topology requires per-VLAN Rapid Spanning Tree Protocol, implies a feature check for all STP-enabled nodes
+
+## Global, Node, Link and Interface Parameters
+
+* **stp.enable** (bool) -- Enable STP. Optional, default: **True**.
+
+## Node Parameters
+
+* **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
+
+## Interface Parameters
+
+* **stp.port_priority** (int 0..255, some platforms have lower max values) -- STP port priority for selecting between multiple ports; ports are blocked based on priority (lower value = higher priority)
+
+

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -10,8 +10,8 @@ The following table describes per-platform support of individual STP features:
 | Operating system   | STP | MSTP | RSTP | Per-VLAN (R)STP | Enable per port
 | ------------------ | :-: | :--: | :--: | :-------------: | :--------------:
 | Arista EOS         | ✅  |  ✅  |  ✅  |       ✅        |       ✅      ! Note: STP is enabled by default, using MSTP
-| Cumulus Linux      | ✅  |  ❌  |  ✅  |       ❌        |       ❌      ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |  ❌  |  ❌  |       ✅        |       ✅      ! Note: STP is disabled by default
+| Cumulus Linux      | ✅  |  ❌  |  ✅  |       ❌        |       ✅      ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |  ❌  |  ❌  |       ✅        |       ❌      ! Note: STP is disabled by default
 
 Note that MSTP/RSTP ports fallback to regular STP upon receiving a plain STP BPDU.
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -7,13 +7,13 @@ Many platforms already support and enable STP by default; this module provides e
 
 The following table describes per-platform support of individual STP features:
 
-| Operating system   | STP | MSTP | RSTP | Per-VLAN RSTP | Enable per port
-| ------------------ | :-: | :--: | :--: | :-----------: | :--------------:
-| Arista EOS         | ✅  |  ✅  |  ✅  |      ✅       |       ✅        ! Note: STP is enabled by default, using MSTP
-| Cumulus Linux      | ✅  |  ❌  |  ✅  |      ❌       |       ❌        ! Note: STP is enabled by default, unless disabled through this module
-| FRR                | ✅  |  ❌  |  ❌  |      ❌       |       ✅        ! Note: STP is disabled by default
+| Operating system   | STP | MSTP | RSTP | Per-VLAN (R)STP | Enable per port
+| ------------------ | :-: | :--: | :--: | :-------------: | :--------------:
+| Arista EOS         | ✅  |  ✅  |  ✅  |       ✅        |       ✅      ! Note: STP is enabled by default, using MSTP
+| Cumulus Linux      | ✅  |  ❌  |  ✅  |       ❌        |       ❌      ! Note: STP is enabled by default, unless disabled through this module
+| FRR                | ✅  |  ❌  |  ❌  |       ✅        |       ✅      ! Note: STP is disabled by default
 
-Note that in real networks MSTP ports fallback to regular STP upon receiving a plain STP BPDU; such a scenario cannot currently be replicated in Netlab, due to the single global default protocol being enforced.
+Note that MSTP/RSTP ports fallback to regular STP upon receiving a plain STP BPDU.
 
 ## Global Parameters
 

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+set -e # Exit immediately when any command fails
+#
+
+#
+# Configure STP on the multi-vlan bridge
+#
+cat >/etc/network/interfaces.d/53-stp.intf <<CONFIG
+
+auto bridge
+iface bridge
+ bridge-stp {{ 'on' if stp.enable|default(True) else 'off' }}
+{% if 'priority' in stp %}
+ mstpctl-treeprio {{ stp.priority }}
+{% endif %}
+
+{#
+ # Disable STP on specific interfaces if requested, configure port priority
+ #}
+{% for ifdata in interfaces if ifdata.vlan is defined and 'stp' in ifdata  %}
+{%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
+iface {{ ifdata.ifname }}
+{%    if not ifdata.stp.enable|default(True) %}
+ mstpctl-portbpdufilter yes   # Disable STP on this port
+{%    elif 'port_priority' in ifdata.stp %}
+ mstpctl-treeportprio {{ ifdata.stp.port_priority }}
+{%    endif %} 
+{%   endif %}
+{% endfor %}
+CONFIG
+
+ifreload -a

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -22,21 +22,20 @@ iface bridge
 {#
  # Disable STP on specific interfaces if requested, configure port priority
  #}
-{% for ifdata in interfaces if ifdata.vlan is defined and 'stp' in ifdata  %}
-{%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
+{% for ifdata in interfaces if 'stp' in ifdata  %}
 iface {{ ifdata.ifname }}
-{%    if not ifdata.stp.enable|default(True) %}
+{%  if not ifdata.stp.enable|default(True) %}
  mstpctl-portbpdufilter yes   # Disable STP on this port
-{%    elif 'port_priority' in ifdata.stp %}
+{%  elif 'port_priority' in ifdata.stp %}
 #
 # Use 4x port_priority to get the same 4-bit value on the wire
 #
+{%     set restart_mstpd=True %}
  mstpctl-treeportprio {{ ifdata.stp.port_priority * 4 }}
 #
 # Newer versions 5.x support mstpctl-port-vlan-priority <vlan id>={{ ifdata.stp.port_priority }}
 #
-{%    endif %} 
-{%   endif %}
+{%  endif %}
 {% endfor %}
 CONFIG
 
@@ -46,4 +45,6 @@ ifreload -a
 # If STP port priority was changed, the system sends duplicate BDPUs with both the old and new port priority
 # This causes peers to remain in 'listening' state forever
 # Restart mstpd to fix that
+{% if restart_mstpd is defined %}
 service mstpd restart
+{% endif %}

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -11,6 +11,9 @@ cat >/etc/network/interfaces.d/53-stp.intf <<CONFIG
 auto bridge
 iface bridge
  bridge-stp {{ 'on' if stp.enable|default(True) else 'off' }}
+ #
+ # Newer versions support 'mstpctl-pvrst-mode yes' to enable PVRST
+ #
 {% if 'priority' in stp %}
  mstpctl-treeprio {{ stp.priority }}
 {% endif %}

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -11,8 +11,9 @@ cat >/etc/network/interfaces.d/53-stp.intf <<CONFIG
 auto bridge
 iface bridge
  bridge-stp {{ 'on' if stp.enable|default(True) else 'off' }}
+ mstpctl-forcevers stp {# Other options are rstp or mstp #}
  #
- # Newer versions support 'mstpctl-pvrst-mode yes' to enable PVRST
+ # Newer versions 5.x support 'mstpctl-pvrst-mode yes' to enable PVRST
  #
 {% if 'priority' in stp %}
  mstpctl-treeprio {{ stp.priority }}
@@ -27,10 +28,22 @@ iface {{ ifdata.ifname }}
 {%    if not ifdata.stp.enable|default(True) %}
  mstpctl-portbpdufilter yes   # Disable STP on this port
 {%    elif 'port_priority' in ifdata.stp %}
- mstpctl-treeportprio {{ ifdata.stp.port_priority }}
+#
+# Use 4x port_priority to get the same 4-bit value on the wire
+#
+ mstpctl-treeportprio {{ ifdata.stp.port_priority * 4 }}
+#
+# Newer versions 5.x support mstpctl-port-vlan-priority <vlan id>={{ ifdata.stp.port_priority }}
+#
 {%    endif %} 
 {%   endif %}
 {% endfor %}
 CONFIG
 
 ifreload -a
+
+#
+# If STP port priority was changed, the system sends duplicate BDPUs with both the old and new port priority
+# This causes peers to remain in 'listening' state forever
+# Restart mstpd to fix that
+service mstpd restart

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -11,7 +11,7 @@ cat >/etc/network/interfaces.d/53-stp.intf <<CONFIG
 auto bridge
 iface bridge
  bridge-stp {{ 'on' if stp.enable|default(True) else 'off' }}
- mstpctl-forcevers stp {# Other options are rstp or mstp #}
+ mstpctl-forcevers {{ stp.protocol }} {# options are stp, rstp or mstp #}
  #
  # Newer versions 5.x support 'mstpctl-pvrst-mode yes' to enable PVRST
  #

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -1,4 +1,11 @@
-spanning-tree mode {{ stp.protocol }} {# options are stp, rstp or mstp #}
+{% if not stp.enable|default(True) %}
+{%  set mode = "none" %}
+{% else %}
+{%  set proto_map = { 'stp': 'rstp', 'rstp': 'rstp', 'pvrst': 'rapid-pvst', 'mstp': 'mstp' } %}
+{%  set mode = proto_map[stp.protocol] %}
+{% endif %}
+{# options are 'none', rstp, rapid-pvst or mstp (default if not set) #}
+spanning-tree mode {{ mode }} 
 
 {% if 'priority' in stp %}
 spanning-tree priority {{ stp.priority }}

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -11,25 +11,29 @@ spanning-tree mode {{ mode }}
 spanning-tree priority {{ stp.priority }}
 {% endif %}
 
-{# Check for per-VLAN priority; implies Rapid-PVST #}
+{# Check for per-VLAN enable and priority; implies Rapid-PVST #}
 {% if vlans is defined %}
-{%   for vname,vdata in vlans.items() if 'stp' in vdata and vdata.stp.priority is defined %}
+{%   for vname,vdata in vlans.items() if 'stp' in vdata %}
+{%    if not vdata.stp.enable|default(True) %}
+no spanning-tree vlan-id {{ vdata.id }}
+{%    elif 'priority' in vdata.stp %}
 spanning-tree vlan-id {{ vdata.id }} priority {{ vdata.stp.priority }}
+{%    endif %}
 {%   endfor +%}
 {% endif %}
 
-{% for ifdata in interfaces if ifdata.vlan is defined and 'stp' in ifdata  %}
+{% for ifdata in interfaces if 'stp' in ifdata %}
 {%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
 interface {{ ifdata.ifname }}
 {%    if not ifdata.stp.enable|default(True) %}
- no spanning-tree vlan-id {{ ifdata.vlan.trunk_id }}   # Disable STP on this VLAN
+ ! Disable STP on this interface, i.e. dont receive or send BPDUs
+ spanning-tree bpdufilter enable
 {%    elif 'port_priority' in ifdata.stp %}
 #
 # Use 4x port_priority to get the same 4-bit value on the wire
 #
  spanning-tree port-priority {{ ifdata.stp.port_priority * 4 }}
 #
-{%     endif %} 
 {%    endif %} 
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -1,0 +1,20 @@
+spanning-tree mode {{ stp.protocol }} {# options are stp, rstp or mstp #}
+
+{% if 'priority' in stp %}
+spanning-tree priority {{ stp.priority }}
+{% endif %}
+
+{% for ifdata in interfaces if ifdata.vlan is defined and 'stp' in ifdata  %}
+{%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
+interface {{ ifdata.ifname }}
+{%    if not ifdata.stp.enable|default(True) %}
+ no spanning-tree vlan-id {{ ifdata.vlan.trunk_id }}   # Disable STP on this port
+{%    elif 'port_priority' in ifdata.stp %}
+#
+# Use 4x port_priority to get the same 4-bit value on the wire
+#
+ spanning-tree port-priority {{ ifdata.stp.port_priority * 4 }}
+#
+{%    endif %} 
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -11,16 +11,19 @@ spanning-tree mode {{ mode }}
 spanning-tree priority {{ stp.priority }}
 {% endif %}
 
+{# Check for per-VLAN priority; implies Rapid-PVST #}
+{% if vlans is defined %}
+{%   for vname,vdata in vlans.items() if 'stp' in vdata and vdata.stp.priority is defined %}
+spanning-tree vlan-id {{ vdata.id }} priority {{ vdata.stp.priority }}
+{%   endfor +%}
+{% endif %}
+
 {% for ifdata in interfaces if ifdata.vlan is defined and 'stp' in ifdata  %}
 {%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
 interface {{ ifdata.ifname }}
 {%    if not ifdata.stp.enable|default(True) %}
  no spanning-tree vlan-id {{ ifdata.vlan.trunk_id }}   # Disable STP on this VLAN
-{%    else %}
-{%     if 'priority' in ifdata.stp %}
- spanning-tree vlan-id {{ ifdata.vlan.trunk_id }} priority {{ ifdata.stp.priority }}
-{%     endif %}
-{%     if 'port_priority' in ifdata.stp %}
+{%    elif 'port_priority' in ifdata.stp %}
 #
 # Use 4x port_priority to get the same 4-bit value on the wire
 #

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -15,13 +15,18 @@ spanning-tree priority {{ stp.priority }}
 {%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
 interface {{ ifdata.ifname }}
 {%    if not ifdata.stp.enable|default(True) %}
- no spanning-tree vlan-id {{ ifdata.vlan.trunk_id }}   # Disable STP on this port
-{%    elif 'port_priority' in ifdata.stp %}
+ no spanning-tree vlan-id {{ ifdata.vlan.trunk_id }}   # Disable STP on this VLAN
+{%    else %}
+{%     if 'priority' in ifdata.stp %}
+ spanning-tree vlan-id {{ ifdata.vlan.trunk_id }} priority {{ ifdata.stp.priority }}
+{%     endif %}
+{%     if 'port_priority' in ifdata.stp %}
 #
 # Use 4x port_priority to get the same 4-bit value on the wire
 #
  spanning-tree port-priority {{ ifdata.stp.port_priority * 4 }}
 #
+{%     endif %} 
 {%    endif %} 
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/stp/frr.j2
+++ b/netsim/ansible/templates/stp/frr.j2
@@ -11,9 +11,9 @@ set -e # Exit immediately when any command fails
 brctl setportprio vlan{{ i.vlan.access_id }} {{ i.ifname }} {{ i.stp.port_priority }}
 {%    endif %}
 
-{# Check if priority defined at node level #}
-{%  elif i.type=='svi' and 'priority' in stp %}
-brctl setbridgeprio {{ i.ifname }} {{ stp.priority }}
+{# Check if priority defined at node or VLAN level #}
+{%  elif i.type=='svi' and (i.stp.priority is defined or 'priority' in stp) %}
+brctl setbridgeprio {{ i.ifname }} {{ i.stp.priority|default(stp.priority) }}
 {%  endif %}
 {% endfor %}
 

--- a/netsim/ansible/templates/stp/frr.j2
+++ b/netsim/ansible/templates/stp/frr.j2
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+set -e # Exit immediately when any command fails
+
+{# Configure STP priority on VLAN bridges and ports #}
+{% for i in interfaces %}
+
+{# Check if port_priority defined at link/interface level #}
+{%  if i.stp is defined and 'port_priority' in i.stp %}
+{%    if i.vlan.access_id is defined and i.vlan.mode|default('') != 'route' %}
+brctl setportprio vlan{{ i.vlan.access_id }} {{ i.ifname }} {{ i.stp.port_priority }}
+{%    endif %}
+
+{# Check if priority defined at node level #}
+{%  elif i.type=='svi' and 'priority' in stp %}
+brctl setbridgeprio {{ i.ifname }} {{ stp.priority }}
+{%  endif %}
+{% endfor %}
+
+exit 0

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -12,6 +12,12 @@ fi
 {% for i in interfaces if i.type == 'svi' %}
 if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   brctl addbr {{ i.ifname }}
+
+{# If STP is required, enable it before bringing up the bridge device to avoid any forwarding loops #}
+{%  if 'stp' in module|default([]) and (i.stp|default(stp)).enable|default(True) %}
+  brctl stp {{ i.ifname }} on
+{%  endif %}
+
   ip link set dev {{ i.ifname }} up
   ip addr flush dev {{ i.ifname }}
 {%   if 'ipv4' in i and (i.ipv4 is string or 'ipv4' in loopback) %}

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -93,8 +93,10 @@ features:
     community:
       expanded: True
   stp:
-    pvrst: False  # Platform supports it, but current implementation based on single VLAN-aware bridge does not
-    max_port_priority: 63
+    pvrst: False  # Platform supports it, but current implementation based on single VLAN-aware bridge does not in current (old) version
+    port_priority:
+      max: 240
+      multiple: 16
   vlan:
     model: switch
     svi_interface_name: "vlan{vlan}"

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -93,7 +93,8 @@ features:
     community:
       expanded: True
   stp:
-    pvrst: False  # Platform supports it, but current implementation based on single VLAN-aware bridge does not in current (old) version
+    supported_protocols: [stp,mstp,rstp] # Platform supports pvrst too, but current implementation based on single VLAN-aware bridge 
+                                         # does not in current (old) version
     port_priority:
       max: 240
       multiple: 16

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -92,6 +92,9 @@ features:
     aspath: True
     community:
       expanded: True
+  stp:
+    pvrst: False  # Platform supports it, but current implementation based on single VLAN-aware bridge does not
+    max_port_priority: 63
   vlan:
     model: switch
     svi_interface_name: "vlan{vlan}"

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -93,8 +93,8 @@ features:
     community:
       expanded: True
   stp:
-    supported_protocols: [stp,mstp,rstp] # Platform supports pvrst too, but current implementation based on single VLAN-aware bridge 
-                                         # does not in current (old) version
+    supported_protocols: [stp,rstp] # Platform supports pvrst too, but current implementation based on single VLAN-aware bridge 
+                                    # does not in current (old) version
     port_priority:
       max: 240
       multiple: 16

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -95,6 +95,7 @@ features:
   stp:
     supported_protocols: [stp,rstp] # Platform supports pvrst too, but current implementation based on single VLAN-aware bridge 
                                     # does not in current (old) version
+    enable_per_port: True
     port_priority:
       max: 240
       multiple: 16

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -72,6 +72,11 @@ features:
     community:
       expanded: True
   sr: true
+  stp:
+    supported_protocols: [stp,rstp,mstp,pvrst] # See https://www.arista.com/assets/data/pdf/Whitepapers/STPInteroperabilitywithCisco.pdf
+    port_priority:
+      max: 240
+      multiple: 16
   vlan:
     model: l3-switch
     native_routed: true

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -74,6 +74,7 @@ features:
   sr: true
   stp:
     supported_protocols: [stp,rstp,mstp,pvrst] # See https://www.arista.com/assets/data/pdf/Whitepapers/STPInteroperabilitywithCisco.pdf
+    enable_per_port: True
     port_priority:
       max: 240
       multiple: 16

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -107,6 +107,7 @@ features:
   sr: true
   stp:
     supported_protocols: [stp]  # Implementation uses a separate bridge per VLAN
+    enable_per_port: False
     port_priority:
       max: 63
   vlan:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -107,7 +107,8 @@ features:
   sr: true
   stp:
     pvrst: True  # Implementation uses a separate bridge per VLAN
-    max_port_priority: 63
+    port_priority:
+      max: 63
   vlan:
     mixed_trunk: true
     model: router

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -106,7 +106,7 @@ features:
       expanded: True
   sr: true
   stp:
-    supported_protocols: [stp]  # Implementation uses a separate bridge per VLAN
+    supported_protocols: [stp,pvrst]  # Implementation uses a separate bridge per VLAN
     enable_per_port: False
     port_priority:
       max: 63

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -106,7 +106,7 @@ features:
       expanded: True
   sr: true
   stp:
-    supported_protocols: [stp,mstp]  # Implementation uses a separate bridge per VLAN
+    supported_protocols: [stp]  # Implementation uses a separate bridge per VLAN
     port_priority:
       max: 63
   vlan:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -106,7 +106,7 @@ features:
       expanded: True
   sr: true
   stp:
-    pvrst: True  # Implementation uses a separate bridge per VLAN
+    supported_protocols: [stp,mstp]  # Implementation uses a separate bridge per VLAN
     port_priority:
       max: 63
   vlan:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -105,6 +105,9 @@ features:
     community:
       expanded: True
   sr: true
+  stp:
+    pvrst: True  # Implementation uses a separate bridge per VLAN
+    max_port_priority: 63
   vlan:
     mixed_trunk: true
     model: router

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -1,0 +1,35 @@
+#
+# STP transformation module
+#
+from box import Box
+
+from ..augment import devices
+from ..utils import log
+
+from . import _Module
+
+class STP(_Module):
+
+  # Check for device support when pvrst is required
+  def node_pre_transform(self, node: Box, topology: Box) -> None:
+
+    if not topology.stp.get('pvrst',False):
+      return
+
+    if not 'stp' in node.get('module',[]):
+      return
+    
+    features = devices.get_device_features(node,topology.defaults)
+
+    if not 'stp' in features:
+      log.error(
+        f'node {node.name} (device {node.device}) does not support STP module',
+        log.IncorrectValue,
+        'stp')
+      return
+
+    if not features.stp.get('pvrst',False):
+      log.error(
+        f'node {node.name} (device {node.device}) does not support per-VLAN STP (PVRST)',
+        log.IncorrectValue,
+        'stp')

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -33,3 +33,31 @@ class STP(_Module):
         f'node {node.name} (device {node.device}) does not support per-VLAN STP (PVRST)',
         log.IncorrectValue,
         'stp')
+
+  # Check max port_priority values
+  def node_post_transform(self, node: Box, topology: Box) -> None:
+    if not 'stp' in node.get('module',[]):
+      return
+    features = devices.get_device_features(node,topology.defaults)
+
+    priority = node.get('stp.priority',0)
+    if priority and (priority % 4096):
+        log.error(
+            f'node {node.name} (device {node.device}) stp.priority: {priority} must be a multiple of 4096',
+            log.IncorrectValue,
+            'stp')
+
+    port_priority = features.get('stp.port_priority', { 'max': 255 } )
+    for intf in node.get('interfaces',[]):
+      if 'stp' in intf:
+        val = intf.get('stp.port_priority',0)
+        if val > port_priority.max:
+          log.error(
+            f'node {node.name} (device {node.device}) only supports stp.port_priority up to {port_priority.max}, found {val}',
+            log.IncorrectValue,
+            'stp')
+        elif 'multiple' in port_priority and (val % port_priority.multiple):
+          log.error(
+            f'node {node.name} (device {node.device}) stp.port_priority {val} must be a multiple of {port_priority.multiple}',
+            log.IncorrectValue,
+            'stp')

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -61,3 +61,11 @@ class STP(_Module):
             f'node {node.name} (device {node.device}) stp.port_priority {val} must be a multiple of {port_priority.multiple}',
             log.IncorrectValue,
             'stp')
+        
+        # Check if per-VLAN priority is being used
+        if intf.type=='svi' and 'priority' in intf.stp:
+          if not features.stp.get('pvrst',False):
+            log.error(
+              f'node {node.name} (device {node.device}) does not support per-VLAN STP (PVRST) used on VLAN {intf.name}',
+              log.IncorrectValue,
+              'stp')

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -53,16 +53,17 @@ class STP(_Module):
           log.IncorrectValue,
           'stp')
       
-      # Check if per-VLAN priority is being used
-      if intf.type=='svi' and 'priority' in intf.stp:
+    # Check if per-VLAN priority is being used
+    for vname,vdata in node.get('vlans',{}).items():
+      if vdata.get('stp.priority',None):
         stp_proto = topology.get('stp.protocol','stp')
-        if stp_proto != 'mstp':
+        if stp_proto != 'pvrst':
           log.error(
-            f'Topology requires per-VLAN STP (MSTP) used on VLAN {intf.name} but global default is {stp_proto}',
+            f"Topology requires per-VLAN STP (pvrst) used on VLAN '{vname}' but global default is '{stp_proto}'",
             log.IncorrectValue,
             'stp')
-        elif not 'mstp' in features.get('stp.supported_protocols',[]):
+        elif not 'pvrst' in features.get('stp.supported_protocols',[]):
           log.error(
-            f'node {node.name} (device {node.device}) does not support per-VLAN STP (MSTP) used on VLAN {intf.name}',
+            f"node {node.name} (device {node.device}) does not support per-VLAN STP (pvrst) used on VLAN '{vname}'",
             log.IncorrectValue,
             'stp')

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -52,6 +52,12 @@ class STP(_Module):
           f'node {node.name} (device {node.device}) stp.port_priority {val} must be a multiple of {port_priority.multiple}',
           log.IncorrectValue,
           'stp')
+
+      if 'enable' in intf.stp and not features.get('stp.enable_per_port',False):
+        log.error(
+          f'node {node.name} (device {node.device}) does not support enabling/disabling STP only on a specific port ({intf.ifname})',
+          log.IncorrectValue,
+          'stp')
       
     # Check if per-VLAN priority is being used
     for vname,vdata in node.get('vlans',{}).items():

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -24,7 +24,7 @@ attributes:
 _top:               # Modification of global defaults
   attributes:
     node_vlan:
-      priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node
+      stp.priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node
 
 features:
   mstp: Multiple Spanning Tree Protocol  # On Linux, STP + VLAN-aware bridge is interoperable with MSTP

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -34,3 +34,4 @@ _top:               # Modification of global defaults
 
 features:
   supported_protocols: Subset of supported STP variants
+  enable_per_port: Whether the device supports port level granularity for enable/disable

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -21,7 +21,7 @@ attributes:
   link:
     enable:
      copy: global
-  node_copy: [ enable ]
+  # node_copy: [ enable ]  # controlled at node vlan level, don't copy to interfaces
   interface:
     enable: bool
     port_priority: { type: int, min_value: 0, max_value: 255 } # Used in determining root/designated ports, some platforms use lower max
@@ -30,7 +30,7 @@ attributes:
 _top:               # Modification of global defaults
   attributes:
     node_vlan:
-      stp.priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node, implies mstp
+      stp.priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node, implies pvrst
 
 features:
   supported_protocols: Subset of supported STP variants

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -4,27 +4,33 @@
 requires: [ vlan ]  # Perhaps not on all platforms
 transform_after: [ vlan ]
 config_after: [ vlan ]
-no_propagate: [ pvrst ]
+no_propagate: [ protocol ]
 
 enable: True        # By default, enable STP everywhere (on all bridges created by Netlab) when this module is used
+protocol: "stp"     # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
 
 attributes:
   global:
     enable: bool
-    pvrst: bool      # Topology requires Per-VLAN Rapid Spanning Tree (802.1w)
+    protocol: { type: str, valid_values: [stp,rstp,mstp,pvrst] }  # mstp = IEEE 802.1s, pvrst = Per-VLAN Rapid Spanning Tree (802.1w)
   node:
-    enable: bool
+    enable:
+      copy: global
+    # protocol: By design Netlab enforces a single, consistent variant of STP on all supporting nodes
     priority: { type: int, min_value: 0, max_value: 61440 }    # Increments of 4096, default 32768, lower value = higher priority
+  link:
+    enable:
+     copy: global
+  node_copy: [ enable ]
   interface:
     enable: bool
     port_priority: { type: int, min_value: 0, max_value: 255 } # Used in determining root/designated ports, some platforms use lower max
-  link:
-    enable: bool
+
 
 _top:               # Modification of global defaults
   attributes:
     node_vlan:
-      stp.priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node
+      stp.priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node, implies mstp
 
 features:
-  mstp: Multiple Spanning Tree Protocol  # On Linux, STP + VLAN-aware bridge is interoperable with MSTP
+  supported_protocols: Subset of supported STP variants

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -4,7 +4,7 @@
 requires: [ vlan ]  # Perhaps not on all platforms
 transform_after: [ vlan ]
 config_after: [ vlan ]
-no_propagate: [ protocol ]
+# no_propagate: [ protocol ]
 
 enable: True        # By default, enable STP everywhere (on all bridges created by Netlab) when this module is used
 protocol: "stp"     # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
@@ -16,8 +16,8 @@ attributes:
   node:
     enable:
       copy: global
-    # protocol: By design Netlab enforces a single, consistent variant of STP on all supporting nodes
     priority: { type: int, min_value: 0, max_value: 61440 }    # Increments of 4096, default 32768, lower value = higher priority
+    protocol:
   link:
     enable:
      copy: global

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -1,0 +1,30 @@
+# STP default settings and attributes
+#
+---
+requires: [ vlan ]  # Perhaps not on all platforms
+transform_after: [ vlan ]
+config_after: [ vlan ]
+no_propagate: [ pvrst ]
+
+enable: True        # By default, enable STP everywhere (on all bridges created by Netlab) when this module is used
+
+attributes:
+  global:
+    enable: bool
+    pvrst: bool      # Topology requires Per-VLAN Rapid Spanning Tree (802.1w)
+  node:
+    enable: bool
+    priority: { type: int, min_value: 0, max_value: 61440 }    # Increments of 4096, default 32768, lower value = higher priority
+  interface:
+    enable: bool
+    port_priority: { type: int, min_value: 0, max_value: 255 } # Used in determining root/designated ports, some platforms use lower max
+  link:
+    enable: bool
+
+_top:               # Modification of global defaults
+  attributes:
+    node_vlan:
+      priority: { type: int, min_value: 0, max_value: 61440 }  # Per-VLAN STP priority for this node
+
+features:
+  mstp: Multiple Spanning Tree Protocol  # On Linux, STP + VLAN-aware bridge is interoperable with MSTP

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -51,7 +51,6 @@ attributes:
     vlan:
     mtu:
     bandwidth:
-    stp:
     _selfloop_ifindex:
     stp:
   #

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -40,7 +40,7 @@ attributes:
   #vlan_svi_no_propagate:
   #  gateway:
   #
-  # Do not copy these attributes into SVI interfaces
+  # Do not copy these attributes into SVI interfaces, and don't pop() them
   phy_ifattr:
     bridge:
     ifindex:
@@ -53,6 +53,7 @@ attributes:
     bandwidth:
     stp:
     _selfloop_ifindex:
+    stp:
   #
   # Keep these subinterface attributes
   keep_subif:

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -28,6 +28,7 @@ attributes:
     mode:
     prefix:
     evpn:
+    stp:
 
   # Copy these attributes from node VLAN data into interface-on-link data
   copy_vlan_to_intf:

--- a/tests/errors/invalid-module.log
+++ b/tests/errors/invalid-module.log
@@ -1,5 +1,5 @@
 IncorrectValue in topology: attribute nodes.r2.module has invalid value(s): whatever
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,stp,vlan,vrf,vxlan
 IncorrectValue in topology: attribute module has invalid value(s): provider
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,stp,vlan,vrf,vxlan
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/module-missing-prerequisite.log
+++ b/tests/errors/module-missing-prerequisite.log
@@ -1,3 +1,3 @@
 IncorrectValue in topology: attribute nodes.r1.module has invalid value(s): mody
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,modx,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,modx,mpls,ospf,ripv2,routing,sr,srv6,stp,vlan,vrf,vxlan
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/validate-list.log
+++ b/tests/errors/validate-list.log
@@ -1,5 +1,5 @@
 IncorrectValue in groups: attribute groups.g1.module has invalid value(s): a
-... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,vlan,vrf,vxlan
+... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,stp,vlan,vrf,vxlan
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
 ... use 'netlab show attributes group' to display valid attributes
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary

--- a/tests/integration/stp/01-vlan-loop-single.yml
+++ b/tests/integration/stp/01-vlan-loop-single.yml
@@ -1,0 +1,36 @@
+---
+message: |
+  The devices under test form a connected triangle (loop) without IP addresses
+  in the red VLAN
+
+  h1 and h2 should be able to ping each other, and no forwarding loop should occur
+
+  The bridge with the highest priority (s1) should become the root, the link s2-s3 should get blocked
+  Use ```docker exec -it clab-stp-s3 /usr/sbin/brctl showstp vlan1000``` to verify
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1, s2, s3 ]
+    module: [ vlan, stp ]
+
+nodes:
+ s1:
+  stp.priority: 1024  # High STP bridge priority (low value) -> becomes root
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2, s1-s2, s1-s3, s2-s3 ]
+
+validate:
+  ping:
+    description: Pinging H2 from H1
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')

--- a/tests/integration/stp/01-vlan-loop-single.yml
+++ b/tests/integration/stp/01-vlan-loop-single.yml
@@ -20,7 +20,7 @@ groups:
 
 nodes:
  s1:
-  stp.priority: 1024  # High STP bridge priority (low value) -> becomes root
+  stp.priority: 4096  # High STP bridge priority (low value) -> becomes root
 
 vlans:
   red:

--- a/tests/integration/stp/02-vlan-loop-multiple.yml
+++ b/tests/integration/stp/02-vlan-loop-multiple.yml
@@ -2,11 +2,16 @@
 message: |
   The devices under test form a connected triangle (loop) with 2 VLANs. 
   
-  If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do
+  If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do.
+  Per-VLAN priority settings should make S1 root for red, and S2 for blue VLAN
 
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
+
+  For FRR, use
+  ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` and
+  ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001``` and
 
 stp.pvrst: True # Topology requires running STP per VLAN
 
@@ -27,6 +32,12 @@ vlans:
   blue:
     mode: bridge
     links: [ s1-h3, s3-h4, s1-s3, s2-s3 ]  # NOT s1-s2
+
+nodes:
+ s1:
+  vlans.red.stp.priority: 4096   # Test per-VLAN priority
+ s2:
+  vlans.blue.stp.priority: 4096
 
 validate:
   ping_red:

--- a/tests/integration/stp/02-vlan-loop-multiple.yml
+++ b/tests/integration/stp/02-vlan-loop-multiple.yml
@@ -1,0 +1,47 @@
+---
+message: |
+  The devices under test form a connected triangle (loop) with 2 VLANs. 
+  
+  If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+
+stp.pvrst: True # Topology requires running STP per VLAN
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2,s3 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2, s1-s2, s2-s3 ]  # NOT s1-s3
+  blue:
+    mode: bridge
+    links: [ s1-h3, s3-h4, s1-s3, s2-s3 ]  # NOT s1-s2
+
+validate:
+  ping_red:
+    description: Ping-based reachability test in VLAN red
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping_blue:
+    description: Ping-based reachability test in VLAN blue
+    nodes: [ h3 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 20
+    plugin: ping('h4')
+  inter_vlan:
+    description: Ping-based reachability test between blue and red VLANs
+    nodes: [ h1 ]
+    plugin: ping('h3',expect='fail')

--- a/tests/integration/stp/02-vlan-loop-multiple.yml
+++ b/tests/integration/stp/02-vlan-loop-multiple.yml
@@ -28,10 +28,21 @@ groups:
 vlans:
   red:
     mode: bridge
-    links: [ s1-h1, s2-h2, s1-s2, s2-s3 ]  # NOT s1-s3
+    links: [ s1-h1, s2-h2, s1-s2 ]  # NOT s1-s3
   blue:
     mode: bridge
-    links: [ s1-h3, s3-h4, s1-s3, s2-s3 ]  # NOT s1-s2
+    links: [ s1-h3, s3-h4, s1-s3 ]  # NOT s1-s2
+
+links:
+- s2:
+  s3:
+  # vlan.trunk: [ red, blue ]
+  vlan.access: red
+
+- s2:
+  s3:
+  # vlan.trunk: [ red, blue ]
+  vlan.access: blue
 
 nodes:
  s1:

--- a/tests/integration/stp/02-vlan-loop-multiple.yml
+++ b/tests/integration/stp/02-vlan-loop-multiple.yml
@@ -13,7 +13,7 @@ message: |
   ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` and
   ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001``` and
 
-stp.pvrst: True # Topology requires running STP per VLAN
+stp.protocol: mstp # Topology requires running STP per VLAN
 
 groups:
   _auto_create: True

--- a/tests/integration/stp/03-vlan-multi-link.yml
+++ b/tests/integration/stp/03-vlan-multi-link.yml
@@ -7,6 +7,7 @@ message: |
   The bridge with the highest priority (s2) should become the root, all but one port should get blocked by S1 in order of port priority
   For FRR, use ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` to verify
   Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
+  cEOS: ```docker exec -it clab-stp-s2 Cli -c "show spanning-tree"```
 
 groups:
   _auto_create: True

--- a/tests/integration/stp/03-vlan-multi-link.yml
+++ b/tests/integration/stp/03-vlan-multi-link.yml
@@ -30,11 +30,11 @@ vlans:
     - s2-h2
     # Dual link between s1/s2
     - s1:
-       stp.port_priority: 16  # S1 uses this link to send to S2, unless it is down
       s2:
-    - s1:
        stp.port_priority: 32  # Backup link (lower priority)
+    - s1:
       s2:
+       stp.port_priority: 16  # Sent to S1 which should cause it to select this link as root port
 
 validate:
   ping:

--- a/tests/integration/stp/03-vlan-multi-link.yml
+++ b/tests/integration/stp/03-vlan-multi-link.yml
@@ -1,0 +1,45 @@
+---
+message: |
+  The devices under test have multiple links between them which form a loop unless STP blocks all but one
+
+  h1 and h2 should be able to ping each other, and no forwarding loop should occur
+
+  The bridge with the highest priority (s2) should become the root, all but one port should get blocked by S1 in order of port priority
+  For FRR, use ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` to verify
+  Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1, s2 ]
+    module: [ vlan, stp ]
+
+nodes:
+ s2:
+  stp.priority: 4096  # High STP bridge priority (low value) -> becomes root
+
+vlans:
+  red:
+    mode: bridge
+    links: 
+    - s1-h1
+    - s2-h2
+    # Dual link between s1/s2
+    - s1:
+       stp.port_priority: 1  # S1 uses this link to send to S2, unless it is down
+      s2:
+    - s1:
+       stp.port_priority: 2
+      s2:
+
+validate:
+  ping:
+    description: Pinging H2 from H1
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')

--- a/tests/integration/stp/03b-vlan-multi-link-no-stp.yml
+++ b/tests/integration/stp/03b-vlan-multi-link-no-stp.yml
@@ -8,6 +8,8 @@ message: |
   For FRR, use ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` to verify
   Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
 
+  This test removes the STP module, and relies on Cumulus' default configuration (it fails)
+
 groups:
   _auto_create: True
   hosts:
@@ -16,25 +18,27 @@ groups:
     provider: clab
   switches:
     members: [ s1, s2 ]
-    module: [ vlan, stp ]
-
-nodes:
- s2:
-  stp.priority: 4096  # High STP bridge priority (low value) -> becomes root
+    module: [ vlan ]
 
 vlans:
   red:
     mode: bridge
-    links:
-    - s1-h1
-    - s2-h2
-    # Dual link between s1/s2
-    - s1:
-       stp.port_priority: 16  # S1 uses this link to send to S2, unless it is down
-      s2:
-    - s1:
-       stp.port_priority: 32  # Backup link (lower priority)
-      s2:
+    links: [ s1-h1, s2-h2 ]
+  untagged:
+    id: 1
+    mode: bridge
+
+links: # Dual link between s1/s2
+- s1:
+   # stp.port_priority: 1  # S1 uses this link to send to S2, unless it is down
+  s2:
+  vlan.trunk: [ untagged, red ]  # Must be a trunk allowing packets on VLAN 1 for this topology to work on Cumulus
+  vlan.native: untagged
+- s1:
+   # stp.port_priority: 2
+  s2:
+  vlan.trunk: [ untagged, red ]
+  vlan.native: untagged
 
 validate:
   ping:

--- a/tests/integration/stp/04-disable-stp.yml
+++ b/tests/integration/stp/04-disable-stp.yml
@@ -1,0 +1,59 @@
+---
+message: |
+  The devices under test form a connected triangle (loop) with 2 VLANs. 
+
+  Since the VLANs themselves don't form a loop, STP can be disabled (making sure untagged packets are disallowed using a trunk)
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+
+stp.enable: False
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2,s3 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2 ]
+  blue:
+    mode: bridge
+    links: [ s1-h3, s3-h4 ]
+
+links:
+- s1:
+  s2:
+  vlan.trunk: [red]
+- s1:
+  s3:
+  vlan.trunk: [blue]
+- s2:
+  s3:
+  vlan.trunk: [red,blue]
+  vlan.native: red       # Disallow untagged packets on this link to break the native loop
+
+validate:
+  ping_red:
+    description: Ping-based reachability test in VLAN red
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping_blue:
+    description: Ping-based reachability test in VLAN blue
+    nodes: [ h3 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 20
+    plugin: ping('h4')
+  inter_vlan:
+    description: Ping-based reachability test between blue and red VLANs
+    nodes: [ h1 ]
+    plugin: ping('h3',expect='fail')

--- a/tests/integration/stp/05-mstp.yml
+++ b/tests/integration/stp/05-mstp.yml
@@ -1,0 +1,59 @@
+---
+message: |
+  The devices under test form a connected triangle (loop) with 2 VLANs. 
+
+  Since the VLANs themselves don't form a loop, STP can be disabled (making sure untagged packets are disallowed using a trunk)
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+
+stp.protocol: mstp
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2,s3 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2 ]
+  blue:
+    mode: bridge
+    links: [ s1-h3, s3-h4 ]
+
+links:
+- s1:
+  s2:
+  vlan.trunk: [red]
+- s1:
+  s3:
+  vlan.trunk: [blue]
+- s2:
+  s3:
+  vlan.trunk: [red,blue]
+  vlan.native: red       # Disallow untagged packets on this link to break the native loop
+
+validate:
+  ping_red:
+    description: Ping-based reachability test in VLAN red
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping_blue:
+    description: Ping-based reachability test in VLAN blue
+    nodes: [ h3 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 20
+    plugin: ping('h4')
+  inter_vlan:
+    description: Ping-based reachability test between blue and red VLANs
+    nodes: [ h1 ]
+    plugin: ping('h3',expect='fail')

--- a/tests/integration/stp/06-disable-stp-per-vlan.yml
+++ b/tests/integration/stp/06-disable-stp-per-vlan.yml
@@ -1,19 +1,15 @@
 ---
 message: |
   The devices under test form a connected triangle (loop) with 2 VLANs. 
-  
-  If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do.
-  Per-VLAN priority settings should make S1 root for red, and S2 for blue VLAN
+
+  Since the VLANs themselves don't form a loop, STP can be disabled (making sure untagged packets are disallowed using a trunk).
+  However, in this test we enable STP on the blue VLAN just in case
 
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
 
-  For FRR, use
-  ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` and
-  ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001``` and
-
-stp.protocol: pvrst # Topology requires running STP per VLAN
+stp.enable: True # Globally enabled
 
 groups:
   _auto_create: True
@@ -28,27 +24,23 @@ groups:
 vlans:
   red:
     mode: bridge
-    links: [ s1-h1, s2-h2, s1-s2 ]  # NOT s1-s3
+    links: [ s1-h1, s2-h2 ]
+    stp.enable: False # Disable on 'red' VLAN
   blue:
     mode: bridge
-    links: [ s1-h3, s3-h4, s1-s3 ]  # NOT s1-s2
+    links: [ s1-h3, s3-h4 ]
 
 links:
+- s1:
+  s2:
+  vlan.trunk: [red]
+- s1:
+  s3:
+  vlan.trunk: [blue]
 - s2:
   s3:
-  # vlan.trunk: [ red, blue ]
-  vlan.access: red
-
-- s2:
-  s3:
-  # vlan.trunk: [ red, blue ]
-  vlan.access: blue
-
-nodes:
- s1:
-  vlans.red.stp.priority: 4096   # Test per-VLAN priority
- s2:
-  vlans.blue.stp.priority: 4096
+  vlan.trunk: [red,blue]
+  vlan.native: red       # Disallow untagged packets on this link to break the native loop
 
 validate:
   ping_red:

--- a/tests/integration/stp/06-disable-stp-per-vlan.yml
+++ b/tests/integration/stp/06-disable-stp-per-vlan.yml
@@ -35,6 +35,7 @@ links:
   s2:
   vlan.trunk: [red]
 - s1:
+   stp.enable: False # Disable on this blue port too
   s3:
   vlan.trunk: [blue]
 - s2:

--- a/tests/integration/stp/06-disable-stp-per-vlan.yml
+++ b/tests/integration/stp/06-disable-stp-per-vlan.yml
@@ -9,6 +9,10 @@ message: |
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
 
+  Checks:
+  cEOS: ```docker exec -it clab-stp-s2 Cli -c "show spanning-tree"```
+  Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
+
 stp.enable: True # Globally enabled
 
 groups:
@@ -42,10 +46,14 @@ links:
   s3:
   vlan.trunk: [red,blue]
   vlan.native: red       # Disallow untagged packets on this link to break the native loop
+- s2:
+   stp.enable: False # Disable on a port without a VLAN
+  s3:
+  pool: l2only
 
 validate:
   ping_red:
-    description: Ping-based reachability test in VLAN red
+    description: Ping-based reachability test in VLAN red h1->s1->s2->h2 (STP disabled)
     nodes: [ h1 ]
     wait_msg: Waiting for STP to enable the ports
     wait: 45

--- a/tests/topology/expected/stp-mstp.yml
+++ b/tests/topology/expected/stp-mstp.yml
@@ -1,0 +1,811 @@
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+    node_data:
+      provider: clab
+  switches:
+    members:
+    - s1
+    - s2
+    - s3
+    module:
+    - vlan
+    - stp
+input:
+- topology/input/stp-mstp.yml
+- package:topology-defaults.yml
+libvirt:
+  providers:
+    clab: true
+links:
+- bridge: input_1
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 1
+    ifname: swp1
+    node: s1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 1
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_2
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 1
+    ifname: swp1
+    node: s2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_3
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: swp2
+    node: s1
+    vlan:
+      access: red
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: swp2
+    node: s2
+    vlan:
+      access: red
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_4
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: swp3
+    node: s2
+    vlan:
+      access: red
+  - _vlan_mode: bridge
+    ifindex: 1
+    ifname: swp1
+    node: s3
+    vlan:
+      access: red
+  linkindex: 4
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_5
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: swp3
+    node: s1
+    vlan:
+      access: blue
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.5/24
+    node: h3
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 5
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_6
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: swp2
+    node: s3
+    vlan:
+      access: blue
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.6/24
+    node: h4
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 6
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_7
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 4
+    ifname: swp4
+    node: s1
+    vlan:
+      access: blue
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: swp3
+    node: s3
+    vlan:
+      access: blue
+  linkindex: 7
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_8
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 4
+    ifname: swp4
+    node: s2
+    vlan:
+      access: blue
+  - _vlan_mode: bridge
+    ifindex: 4
+    ifname: swp4
+    node: s3
+    vlan:
+      access: blue
+  linkindex: 8
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+module:
+- vlan
+- stp
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h1/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h1
+    id: 3
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 1
+      mtu: 1500
+      name: h1 -> [s1,s2,h2,s3]
+      neighbors:
+      - ifname: vlan1000
+        node: s1
+      - ifname: vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: vlan1000
+        node: s3
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    mtu: 1500
+    name: h1
+    provider: clab
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h2/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h2
+    id: 4
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      linkindex: 2
+      mtu: 1500
+      name: h2 -> [h1,s1,s2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: vlan1000
+        node: s1
+      - ifname: vlan1000
+        node: s2
+      - ifname: vlan1000
+        node: s3
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    mtu: 1500
+    name: h2
+    provider: clab
+    role: host
+  h3:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h3/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h3
+    id: 5
+    interfaces:
+    - bridge: input_5
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.5/24
+      linkindex: 5
+      mtu: 1500
+      name: h3 -> [s1,s3,s2,h4]
+      neighbors:
+      - ifname: vlan1001
+        node: s1
+      - ifname: vlan1001
+        node: s3
+      - ifname: vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
+    mtu: 1500
+    name: h3
+    provider: clab
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h4/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h4
+    id: 6
+    interfaces:
+    - bridge: input_6
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.6/24
+      linkindex: 6
+      mtu: 1500
+      name: h4 -> [h3,s1,s3,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: vlan1001
+        node: s1
+      - ifname: vlan1001
+        node: s3
+      - ifname: vlan1001
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.106
+      mac: 08:4f:a9:00:00:06
+    mtu: 1500
+    name: h4
+    provider: clab
+    role: host
+  s1:
+    af:
+      ipv4: true
+    box: CumulusCommunity/cumulus-vx:4.4.5
+    device: cumulus
+    id: 1
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: swp1
+      linkindex: 1
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_3
+      ifindex: 2
+      ifname: swp2
+      linkindex: 3
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_5
+      ifindex: 3
+      ifname: swp3
+      linkindex: 5
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_7
+      ifindex: 4
+      ifname: swp4
+      linkindex: 7
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1000
+      name: VLAN red (1000) -> [h1,s2,h2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: vlan1000
+        node: s3
+      stp:
+        enable: true
+        priority: 4096
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      name: VLAN blue (1001) -> [h3,s3,s2,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: vlan1001
+        node: s3
+      - ifname: vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      stp:
+        enable: true
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vlan
+    - stp
+    mtu: 1500
+    name: s1
+    stp:
+      enable: true
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        stp:
+          priority: 4096
+  s2:
+    af:
+      ipv4: true
+    box: CumulusCommunity/cumulus-vx:4.4.5
+    device: cumulus
+    id: 2
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: swp1
+      linkindex: 2
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_3
+      ifindex: 2
+      ifname: swp2
+      linkindex: 3
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      ifindex: 3
+      ifname: swp3
+      linkindex: 4
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_8
+      ifindex: 4
+      ifname: swp4
+      linkindex: 8
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1000
+      name: VLAN red (1000) -> [h1,s1,h2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: vlan1000
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: vlan1000
+        node: s3
+      stp:
+        enable: true
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      name: VLAN blue (1001) -> [h3,s1,s3,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: vlan1001
+        node: s1
+      - ifname: vlan1001
+        node: s3
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      stp:
+        enable: true
+        priority: 4096
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - vlan
+    - stp
+    mtu: 1500
+    name: s2
+    stp:
+      enable: true
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+        stp:
+          priority: 4096
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s3:
+    af:
+      ipv4: true
+    box: CumulusCommunity/cumulus-vx:4.4.5
+    device: cumulus
+    id: 7
+    interfaces:
+    - bridge: input_4
+      ifindex: 1
+      ifname: swp1
+      linkindex: 4
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_6
+      ifindex: 2
+      ifname: swp2
+      linkindex: 6
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_7
+      ifindex: 3
+      ifname: swp3
+      linkindex: 7
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_8
+      ifindex: 4
+      ifname: swp4
+      linkindex: 8
+      mtu: 1500
+      stp:
+        enable: true
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: vlan1000
+      name: VLAN red (1000) -> [h1,s1,s2,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: vlan1000
+        node: s1
+      - ifname: vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      stp:
+        enable: true
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 6
+      ifname: vlan1001
+      name: VLAN blue (1001) -> [h3,s1,s2,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: vlan1001
+        node: s1
+      - ifname: vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      stp:
+        enable: true
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.7/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.107
+      mac: 08:4f:a9:00:00:07
+    module:
+    - vlan
+    - stp
+    mtu: 1500
+    name: s3
+    stp:
+      enable: true
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+provider: libvirt
+stp:
+  enable: true
+  protocol: mstp
+vlans:
+  blue:
+    host_count: 2
+    id: 1001
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.1.5/24
+      node: h3
+    - ifname: vlan1001
+      node: s1
+    - ifname: vlan1001
+      node: s3
+    - ifname: vlan1001
+      node: s2
+    - ifname: eth1
+      ipv4: 172.16.1.6/24
+      node: h4
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.1.0/24
+  red:
+    host_count: 2
+    id: 1000
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: vlan1000
+      node: s1
+    - ifname: vlan1000
+      node: s2
+    - ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    - ifname: vlan1000
+      node: s3
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/expected/stp-mstp.yml
+++ b/tests/topology/expected/stp-mstp.yml
@@ -23,11 +23,34 @@ libvirt:
   providers:
     clab: true
 links:
-- bridge: input_1
+- interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s2
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s3
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
+  linkindex: 1
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      blue: {}
+      red: {}
+- bridge: input_2
   interfaces:
   - _vlan_mode: bridge
     ifindex: 1
-    ifname: swp1
+    ifname: Ethernet1
     node: s1
     vlan:
       access: red
@@ -35,29 +58,6 @@ links:
     ifname: eth1
     ipv4: 172.16.0.3/24
     node: h1
-  libvirt:
-    provider:
-      clab: true
-  linkindex: 1
-  node_count: 2
-  prefix:
-    allocation: id_based
-    ipv4: 172.16.0.0/24
-  type: lan
-  vlan:
-    access: red
-- bridge: input_2
-  interfaces:
-  - _vlan_mode: bridge
-    ifindex: 1
-    ifname: swp1
-    node: s2
-    vlan:
-      access: red
-  - ifindex: 1
-    ifname: eth1
-    ipv4: 172.16.0.4/24
-    node: h2
   libvirt:
     provider:
       clab: true
@@ -73,16 +73,17 @@ links:
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
-    ifname: swp2
-    node: s1
-    vlan:
-      access: red
-  - _vlan_mode: bridge
-    ifindex: 2
-    ifname: swp2
+    ifname: Ethernet2
     node: s2
     vlan:
       access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  libvirt:
+    provider:
+      clab: true
   linkindex: 3
   node_count: 2
   prefix:
@@ -94,15 +95,15 @@ links:
 - bridge: input_4
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 3
-    ifname: swp3
-    node: s2
+    ifindex: 2
+    ifname: Ethernet2
+    node: s1
     vlan:
       access: red
   - _vlan_mode: bridge
-    ifindex: 1
-    ifname: swp1
-    node: s3
+    ifindex: 3
+    ifname: Ethernet3
+    node: s2
     vlan:
       access: red
   linkindex: 4
@@ -117,7 +118,7 @@ links:
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3
-    ifname: swp3
+    ifname: Ethernet3
     node: s1
     vlan:
       access: blue
@@ -140,7 +141,7 @@ links:
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
-    ifname: swp2
+    ifname: Ethernet2
     node: s3
     vlan:
       access: blue
@@ -163,39 +164,17 @@ links:
   interfaces:
   - _vlan_mode: bridge
     ifindex: 4
-    ifname: swp4
+    ifname: Ethernet4
     node: s1
     vlan:
       access: blue
   - _vlan_mode: bridge
     ifindex: 3
-    ifname: swp3
+    ifname: Ethernet3
     node: s3
     vlan:
       access: blue
   linkindex: 7
-  node_count: 2
-  prefix:
-    allocation: id_based
-    ipv4: 172.16.1.0/24
-  type: lan
-  vlan:
-    access: blue
-- bridge: input_8
-  interfaces:
-  - _vlan_mode: bridge
-    ifindex: 4
-    ifname: swp4
-    node: s2
-    vlan:
-      access: blue
-  - _vlan_mode: bridge
-    ifindex: 4
-    ifname: swp4
-    node: s3
-    vlan:
-      access: blue
-  linkindex: 8
   node_count: 2
   prefix:
     allocation: id_based
@@ -222,22 +201,22 @@ nodes:
     hostname: clab-input-h1
     id: 3
     interfaces:
-    - bridge: input_1
+    - bridge: input_2
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.3/24
-      linkindex: 1
+      linkindex: 2
       mtu: 1500
       name: h1 -> [s1,s2,h2,s3]
       neighbors:
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s1
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
         node: h2
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s3
       type: lan
     mgmt:
@@ -262,22 +241,22 @@ nodes:
     hostname: clab-input-h2
     id: 4
     interfaces:
-    - bridge: input_2
+    - bridge: input_3
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
-      linkindex: 2
+      linkindex: 3
       mtu: 1500
       name: h2 -> [h1,s1,s2,s3]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h1
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s1
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s2
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s3
       type: lan
     mgmt:
@@ -310,11 +289,11 @@ nodes:
       mtu: 1500
       name: h3 -> [s1,s3,s2,h4]
       neighbors:
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s1
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s2
       - ifname: eth1
         ipv4: 172.16.1.6/24
@@ -353,11 +332,11 @@ nodes:
       - ifname: eth1
         ipv4: 172.16.1.5/24
         node: h3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s1
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s2
       type: lan
     mgmt:
@@ -371,26 +350,24 @@ nodes:
   s1:
     af:
       ipv4: true
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: arista/veos
+    device: eos
     id: 1
     interfaces:
-    - bridge: input_1
+    - bridge: input_2
       ifindex: 1
-      ifname: swp1
-      linkindex: 1
-      mtu: 1500
+      ifname: Ethernet1
+      linkindex: 2
       stp:
         enable: true
       type: lan
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_3
+    - bridge: input_4
       ifindex: 2
-      ifname: swp2
-      linkindex: 3
-      mtu: 1500
+      ifname: Ethernet2
+      linkindex: 4
       stp:
         enable: true
       type: lan
@@ -399,9 +376,8 @@ nodes:
         access_id: 1000
     - bridge: input_5
       ifindex: 3
-      ifname: swp3
+      ifname: Ethernet3
       linkindex: 5
-      mtu: 1500
       stp:
         enable: true
       type: lan
@@ -410,9 +386,8 @@ nodes:
         access_id: 1001
     - bridge: input_7
       ifindex: 4
-      ifname: swp4
+      ifname: Ethernet4
       linkindex: 7
-      mtu: 1500
       stp:
         enable: true
       type: lan
@@ -421,18 +396,18 @@ nodes:
         access_id: 1001
     - bridge_group: 1
       ifindex: 5
-      ifname: vlan1000
+      ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s2,h2,s3]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h1
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s2
       - ifname: eth1
         ipv4: 172.16.0.4/24
         node: h2
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s3
       stp:
         enable: true
@@ -444,15 +419,15 @@ nodes:
         name: red
     - bridge_group: 2
       ifindex: 6
-      ifname: vlan1001
+      ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s3,s2,h4]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.5/24
         node: h3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s2
       - ifname: eth1
         ipv4: 172.16.1.6/24
@@ -466,22 +441,22 @@ nodes:
         name: blue
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: eth0
+      ifname: Management1
       ipv4: 192.168.121.101
       mac: 08:4f:a9:00:00:01
     module:
     - vlan
     - stp
-    mtu: 1500
     name: s1
     stp:
       enable: true
+      protocol: mstp
     vlan:
       max_bridge_group: 2
     vlans:
@@ -504,26 +479,31 @@ nodes:
   s2:
     af:
       ipv4: true
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: arista/veos
+    device: eos
     id: 2
     interfaces:
-    - bridge: input_2
-      ifindex: 1
-      ifname: swp1
-      linkindex: 2
-      mtu: 1500
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s2 -> s3
+      neighbors:
+      - ifname: Ethernet1
+        node: s3
       stp:
         enable: true
-      type: lan
+      type: p2p
       vlan:
-        access: red
-        access_id: 1000
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
     - bridge: input_3
       ifindex: 2
-      ifname: swp2
+      ifname: Ethernet2
       linkindex: 3
-      mtu: 1500
       stp:
         enable: true
       type: lan
@@ -532,40 +512,28 @@ nodes:
         access_id: 1000
     - bridge: input_4
       ifindex: 3
-      ifname: swp3
+      ifname: Ethernet3
       linkindex: 4
-      mtu: 1500
       stp:
         enable: true
       type: lan
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_8
-      ifindex: 4
-      ifname: swp4
-      linkindex: 8
-      mtu: 1500
-      stp:
-        enable: true
-      type: lan
-      vlan:
-        access: blue
-        access_id: 1001
     - bridge_group: 1
-      ifindex: 5
-      ifname: vlan1000
+      ifindex: 6
+      ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h2,s3]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h1
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s1
       - ifname: eth1
         ipv4: 172.16.0.4/24
         node: h2
-      - ifname: vlan1000
+      - ifname: Vlan1000
         node: s3
       stp:
         enable: true
@@ -575,16 +543,16 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 6
-      ifname: vlan1001
+      ifindex: 7
+      ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s3,h4]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.5/24
         node: h3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s1
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s3
       - ifname: eth1
         ipv4: 172.16.1.6/24
@@ -599,22 +567,22 @@ nodes:
         name: blue
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: eth0
+      ifname: Management1
       ipv4: 192.168.121.102
       mac: 08:4f:a9:00:00:02
     module:
     - vlan
     - stp
-    mtu: 1500
     name: s2
     stp:
       enable: true
+      protocol: mstp
     vlan:
       max_bridge_group: 2
     vlans:
@@ -637,26 +605,31 @@ nodes:
   s3:
     af:
       ipv4: true
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: arista/veos
+    device: eos
     id: 7
     interfaces:
-    - bridge: input_4
-      ifindex: 1
-      ifname: swp1
-      linkindex: 4
-      mtu: 1500
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s3 -> s2
+      neighbors:
+      - ifname: Ethernet1
+        node: s2
       stp:
         enable: true
-      type: lan
+      type: p2p
       vlan:
-        access: red
-        access_id: 1000
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
     - bridge: input_6
       ifindex: 2
-      ifname: swp2
+      ifname: Ethernet2
       linkindex: 6
-      mtu: 1500
       stp:
         enable: true
       type: lan
@@ -665,20 +638,8 @@ nodes:
         access_id: 1001
     - bridge: input_7
       ifindex: 3
-      ifname: swp3
+      ifname: Ethernet3
       linkindex: 7
-      mtu: 1500
-      stp:
-        enable: true
-      type: lan
-      vlan:
-        access: blue
-        access_id: 1001
-    - bridge: input_8
-      ifindex: 4
-      ifname: swp4
-      linkindex: 8
-      mtu: 1500
       stp:
         enable: true
       type: lan
@@ -686,38 +647,16 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 5
-      ifname: vlan1000
-      name: VLAN red (1000) -> [h1,s1,s2,h2]
-      neighbors:
-      - ifname: eth1
-        ipv4: 172.16.0.3/24
-        node: h1
-      - ifname: vlan1000
-        node: s1
-      - ifname: vlan1000
-        node: s2
-      - ifname: eth1
-        ipv4: 172.16.0.4/24
-        node: h2
-      stp:
-        enable: true
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: bridge
-        name: red
-    - bridge_group: 2
       ifindex: 6
-      ifname: vlan1001
+      ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s2,h4]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.5/24
         node: h3
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s1
-      - ifname: vlan1001
+      - ifname: Vlan1001
         node: s2
       - ifname: eth1
         ipv4: 172.16.1.6/24
@@ -729,36 +668,58 @@ nodes:
       vlan:
         mode: bridge
         name: blue
+    - bridge_group: 2
+      ifindex: 7
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,s1,s2,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: Vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      stp:
+        enable: true
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.7/32
       neighbors: []
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: eth0
+      ifname: Management1
       ipv4: 192.168.121.107
       mac: 08:4f:a9:00:00:07
     module:
     - vlan
     - stp
-    mtu: 1500
     name: s3
     stp:
       enable: true
+      protocol: mstp
     vlan:
       max_bridge_group: 2
     vlans:
       blue:
-        bridge_group: 2
+        bridge_group: 1
         id: 1001
         mode: bridge
         prefix:
           allocation: id_based
           ipv4: 172.16.1.0/24
       red:
-        bridge_group: 1
+        bridge_group: 2
         id: 1000
         mode: bridge
         prefix:
@@ -777,11 +738,11 @@ vlans:
     - ifname: eth1
       ipv4: 172.16.1.5/24
       node: h3
-    - ifname: vlan1001
+    - ifname: Vlan1001
       node: s1
-    - ifname: vlan1001
+    - ifname: Vlan1001
       node: s3
-    - ifname: vlan1001
+    - ifname: Vlan1001
       node: s2
     - ifname: eth1
       ipv4: 172.16.1.6/24
@@ -797,14 +758,14 @@ vlans:
     - ifname: eth1
       ipv4: 172.16.0.3/24
       node: h1
-    - ifname: vlan1000
+    - ifname: Vlan1000
       node: s1
-    - ifname: vlan1000
+    - ifname: Vlan1000
       node: s2
     - ifname: eth1
       ipv4: 172.16.0.4/24
       node: h2
-    - ifname: vlan1000
+    - ifname: Vlan1000
       node: s3
     prefix:
       allocation: id_based

--- a/tests/topology/expected/stp-pvrst.yml
+++ b/tests/topology/expected/stp-pvrst.yml
@@ -1,0 +1,738 @@
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+    node_data:
+      provider: clab
+  switches:
+    members:
+    - s1
+    - s2
+    - s3
+    module:
+    - vlan
+    - stp
+input:
+- topology/input/stp-pvrst.yml
+- package:topology-defaults.yml
+libvirt:
+  providers:
+    clab: true
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s2
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s3
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
+  linkindex: 1
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      blue: {}
+      red: {}
+- bridge: input_2
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 1
+    ifname: Ethernet1
+    node: s1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_3
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_4
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s1
+    vlan:
+      access: red
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: Ethernet3
+    node: s2
+    vlan:
+      access: red
+  linkindex: 4
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- bridge: input_5
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: Ethernet3
+    node: s1
+    vlan:
+      access: blue
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.5/24
+    node: h3
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 5
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_6
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s3
+    vlan:
+      access: blue
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.6/24
+    node: h4
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 6
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- bridge: input_7
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 4
+    ifname: Ethernet4
+    node: s1
+    vlan:
+      access: blue
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: Ethernet3
+    node: s3
+    vlan:
+      access: blue
+  linkindex: 7
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+module:
+- vlan
+- stp
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h1/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h1
+    id: 3
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 2
+      mtu: 1500
+      name: h1 -> [s1,s2,h2,s3]
+      neighbors:
+      - ifname: Vlan1000
+        node: s1
+      - ifname: Vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        node: s3
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    mtu: 1500
+    name: h1
+    provider: clab
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h2/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h2
+    id: 4
+    interfaces:
+    - bridge: input_3
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      linkindex: 3
+      mtu: 1500
+      name: h2 -> [h1,s1,s2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: Vlan1000
+        node: s2
+      - ifname: Vlan1000
+        node: s3
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    mtu: 1500
+    name: h2
+    provider: clab
+    role: host
+  h3:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h3/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h3
+    id: 5
+    interfaces:
+    - bridge: input_5
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.5/24
+      linkindex: 5
+      mtu: 1500
+      name: h3 -> [s1,s3,s2,h4]
+      neighbors:
+      - ifname: Vlan1001
+        node: s1
+      - ifname: Vlan1001
+        node: s3
+      - ifname: Vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
+    mtu: 1500
+    name: h3
+    provider: clab
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h4/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h4
+    id: 6
+    interfaces:
+    - bridge: input_6
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.6/24
+      linkindex: 6
+      mtu: 1500
+      name: h4 -> [h3,s1,s3,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: Vlan1001
+        node: s1
+      - ifname: Vlan1001
+        node: s3
+      - ifname: Vlan1001
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.106
+      mac: 08:4f:a9:00:00:06
+    mtu: 1500
+    name: h4
+    provider: clab
+    role: host
+  s1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 1
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 4
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_5
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 5
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_7
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 7
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 5
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,s2,h2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        node: s3
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 6
+      ifname: Vlan1001
+      name: VLAN blue (1001) -> [h3,s3,s2,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: Vlan1001
+        node: s3
+      - ifname: Vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vlan
+    - stp
+    name: s1
+    stp:
+      enable: true
+      protocol: pvrst
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        stp:
+          priority: 4096
+  s2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s2 -> s3
+      neighbors:
+      - ifname: Ethernet1
+        node: s3
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
+    - bridge: input_3
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 3
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 4
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 6
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,s1,h2,s3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        node: s3
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 7
+      ifname: Vlan1001
+      name: VLAN blue (1001) -> [h3,s1,s3,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: Vlan1001
+        node: s1
+      - ifname: Vlan1001
+        node: s3
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - vlan
+    - stp
+    name: s2
+    stp:
+      enable: true
+      protocol: pvrst
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+        stp:
+          priority: 4096
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s3:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 7
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: s3 -> s2
+      neighbors:
+      - ifname: Ethernet1
+        node: s2
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
+    - bridge: input_6
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 6
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge: input_7
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 7
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 6
+      ifname: Vlan1001
+      name: VLAN blue (1001) -> [h3,s1,s2,h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.5/24
+        node: h3
+      - ifname: Vlan1001
+        node: s1
+      - ifname: Vlan1001
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.1.6/24
+        node: h4
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    - bridge_group: 2
+      ifindex: 7
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,s1,s2,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: Vlan1000
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.7/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.107
+      mac: 08:4f:a9:00:00:07
+    module:
+    - vlan
+    - stp
+    name: s3
+    stp:
+      enable: true
+      protocol: pvrst
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 1
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 2
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+provider: libvirt
+stp:
+  enable: true
+  protocol: pvrst
+vlans:
+  blue:
+    host_count: 2
+    id: 1001
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.1.5/24
+      node: h3
+    - ifname: Vlan1001
+      node: s1
+    - ifname: Vlan1001
+      node: s3
+    - ifname: Vlan1001
+      node: s2
+    - ifname: eth1
+      ipv4: 172.16.1.6/24
+      node: h4
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.1.0/24
+  red:
+    host_count: 2
+    id: 1000
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: Vlan1000
+      node: s1
+    - ifname: Vlan1000
+      node: s2
+    - ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    - ifname: Vlan1000
+      node: s3
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/stp-mstp.yml
+++ b/tests/topology/input/stp-mstp.yml
@@ -1,0 +1,27 @@
+---
+defaults.device: cumulus
+stp.protocol: mstp # Topology requires running STP per VLAN
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2,s3 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2, s1-s2, s2-s3 ]  # NOT s1-s3
+  blue:
+    mode: bridge
+    links: [ s1-h3, s3-h4, s1-s3, s2-s3 ]  # NOT s1-s2
+
+nodes:
+ s1:
+  vlans.red.stp.priority: 4096   # Test per-VLAN priority
+ s2:
+  vlans.blue.stp.priority: 4096

--- a/tests/topology/input/stp-mstp.yml
+++ b/tests/topology/input/stp-mstp.yml
@@ -1,5 +1,5 @@
 ---
-defaults.device: cumulus
+defaults.device: eos
 stp.protocol: mstp # Topology requires running STP per VLAN
 
 groups:
@@ -15,10 +15,15 @@ groups:
 vlans:
   red:
     mode: bridge
-    links: [ s1-h1, s2-h2, s1-s2, s2-s3 ]  # NOT s1-s3
+    links: [ s1-h1, s2-h2, s1-s2 ]  # NOT s1-s3
   blue:
     mode: bridge
-    links: [ s1-h3, s3-h4, s1-s3, s2-s3 ]  # NOT s1-s2
+    links: [ s1-h3, s3-h4, s1-s3 ]  # NOT s1-s2
+
+links:
+- s2:
+  s3:
+  vlan.trunk: [red,blue]
 
 nodes:
  s1:

--- a/tests/topology/input/stp-pvrst.yml
+++ b/tests/topology/input/stp-pvrst.yml
@@ -1,6 +1,6 @@
 ---
 defaults.device: eos
-stp.protocol: mstp # Topology requires running STP per VLAN
+stp.protocol: pvrst  # Topology requires running STP per VLAN
 
 groups:
   _auto_create: True


### PR DESCRIPTION
* Brings enable/disable STP under Netlab control
* ```stp.protocol```: One of ```stp```(default),```mstp```,```rstp```,```pvrst```, global flavor to run on all supporting nodes
* ```stp.priority``` for setting bridge priority
* ```stp.port_priority``` for selecting between multiple local interfaces

PR modifies FRR vlan template to enable STP before the bridge is enabled, to prevent loops also during startup. A slight violation of modularity, but warranted imho

Cumulus container was found to start sending duplicate BPDUs with both old and new port priority values, requiring a mstpd daemon restart to restore sanity

```
## Platform Support

The following table describes per-platform support of individual STP features:

| Operating system   | STP | MSTP | RSTP | Per-VLAN (R)STP | Enable per port
| ------------------ | :-: | :--: | :--: | :-------------: | :--------------:
| Arista EOS         | ✅  |  ✅  |  ✅  |       ✅        |       ✅      ! Note: STP is enabled by default, using MSTP
| Cumulus Linux      | ✅  |  ❌  |  ✅  |       ❌        |       ✅      ! Note: STP is enabled by default, unless disabled through this module
| FRR                | ✅  |  ❌  |  ❌  |       ✅        |       ❌      ! Note: STP is disabled by default
```