### PR TITLE
Use containerlab 'restart-policy' keyword to prevent FRR restarts

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -17,7 +17,7 @@
 
 ## Supported Versions
 
-Recent _netlab_ releases were tested with _containerlab_ version 0.55.0. That's also the version the **netlab install containerlab** command installs.
+The latest _netlab_ release was tested with _containerlab_ version 0.59.0. That's also the version the **netlab install containerlab** command installs.
 
 If needed, use ```sudo containerlab version upgrade``` to upgrade to the latest _containerlab_ version.
 
@@ -287,10 +287,11 @@ You can also change these *containerlab* parameters:
 
 * **clab.kind** -- [containerlab device kind](https://containerlab.dev/manual/kinds/). Set in the system defaults for all supported devices; use it only to specify the device type for [unknown devices](platform-unknown).
 * **clab.type** to set node type (used by Nokia SR OS and Nokia SR Linux).
-* **clab.env** to set container environment (used to [set interface names for Arista cEOS](https://containerlab.dev/manual/kinds/ceos/#additional-interface-naming-considerations))
-* **clab.ports** to map container ports to host ports
-* **clab.cmd** to execute a command in a container.
-* **clab.startup-delay** to make certain node(s) to boot/start later than others (amount in seconds)
+* **clab.env** to [set container environment](https://containerlab.dev/manual/nodes/#env) (used to [set interface names for Arista cEOS](https://containerlab.dev/manual/kinds/ceos/#additional-interface-naming-considerations))
+* **clab.ports** to [map container ports to host ports](https://containerlab.dev/manual/nodes/#ports)
+* **clab.cmd** to [change the command of a container image](https://containerlab.dev/manual/nodes/#cmd).
+* **clab.startup-delay** to make certain node(s) [boot/start later than others](https://containerlab.dev/manual/nodes/#startup-delay) (amount in seconds)
+* **clab.restart-policy** to set the [container restart policy](https://containerlab.dev/manual/nodes/#restart-policy)
 
 ```{warning}
 String values (for example, the command to execute specified in **clab.cmd**) are put into single quotes when written into the `clab.yml` containerlab configuration file. Ensure you're not using single quotes in your command line.

--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install a specific version of Containerlab
-CONTAINERLAB_VERSION="0.58.0"
+CONTAINERLAB_VERSION="0.59.0"
 
 cat <<EOM
 Docker/Containerlab Installation Script

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,7 +3,7 @@
 #
 description: containerlab with Docker
 config: clab.yml
-node_config_attributes: [ type, cmd, env, ports, startup-delay ]
+node_config_attributes: [ type, cmd, env, ports, startup-delay, restart-policy ]
 template: clab.j2
 # Preserve env to allow user to configure PATH
 start: sudo -E containerlab deploy --reconfigure -t clab.yml
@@ -13,8 +13,8 @@ act_title: "Running containers"
 probe:
 - cmd: "containerlab version"
   err: "Containerlab is not installed"
-- cmd: [ bash, '-c', "[[ `containerlab version|awk '/version/ {print $2}'` > '0.42' ]] && echo OK" ]
-  err: "Containerlab version is too old, please upgrade to 0.43 or later"
+- cmd: [ bash, '-c', "[[ `containerlab version|awk '/version/ {print $2}'` > '0.58.z' ]] && echo OK" ]
+  err: "Containerlab version is too old, please upgrade to 0.59.0 or later with 'sudo containerlab version upgrade'"
 
 cleanup: [ clab.yml, clab_files ]
 bridge_type: bridge # Use 'ovs-bridge' to create Openvswitch bridges

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -22,37 +22,41 @@ topology:
 {%   if n.mgmt.ipv6 is defined %}
       mgmt-ipv6: {{ n.mgmt.ipv6 }}
 {%   endif %}
-      kind: {{ clab.kind | default(n.device) }}
-{%    for cset in defaults.providers.clab.node_config_attributes if clab[cset] is defined %}
-{%      if clab[cset] is string %}
+{%   set kind = clab.kind | default(n.device) %}
+      kind: {{ kind }}
+{%   if kind == 'linux' and 'restart-policy' not in clab %}
+      restart-policy: 'no'
+{%   endif %}
+{%   for cset in defaults.providers.clab.node_config_attributes if clab[cset] is defined %}
+{%     if clab[cset] is string %}
       {{ cset }}: '{{ clab[cset] }}'
-{%      else %}
+{%     else %}
       {{ cset }}: {{ clab[cset] }}
-{%      endif %}
-{%    endfor %}
+{%     endif %}
+{%   endfor %}
       image: {{ clab.image|default(n.box) }}
       runtime: {{ clab.runtime|default(defaults.providers.clab.runtime) }}
-{%    if groups is defined %}
+{%   if groups is defined %}
       group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor %}
 
-{%    endif %}
-{% if 'srl-agents' in clab %}
+{%   endif %}
+{%   if 'srl-agents' in clab %}
       extras:
         srl-agents: {{ clab['srl-agents'] }}
-{% endif %}
-{% if 'binds' in clab %}
+{%   endif %}
+{%   if 'binds' in clab %}
       binds:
-{% for bind_item in clab.binds %}
+{%     for bind_item in clab.binds %}
       - {{ bind_item }}
-{% endfor %}
-{% endif %}
-{% if 'startup-config' in clab %}
-{%   set cfg = clab['startup-config'] %}
+{%     endfor %}
+{%   endif %}
+{%   if 'startup-config' in clab %}
+{%     set cfg = clab['startup-config'] %}
       startup-config: {{ ("|\n" + cfg) | indent(8) if '\n' in cfg else cfg }}
-{% endif %}
-{% if clab.license is defined %}
+{%   endif %}
+{%   if clab.license is defined %}
       license: {{ clab.license }}
-{% endif %}
+{%   endif %}
 {% endfor %}
 
 {% if links|default([]) %}


### PR DESCRIPTION
Containerlab sets the Docker restart policy of Linux-based containers to 'on-failure' which restarts all lab nodes with kind=linux (FRR, IOSv) after a server reboot without the necessary connectivity (veth pairs)

The containerlab 0.59.0 release added 'restart-policy' keyword. That keyword is now part of configurable 'clab' parameters and is set by default to 'no' on Linux containers.

Template fixes include indentation cleanup; documentation fixes include URLs to various clab parameters

Fixes #1399