### PR TITLE
Jvb fix access vlan gateway

### DIFF
--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -55,6 +55,7 @@ links:
     protocol: vrrp
     vrrp:
       group: 1
+      priority: 100
   interfaces:
   - _vlan_mode: irb
     gateway:
@@ -91,6 +92,7 @@ links:
     protocol: vrrp
     vrrp:
       group: 1
+      priority: 200
   interfaces:
   - _vlan_mode: irb
     gateway:
@@ -139,6 +141,7 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          priority: 100
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
@@ -188,6 +191,7 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          priority: 200
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.5/24


### PR DESCRIPTION
1. In ```check_link_vlan_attributes```, reverse the order: First check if the vlan exists on the node, and if so add the node to the node_set. Only after that check the global vlans
2. ```copy_vlan_attributes```: Also copy gateway attributes, if any
3. ```set_link_vlan_prefix```, after copying global vlan attributes also copy any node level vlan attributes, overriding the global ones if any
4. ```link_pre_transform``` populate the node_set for access and native vlans, line 175 was doing this only when a node vlan was present

Fixes https://github.com/ipspace/netlab/pull/1422