### PR TITLE
#1418 - vrrp no preempt needs to be explicit on cEOS

### DIFF
--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -92,6 +92,6 @@ More complex topologies, such as multiple VRRPv3 instances *on the same subnet*,
 
 * **vrrp.group** (default: 1) -- VRRP group
 * **vrrp.priority** (interface parameter, integer)
-* **vrrp.preempt** (interface parameter, boolean)
+* **vrrp.preempt** (interface parameter, boolean) -- VRRP preempting is enabled by default; you can disable it with **vrrp.preempt: False**.
 
 No other aspect of VRRP (VRRP version, timers...) is manageable through *netlab* parameters; if you want to configure them, create a plugin to implement additional VRRP functionality.

--- a/netsim/ansible/templates/gateway/arubacx.j2
+++ b/netsim/ansible/templates/gateway/arubacx.j2
@@ -30,7 +30,7 @@ interface {{ intf.ifname }}
   address fe80::1 primary
   address {{ intf.gateway[af]|ipaddr('address') }} secondary
 {%       endif %}
-{%       if intf.gateway.vrrp.preempt|default(False) %}
+{%       if intf.gateway.vrrp.preempt|default(True) %}
   preempt
 {%       else %}
   no preempt

--- a/netsim/ansible/templates/gateway/cumulus.j2
+++ b/netsim/ansible/templates/gateway/cumulus.j2
@@ -26,6 +26,8 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     else %}
+  no vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     endif %}
 {% endfor %}
 do write

--- a/netsim/ansible/templates/gateway/cumulus.j2
+++ b/netsim/ansible/templates/gateway/cumulus.j2
@@ -24,7 +24,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
   vrrp {{ intf.gateway.vrrp.group }} priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(False) %}
+{%     if intf.gateway.vrrp.preempt|default(True) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     else %}
   no vrrp {{ intf.gateway.vrrp.group }} preempt

--- a/netsim/ansible/templates/gateway/dellos10.j2
+++ b/netsim/ansible/templates/gateway/dellos10.j2
@@ -35,7 +35,7 @@ interface {{ intf.ifname }}
 {%       if 'priority' in intf.gateway.vrrp %}
     priority {{ intf.gateway.vrrp.priority }}
 {%       endif %}
-{%       if not intf.gateway.vrrp.preempt|default(False) %}
+{%       if not intf.gateway.vrrp.preempt|default(True) %}
     no preempt
 {%       endif %}
 {%     endfor %}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -21,6 +21,8 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     else %}
+  no vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -19,7 +19,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
   vrrp {{ intf.gateway.vrrp.group }} priority-level {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(True) %}
+{%     if intf.gateway.vrrp.preempt|default(False) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     else %}
   no vrrp {{ intf.gateway.vrrp.group }} preempt

--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -19,7 +19,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
   vrrp {{ intf.gateway.vrrp.group }} priority-level {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(False) %}
+{%     if intf.gateway.vrrp.preempt|default(True) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     else %}
   no vrrp {{ intf.gateway.vrrp.group }} preempt

--- a/netsim/ansible/templates/gateway/frr.vrrp-config.j2
+++ b/netsim/ansible/templates/gateway/frr.vrrp-config.j2
@@ -6,7 +6,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
   vrrp {{ intf.gateway.vrrp.group }} priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(False) %}
+{%     if intf.gateway.vrrp.preempt|default(True) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     else %}
   no vrrp {{ intf.gateway.vrrp.group }} preempt

--- a/netsim/ansible/templates/gateway/frr.vrrp-config.j2
+++ b/netsim/ansible/templates/gateway/frr.vrrp-config.j2
@@ -8,6 +8,8 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
   vrrp {{ intf.gateway.vrrp.group }} preempt
+{%     else %}
+  no vrrp {{ intf.gateway.vrrp.group }} preempt
 {%     endif %}
 {%   for af in 'ipv4','ipv6' if af in intf.gateway %}
   vrrp {{ intf.gateway.vrrp.group }} {{ af|replace('ipv4','ip') }} {{ intf.gateway[af]|ipaddr('address') }}

--- a/netsim/ansible/templates/gateway/ios.j2
+++ b/netsim/ansible/templates/gateway/ios.j2
@@ -16,6 +16,8 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
     preempt
+{%     else %}
+    no preempt
 {%     endif %}
 {%     endfor %}
 {%   endif %}

--- a/netsim/ansible/templates/gateway/ios.j2
+++ b/netsim/ansible/templates/gateway/ios.j2
@@ -14,7 +14,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
     priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(False) %}
+{%     if intf.gateway.vrrp.preempt|default(True) %}
     preempt
 {%     else %}
     no preempt

--- a/netsim/ansible/templates/gateway/nxos.j2
+++ b/netsim/ansible/templates/gateway/nxos.j2
@@ -18,6 +18,8 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%     if intf.gateway.vrrp.preempt|default(False) %}
     preempt
+{%     else %}
+    no preempt
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/gateway/nxos.j2
+++ b/netsim/ansible/templates/gateway/nxos.j2
@@ -16,7 +16,7 @@ interface {{ intf.ifname }}
 {%     if 'priority' in intf.gateway.vrrp %}
     priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if intf.gateway.vrrp.preempt|default(False) %}
+{%     if intf.gateway.vrrp.preempt|default(True) %}
     preempt
 {%     else %}
     no preempt

--- a/netsim/ansible/templates/gateway/sros.j2
+++ b/netsim/ansible/templates/gateway/sros.j2
@@ -22,7 +22,7 @@ updates:
       mac: {{ intf.gateway.anycast.mac|hwaddr('linux') }}
 {%    endif %}
 {%    if intf.gateway.protocol == 'vrrp' %}
-      preempt: {{ intf.gateway.vrrp.preempt|default(False)|bool }}
+      preempt: {{ intf.gateway.vrrp.preempt|default(True)|bool }}
 {%     if 'priority' in intf.gateway.vrrp %}
       priority: {{ intf.gateway.vrrp.priority }}
 {%     endif %}

--- a/netsim/ansible/templates/gateway/vyos.j2
+++ b/netsim/ansible/templates/gateway/vyos.j2
@@ -19,7 +19,7 @@ set high-availability vrrp group {{ vrrp_name }} address {{ intf.gateway[af] }}
 {%     if 'priority' in intf.gateway.vrrp %}
 set high-availability vrrp group {{ vrrp_name }} priority {{ intf.gateway.vrrp.priority }}
 {%     endif %}
-{%     if not intf.gateway.vrrp.preempt|default(False) %}
+{%     if not intf.gateway.vrrp.preempt|default(True) %}
 set high-availability vrrp group {{ vrrp_name }} no-preempt
 {%     endif %}
 


### PR DESCRIPTION
#1418 - simple tweak to force the `no vrrp <group> preempt`