### PR TITLE
Fix: check the VLAN/interface fwd mode compatibility

### DIFF
--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -15,14 +15,21 @@ evpn:
 bgp:
   igp: >
     Add a supported IGP (ospf, isis, eigrp) to the list of modules.
+
 report:
   source: >
     A report can be specified in a file with .j2 suffix within 'reports' subdirectory in
     package-, system-, user- or current directory. You can also specify a report in a
     defaults.outputs.report setting.
+
 quirks:
   junos_lb: >
     Junos devices cannot have more than one loopback interface per routing instance
+
+vlan:
+  fwd_mode_check: >
+    You can disable this error with "defaults.vlan.warnings.mixed_fwd: False", but then
+    you might get the same IP prefix assigned to multiple segments of the routed VLAN.
 
 vrf:
   inactive: >

--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -27,8 +27,8 @@ quirks:
     Junos devices cannot have more than one loopback interface per routing instance
 
 vlan:
-  fwd_mode_check: >
-    You can disable this error with "defaults.vlan.warnings.mixed_fwd: False", but then
+  mixed_fwd_check: >
+    You can disable this error with "defaults.vlan.warnings.mixed_fwd_check: False", but then
     you might get the same IP prefix assigned to multiple segments of the routed VLAN.
 
 vrf:

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -297,14 +297,33 @@ def validate_link_vlan_attributes(link: Box,v_attr: Box,topology: Box) -> bool:
   return link_ok
 
 """
-check_link_interface_attributes -- validate that the interfaces in bridge/IRB mode do not
-carry any extra attributes
+check_link_interface_attributes:
+
+Validate that the interfaces in bridge/IRB mode
+
+* do not carry any extra attributes
+* are not connected to global VLANs with 'mode: route'
 """
 def check_link_interface_attributes(link: Box, intf: Box, topology: Box) -> None:
   valid_attr = list(topology.defaults.vlan.attributes.phy_ifattr) + [ 'node','_vlan_mode' ]
   vlan_mode = get_vlan_interface_mode(intf)                 # Get interface VLAN forwarding mode
   if vlan_mode is None or vlan_mode == 'route':             # No access VLAN or routed subinterface
     return                                                  # ... interface attributes are OK
+
+  if 'vlan_name' in link and 'vlans' in topology:           # Check forwarding mode for global access VLANs
+    if link.vlan_name in topology.vlans:                    # Is the access VLAN a global VLAN?
+      vname = link.vlan_name
+      vlan_fwd = topology.vlans[vname].get('mode','')
+      #
+      # Do we have a bridge/IRB device connected to a routed VLAN (and do we care)?
+      if vlan_fwd == 'route' and topology.defaults.vlan.warnings.mixed_fwd:
+        log.error(
+          f"Node {intf.node} using VLAN forwarding mode {vlan_mode} is connected to global routed VLAN {vname} " +\
+          f"on {link._linkname}",
+          category=log.IncorrectType,
+          hint='fwd_mode_check',
+          module='vlan')        
+        return
 
   invalid = []                                              # This is where we collect invalid attributes
   for attr in intf.keys():                                  # Now iterate over interface attributes

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -316,7 +316,7 @@ def check_link_interface_attributes(link: Box, intf: Box, topology: Box) -> None
       vlan_fwd = topology.vlans[vname].get('mode','')
       #
       # Do we have a bridge/IRB device connected to a routed VLAN (and do we care)?
-      if vlan_fwd == 'route' and topology.defaults.vlan.warnings.mixed_fwd:
+      if vlan_fwd == 'route' and topology.defaults.vlan.warnings.mixed_fwd_check:
         log.error(
           f"Node {intf.node} using VLAN forwarding mode {vlan_mode} is connected to global routed VLAN {vname} " +\
           f"on {link._linkname}",

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -96,3 +96,6 @@ _top:                               # Modification of global defaults
         _subtype: node_vlan
         _keytype: id
         _requires: [ vlan ]
+
+warnings:
+  mixed_fwd: True

--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -98,4 +98,4 @@ _top:                               # Modification of global defaults
         _requires: [ vlan ]
 
 warnings:
-  mixed_fwd: True
+  mixed_fwd_check: True

--- a/tests/topology/input/rt-vlan-mode-link-route.yml
+++ b/tests/topology/input/rt-vlan-mode-link-route.yml
@@ -2,7 +2,7 @@
 # of link-, node- and vlan forwarding modes, in particular with mode = route
 #
 
-defaults.vlan.warnings.mixed_fwd: False
+defaults.vlan.warnings.mixed_fwd_check: False
 defaults.device: frr
 module: [ vlan ]
 

--- a/tests/topology/input/rt-vlan-mode-link-route.yml
+++ b/tests/topology/input/rt-vlan-mode-link-route.yml
@@ -2,6 +2,7 @@
 # of link-, node- and vlan forwarding modes, in particular with mode = route
 #
 
+defaults.vlan.warnings.mixed_fwd: False
 defaults.device: frr
 module: [ vlan ]
 

--- a/tests/topology/input/vlan-routed-vrf.yml
+++ b/tests/topology/input/vlan-routed-vrf.yml
@@ -1,4 +1,4 @@
-defaults.vlan.warnings.mixed_fwd: False
+defaults.vlan.warnings.mixed_fwd_check: False
 
 addressing:
   unnumbered:

--- a/tests/topology/input/vlan-routed-vrf.yml
+++ b/tests/topology/input/vlan-routed-vrf.yml
@@ -1,3 +1,5 @@
+defaults.vlan.warnings.mixed_fwd: False
+
 addressing:
   unnumbered:
     ipv4: True


### PR DESCRIPTION
Connecting a bridge/IRB interface to two segments of a routed VLAN results in a shared IP prefix used on both segments.

This change checks for the forwarding mode mismatch and triggers an error that can be disabled with a defaults setting (because someone might want to use the shared IP prefix)

It turns out several routed VLAN transformation tests relied on this behavior, so they got the VLAN default tweak.

Fixes #1461