### PR TITLE
Fix: copy select node VLAN data into intf data before link transform

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -789,7 +789,7 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
                                                                             # Overwrite interface settings with VLAN settings
       vlan_ifdata = vlan_ifdata + {
                       k:v for k,v in vlan_data.items()
-                        if k not in svi_skipattr and
+                        if k not in svi_skipattr and k not in copy_attr and
                            (v is not True or k not in vlan_ifdata) }
       fix_vlan_mode_attribute(vlan_ifdata)
       node.interfaces.append(vlan_ifdata)                                   # ... and add SVI interface to list of node interfaces
@@ -1279,6 +1279,29 @@ class VLAN(_Module):
 
   def module_pre_link_transform(self, topology: Box) -> None:
     create_loopback_vlan_links(topology)
+
+  # We need to copy a few attributes from node VLAN data into access link interface data, for example
+  # the node IPv4/IPv6 address (to support static addressing) and "gateway" attribute to enable
+  # selective VLAN gateway module activation
+  #
+  # This operation needs to be done when the link data structures have already been transformed into
+  # the canonical "interfaces" list format, so we cannot do it any sooner than this point.
+  #
+  def link_pre_link_transform(self, link: Box, topology: Box) -> None:
+    if 'vlan' not in link:
+      return
+
+    for intf in link.interfaces:
+      vname = intf.get('vlan.access',None)
+      if not vname:
+        continue
+      if vname not in topology.nodes[intf.node].get('vlans',{}):
+        continue
+      vdata = topology.nodes[intf.node].vlans[vname]
+      for attr in topology.defaults.vlan.attributes.copy_vlan_to_intf:
+        if attr not in vdata:
+          continue
+        intf[attr] = vdata[attr]
 
   def module_post_link_transform(self, topology: Box) -> None:
     for n in topology.nodes.values():

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1299,9 +1299,8 @@ class VLAN(_Module):
         continue
       vdata = topology.nodes[intf.node].vlans[vname]
       for attr in topology.defaults.vlan.attributes.copy_vlan_to_intf:
-        if attr not in vdata:
-          continue
-        intf[attr] = vdata[attr]
+        if attr in vdata:
+          intf[attr] = vdata[attr]
 
   def module_post_link_transform(self, topology: Box) -> None:
     for n in topology.nodes.values():

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -28,6 +28,13 @@ attributes:
     mode:
     prefix:
     evpn:
+
+  # Copy these attributes from node VLAN data into interface-on-link data
+  copy_vlan_to_intf:
+    ipv4:
+    ipv6:
+    gateway:
+
   #
   # Do not copy these VLAN attributes into SVI interfaces
   #vlan_svi_no_propagate:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -58,7 +58,11 @@ links:
   interfaces:
   - _vlan_mode: irb
     gateway:
+      id: 1
       ipv4: 172.16.0.1/24
+      protocol: vrrp
+      vrrp:
+        priority: 100
     ifindex: 2
     ifname: Ethernet2
     ipv4: 172.16.0.2/24
@@ -90,7 +94,11 @@ links:
   interfaces:
   - _vlan_mode: irb
     gateway:
+      id: 1
       ipv4: 172.16.0.1/24
+      protocol: vrrp
+      vrrp:
+        priority: 200
     ifindex: 2
     ifname: Ethernet2
     ipv4: 172.16.0.3/24
@@ -149,6 +157,7 @@ nodes:
           protocol: vrrp
           vrrp:
             group: 1
+            priority: 200
         ifname: Vlan1000
         ipv4: 172.16.0.3/24
         node: s2
@@ -200,6 +209,7 @@ nodes:
           protocol: vrrp
           vrrp:
             group: 1
+            priority: 200
         ifname: Vlan1000
         ipv4: 172.16.0.3/24
         node: s2
@@ -268,6 +278,7 @@ nodes:
           protocol: vrrp
           vrrp:
             group: 1
+            priority: 200
         ifname: Vlan1000
         ipv4: 172.16.0.3/24
         node: s2
@@ -288,7 +299,7 @@ nodes:
           group: 1
       ifindex: 6
       ifname: Vlan1001
-      ipv4: 172.16.1.2/24
+      ipv4: 172.16.1.24/24
       name: VLAN blue (1001) -> [s2]
       neighbors:
       - gateway:
@@ -331,6 +342,7 @@ nodes:
         gateway:
           protocol: vrrp
         id: 1001
+        ipv4: 24
         mode: irb
         prefix:
           allocation: id_based
@@ -423,7 +435,7 @@ nodes:
       name: VLAN blue (1001) -> [s1]
       neighbors:
       - ifname: Vlan1001
-        ipv4: 172.16.1.2/24
+        ipv4: 172.16.1.24/24
         node: s1
       type: svi
       virtual_interface: true
@@ -491,7 +503,7 @@ vlans:
       ipv4: 172.16.1.3/24
       node: s2
     - ifname: Vlan1001
-      ipv4: 172.16.1.2/24
+      ipv4: 172.16.1.24/24
       node: s1
     prefix:
       allocation: id_based
@@ -519,6 +531,7 @@ vlans:
         protocol: vrrp
         vrrp:
           group: 1
+          priority: 200
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       node: s2

--- a/tests/topology/input/vlan-vrrp.yml
+++ b/tests/topology/input/vlan-vrrp.yml
@@ -2,6 +2,8 @@
 # VLAN-VRRP test case (regression test for #1344, #1349)
 # Blue VLAN + node-level VRRP priority is the regression test for #1370
 #
+# ipv4: 24 on blue VLAN: regression test for #1411
+#
 
 groups:
   switches:
@@ -24,6 +26,8 @@ nodes:
   s1:
     vlans.red:
       gateway.vrrp.priority: 100
+    vlans.blue:
+      ipv4: 24
   s2:
     gateway.vrrp.priority: 180
     vlans.red:


### PR DESCRIPTION
Majority of node VLAN data is copied into SVI interface data after the link transformation. However, that means we could not influence the SVI IP address or selectively enable gateway functionality on a node VLAN.

This fix copies a subset of node vlan data into link interface data for all (virtual or real) access VLAN links, and ensures those attributes do not overwrite the results of link transformation.

Fixes #1411, probably also VLAN part of #1413 (need a regression test after #1422 is merged)