### PR TITLE
Bug fix: reject per-link irb/bridge VLAN interface attributes

### DIFF
--- a/docs/module/dhcp.md
+++ b/docs/module/dhcp.md
@@ -68,7 +68,7 @@ You can enable the DHCP client on all non-relaying devices attached to a link wi
 
 ```{warning}
 * While you can use the **‌dhcp.client** parameter to enable DHCP for all hosts attached to a VLAN segment ([see example](dhcp-vlan-example)), do not use DHCP on [routed VLANs](vlan-addressing-routed).
-* The Default router IP address is not set for the VLAN-serving DHCP pools unless you use the **‌gateway** module with anycast or VRRP default gateway on the VLAN.
+* You cannot use **‌dhcp.client** link/VLAN parameter to enable the DHCP client on a VLAN interface. You have to enable the DHCP client on an IRB VLAN interface within the node **‌vlans** dictionary ([more details](vlan-interface-parameters)).
 ```
 
 ## Interface Parameters

--- a/docs/module/vlan.md
+++ b/docs/module/vlan.md
@@ -206,6 +206,7 @@ The VLAN **mode** can be set in global- or node **vlans** dictionary or with the
 
 [^VVR]: You can use this functionality to implement VXLAN-to-VXLAN routing in a router-on-a-stick design or asymmetric IRB.
 
+(vlan-interface-parameters)=
 ### VLAN Interface Parameters
 
 You can change VLAN interface[^VLANIF] parameters within the node **vlans** dictionary. For example, use the following definitions to set the OSPF cost for the **red** VLAN interface on node **s1**:
@@ -229,7 +230,7 @@ links:
   ...
 ```
 
-You can also set interface parameters for every interface connected to a routed VLAN within global VLAN definition. For example, you could set the OSPF cost for all interfaces connected to the **red** VLAN:
+You can also set interface parameters for every interface connected to a routed VLAN within the global VLAN definition. For example, you could set the OSPF cost for all interfaces connected to the **red** VLAN:
 
 ```
 vlans:

--- a/netsim/modules/dhcp.py
+++ b/netsim/modules/dhcp.py
@@ -329,6 +329,9 @@ class DHCP(_Module):
 
         # Copy link DHCP client status to interface in case the node does not have DHCP module enabled
         if link.get(f'dhcp.client.{af}',False) and intf.get(f'dhcp.client.{af}',None) is not False:
+          vlan_intf = intf.get('_vlan_mode',None)
+          if vlan_intf in ['bridge','irb']:         # No automatic DHCP clients on bridging/IRB interfaces
+            continue
           intf.dhcp.client[af] = True
 
         if intf.get(f'dhcp.client.{af}',False):     # Do we have DHCP client on this interface?

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -50,6 +50,7 @@ attributes:
     type:
     vlan:
     mtu:
+    stp:
     _selfloop_ifindex:
   #
   # Keep these subinterface attributes

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -50,6 +50,7 @@ attributes:
     type:
     vlan:
     mtu:
+    bandwidth:
     stp:
     _selfloop_ifindex:
   #

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -4,6 +4,8 @@ dhcp:
     excluded:
       ipv4:
       - 172.16.0.2
+    gateway:
+      ipv4: 172.16.0.2
     ipv4: 172.16.0.0/24
     name: vlan_red
   - clean_name: vlan_blue
@@ -73,9 +75,6 @@ links:
       group: 1
   interfaces:
   - _vlan_mode: irb
-    dhcp:
-      server:
-      - dhs
     gateway:
       ipv6: 2001:db8:cafe:1::1/64
     ifindex: 2
@@ -106,11 +105,10 @@ links:
       ipv4: true
     subnet:
       ipv4: true
+  gateway:
+    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
-    dhcp:
-      client:
-        ipv4: true
     ifindex: 3
     ifname: Ethernet3
     ipv4: 172.16.0.2/24
@@ -138,11 +136,10 @@ links:
       ipv4: true
     subnet:
       ipv4: true
+  gateway:
+    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
-    dhcp:
-      client:
-        ipv4: true
     ifindex: 4
     ifname: Ethernet4
     ipv4: 172.16.0.2/24
@@ -197,6 +194,8 @@ nodes:
         excluded:
           ipv4:
           - 172.16.0.2
+        gateway:
+          ipv4: 172.16.0.2
         ipv4: 172.16.0.0/24
         name: vlan_red
       - clean_name: vlan_blue
@@ -393,6 +392,14 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
+      dhcp:
+        relay:
+          ipv4:
+          - 192.168.42.6
+          ipv6:
+          - 2001:db8:cafe:d001::6
+        server:
+        - dhs
       gateway:
         anycast:
           mac: 0200.cafe.00ff
@@ -469,6 +476,9 @@ nodes:
     vlans:
       blue:
         bridge_group: 1
+        dhcp:
+          server:
+          - dhs
         id: 1001
         mode: irb
         prefix:

--- a/tests/topology/input/dhcp-vlan.yml
+++ b/tests/topology/input/dhcp-vlan.yml
@@ -24,6 +24,8 @@ nodes:
     vlans:
       red:
         dhcp.server: dhs
+      blue:
+        dhcp.server: dhs
   h1:
     device: linux
   h2:
@@ -40,7 +42,6 @@ links:
     ipv4: 192.168.42.0/24
     ipv6: 2001:db8:cafe:d001::/64
 - s1:
-    dhcp.server: dhs
   h3:
     ipv4: dhcp
     ipv6: dhcp


### PR DESCRIPTION
This fix introduces a strict check of link interface attributes for VLAN access connections where the VLAN forwarding mode is 'bridge' or 'irb'. The only exceptions are the physical interface attributes, STP parameters, and 'no IPv4/IPv6' parameters.

The fix resulted in 'dhcp-vlan' transformation test failure, and after fixing that transformation test, #1359 magically disappeared.

Replaces #1442, accidentally fixes #1359