### PR TITLE
Dell OS10: Only enable VRRP version 3 if ipv6 is used

### DIFF
--- a/netsim/ansible/templates/gateway/dellos10.j2
+++ b/netsim/ansible/templates/gateway/dellos10.j2
@@ -7,7 +7,7 @@
 ip virtual-router mac-address {{ anycast_mac }}
 {%     endif %}
 {%     if intf.gateway.protocol == 'vrrp' %}
-vrrp version 3
+vrrp version {{ 3 if 'ipv6' in af else 2 }}
 {%     endif %}
 !
 {%   endif %}


### PR DESCRIPTION
OS10 defaults to VRRP version 2, which only supports ipv4, has different timer resolution and supports authentication

When modeling an ipv4-only network, the version needs to be set to 2

Context: https://www.dell.com/support/kbdoc/en-us/000135285/vrrp-version-2-and-version-3-in-dell-emc-networking-os10-switches