### PR TITLE
Be extra pedantic about IP address values

### DIFF
--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -52,9 +52,9 @@ interface {{ l.ifname }}
     Set interface IPv4 addresses
 #}
 {% if 'ipv4' in l %}
-{%   if l.ipv4 == True %}
+{%   if l.ipv4 is sameas True %}
  ip address unnumbered {{ l._parent_intf }}
-{%   elif l.ipv4|ipv4 %}
+{%   elif l.ipv4 is string and l.ipv4|ipv4 %}
  ip address {{ l.ipv4 }}
 {%   else %}
 ! Invalid IPv4 address {{ l.ipv4 }}
@@ -65,9 +65,9 @@ interface {{ l.ifname }}
 #}
 {% if 'ipv6' in l %}
  ipv6 nd ra interval 5
-{%   if l.ipv6 == True %}
+{%   if l.ipv6 is sameas True %}
  ipv6 enable
-{%   elif l.ipv6|ipv6 %}
+{%   elif l.ipv6 is string and l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
 {%   else %}
 ! Invalid IPv6 address {{ l.ipv6 }}


### PR DESCRIPTION
Errors in transformation logic can lead to ```int``` type values being passed to templates.

As it turns out, ```ipv4``` believes ```1``` is a perfectly valid IP address -  this PR correctly marks it as "invalid"