### PR TITLE
Fix order of vrf normalization

### DIFF
--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -416,12 +416,12 @@ class VRF(_Module):
 
     init_vrf_static_ids(topology)
 
+    normalize_vrf_ids(topology)                         # Normalize global and node vrfs, if any
     if not 'vrfs' in topology:                          # No global VRFs, nothing to do
       return
 
     create_vrf_links(topology)                          # Create VRF links (and remove 'links' attribute)
     log.exit_on_error()
-    normalize_vrf_ids(topology)
     populate_vrf_static_ids(topology)
     set_vrf_ids(topology,topology)
     set_import_export_rt(topology,topology)

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -1,3 +1,21 @@
+bgp:
+  advertise_loopback: true
+  as: 65000
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+evpn:
+  session:
+  - ibgp
+groups:
+  as65000:
+    members:
+    - n1
+    - n2
 input:
 - topology/input/null-vrfs.yml
 - package:topology-defaults.yml
@@ -18,13 +36,42 @@ links:
     ipv4: 10.1.0.0/30
   type: p2p
 module:
+- bgp
 - vrf
+- evpn
 name: input
 nodes:
   n1:
     af:
       ipv4: true
       vpnv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        - large
+        ibgp:
+        - standard
+        - large
+        - extended
+        ibgp_localas:
+        - standard
+        - large
+        - extended
+      ipv4: true
+      neighbors:
+      - _source_ifname: lo
+        activate:
+          ipv4: true
+        as: 65000
+        evpn: true
+        ipv4: 10.0.0.2
+        name: n2
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.1
     box: quay.io/frrouting/frr:10.0.1
     clab:
       binds:
@@ -35,6 +82,9 @@ nodes:
       - hosts:/etc/hosts
       kind: linux
     device: frr
+    evpn:
+      session:
+      - ibgp
     hostname: clab-input-n1
     id: 1
     interfaces:
@@ -62,7 +112,9 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:00:00:01
     module:
+    - bgp
     - vrf
+    - evpn
     mtu: 1500
     name: n1
     vrf:
@@ -71,6 +123,10 @@ nodes:
       node:
         af:
           ipv4: true
+        bgp:
+          import:
+            connected:
+              auto: true
         export:
         - '65000:1'
         id: 1
@@ -81,6 +137,33 @@ nodes:
   n2:
     af:
       ipv4: true
+    bgp:
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        - large
+        ibgp:
+        - standard
+        - large
+        - extended
+        ibgp_localas:
+        - standard
+        - large
+        - extended
+      ipv4: true
+      neighbors:
+      - _source_ifname: lo
+        activate:
+          ipv4: true
+        as: 65000
+        evpn: true
+        ipv4: 10.0.0.1
+        name: n1
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.2
     box: quay.io/frrouting/frr:10.0.1
     clab:
       binds:
@@ -91,6 +174,9 @@ nodes:
       - hosts:/etc/hosts
       kind: linux
     device: frr
+    evpn:
+      session:
+      - ibgp
     hostname: clab-input-n2
     id: 2
     interfaces:
@@ -118,7 +204,9 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:00:00:02
     module:
+    - bgp
     - vrf
+    - evpn
     mtu: 1500
     name: n2
     vrf:

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -1,0 +1,128 @@
+input:
+- topology/input/null-vrfs.yml
+- package:topology-defaults.yml
+links:
+- interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.1/30
+    node: n1
+    vrf: node
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.2/30
+    node: n2
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+module:
+- vrf
+name: input
+nodes:
+  n1:
+    af:
+      ipv4: true
+      vpnv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/n1/daemons:/etc/frr/daemons
+      - clab_files/n1/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-n1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      mtu: 1500
+      name: n1 -> n2
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.2/30
+        node: n2
+      type: p2p
+      vrf: node
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vrf
+    mtu: 1500
+    name: n1
+    vrf:
+      as: 65000
+    vrfs:
+      node:
+        af:
+          ipv4: true
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        rd: '65000:1'
+        vrfidx: 100
+  n2:
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.0.1
+    clab:
+      binds:
+      - clab_files/n2/daemons:/etc/frr/daemons
+      - clab_files/n2/hosts:/etc/hosts
+      config_templates:
+      - daemons:/etc/frr/daemons
+      - hosts:/etc/hosts
+      kind: linux
+    device: frr
+    hostname: clab-input-n2
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      mtu: 1500
+      name: n2 -> n1
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.1/30
+        node: n1
+        vrf: node
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    module:
+    - vrf
+    mtu: 1500
+    name: n2
+    vrf:
+      as: 65000
+provider: clab
+vrf:
+  as: 65000

--- a/tests/topology/input/null-vrfs.yml
+++ b/tests/topology/input/null-vrfs.yml
@@ -2,10 +2,12 @@
 #
 # Regression test for issue with topology containing only node local vrfs
 #
-module: [vrf]
+module: [vrf,bgp,evpn]
 
 defaults.device: frr
 defaults.provider: clab
+
+bgp.as: 65000
 
 # No global vrfs defined -> bug
 # vrfs:

--- a/tests/topology/input/null-vrfs.yml
+++ b/tests/topology/input/null-vrfs.yml
@@ -1,0 +1,24 @@
+---
+#
+# Regression test for issue with topology containing only node local vrfs
+#
+module: [vrf]
+
+defaults.device: frr
+defaults.provider: clab
+
+# No global vrfs defined -> bug
+# vrfs:
+# global:
+
+nodes:
+ n1:
+  vrfs:
+   node:
+ n2:
+
+links:
+- n1:
+   vrf: node
+  n2:
+   # vrf: global


### PR DESCRIPTION
If a topology contains only node local vrfs, normalization is skipped