### PR TITLE
Bug fix: copy node VLAN data into interface data on all links

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1315,9 +1315,6 @@ class VLAN(_Module):
   # the canonical "interfaces" list format, so we cannot do it any sooner than this point.
   #
   def link_pre_link_transform(self, link: Box, topology: Box) -> None:
-    if 'vlan' not in link:
-      return
-
     for intf in link.interfaces:
       vname = intf.get('vlan.access',None)
       if not vname:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -86,7 +86,7 @@ links:
   - _vlan_mode: irb
     ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.0.4/24
+    ipv4: 172.16.0.42/24
     node: s3
     vlan:
       access: red
@@ -98,8 +98,6 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-  vlan:
-    access: red
 module:
 - vlan
 - ospf
@@ -136,7 +134,7 @@ nodes:
         ipv4: 172.16.0.3/24
         node: s2
       - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.42/24
         node: s3
       - ifname: eth1
         ipv4: 172.16.0.5/24
@@ -183,7 +181,7 @@ nodes:
         ipv4: 172.16.0.3/24
         node: s2
       - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.42/24
         node: s3
       type: lan
     mgmt:
@@ -249,7 +247,7 @@ nodes:
         ipv4: 172.16.0.3/24
         node: s2
       - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.42/24
         node: s3
       - ifname: eth1
         ipv4: 172.16.0.5/24
@@ -343,7 +341,7 @@ nodes:
         ipv4: 172.16.0.2/24
         node: s1
       - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.42/24
         node: s3
       - ifname: eth1
         ipv4: 172.16.0.5/24
@@ -417,7 +415,7 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Vlan1000
-      ipv4: 172.16.0.4/24
+      ipv4: 172.16.0.42/24
       name: VLAN red (1000) -> [h1,s1,s2,h2]
       neighbors:
       - ifname: eth1
@@ -457,6 +455,7 @@ nodes:
       red:
         bridge_group: 1
         id: 1000
+        ipv4: 42
         mode: irb
         prefix:
           allocation: id_based
@@ -479,7 +478,7 @@ vlans:
       ipv4: 172.16.0.3/24
       node: s2
     - ifname: Vlan1000
-      ipv4: 172.16.0.4/24
+      ipv4: 172.16.0.42/24
       node: s3
     - ifname: eth1
       ipv4: 172.16.0.5/24

--- a/tests/topology/input/vlan-access-single.yml
+++ b/tests/topology/input/vlan-access-single.yml
@@ -9,13 +9,13 @@ nodes:
     device: linux
   s1:
     device: eos
-    module: [ ospf,vlan ]
+    module: [ ospf, vlan ]
     vlans:
       red:
         ospf.cost: 10
   s2:
     device: eos
-    module: [ vlan,ospf ]
+    module: [ vlan, ospf ]
     vlans:
       red:
         ospf.cost: 20
@@ -23,6 +23,9 @@ nodes:
   s3:                       # Add a third device to test non-propagation of irrelevant module parameters
     device: eos
     module: [ vlan ]
+    vlans:
+      red:
+        ipv4: 42            # Regression test for 1436
 
   h2:
     device: linux
@@ -39,5 +42,6 @@ links:
     vlan.access: red
   h2:
 - s1:
+    vlan.access: red
   s3:
-  vlan.access: red
+    vlan.access: red


### PR DESCRIPTION
A premature optimization in VLAN pre_link_transform code skipped links that did not have the link-level VLAN attribute, ignoring links where the access VLAN was specified on an interface.

Fixes #1436 (root cause found by @jbemmel in #1442)