### PR TITLE
Fix clab device specific kernel module loading

### DIFF
--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -29,6 +29,7 @@ group_vars:
 clab:
   image: python:3.9-alpine
   mtu: 1500
+  kmods:
   node:
     kind: linux
     config_templates:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -29,7 +29,6 @@ group_vars:
 clab:
   image: python:3.9-alpine
   mtu: 1500
-  kmods:
   node:
     kind: linux
     config_templates:

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -128,7 +128,7 @@ def load_kmods(topology: Box) -> None:
     ddata = devices.get_provider_data(ndata,defs)           # Get device data for the current node
     if 'kmods' not in ddata:                                # Kmods attribute is not there, the device is not using kernel modules
       continue
-    must_be_dict(ddata,'kmods',path=f'clab.{ndata.device}',create_empty=True)
+    must_be_dict(ddata,'kmods',path=f'defaults.devices.{ndata.device}.clab',create_empty=True)
     kdata = clab_kmods + ddata.kmods                        # Merge device-specific modules with system-wide kernel module definition
 
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -10,6 +10,7 @@ import argparse
 from . import _Provider,get_forwarded_ports
 from ..utils import log, strings
 from ..data import filemaps, get_empty_box, append_to_list
+from ..data.types import must_be_dict
 from ..cli import is_dry_run,external_commands
 from ..augment import devices
 from ..cli import external_commands
@@ -127,13 +128,12 @@ def load_kmods(topology: Box) -> None:
     ddata = devices.get_provider_data(ndata,defs)           # Get device data for the current node
     if 'kmods' not in ddata:                                # Kmods attribute is not there, the device is not using kernel modules
       continue
-    kdata = ndata.kmods or clab_kmods                       # Get device-specific or system-wide kernel module definition
-    if isinstance(kdata,list):                              # ... some devices specify just the netlab modules that need kmods
-      kdata = { k:clab_kmods[k] for k in kdata}             # ... in which case build the dictionary from system-wide values
+    must_be_dict(ddata,'kmods',path=f'clab.{ndata.device}',create_empty=True)
+    kdata = clab_kmods + ddata.kmods                        # Merge device-specific modules with system-wide kernel module definition
 
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules
     #
-    for m in ndata.module:                                  # Now iterate over all the netlab modules the node uses
+    for m in (['initial']+ndata.get('module',[])):          # Now iterate over all the netlab modules the node uses
       if m not in kdata:                                    # ... and if the netlab modules does not need kernel modules
         continue                                            # ... move on
       for kmod in kdata[m]:                                 # Next, add individual kernel modules in the kdata entry
@@ -179,7 +179,7 @@ class Containerlab(_Provider):
         self.create_extra_files(n,topology)
 
   def pre_start_lab(self, topology: Box) -> None:
-    log.print_verbose('pre-start hook for Containerlab - create any bridges')
+    log.print_verbose('pre-start hook for Containerlab - create any bridges and load kernel modules')
     for brname in list_bridges(topology):
       if use_ovs_bridge(topology):
         create_ovs_bridge(brname)


### PR DESCRIPTION
The current devices only use ```kmods:``` (empty) to specify they need system default kernel modules loaded

* Cumulus NVUE needs ebtables loaded too, regardless of which modules are used (modeled as depending on 'initial')
* Linux nodes don't need any (don't support any modules that would require additional kmods); ndata.module becomes ```{}``` for hosts

The original code wasn't actually using ```ddata.kmods```, but because none of the current devices had any value for it that didn't cause any issues