### PR TITLE
Install bridge-utils when using Libvirt

### DIFF
--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -36,7 +36,7 @@ else
   curl -s https://deb.frrouting.org/frr/keys.asc | apt-key add -
   FRRVER="frr-stable"
   echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER > /etc/apt/sources.list.d/frr.list
-  apt-get update -qq && apt-get install -qq frr frr-pythontools
+  apt-get update -qq && apt-get install -qq frr frr-pythontools bridge-utils
 fi
 {% else %}
 {%   if netlab_mgmt_vrf|default(False) %}


### PR DESCRIPTION
Needed for VLAN templates

Fixes https://github.com/ipspace/netlab/issues/1429