### PR TITLE
Dell OS10: Remove escaping of commas in interface descriptions

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -41,7 +41,7 @@ interface {{ l.ifname }}
  mtu {{ l.mtu + 32 }}
 {% endif %}
 {% if l.name is defined %}
- description "{{ l.name | replace(",", "\\\\,") }}{{ " ["+l.role+"]" if l.role is defined else "" }}"
+ description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}"
 {% elif l.type|default("") == "stub" %}
  description "Stub interface"
 {% endif %}


### PR DESCRIPTION
Tested - there is no need, the names look odd with the escaped commas