### PR TITLE
Make quirk errors configurable

### DIFF
--- a/netsim/devices/dellos10.py
+++ b/netsim/devices/dellos10.py
@@ -3,11 +3,13 @@
 #
 from box import Box
 
-from . import _Quirks,need_ansible_collection
+from . import _Quirks,need_ansible_collection,report_quirk
 from ..utils import log
 from ..augment import devices
 
-def check_vlan_ospf(name: str, iflist: list, vname: str) -> None:
+def check_vlan_ospf(node: Box, vname: str) -> None:
+  name = node.name
+  iflist = node.get('interfaces',[])
   err_data = []
   for intf in iflist:
     if 'ospf' not in intf or intf.type != 'svi':
@@ -15,19 +17,19 @@ def check_vlan_ospf(name: str, iflist: list, vname: str) -> None:
     err_data.append(f'Interface {intf.ifname} VRF {vname}')
 
   if err_data:
-    log.error(
-      f'Dell OS10 (node {name}) cannot run OSPF on virtual-network (SVI) interfaces',
-      category=log.IncorrectValue,
+    report_quirk(
+      f'node {name} cannot run OSPF on virtual-network (SVI) interfaces',
+      quirk='svi_ospf',
       more_data=err_data,
-      module='ospf')
+      node=node)
 
 class OS10(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
-    check_vlan_ospf(node.name,node.get('interfaces',[]),'default')
+    check_vlan_ospf(node,'default')
     for vname,vdata in node.get('vrfs',{}).items():
-      check_vlan_ospf(node.name,vdata.get('ospf.interfaces',[]),vname)
+      check_vlan_ospf(node,vname)
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'dellemc.os10')

--- a/netsim/devices/dellos10.py
+++ b/netsim/devices/dellos10.py
@@ -1,15 +1,14 @@
 #
 # Dell OS10 quirks
 #
-from box import Box
+from box import Box,BoxList
 
 from . import _Quirks,need_ansible_collection,report_quirk
 from ..utils import log
 from ..augment import devices
 
-def check_vlan_ospf(node: Box, vname: str) -> None:
+def check_vlan_ospf(node: Box, iflist: BoxList, vname: str) -> None:
   name = node.name
-  iflist = node.get('interfaces',[])
   err_data = []
   for intf in iflist:
     if 'ospf' not in intf or intf.type != 'svi':
@@ -27,9 +26,9 @@ class OS10(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
-    check_vlan_ospf(node,'default')
+    check_vlan_ospf(node,node.interfaces,'default')
     for vname,vdata in node.get('vrfs',{}).items():
-      check_vlan_ospf(node,vname)
+      check_vlan_ospf(node,vdata.get('ospf.interfaces',[]),vname)
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'dellemc.os10')


### PR DESCRIPTION
The generic report_quirk function provides an abstraction on top of log.error that checks whether the specified quirk should be reported, giving the user means of turning off device-specific warnings.

Implemented for OSPF on DellOS10 SVI as a proof-of-concept

Fixes #1501