### PR TITLE
Check for reserved VRF names

### DIFF
--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -55,7 +55,7 @@ These platforms support routing protocols in VRFs:
 | VyOS                  | ✅  | ✅  | ✅  |
 
 ```{note}
-* IS-IS and EIGRP cannot be run within a VRF, but both configuration modules are VRF-aware -- they will not try to configure IS-IS or EIGRP routing on VRF interfaces
+* You cannot run EIGRP within a VRF, but the configuration module is VRF-aware -- it will not try to configure EIGRP routing on VRF interfaces
 * IBGP within a VRF instance does not work. PE-routers and CE-routers MUST HAVE different BGP AS numbers
 * See [VRF Integration Tests Results](https://release.netlab.tools/_html/coverage.vrf) for more details.
 ```
@@ -85,6 +85,7 @@ The keys of the **vrfs** dictionary are VRF names; the values are VRF definition
 Empty VRF definition will get [default RD and RT values](default-vrf-values) assigned during the topology transformation process.
 
 ```{warning}
+* Some VRF names (for example, *‌base*, *‌mgmt*, *‌system*, and *‌global*) cannot be used because they're used internally by network operating systems.
 * Do not reuse VRF names when defining node-specific VRFs. To implement complex VPN topologies, a subtle interaction between global and node-specific VRFs is needed, and _netlab_ assumes that the VRFs with the same name refer to the same routing and forwarding instance.
 * Global VRFs will not be instantiated on a node using the _vrf_ module unless the node is attached to a [VRF link](module-vrf-interface). If you want to create a VRF that uses no external interfaces, add the VRF name to the node **‌vrfs** dictionary.
 * The **‌vrfs** dictionary and the _vrf_ module will be removed from a node with no VRF interfaces or [VRF loopback interfaces](vrf-loopback).

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -115,6 +115,16 @@ def normalize_vrf_dict(obj: Box, topology: Box) -> None:
       obj.vrfs[vname] = {}
 
     vdata = obj.vrfs[vname]
+    if vname in topology.defaults.vrf.attributes.reserved:
+      r_list = ','.join(sorted(topology.defaults.vrf.attributes.reserved))
+      log.error(
+        f"Cannot use VRF {vname} in {obj_name} to avoid confusion with vendor built-in names",
+        more_hints=[
+          f'Reserved VRF names are {r_list}',
+          'Set defaults.vrf.attributes.reserved attribute to change that list' ],
+        category=log.IncorrectValue,
+        module='vrf')
+
     if 'rd' in vdata:
       if vdata.rd is None:      # RD set to None can be used to auto-generate RD while preventing RD inheritance
         continue                # ... skip the rest of the checks

--- a/netsim/modules/vrf.yml
+++ b/netsim/modules/vrf.yml
@@ -13,6 +13,9 @@ attributes:
     loopback:
   link: id
   interface: id
+  # Reserved VRF names
+  reserved: [ default, system, global, base, mgmt, management, junos_mgmt ]
+
 warnings:
   inactive: True
 _top:                               # Modification of global defaults

--- a/netsim/modules/vrf.yml
+++ b/netsim/modules/vrf.yml
@@ -14,7 +14,7 @@ attributes:
   link: id
   interface: id
   # Reserved VRF names
-  reserved: [ default, system, global, base, mgmt, management, junos_mgmt ]
+  reserved: [ default, system, global, base, mgmt, management, mgmt_junos ]
 
 warnings:
   inactive: True

--- a/tests/topology/input/vrf-leaking-loop.yml
+++ b/tests/topology/input/vrf-leaking-loop.yml
@@ -2,6 +2,7 @@
 provider: clab
 
 module: [ vrf, vlan ]
+defaults.vrf.attributes.reserved: []      # Change the list of reserved VRF names
 
 vrfs:
   global:           # Global VRF


### PR DESCRIPTION
Some VRF names cannot be used because they might interfere with built-in VRF names.

Closes #1509