### PR TITLE
Another example of device support being checked later than expected

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -186,7 +186,7 @@ def register_static_transit_vni(topology: Box) -> None:
       continue
 
     for vrf_name,vrf_data in n.vrfs.items():
-      if vrf_data.get('evpn.transit_vni',None):
+      if vrf_data and vrf_data.get('evpn.transit_vni',None):
         log.error(
           f'evpn.transit_vni can be specified only on global VRFs (found in {vrf_name} on {n.name}',
           log.IncorrectValue,

--- a/tests/errors/node-unsupported-module.log
+++ b/tests/errors/node-unsupported-module.log
@@ -1,0 +1,2 @@
+IncorrectValue in modules: Device type vmx used by node n1 is not supported by module evpn
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/node-unsupported-module.yml
+++ b/tests/errors/node-unsupported-module.yml
@@ -1,0 +1,12 @@
+defaults.device: vmx
+defaults.provider: clab
+
+module: [evpn,bgp,vrf]
+
+bgp.as: 65000
+
+nodes:
+  n1:
+   vrfs:
+    test:
+     evpn.bundle: vlan


### PR DESCRIPTION
Being pedantic here, feel free to ignore or de-prioritize - but here's another example of the EVPN module producing an error while the "real" error is lack of device support