### PR TITLE
Refactor Linux bridge function to configure LACP forwarding for Libvirt too

### DIFF
--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -8,7 +8,7 @@ import pathlib
 import argparse
 
 from . import _Provider,get_forwarded_ports
-from ..utils import log, strings
+from ..utils import log, strings, linuxbridge
 from ..data import filemaps, get_empty_box, append_to_list
 from ..data.types import must_be_dict
 from ..cli import is_dry_run,external_commands
@@ -39,14 +39,8 @@ def create_linux_bridge( brname: str ) -> bool:
     return False
   log.print_verbose( f"Enable Linux bridge '{brname}': {status}" )
 
-  status = external_commands.run_command(
-      ['sudo','sh','-c',f'echo 65528 >/sys/class/net/{brname}/bridge/group_fwd_mask'],
-      check_result=True,
-      return_stdout=True)
-  if status is False:
-    return False
-  log.print_verbose( f"Enable LLDP,LACP,802.1X forwarding on Linux bridge '{brname}': {status}" )
-  return True
+  status = linuxbridge.configure_bridge_forwarding(brname)
+  return status
 
 def destroy_linux_bridge( brname: str ) -> bool:
   status = external_commands.run_command(

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -14,7 +14,7 @@ import netaddr
 import argparse
 
 from ..data import types,get_empty_box,get_box
-from ..utils import log,strings
+from ..utils import log,strings,linuxbridge
 from ..utils import files as _files
 from . import _Provider
 from ..augment import devices
@@ -383,17 +383,14 @@ class Libvirt(_Provider):
 
       l.bridge = linux_bridge
       log.print_verbose(f"... network {brname} maps into {linux_bridge}")
-      if not external_commands.run_command(
-          ['sudo','sh','-c',f'echo 0x4000 >/sys/class/net/{linux_bridge}/bridge/group_fwd_mask']):
+      if not linuxbridge.configure_bridge_forwarding(brname):
         log.error(f"Cannot set forwarding mask on Linux bridge {linux_bridge}")
         continue
-      log.print_verbose(f"... set LLDP enabled flag on {linux_bridge}")
       if not external_commands.run_command(
           ['sudo','sh','-c',f'brctl stp {linux_bridge} off']):
         log.error(f"Cannot disable STP on Linux bridge {linux_bridge}")
         continue
       log.print_verbose(f"... disabled STP on {linux_bridge}")
-
 
   def get_lab_status(self) -> Box:
     try:

--- a/netsim/utils/linuxbridge.py
+++ b/netsim/utils/linuxbridge.py
@@ -1,0 +1,15 @@
+from . import log
+from ..cli import external_commands
+
+"""
+configure_bridge_forwarding - Enables LLDP, LACP and 802.1X forwarding on the given Linux bridge
+"""
+def configure_bridge_forwarding(brname: str) -> bool:
+  status = external_commands.run_command(
+      ['sudo','sh','-c',f'echo 65528 >/sys/class/net/{brname}/bridge/group_fwd_mask'],
+      check_result=True,
+      return_stdout=True)
+  if status is False:
+    return False
+  log.print_verbose( f"Enable LLDP,LACP,802.1X forwarding on Linux bridge '{brname}': {status}" )
+  return True


### PR DESCRIPTION
Using Libvirt forwarding for LACP frames is not enabled for the bridges interconnecting the nodes. This PR removes some duplicate code, and consolidates proper bridge forwarding settings in a utils package