### PR TITLE
Found issue with missing 'vlan_name' for access vlans

### DIFF
--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1321,8 +1321,8 @@ class VLAN(_Module):
       for intf in link.interfaces:
         if 'vlan' in intf:
           intf.vlan.mode = 'route'
-          if len(link.interfaces)==2:
-            intf.vlan.routed_link = True                                          # Mark it as a routed link? has issues
+          # if len(link.interfaces)==2:
+          #  intf.vlan.routed_link = True                                          # Mark it as a routed link? has issues
     else:
       set_link_vlan_prefix(link,v_attr,topology)
 

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1302,6 +1302,7 @@ class VLAN(_Module):
     link_vlan = get_link_access_vlan(v_attr)
     routed_vlan = False
     if not link_vlan is None:
+      link.vlan_name = link_vlan                                                  # Mark the use of this vlan to avoid creating loopback vlan
       set_access_vlan_interface_mode(link,link_vlan,topology)
       routed_vlan = routed_access_vlan(link,topology,link_vlan)
       vlan_data = topology.get(f'vlans.{link_vlan}',None)                         # Get global VLAN data

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -1321,6 +1321,8 @@ class VLAN(_Module):
       for intf in link.interfaces:
         if 'vlan' in intf:
           intf.vlan.mode = 'route'
+          if len(link.interfaces)==2:
+            intf.vlan.routed_link = True                                          # Mark it as a routed link? has issues
     else:
       set_link_vlan_prefix(link,v_attr,topology)
 


### PR DESCRIPTION
The ```link_name``` for access vlans does not get populated, resulting in the creation of loopback vlans in certain scenarios (ref https://github.com/ipspace/netlab/blob/a937fa2bb10b437d75da7869cc29ecad5f0c2396/netsim/modules/vlan.py#L652 - e.g. test case rt-vlan-mode-link-route:
```
- sw:
  br:
  vlan.access: red
  vlan.mode: route        # This one should be routed on both ends
```

However, setting the link_name uncovers other issues - e.g. the vrf-leak link in bgp-vrf-local-as looses its neighbors, as the link is not flagged as a "routed_link":
```
 interfaces: # VRF route leaking between red and blue, using BGP peering
  - node: r2
    vrf: red
    bgp.local_as: 65001
    vlan.access: vrf-leak
  - node: r2
    vrf: blue
    bgp.local_as: 65002
    vlan.access: vrf-leak
```

Not ready to merge, but wanted to share the issue