### PR TITLE
Fix: Node VRFs should not have any EVPN attributes

### DIFF
--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -5,8 +5,8 @@ evpn:
     All VLANs that are part of a VRF using asymmetric IRB have to be present on all nodes
     using that VRF. The easiest way to achieve that is to create a group with all
     participating nodes and list VLANs in the 'vlans' attribute of that group
-  node_bundle: |
-    evpn.bundle attribute can be used only in global VRF definition
+  node_attr: |
+    evpn.bundle and evpn.transit_vni attributes can be used only in global VRF definition
   asn: >
     You could use the global 'bgp.as' parameter to specify the AS to use in EVPN
     route targets. 'bgp.as' specified on individual nodes or groups will not work. You


### PR DESCRIPTION
This commit simplifies the EVPN node VRF checks: the node VRFs should not have any EVPN attributes (at the moment).

Inspired by #1489