### PR TITLE
Cleanup prefix handling for L2-only cases

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -419,12 +419,13 @@ def assign_link_prefix(
       link_path: str = 'links') -> Box:
 
   if 'prefix' in link:                                    # Does the link have prefix parameters?
+    if not link.prefix:                                   # There should be no prefix on this link, get out
+      link.pop('prefix',None)
+      return data.get_empty_box()
+
     pfx_data = addressing.parse_prefix(link.prefix,path=link_path)
     if log.debug_active('addr'):                          # pragma: no cover (debugging printout)
       print(f'link {link_path} got prefix {pfx_data} from {link.prefix}')
-    
-    if link.prefix is False:                              # There should be no prefix on this link, get out
-      return pfx_data
 
     if isinstance(link.prefix,str):                       # Is the prefix an IPv4 address?
       link.prefix = addressing.rebuild_prefix(pfx_data)   # ... convert it to prefix dictionary
@@ -990,7 +991,7 @@ def set_default_gateway(link: Box, nodes: Box) -> None:
   link.pop('host_count',None)
 
   # No IPv4 prefix on the link or unnumbered IPv4 link
-  if link.prefix is False or not 'ipv4' in link.prefix or isinstance(link.prefix.ipv4,bool):
+  if not 'ipv4' in link.prefix or isinstance(link.prefix.ipv4,bool):
     return
 
   if log.debug_active('links'):

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -27,7 +27,7 @@ create_lag_member_links -- iterate over topology.links and expand any that have 
 def create_lag_member_links(l: Box, topology: Box) -> None:
   lag_members = l.lag.members
   l.lag.pop("members",None)                      # Remove explicit list of members
-  l2_ifdata = { 'type': "p2p", 'prefix': False } # Construct an L2 member link
+  l2_ifdata = { 'type': "p2p", 'prefix': {} }    # Construct an L2 member link
   for a in list(topology.defaults.lag.attributes.lag_l2_ifattr):
     if a in l:
       l2_ifdata[a] = l[a]

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -104,7 +104,7 @@ def validate_vlan_attributes(obj: Box, topology: Box) -> None:
     vlan_pool.extend(['vlan','lan'])
     pfx_list = links.assign_link_prefix(vdata,vlan_pool,topology.pools,topology.nodes,f'{obj_path}.{vname}')
     vdata.prefix = addressing.rebuild_prefix(pfx_list)
-    if not 'allocation' in vdata.prefix:
+    if vdata.prefix and not 'allocation' in vdata.prefix:
       vdata.prefix.allocation = 'id_based'
 
 """
@@ -652,7 +652,7 @@ def create_vlan_links(link: Box, v_attr: Box, topology: Box) -> None:
         for intf in link_data.interfaces:
           intf.vlan.mode = 'route'
       else:
-        link_data.prefix = prefix
+        link_data.prefix = prefix or {}                     # Normalize False to {}
 
       topology.links.append(link_data)
 
@@ -689,8 +689,8 @@ def create_loopback_vlan_links(topology: Box) -> None:
       link_data = { '_linkname': f'nodes.{n.name}.vlans.{vname}' }      # Create a vlan_member link with fake parent (nobody should ever use it)
       link_data = create_vlan_link_data(link_data,vname,'loopback',topology)
       prefix = topology.vlans[vname].get('prefix',None)                 # Copy VLAN prefix into link_data
-      if prefix:
-        link_data.prefix = prefix
+      if prefix is not None:
+        link_data.prefix = prefix or {}
 
       # Create interface data using fake parent interface
       fake_parent = data.get_box({'node': n.name})

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -229,7 +229,6 @@ links:
   linkindex: 11
   name: l2only LAN link with a host IP address
   node_count: 3
-  prefix: false
   type: lan
 - bridge: input_12
   interfaces:

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -156,7 +156,6 @@ links:
   linkindex: 10
   name: l2only P2P link
   node_count: 2
-  prefix: false
   type: p2p
 - interfaces:
   - ifindex: 12

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -38,7 +38,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   role: external
   type: p2p
   vlan:
@@ -62,7 +61,6 @@ links:
         red: {}
   linkindex: 2
   node_count: 2
-  prefix: {}
   role: external
   type: p2p
   vlan:

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -37,7 +37,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -60,7 +59,6 @@ links:
         red: {}
   linkindex: 2
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/lag-l3-vlan-trunk.yml
+++ b/tests/topology/expected/lag-l3-vlan-trunk.yml
@@ -26,7 +26,6 @@ links:
     ifindex: 1
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: lag
   vlan:
     trunk:
@@ -44,7 +43,6 @@ links:
     ifindex: 1
   linkindex: 2
   node_count: 2
-  prefix: false
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -58,7 +56,6 @@ links:
     ifindex: 1
   linkindex: 3
   node_count: 2
-  prefix: false
   type: p2p
 - interfaces:
   - ifindex: 3
@@ -72,7 +69,6 @@ links:
     ifindex: 1
   linkindex: 4
   node_count: 2
-  prefix: false
   type: p2p
 module:
 - lag

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -37,7 +37,6 @@ links:
   linkindex: 2
   mtu: 1600
   node_count: 2
-  prefix: false
   type: p2p
 - interfaces:
   - ifindex: 2
@@ -52,7 +51,6 @@ links:
   linkindex: 3
   mtu: 1600
   node_count: 2
-  prefix: false
   type: p2p
 module:
 - lag

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -44,7 +44,6 @@ links:
     node: r2
   linkindex: 3
   node_count: 2
-  prefix: false
   type: p2p
 - bridge: input_4
   interfaces:
@@ -59,7 +58,6 @@ links:
     node: r3
   linkindex: 4
   node_count: 3
-  prefix: false
   type: lan
 name: input
 nodes:

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -62,7 +62,6 @@ links:
         blue: {}
   linkindex: 3
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -90,7 +90,6 @@ links:
   linkindex: 4
   name: Simple trunk
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -142,7 +141,6 @@ links:
   linkindex: 6
   name: Routed trunk
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     mode: route
@@ -195,7 +193,6 @@ links:
   linkindex: 8
   name: Trunk between switch and bridge
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -222,7 +219,6 @@ links:
   linkindex: 9
   name: Trunk with bridge
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -21,7 +21,6 @@ links:
         vxlan: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -27,7 +27,6 @@ links:
         green: {}
   linkindex: 1
   node_count: 3
-  prefix: {}
   type: lan
   vlan:
     trunk:

--- a/tests/topology/expected/stp-pvrst.yml
+++ b/tests/topology/expected/stp-pvrst.yml
@@ -40,7 +40,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -36,7 +36,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -45,7 +45,6 @@ links:
         red: {}
   linkindex: 2
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -69,7 +68,6 @@ links:
             mode: route
   linkindex: 3
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -26,7 +26,6 @@ links:
       clab: true
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: lan
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -90,7 +90,6 @@ links:
         red: {}
   linkindex: 4
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -117,7 +116,6 @@ links:
         red: {}
   linkindex: 5
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -143,7 +141,6 @@ links:
         red: {}
   linkindex: 6
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -33,7 +33,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -56,7 +55,6 @@ links:
         red: {}
   linkindex: 2
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -36,7 +36,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:
@@ -59,7 +58,6 @@ links:
         red: {}
   linkindex: 2
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -39,7 +39,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -29,7 +29,6 @@ links:
           vrf: customer2
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -31,7 +31,6 @@ links:
         red: {}
   linkindex: 1
   node_count: 2
-  prefix: {}
   type: p2p
   vlan:
     trunk:


### PR DESCRIPTION
* Normalize the data model to use ```prefix: {}``` to denote "Do not assign a prefix"
* Remove the 'prefix' attribute when it is empty, consistent with IP addresses (device templates don't reference link prefix attribute)