### PR TITLE
Add exec command to usage.txt.

### DIFF
--- a/netsim/cli/usage.txt
+++ b/netsim/cli/usage.txt
@@ -29,6 +29,8 @@ down        Destroy the virtual lab
 
 capture     Start packet capture on the specified node/interface
 
+exec        Executes a command on one or more network devices
+
 Reports and graphs
 ==================
 status      Display the state of lab instances running on the current server


### PR DESCRIPTION
Add exec command to usage.txt. Ensures that the new exec command is listed in the usage banner when netlab command is invoked without any parameters.

This  one slipped between the cracks yesterday. 