### PR TITLE
Further IOLL2 enablement

### DIFF
--- a/netsim/ansible/templates/vlan/iosvl2.j2
+++ b/netsim/ansible/templates/vlan/iosvl2.j2
@@ -5,9 +5,10 @@ vlan {{ vdata.id }}
 !
 {%   endfor +%}
 {% endif %}
-{% for ifdata in interfaces if ifdata.vlan is defined %}
+{% for ifdata in interfaces if ifdata.vlan is defined and ifdata.virtual_interface is not defined %}
 !
 interface {{ ifdata.ifname }}
+
 {%   if ifdata.vlan.trunk_id is defined %}
  switchport
  switchport trunk encapsulation dot1q
@@ -20,4 +21,5 @@ interface {{ ifdata.ifname }}
  switchport
  switchport access vlan {{ ifdata.vlan.access_id }}
 {%   endif %}
+
 {% endfor +%}

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -6,6 +6,7 @@ features:
   vlan:
     model: l3-switch
     svi_interface_name: Vlan{vlan}
+    native_routed: True
     subif_name: "{ifname}.{subif_index}"
 clab:
   group_vars:

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -4,8 +4,9 @@ parent: iol
 
 features:
   vlan:
-    model: switch
+    model: l3-switch
     svi_interface_name: Vlan{vlan}
+    subif_name: "{ifname}.{subif_index}"
 clab:
   group_vars:
     netlab_device_type: ioll2


### PR DESCRIPTION
Ioll2 was promoted to multilayer switch
Routed sub-interfaces where enabled and the vlan template was taught how to configure them
Routed Native vlan was enabled

This change set does not promotes iosvl2 to a multilayer switch.  The platform was not tested. When enabled and tested, depending of the results of the tests, we may have to do away with the symlinks which are still present. 

It also does not contain any attempt to mixed trunks.

Changes where tested on vlan integration test suite.  At this time all tests up and including 61-vlan-routed-native are a success.  test success is dependent of running the correct version of iouyap. 
 