### PR TITLE
Cleanup container names

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -306,6 +306,16 @@ provider: clab
 defaults.providers.clab.node_config_attributes: [ ports, env, user ]
 ```
 
+### defaults.providers.clab.lab_prefix: Controlling container naming
+By default, Netlab uses "clab" as the lab prefix, which causes each container to be named "clab-{ topology name }-{ node name }".
+If you prefer "plain" node names (e.g. matching DNS names used in your network), you can set ```defaults.providers.clab.lab_prefix=""```
+to remove both prefix strings and leave just the node name.
+
+Example:
+```
+netlab up topo.yml -s defaults.providers.clab.lab_prefix=""
+```
+
 ```{eval-rst}
 .. toctree::
    :caption: Installing Container Images

--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -308,14 +308,21 @@ provider: clab
 defaults.providers.clab.node_config_attributes: [ ports, env, user ]
 ```
 
-### defaults.providers.clab.lab_prefix: Controlling container naming
-By default, Netlab uses "clab" as the lab prefix, which causes each container to be named "clab-{ topology name }-{ node name }".
-If you prefer "plain" node names (e.g. matching DNS names used in your network), you can set ```defaults.providers.clab.lab_prefix=""```
-to remove both prefix strings and leave just the node name.
+### Changing Container Names
+
+By default, Netlab uses `clab` as the [containerlab naming prefix](https://containerlab.dev/manual/topo-def-file/#prefix),
+which causes each container to be named `clab-{ topology name }-{ node name }`.
+If you prefer plain node names (e.g. matching DNS names used in your network), set the `defaults.providers.clab.lab_prefix`
+to an empty string to remove both prefix strings, leaving just the node name as the container name.
 
 Example:
 ```
 netlab up topo.yml -s defaults.providers.clab.lab_prefix=""
+```
+
+```{warning}
+Do not change the containerlab lab prefix if you're using the **multilab** plugin to run multiple labs on the same
+server.
 ```
 
 ```{eval-rst}

--- a/netsim/ansible/tasks/deploy-config/linux-clab.yml
+++ b/netsim/ansible/tasks/deploy-config/linux-clab.yml
@@ -4,7 +4,7 @@
   delegate_to: localhost # Run on controller, to avoid dependency on Python
 
 - name: Copy template file into running container
-  shell: docker cp /tmp/{{inventory_hostname}}_config.sh clab-{{ netlab_name }}-{{inventory_hostname}}:/tmp/config.sh
+  shell: docker cp /tmp/{{inventory_hostname}}_config.sh {{ ansible_host }}:/tmp/config.sh
   delegate_to: localhost
 
 - name: "Execute /tmp/config.sh to deploy {{ netsim_action }} config from {{ config_template }}"

--- a/netsim/ansible/tasks/linux/initial-clab.yml
+++ b/netsim/ansible/tasks/linux/initial-clab.yml
@@ -25,7 +25,7 @@
 - name: "Initial container configuration via {{ exec_script }}"
   shell: |
     set -e
-    ip netns exec clab-{{ netlab_name }}-{{ inventory_hostname }} bash {{ exec_script }}
+    ip netns exec {{ ansible_host }} bash {{ exec_script }}
   become: true
   delegate_to: localhost
   tags: [ print_action, always ]

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -67,7 +67,7 @@ def get_instance(args: argparse.Namespace, lab_states: Box) -> Lab_Instance_ID:
   try:
     cur_dir = os.getcwd()
   except Exception as ex:
-    log.fatal(f'Cannot get curent directory: {ex}','')
+    log.fatal(f'Cannot get current directory: {ex}','')
   for id,state in lab_states.items():
     if state.dir == cur_dir:
       return id

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -232,7 +232,7 @@ class Containerlab(_Provider):
   """
   def get_node_name(self, node: str, topology: Box) -> str:
     lab_prefix = topology.get("defaults.providers.clab.lab_prefix")
-    return f'{ lab_prefix }{ topology.name }-{ node }' if lab_prefix else node
+    return f'{ lab_prefix }-{ topology.name }-{ node }' if lab_prefix else node
 
   def validate_node_image(self, node: Box, topology: Box) -> None:
     if not getattr(self,'image_cache',None):                # Create an image cache on first call

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -227,12 +227,12 @@ class Containerlab(_Provider):
   Defines the container host naming convention (globally), this becomes "ansible_host" in Ansible
   and gets added to /etc/hosts for DNS name resolution
 
-  'clab-' is the default Containerlab prefix; it can be configured (including setting it to "")
+  'clab' is the default Containerlab prefix; it can be configured (including setting it to "")
   through "defaults.providers.clab.lab_prefix"
   """
   def get_node_name(self, node: str, topology: Box) -> str:
     lab_prefix = topology.get("defaults.providers.clab.lab_prefix")
-    return f'{ lab_prefix }{ topology.name }-{ node }'
+    return f'{ lab_prefix }{ topology.name }-{ node }' if lab_prefix else node
 
   def validate_node_image(self, node: Box, topology: Box) -> None:
     if not getattr(self,'image_cache',None):                # Create an image cache on first call

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,8 +3,7 @@
 #
 description: containerlab with Docker
 config: clab.yml
-lab_prefix: "clab"
-no_propagate: [ lab_prefix ]
+lab_prefix: "clab" # Containerlab default, set to "" to remove prefix
 node_config_attributes: [ type, cmd, env, ports, startup-delay, restart-policy ]
 template: clab.j2
 # Preserve env to allow user to configure PATH
@@ -28,8 +27,6 @@ kmods:
   vxlan: [ vxlan, udp_tunnel, ip6_udp_tunnel ]
   vrf: [ vrf ]
 attributes:
-  global:
-    lab_prefix:     # Prefix string to be added to all node names, defaults to "clab" if not set
   node:
     type: dict
     _keys:          # Make keys explicit to get around the 'type' attribute

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,7 +3,7 @@
 #
 description: containerlab with Docker
 config: clab.yml
-lab_prefix: "clab-"
+lab_prefix: "clab"
 no_propagate: [ lab_prefix ]
 node_config_attributes: [ type, cmd, env, ports, startup-delay, restart-policy ]
 template: clab.j2
@@ -29,7 +29,7 @@ kmods:
   vrf: [ vrf ]
 attributes:
   global:
-    lab_prefix:     # Prefix string to be added to all node names, defaults to "clab-" if not set
+    lab_prefix:     # Prefix string to be added to all node names, defaults to "clab" if not set
   node:
     type: dict
     _keys:          # Make keys explicit to get around the 'type' attribute

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,6 +3,8 @@
 #
 description: containerlab with Docker
 config: clab.yml
+lab_prefix: "clab-"
+no_propagate: [ lab_prefix ]
 node_config_attributes: [ type, cmd, env, ports, startup-delay, restart-policy ]
 template: clab.j2
 # Preserve env to allow user to configure PATH
@@ -26,6 +28,8 @@ kmods:
   vxlan: [ vxlan, udp_tunnel, ip6_udp_tunnel ]
   vrf: [ vrf ]
 attributes:
+  global:
+    lab_prefix:     # Prefix string to be added to all node names, defaults to "clab-" if not set
   node:
     type: dict
     _keys:          # Make keys explicit to get around the 'type' attribute

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -1,4 +1,5 @@
 name: {{ name }}
+prefix: "{{ defaults.providers.clab.lab_prefix|default( "" ) }}"
 
 {# We have to deal with mgmt._network not being defined or being False-ish #}
 mgmt:

--- a/tests/topology/expected/clab-attributes.yml
+++ b/tests/topology/expected/clab-attributes.yml
@@ -22,7 +22,7 @@ nodes:
       startup-config: start.cfg
       type: unknown
     device: frr
-    hostname: clab-input-n
+    hostname: mylab-input-n
     id: 1
     interfaces: []
     loopback:

--- a/tests/topology/input/clab-attributes.yml
+++ b/tests/topology/input/clab-attributes.yml
@@ -4,6 +4,8 @@
 ---
 provider: clab
 
+defaults.providers.clab.lab_prefix: "mylab"
+
 nodes:
   n:
     device: frr


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1466

Usage: ```netlab up 02-vlan-bridge-multiple.yml -p clab -d frr -s defaults.providers.clab.lab_prefix=""```