### PR TITLE
Document minimum containerlab version as 0.59.0. 

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -141,7 +141,7 @@ Additionally, you might have to execute `sudo update-crypto-policies --set LEGAC
 ## Cisco IOS on Linux (IOL) and IOL Layer-2 Image
 
 * The Cisco IOL and IOL L2 images work only as containers created with Roman Dodin's fork of [vrnetlab](https://github.com/hellt/vrnetlab/).
-* You need Containerlab 0.58.0 or greater to run these images.
+* You need Containerlab 0.59.0 or greater to run these images.
 * You cannot use VLANs 1002 through 1005 with Cisco IOL layer-2 image
 
 See also [common Cisco IOS](caveats-iosv) caveats.


### PR DESCRIPTION
Initial support for IOL images was introduced in 0.58.0, but a breaking change was introduced soon after, to fix the issue with the system bridges having same MAC. In effect, image docker containers will not start under containerlab 0.58.0 anymore.