### PR TITLE
OS10: Disable ipv6 on loopback if not configured

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -22,6 +22,8 @@ interface loopback0
 {% endif %}
 {% if 'ipv6' in loopback %}
  ipv6 address {{ loopback.ipv6 }}
+{% else %}
+ no ipv6 enable
 {% endif %}
 !
 interface {{ mgmt.ifname|default('mgmt1/1/1') }}


### PR DESCRIPTION
By default, OS10 enables ipv6 on loopbacks and assigns a LLA. If the config says 'no ipv6', it should be disabled

Context: #1494 