### PR TITLE
Fix: remove the 'temporary net namespace' hack

### DIFF
--- a/netsim/ansible/tasks/linux/initial-clab.yml
+++ b/netsim/ansible/tasks/linux/initial-clab.yml
@@ -3,17 +3,17 @@
 # the /etc/hosts file is created as a clab bind.
 #
 # The commands to set up Linux networking are executed on the container host in the context
-# of container namespace so we don't need the 'ip' command or Python in the container.
+# of container networking namespace so we don't need the 'ip' command or Python in the container.
 #
 # This task list:
-# 
+#
 # * Creates a random file name that will be used for the initialization script
 # * Creates the networking setup script in the temporary file
-# * Executes a hack that maps Docker container namespace into a well-known namespace
-#   and then executes the networking initialization script within that namespace
-# * Cleans up the mess it made
+# * Executes the setup script within the containerlab container namespace
 #
+---
 - set_fact:
+    # yamllint disable-line rule:line-length
     exec_script: /tmp/config-{{ lookup('password','/dev/null length=8 chars=ascii_letters') }}-{{ inventory_hostname }}.sh
 
 - name: "Create initial container setup from {{ config_template }}"
@@ -25,13 +25,9 @@
 - name: "Initial container configuration via {{ exec_script }}"
   shell: |
     set -e
-    pid=$(docker inspect -f {% raw %}'{{.State.Pid}}'{% endraw %} clab-{{ netlab_name }}-{{inventory_hostname }})
-    mkdir -p /var/run/netns
-    ln -s /proc/$pid/ns/net /var/run/netns/$pid
-    ip netns exec $pid bash {{ exec_script }}
-    rm /var/run/netns/$pid
+    ip netns exec clab-{{ netlab_name }}-{{ inventory_hostname }} bash {{ exec_script }}
   become: true
-  delegate_to: localhost  
+  delegate_to: localhost
   tags: [ print_action, always ]
 
 - file:


### PR DESCRIPTION
Docker containers do not have their network namespaces mapped into the /var/run/netns directory, so we cannot use 'ip netns exec' command with regular containers, and we used a dirty hack to provision Linux container networking.

Containerlab does map the container network namespace into that directory, so we can replace the hack with a much cleaner and more robust solution, using clab container name as the network namespace.

Replaces #1463