### PR TITLE
VRRP version plugin for gateway module

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -14,6 +14,7 @@
    plugins/check.config.md
    plugins/fabric.md
    plugins/multilab.md
+   plugins/vrrp.version.md
 ```
 
 Plugins needed by a topology file are listed in the **plugin** top-level element, for example:

--- a/docs/plugins/vrrp.version.md
+++ b/docs/plugins/vrrp.version.md
@@ -1,0 +1,23 @@
+(plugin-vrrp-version)=
+# VRRP version
+
+The **vrrp.version** plugin enables the configuration of the VRRP protocol version, specifically VRRPv2 (obsolete).
+Netlab only supports VRRPv3 by default
+
+The current version only supports configuring the VRRP version globally for each node, not at a per-interface level
+
+## Supported Platforms
+
+The plugin includes Jinja2 templates for the following platforms:
+
+| Operating system    | VRRPV2 | Notes
+| ------------------- | :----: | 
+| Dell OS10           |   ✅   | VRRPv2 is the default on OS10
+
+## Example config
+```
+module: [gateway]
+plugin: [vrrp.version]  
+
+gateway.vrrp.version: 2 # Optional, this is the assumed default when using this plugin
+```

--- a/netsim/extra/vrrp.version/defaults.yml
+++ b/netsim/extra/vrrp.version/defaults.yml
@@ -1,0 +1,14 @@
+# vrrp.version attributes
+#
+---
+devices:
+  dellos10:
+    features.gateway.vrrp.version: True
+
+gateway:
+  attributes:
+    global:
+      vrrp.version: { type: int, valid_values: [2,3] }
+    node:
+      vrrp.version: { type: int, valid_values: [2,3] }
+      # copy: global -> "must be a dict?"

--- a/netsim/extra/vrrp.version/dellos10.j2
+++ b/netsim/extra/vrrp.version/dellos10.j2
@@ -1,0 +1,1 @@
+vrrp version {{ gateway.vrrp.version|default(2) }}

--- a/netsim/extra/vrrp.version/plugin.py
+++ b/netsim/extra/vrrp.version/plugin.py
@@ -1,0 +1,38 @@
+import typing
+from box import Box
+from netsim.utils import log
+from netsim import api,data
+from netsim.augment import devices
+
+_config_name = 'vrrp.version'
+_requires    = [ 'gateway' ]
+
+def pre_link_transform(topology: Box) -> None:
+  global _config_name
+  # Error if gateway module is not loaded
+  if 'gateway' not in topology.module:
+    log.error(
+      'gateway module is not loaded.',
+      log.IncorrectValue,
+      _config_name)
+
+'''
+post_transform hook
+
+Apply plugin config to nodes running gateway.vrrp for devices that support this plugin
+'''
+def post_transform(topology: Box) -> None:
+  global _config_name
+  for node in topology.nodes.values():
+    if 'gateway' not in node.get('module',[]):         # Skip nodes not running gateway
+      continue
+    elif 'vrrp' not in node.gateway:
+      continue
+
+    features = devices.get_device_features(node,topology.defaults)
+    if 'gateway.vrrp.version' in features:
+      api.node_config(node,_config_name)               # Remember that we have to do extra configuration
+    else:
+      log.error( f'node {node.name} does not support the vrrp.version plugin.',
+        log.IncorrectValue,
+        _config_name)


### PR DESCRIPTION
Provides control over the VRRP protocol version to run, specifically by downgrading to (obsolete) v2