### PR TITLE
VLAN and VRF groups

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -90,7 +90,7 @@ devices:
 
 All anycast servers in a BGP anycast topology should have the same AS number but [do not need IBGP sessions between themselves](https://blog.ipspace.net/2022/01/netsim-plugins.html). A [custom plugin](https://github.com/ipspace/netlab-examples/tree/master/plugins/adjust-bgp-sessions) deletes IBGP sessions for any node with **bgp.anycast** attribute.
 
-The topology file used in the BGP anycast example uses [group node data](../groups.md#setting-node-data-in-groups) on a [BGP AS group](../groups.md#automatic-bgp-groups) to set **bgp.anycast** node attribute on any node in AS 65101
+The topology file used in the BGP anycast example uses [group node data](groups-object-data) on a [BGP AS group](../groups.md#automatic-bgp-groups) to set **bgp.anycast** node attribute on any node in AS 65101
 
 ```yaml
 plugin: [ bgp.anycast ]

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,6 +1,6 @@
 # Groups of Lab Objects (Nodes, VLANs, VRFs)
 
-If you have several lab objects (nodes, VLANs, or VRFs) with similar attributes, use _netlab_ groups to apply a set of valid attributes to all of them.
+If you have several lab objects (nodes, VLANs, or VRFs) with similar attributes, use _netlab_ groups to apply a set of valid attributes to all of them ([link groups](link-groups) are defined within the [links list](topo-links)).
 
 You can define custom groups in lab topology or *netlab* defaults. *netlab* also creates node groups based on node devices (for example, *iosv* or *eos* group) and based on node **bgp.as** attribute (for example, *as65000* for all nodes with **bgp.as** set to 65000)
 
@@ -50,6 +50,10 @@ groups:
     members: [ red_vrf, blue_vrf ]
     type: vrf
     loopback: True
+```
+
+```{tip}
+[Link groups](link-groups) are defined within the [links list](topo-links).
 ```
 
 (default-groups)=

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,11 +1,15 @@
-# Groups of Lab Devices (Nodes)
+# Groups of Lab Objects (Nodes, VLANs, VRFs)
 
-Network devices (nodes) used in a virtual lab are automatically grouped into platform-specific groups like *iosv* or *nxos*. You can use these groups or custom groups to:
+If you have several lab objects (nodes, VLANs, or VRFs) with similar attributes, use _netlab_ groups to apply a set of valid attributes to all of them.
 
-* Set node attributes or Ansible group variables
+You can define custom groups in lab topology or *netlab* defaults. *netlab* also creates node groups based on node devices (for example, *iosv* or *eos* group) and based on node **bgp.as** attribute (for example, *as65000* for all nodes with **bgp.as** set to 65000)
+
+You can use custom- and netlab-created object groups to set node, VLAN, or VRF attributes. You can also use the node groups to:
+
+* Set Ansible group variables
 * Set device type or [configuration modules](module-reference.md) for a set of devices
 * Attach additional configuration templates to a set of devices
-* Limit the scope of **[netlab](netlab/cli.md)** commands that invoke Ansible playbooks. 
+* Limit the scope of **[netlab](netlab/cli.md)** commands that invoke Ansible playbooks.
 
 For example, you could use `netlab config mpls.j2 --limit iosv` to deploy configuration specified in Jinja2 template `mpls.j2` only on Cisco IOSv devices.
 
@@ -16,10 +20,10 @@ For example, you could use `netlab config mpls.j2 --limit iosv` to deploy config
    :backlinks: none
 ```
 
-## Custom Node Groups
+(groups-create)=
+## Creating Custom Object Groups
 
-Virtual lab topology can specify additional (custom) device groups in the **groups** top-level parameter. The **groups** parameter must be a dictionary with group names as dictionary keys. Dictionary values could be either a list of member nodes or a further dictionary specifying **members**:
-
+Lab topology can specify custom object groups in the **groups** top-level parameter. The **groups** parameter must be a dictionary with group names as dictionary keys. Dictionary values could be either a list of member nodes or a further dictionary specifying **members**:
 
 ```
 ---
@@ -33,16 +37,20 @@ groups:
     members: [ d,e,f ]
 ```
 
-The custom node groups are used to create additional groups in the Ansible inventory file. You can use custom node groups in any **netlab** command that invokes an Ansible playbook.
+The custom groups are assumed to contain nodes. To create a VLAN or a VRF group, set the group **type** to **vlan** or **vrf**, for example:
 
-For example, `netlab config mpls.j2 --limit g1` would deploy configuration template `mpls.j2` only on lab devices A, B, and C.
-
-(group-special-names)=
-### Special Group Names
-
-The following groups have special meaning in *netlab*-generated Ansible inventory:
-
-* `unprovisioned`: **netlab up** and **netlab initial** will skip devices in this group while deploying device configurations.
+```
+groups:
+  ce_vlan:
+    members: [ red_vlan, blue_vlan ]
+    type: vlan
+    ospf.cost: 1
+    vlan.mode: route
+  ce_vrf:
+    members: [ red_vrf, blue_vrf ]
+    type: vrf
+    loopback: True
+```
 
 (default-groups)=
 ### Default Groups
@@ -59,20 +67,20 @@ The only peculiarity of the default groups is the handling of group members:
 
 [^DGM]: That makes it possible to have default group members not present in the lab topology.
 
-(group-node-data)=
-## Setting Node Data in Groups
+(groups-object-data)=
+## Setting Object Data in Groups
 
-Sometimes, you'd like to set a node attribute for all group members. For example, in a BGP anycast scenario, we should set **[bgp.advertise_loopback](module/bgp.md#advertised-bgp-prefixes)** to *false* on all anycast server -- they should advertise only the anycast prefix, not individual loopback prefixes. 
+Sometimes, you'd like to set an attribute for all group members. For example, in a BGP anycast scenario, we should set **[bgp.advertise_loopback](module/bgp.md#advertised-bgp-prefixes)** to *false* on all anycast server -- they should advertise only the anycast prefix, not individual loopback prefixes. 
 
-While it's perfectly OK to set the desired attribute(s) on individual nodes, it's much more convenient to set them in a group definition -- you can use any valid node attribute (including configuration module node attributes[^MNA]) in group definitions[^NDT].
+While it's perfectly OK to set the desired attribute(s) on individual nodes, it's much more convenient to specify them in a group definition -- you can use any valid node, VLAN, or VRF attribute (including configuration module attributes[^MNA]) in group definitions[^NDT].
 
-[^MNA]: If a group definition contains a **module** attribute, you cannot set attributes for modules not listed in the **module** attribute in the group definition.
+[^MNA]: If a node group definition contains a **module** attribute, you cannot set attributes for modules not listed in the **module** attribute in the group definition. VLAN and VRF groups can use only modules specified in the topology-level **module** attribute.
  
 [^NDT]: Node attributes were stored in **node_data** group attribute prior to *netlab* release 1.4. While you can still use the **node_data** dictionary, it has a few undesired side effects that we'll not fix. It is deprecated in release 1.8; using it will generate a warning during the data transformation phase.
 
-The node group attribute will be set on all members of the group. The data is [deep-merged](defaults.md#deep-merging) with the existing node data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute[^NDGP].
+The group attributes will be set on all members of the group. The data is [deep-merged](defaults-deep-merging) with the existing object data -- for example, you could set **bgp.advertise_loopback** attribute in group definition without affecting **bgp.as** node attribute[^NDGP].
 
-[^NDGP]: In a topology with hierarchical groups, attributes from the innermost groups take precedence. Node attributes from groups with static members have precedence over node attributes from BGP-generated groups.
+[^NDGP]: In a topology with [hierarchical groups](groups-hierarchy), attributes from the innermost groups take precedence. Node attributes from groups with static members have precedence over node attributes from BGP-generated groups.
 
 Using this functionality, a BGP anycast topology file becomes much more concise than it would have been otherwise:
 
@@ -93,9 +101,10 @@ groups:
 nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
 ```
 
-### Using Group Node Data with VRFs and VLANs
+(groups-node-vlan-vrf)=
+### Specifying VLANs and VRFs in Node Groups
 
-VRFs and VLANs mentioned in **vrfs** or **vlans** group attributes will be defined as global (topology-wide) VRFs/VLANs. The VLAN ID/VNI or VRF RT/RD values will be copied from **vlans**/**vrfs** into global **vlans**/**vrfs**. Every VLAN  needs a unique ID/VNI (likewise for VRF RT/RD), so you cannot define different ID/VNI or RT/RD values for the same VLAN/VRF in different groups.
+VRFs and VLANs mentioned in a node group's **vrfs** or **vlans** attributes become global (topology-wide) VRFs/VLANs. The VLAN ID/VNI or VRF RT/RD values (when specified) are copied from the **vlans**/**vrfs** group data into global **vlans**/**vrfs** dictionaries. Every VLAN needs a unique ID/VNI (likewise for VRF RT/RD), so you cannot define different ID/VNI or RT/RD values for the same VLAN/VRF in multiple groups.
 
 Example:
 
@@ -119,22 +128,23 @@ links:
   vlan.trunk: [ red, blue ]
 ```
 
-The above topology will:
+The above topology:
 
-* Create topology-wide *red* and *blue* VLANs.
-* Auto-assign VLAN ID and VNI to those VLANs.
-* Copy group **vlans** into R1 and R2 (setting OSPF cost for VLAN interfaces)
-* Merge the global **vlans** definitions into **nodes.r1.vlans** and **nodes.r2.vlans**, ensuring the VLANs on R1 and R2 have the correct VLAN ID/VNI.
+* Creates topology-wide *red* and *blue* VLANs.
+* Auto-assigns VLAN ID and VNI to those VLANs.
+* Copies group **vlans** into R1 and R2 (setting OSPF cost for VLAN interfaces)
+* Merges the global **vlans** definitions into **nodes.r1.vlans** and **nodes.r2.vlans**, ensuring the VLANs on R1 and R2 have the correct VLAN ID/VNI.
 
 ```{tip}
 As the group VLANs/VRFs are copied into all nodes in a group, you'll get all VLANs/VRFs (and VLAN interfaces) mentioned in the group definition defined on all group members regardless of whether they use those VLANs/VRFs.
 ```
 
-## Setting Device Type or List of Modules in Groups
+(groups-device-module)=
+### Setting Device Type or List of Modules in Node Groups
 
-You can set node device type (**device** attribute) or the list of configuration modules (**module** attribute) in group definitions, but only on groups with static members.
+You can set node device type (**device** attribute) or the list of configuration modules (**module** attribute) in a node group definition, but only on groups with static members.
 
-The device type is copied from groups to nodes with no **device** attribute. Modules listed in a group are added to the node **module** attribute. The merging of node- and group modules takes precedence over the global (topology-level) list of modules.
+The device type is copied from a group definition to member nodes with no **device** attribute. Modules listed in a group are added to the member node **module** attribute. The merging of node- and group modules takes precedence over the global (topology-level) list of modules.
 
 The following example uses this functionality to:
 
@@ -159,15 +169,34 @@ nodes: [ l1, l2, l3, s1, a1, a2, a3 ]
 ```
 
 **Notes:**
-* The BGP module specified in the **anycast** group is added to the list of modules specified in the group members. No group members have an explicit module definition, resulting in `module: [ bgp ]` being set on A1, A2, and A3.
+* _netlab_ adds the BGP module specified in the **anycast** group to the list of modules of individual group members. No group members have an explicit module definition, resulting in `module: [ bgp ]` being set on A1, A2, and A3.
 * Device type specified in the **anycast** group is copied into A1, A2, and A3.
 * Default device type specified in **defaults.device** is copied into nodes that still have no device type (L1, L2, L3, S1)
 * Default list of modules (`module: [ bgp, ospf ]`) is copied into nodes that still have no **module** attribute (L1, L2, L3, S1).
 
-(group-ansible-vars)
-## Ansible Group Variables
+(groups-ansible-inventory)=
+## Netlab Groups in Ansible Inventory
 
-Group definition could include Ansible group inventory variables in the **vars** element, a dictionary of name/value pairs. The following example creates two groups (g1 and g2) and sets Ansible group variables on g2.
+The custom node groups are used to create additional groups in the Ansible inventory file. You can use custom node groups in any **netlab** command that invokes an Ansible playbook.
+
+For example, given the following lab topology, `netlab config mpls.j2 --limit g1` would deploy configuration template `mpls.j2` only on lab devices A, B, and C.
+
+```
+---
+defaults.device: iosv
+  
+nodes: [ a,b,c,d,e,f ]
+
+groups:
+  g1: [ a,b,c ]
+  g2:
+    members: [ d,e,f ]
+```
+
+(group-ansible-vars)=
+### Ansible Group Variables
+
+A node group definition could include Ansible group inventory variables in the **vars** element (a dictionary of name/value pairs). The following example creates two groups (g1 and g2) and sets Ansible group variables on g2.
 
 ```
 ---
@@ -188,9 +217,16 @@ Group variables are stored in **group_vars** directory when **[netlab create](ne
 
 ```{warning}
 * Use this functionality only when you need custom attributes in Jinja2 templates but don't want to specify them as [valid node attributes](extend-attributes.md).
-* You cannot use Ansible group variables to overwrite node data specified in a custom group. The [group node data](group-node-data) is copied into the node data and stored in Ansible host variables.
+* You cannot use Ansible group variables to overwrite node data specified in a custom group. The [group node data](groups-object-data) is copied into the node data and stored in Ansible host variables.
 * Ansible inventory is not used in the **[‌netlab connect](netlab/connect.md)** command. To overwrite connection-specific variables (connection method, username, password), specify `ansible_something` or `netlab_something` variables in node data. See [Node Attributes](node-ansible-data) for more details.
 ```
+
+(group-special-names)=
+### Special Ansible Group Names
+
+The following groups have special meaning in *netlab*-generated Ansible inventory:
+
+* `unprovisioned`: **netlab up** and **netlab initial** will skip devices in this group while deploying device configurations.
 
 ### Changing Group Variables for Predefined Groups
 
@@ -229,7 +265,7 @@ groups.cumulus.vars.ansible_user: other
 
 ## Automatic BGP Groups
 
-The BGP module creates a group named *asnnn* where *nnn* is the AS number for every BGP AS present in the lab topology. The members of the group are all nodes in that autonomous system.
+The BGP module creates a node group named *asnnn* where *nnn* is the AS number for every BGP AS present in the lab topology. The members of the group are all nodes in that autonomous system.
 
 You can set inventory variables (with **vars** attribute), deployment templates (with **config** attribute), or node data on an automatic BGP group, but you cannot specify static group members.
 
@@ -312,6 +348,7 @@ groups:
     - e
 ```
 
+(groups-hierarchy)=
 ## Hierarchical Groups
 
 *netlab* supports _hierarchical groups_ -- groups could be members of other groups, for example:
@@ -339,9 +376,9 @@ g2:
     d: {}
 ```
 
-### Node Data in Hierarchical Groups
+### Object Data in Hierarchical Groups
 
-When faced with a group hierarchy, processing of node data takes great care to use the node values specified in the most specific group (see also [](custom-config-groups))
+When faced with a group hierarchy, processing of object (node, VLAN, or VRF) data takes great care to use the object values specified in the most specific group (see also [](custom-config-groups))
 
 Continuing the previous example, now with node data in groups[^FINV]:
 
@@ -362,7 +399,7 @@ groups:
 * Nodes **a**, **b** and **d** (direct and indirect members of group **g2**) will have the node attribute **foo** set to **bar**.
 * Node **e** (member of group **g3**) will have the node attribute **foo** set to **baz** -- **g3** overwrites the **foo** value set by the parent group **g2**.
 
-Group node data processing performs [deep dictionary merge](defaults.md#deep-merging) when an attribute specified in the group ‌and the current value of the node attribute are both dictionaries, allowing you to specify various parts of the same dictionary in different groups, for example:
+Group data processing performs [deep dictionary merge](defaults-deep-merging) when an attribute specified in the group ‌and the current value of the member attribute are both dictionaries, allowing you to define various parts of the same data structure in different groups, for example:
 
 ```
 nodes:
@@ -394,14 +431,14 @@ groups:
 * Nodes **c** and **f** do not have any BGP-related attributes
 
 (groups-auto-create)=
-## Create Nodes From Group Members
+## Create Objects From Group Members
 
-The group **members** attribute must contain valid node names specified in the **nodes** dictionary to prevent typos and duplicate names. However, if a group contains **\_auto\_create**  attribute set to *True*, _netlab_ creates missing nodes from group members. You can set the **\_auto\_create** attribute:
+To prevent typos and duplicate names, the group **members** attribute must contain valid group-type-specific object names specified in the **nodes**, **vlans**, or **vrfs** dictionary. However, if a group contains **\_auto\_create**  attribute set to *True*, *netlab* creates missing objects from group members. You can set the **\_auto\_create** attribute:
 
 * In individual groups. You can specify the **\_auto\_create** attribute in individual default groups to create nodes in all labs using those defaults.
 * In **groups** or **defaults.groups** dictionary. The global **\_auto\_create**  attribute does not apply to default groups.
 
-For example, the following topology creates nodes from the members of all topology groups (due to global **\_auto\_create** attribute) and from the members of the **g2** default group:
+For example, due to the global **\_auto\_create** attribute, the following topology creates nodes from the members of all topology groups (**g3**). It also creates nodes from the members of the **g2** default group due to the group **\_auto\_create** attribute.
 
 ```
 defaults:

--- a/docs/netlab/connect.md
+++ b/docs/netlab/connect.md
@@ -36,7 +36,7 @@ The [**‌--show** option](netlab-connect-show) must be used _after_ the host pa
 
 **netlab connect** uses the lab snapshot file (default: `netlab.snapshot.yml`) to read device- and node information. You can overwrite the default snapshot file with the `--snapshot` command line parameter.
 
-**netlab connect** command uses the following device data. Most of that data is derived from the device **group_vars**, although you can override it on [node-](node-ansible-data) or [custom group](group-node-data) level; use the **[`netlab inspect --node _name_`](inspect.md)** command to inspect it.
+**netlab connect** command uses the following device data. Most of that data is derived from the device **group_vars**, although you can override it on [node-](node-ansible-data) or [custom group](groups-object-data) level; use the **[`netlab inspect --node _name_`](inspect.md)** command to inspect it.
 
 * `ansible_connection`: Use **docker exec** if the connection is set to `docker`[^cd]. Use **ssh** if the connection is set to `ssh`, `paramiko`[^cp], `network_cli`[^cc], or `netconf`[^cn]. Fail for all other connection types.
 * `ansible_host`: IP address or alternate FQDN for the lab device (default: hostname specified on the command line)

--- a/docs/release/1.0.md
+++ b/docs/release/1.0.md
@@ -10,7 +10,7 @@
 ## New Functionality in Release 1.0.6
 
 * [Plugin packages](../plugins.md) and module extensions.
-* [Hierarchical device groups](../groups.md#hierarchical-groups)
+* [Hierarchical device groups](groups-hierarchy)
 * Device-specific module attributes ([more details](../dev/module-attributes.md))
 * [Custom deployment templates](custom-config) are deployed as part of [initial device configuration](../netlab/initial.md).
 * **[netlab initial](../netlab/initial.md)** command includes `--fast` option which uses **free** strategy in Ansible playbooks for faster configuration deployment.
@@ -41,7 +41,7 @@
 
 ## New Functionality in Release 1.0.2
 
-* You can [set node attributes on all members in a custom group](../groups.md#setting-node-data-in-groups) with the **node_data** group attribute.
+* You can [set node attributes on all members in a custom group](groups-object-data) with the **node_data** group attribute.
 * [BGP module](../module/bgp.md) creates [custom groups based on node AS numbers](../groups.md#automatic-bgp-groups).
 * Experimental release of [custom plugins](../plugins.md). I don't expect the plugin structure to change (much), but there is no well-defined API to set data structures in the rest of the *netlab* code (yet).
 

--- a/docs/release/1.2.md
+++ b/docs/release/1.2.md
@@ -30,7 +30,7 @@
 * [netlab restart](../netlab/restart.md) command restarts or reconfigures the lab
 * [Use the snapshot file to start a lab](../netlab/up.md) from a topology previously modified through CLI arguments
 * [Specify NIC model used by *libvirt* virtualization provider](../nodes.md#libvirt-attributes) (by Stefano Sasso)
-* [Set device type or configuration modules in groups](../groups.md#setting-device-type-or-list-of-modules-in-groups)
+* [Set device type or configuration modules in groups](groups-device-module)
 * Persistent Linux network provisioning (by Stefano Sasso)
 * Debian supported by the [installation scripts](../netlab/install.md) (by Jody Lemoine)
 

--- a/docs/release/1.3.md
+++ b/docs/release/1.3.md
@@ -12,7 +12,7 @@ Release 1.3.3 is a bug fix release. New functionality will be added in release 1
 * [EVPN](../module/evpn.md) (bridging and symmetric IRB) on Nexus OS
 * EVPN VLAN bundle service on SR Linux
 * EVPN transit VNI [shared between VRFs](../module/evpn.md#integrated-routing-and-bridging)
-* [Define VLAN and VRF parameters in groups](../groups.md#using-group-node-data-with-vrfs-and-vlans)
+* [Define VLAN and VRF parameters in groups](groups-node-vlan-vrf)
 * [Disable OSPF, EIGRP, or IS-IS](routing_disable) on a link or an interface 
 * [Disable EBGP sessions](routing_disable) on a link or an interface
 * EVPN over IPv6 LLA sessions on Cumulus Linux and FRR

--- a/docs/release/1.4.md
+++ b/docs/release/1.4.md
@@ -45,8 +45,8 @@ Other few features include:
 * [Control allocation of VNI identifiers](../module/vxlan.md#selecting-vxlan-enabled-vlans) with **vxlan.vlans** attribute
 * [Specify EVPN-enabled VLANs and VRFs](../module/evpn.md#global-evpn-parameters) with **evpn.vlans** and **evpn.vrfs** lists
 * VLAN interfaces are [created for all VLANs listed in node **vlans** dictionary](module-vlan-creating-interfaces) even when there's no physical interface using a particular VLAN.
-* VLANs and VRFs mentioned in group **vlans**/**vrfs** dictionaries are [copied into all group members](../groups.md#using-group-node-data-with-vrfs-and-vlans), resulting in VLAN interfaces and VRFs on all group members.
-* **node_data** is deprecated -- you can [specify node attributes directly in group data](../groups.md#setting-node-data-in-groups).
+* VLANs and VRFs mentioned in group **vlans**/**vrfs** dictionaries are [copied into all group members](groups-node-vlan-vrf), resulting in VLAN interfaces and VRFs on all group members.
+* **node_data** is deprecated -- you can [specify node attributes directly in group data](groups-object-data).
 * [**unmanaged** devices](../example/external.md#unmanaged-devices) participate in data transformation process but are not part of virtual lab topology.
 * [Devices in **unprovisioned** group](../example/external.md#unprovisioned-devices) are not configured during the **netlab initial** process.
 * Routing protocols could be [disabled for the whole VRF](routing_disable)

--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -21,7 +21,7 @@ from . import nodes
 '''
 Return members of the specified group. Recurse through child groups if needed
 '''
-def group_members(topology: Box, group: str, count: int = 0) -> list:
+def group_members(topology: Box, group: str, grp_type: str = 'node', count: int = 0) -> list:
   members: typing.List[str] = []
   if not group in topology.groups:  # pragma: no cover (just-in case catch, impossible to get here)
     log.error(
@@ -36,11 +36,16 @@ def group_members(topology: Box, group: str, count: int = 0) -> list:
       module='groups',
       header=True)
 
-  for m in topology.groups[group].members:
-    if m in topology.nodes:
+  gdata = topology.groups[group]
+  if gdata.get('type','node') != grp_type:
+    return []
+
+  for m in gdata.members:
+    m_ns = grp_type + 's'
+    if m in topology[m_ns]:
       members = members + [ m ]
     if m in topology.groups:
-      members = members + group_members(topology,m,count + 1)
+      members = members + group_members(topology,m,grp_type,count + 1)
 
   return members
 
@@ -254,18 +259,17 @@ def auto_create_members(
       if n in topology.get('groups',{}) or n in topology.get('defaults.groups',{}):
         continue
 
-      if n in topology.nodes:                     # Skip if the member is already a known node
+      obj_ns = gdata.get('type','node') + 's'
+
+      if n in topology[obj_ns]:                   # Skip if the member is already a known object
         continue
 
-      topology.nodes[n].name = n                  # Otherwise create an empty node data structure
-      topology.nodes[n].interfaces = []           # ... with an empty interface list
+      if obj_ns == 'nodes':                       # For auto-created nodes...
+        topology[obj_ns][n].name = n              # ... create an empty node data structure
+        topology[obj_ns][n].interfaces = []       # ... with an empty interface list
+      else:
+        topology[obj_ns][n] = {}                  # For all others, create a placeholder object
   
-  '''
-  Transform group-as-list into group-as-dictionary
-  '''
-  for grp in parent.groups.keys():
-    gpath = f'{parent_path or "topology"}.groups.{grp}'
-
 '''
 Add node-level group settings to global groups
 '''
@@ -387,22 +391,28 @@ def copy_group_node_data(topology: Box,pfx: str) -> None:
     if not 'node_data' in gdata:                                      # No group data, skip
       continue
 
-    g_members = group_members(topology,grp)                           # Get recursive list of members
+    g_type = gdata.get('type','node')
+    g_members = group_members(topology,grp,g_type)                    # Get recursive list of members
     if log.debug_active('groups'):
       print(f'copy node data {grp}: {gdata.node_data}')
+
+    g_ns = g_type + 's'                                               # Get the target object dictionary
     for name in g_members:                                            # Iterate over group members
-      if not name in topology.nodes:                                  # Member is not a node, skip it
-        continue
+      if not name in topology[g_ns]:                                  # Unknown member, skip it
+        continue                                                      # ... should have been detected earlier
 
       if log.debug_active('groups'):
-        print(f'... merging node data with {name}')
+        print(f'... merging {g_type} data with {name}')
       merge_data = data.get_box(gdata.node_data)
-      if 'module' in topology.nodes[name]:
+      if g_type == 'node' and 'module' in topology.nodes[name]:
         for m in topo_modules:
           if not m in topology.nodes[name].module:
             merge_data.pop(m,None)
 
-      topology.nodes[name] = merge_data + topology.nodes[name]
+      if topology[g_ns][name] is None:                                # We're early in data processing, some objects
+        topology[g_ns][name] = {}                                     # ... might not have been initialized
+      if isinstance(topology[g_ns][name],Box):                        # If the object is a box
+        topology[g_ns][name] = merge_data + topology[g_ns][name]      # ... merge group data with it
 
 '''
 Export node_data from groups to topology
@@ -585,14 +595,21 @@ def node_config_templates(topology: Box) -> None:
   with node templates.
   '''
 
-  for group_name in reverse_topsort(topology):
-    if not 'config' in topology.groups[group_name]:
+  for group_name in reverse_topsort(topology):              # Iterate over all groups
+    gdata = topology.groups[group_name]
+    if not 'config' in gdata:                               # Skip a group if it has no 'config' attribute
       continue
 
     must_be_list(topology.groups[group_name],'config',f'groups.{group_name}')
-    g_members = group_members(topology,group_name)
-    for name,ndata in topology.nodes.items():
-      if name in g_members or group_name == 'all':
+    g_members = group_members(topology,group_name)          # Get node members of the group
+    if not g_members:
+      return
+
+    for name,ndata in topology.nodes.items():               # Iterate over nodes
+      if name in g_members or group_name == 'all':          # Match members or 'all' group
+        #
+        # Make sure the node 'config' attribute is a list and prepend group config value to it
+        # ... because the node config template might modify the settings from the group config template
         if not must_be_list(ndata,'config',f'nodes.{name}') is None:
           ndata.config = topology.groups[group_name].config + ndata.config
 

--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -112,7 +112,6 @@ def check_group_data_structure(
   '''
 
   list_of_modules = modules.list_of_modules(topology)
-  group_attr = topology.defaults.attributes.group
 
   # Allow provider- and tool- specific node attributes
   extra = get_object_attributes(['providers','tools'],topology)
@@ -128,6 +127,18 @@ def check_group_data_structure(
       continue
 
     gpath=f'{gpath}.{grp}'
+    g_type = gdata.get('type','node')
+    gt_values = ['node','vlan','vrf']
+    if g_type not in gt_values:
+      log.error(
+        f"Invalid group type for group {grp}; can be {','.join(gt_values)}",
+        category=log.IncorrectType,
+        module='groups')
+
+    g_namespace = [ f'{g_type}_group' ]
+    g_namespace.extend(topology.defaults.attributes[g_namespace[0]].get('_namespace',[]))
+    group_attr = topology.defaults.attributes[g_namespace[0]]
+
     g_modules = gdata.get('module',[])
     if g_modules:                           # Modules specified in the group -- we know what these nodes will use
       gm_source = 'group'
@@ -139,8 +150,8 @@ def check_group_data_structure(
       data=gdata,
       topology=topology,
       data_path=gpath,
-      data_name='group',
-      attr_list=[ 'group','node' ],
+      data_name=g_namespace[0],
+      attr_list=g_namespace,
       module='groups',
       modules=g_modules,
       module_source=gm_source,

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -108,7 +108,7 @@ def get_valid_attributes(
 
       remove_required_flag(add_attr)                        # Remove required flags from the secondary namespace attributes
 
-    valid += add_attr                                       # ... nope, add to list of attributes and move on
+    valid = add_attr + valid                                # ... nope, merge with existing list and move on
 
     internal_atlist = f'{atlist}_internal'                  # Internal object attributes (used by links)
     if internal_atlist in attributes:                       # Add internal attributes if they exist

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -138,6 +138,22 @@ node_group:
   device: device
   module: list
 
+vlan_group:
+  _description: VLAN groups
+  _namespace: [ vlan, link ]
+  type: str
+  members:
+    type: list
+    _subtype: id
+
+vrf_group:
+  _description: VRF groups
+  _namespace: [ vrf ]
+  type: str
+  members:
+    type: list
+    _subtype: id
+
 _prefix:                    # Generic named prefix entry
   ipv4: { type: ipv4, use: prefix }
   ipv6: { type: ipv6, use: prefix }

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -124,7 +124,9 @@ prefix:                     # Link prefix (called by link module directly)
   ipv6: { type: ipv6, use: prefix }
   allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
 
-group:
+node_group:
+  _description: Node groups
+  _namespace: [ node ]
   members:
     type: list
     _subtype: id

--- a/tests/errors/group-invalid-attr-type.log
+++ b/tests/errors/group-invalid-attr-type.log
@@ -1,6 +1,6 @@
 IncorrectAttr in groups: topology.groups.g1 uses an attribute from module bgp which is not enabled in topology
-IncorrectAttr in groups: Invalid group attribute 'foo' found in topology.groups.g1
-... use 'netlab show attributes group' to display valid attributes
+IncorrectAttr in groups: Invalid node_group attribute 'foo' found in topology.groups.g1
+... use 'netlab show attributes node_group' to display valid attributes
 IncorrectType in groups: attribute 'groups.g1.config' must be a scalar or a list, found dictionary
 IncorrectType in groups: attribute 'defaults.groups.g2.config' must be a scalar or a list, found dictionary
 IncorrectAttr in groups: defaults.groups.g2 uses an attribute from module bgp which is not enabled in topology

--- a/tests/errors/invalid-group-attribute.log
+++ b/tests/errors/invalid-group-attribute.log
@@ -1,3 +1,3 @@
-IncorrectAttr in groups: Invalid group attribute 'unknown' found in topology.groups.g1
-... use 'netlab show attributes group' to display valid attributes
+IncorrectAttr in groups: Invalid node_group attribute 'unknown' found in topology.groups.g1
+... use 'netlab show attributes node_group' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/invalid-group-vars-element.log
+++ b/tests/errors/invalid-group-vars-element.log
@@ -1,3 +1,3 @@
 IncorrectType in groups: attribute 'groups.g1.vars' must be a dictionary, found str
-... use 'netlab show attributes group' to display valid attributes
+... use 'netlab show attributes node_group' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/validate-list.log
+++ b/tests/errors/validate-list.log
@@ -1,6 +1,6 @@
 IncorrectValue in groups: attribute groups.g1.module has invalid value(s): a
 ... valid values are: bfd,bgp,dhcp,eigrp,evpn,gateway,isis,lag,mpls,ospf,ripv2,routing,sr,srv6,stp,vlan,vrf,vxlan
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
-... use 'netlab show attributes group' to display valid attributes
+... use 'netlab show attributes node_group' to display valid attributes
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -2,11 +2,11 @@ groups:
   ce_vlan:
     members:
     - red_vlan
+    - blue_vlan
     node_data:
+      mode: route
       ospf:
         cost: 1
-      vlan:
-        mode: route
       vrf: red_vrf
     type: vlan
   ce_vrf:
@@ -21,7 +21,7 @@ groups:
     - h1
     - h2
   sw:
-    device: eos
+    device: none
     members:
     - s1
     - s2
@@ -31,70 +31,74 @@ input:
 links:
 - bridge: input_1
   gateway:
-    ipv4: 172.16.0.4/24
+    ipv4: 172.16.2.4/24
   interfaces:
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.1/24
+    ipv4: 172.16.2.1/24
     node: h1
-  - _vlan_mode: irb
+  - _vlan_mode: route
     ifindex: 1
-    ifname: Ethernet1
-    ipv4: 172.16.0.4/24
+    ifname: eth1
+    ipv4: 172.16.2.4/24
     node: s2
     vlan:
-      access: red_vlan
+      access: blue_vlan
+      mode: route
   linkindex: 1
   node_count: 2
   ospf:
     cost: 1
   prefix:
-    allocation: id_based
-    ipv4: 172.16.0.0/24
+    ipv4: 172.16.2.0/24
+  role: stub
   type: lan
   vlan:
-    access: red_vlan
+    access: blue_vlan
     mode: route
   vrf: red_vrf
 - bridge: input_2
   gateway:
-    ipv4: 172.16.0.4/24
+    ipv4: 172.16.3.4/24
   interfaces:
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.2/24
+    ipv4: 172.16.3.2/24
     node: h2
-  - _vlan_mode: irb
+  - _vlan_mode: route
     ifindex: 2
-    ifname: Ethernet2
-    ipv4: 172.16.0.4/24
+    ifname: eth2
+    ipv4: 172.16.3.4/24
     node: s2
     vlan:
-      access: red_vlan
+      access: blue_vlan
+      mode: route
   linkindex: 2
   node_count: 2
   ospf:
     cost: 1
   prefix:
-    allocation: id_based
-    ipv4: 172.16.0.0/24
+    ipv4: 172.16.3.0/24
+  role: stub
   type: lan
   vlan:
-    access: red_vlan
+    access: blue_vlan
     mode: route
   vrf: red_vrf
 - interfaces:
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     node: s1
     vlan:
       trunk:
+        blue_vlan: {}
         red_vlan: {}
   - ifindex: 3
-    ifname: Ethernet3
+    ifname: eth3
     node: s2
     vlan:
       trunk:
+        blue_vlan: {}
         red_vlan: {}
   linkindex: 3
   node_count: 2
@@ -102,7 +106,48 @@ links:
   type: p2p
   vlan:
     trunk:
+      blue_vlan: {}
       red_vlan: {}
+- bridge: input_4
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.0.3/24
+    node: s1
+    vlan:
+      access: red_vlan
+  linkindex: 4
+  node_count: 1
+  ospf:
+    cost: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red_vlan
+  vrf: red_vrf
+- bridge: input_5
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 4
+    ifname: eth4
+    ipv4: 172.16.0.4/24
+    node: s2
+    vlan:
+      access: red_vlan
+  linkindex: 5
+  node_count: 1
+  ospf:
+    cost: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red_vlan
+  vrf: red_vrf
 module:
 - vlan
 - ospf
@@ -118,23 +163,18 @@ nodes:
     interfaces:
     - bridge: input_1
       gateway:
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.2.4/24
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.1/24
+      ipv4: 172.16.2.1/24
       linkindex: 1
-      name: h1 -> [s2,s1,h2]
+      name: h1 -> s2
       neighbors:
-      - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+      - ifname: eth1
+        ipv4: 172.16.2.4/24
         node: s2
         vrf: red_vrf
-      - ifname: Vlan1000
-        ipv4: 172.16.0.3/24
-        node: s1
-      - ifname: eth1
-        ipv4: 172.16.0.2/24
-        node: h2
+      role: stub
       type: lan
     mgmt:
       ifname: eth0
@@ -151,23 +191,18 @@ nodes:
     interfaces:
     - bridge: input_2
       gateway:
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.3.4/24
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.2/24
+      ipv4: 172.16.3.2/24
       linkindex: 2
-      name: h2 -> [s2,s1,h1]
+      name: h2 -> s2
       neighbors:
-      - ifname: Vlan1000
-        ipv4: 172.16.0.4/24
+      - ifname: eth2
+        ipv4: 172.16.3.4/24
         node: s2
         vrf: red_vrf
-      - ifname: Vlan1000
-        ipv4: 172.16.0.3/24
-        node: s1
-      - ifname: eth1
-        ipv4: 172.16.0.1/24
-        node: h1
+      role: stub
       type: lan
     mgmt:
       ifname: eth0
@@ -179,39 +214,65 @@ nodes:
     af:
       ipv4: true
       vpnv4: true
-    box: arista/veos
-    device: eos
+    box: none
+    device: none
     id: 3
     interfaces:
     - ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
       linkindex: 3
       name: s1 -> s2
       neighbors:
-      - ifname: Ethernet3
+      - ifname: eth3
         node: s2
+      subif_index: 1
       type: p2p
       vlan:
         trunk:
+          blue_vlan: {}
           red_vlan: {}
         trunk_id:
         - 1000
-    - bridge_group: 1
+    - bridge: input_4
+      ifindex: 2
+      ifname: eth2
+      linkindex: 4
+      name: '[Access VLAN red_vlan] s1 -> stub'
+      neighbors: []
+      type: lan
+      vlan:
+        access: red_vlan
+        access_id: 1000
+    - bridge_group: 2
       ifindex: 3
+      ifname: eth1.1001
+      ipv4: 172.16.4.3/24
+      name: s1 -> s2
+      neighbors:
+      - ifname: eth3.1001
+        ipv4: 172.16.4.4/24
+        node: s2
+        vrf: red_vrf
+      parent_ifindex: 1
+      parent_ifname: eth1
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access_id: 1001
+        mode: route
+        name: blue_vlan
+        routed_link: true
+      vrf: red_vrf
+    - bridge_group: 1
+      ifindex: 5
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
-      name: VLAN red_vlan (1000) -> [s2,h1,h2]
+      name: VLAN red_vlan (1000) -> [s2]
       neighbors:
       - ifname: Vlan1000
         ipv4: 172.16.0.4/24
         node: s2
         vrf: red_vrf
-      - ifname: eth1
-        ipv4: 172.16.0.1/24
-        node: h1
-      - ifname: eth1
-        ipv4: 172.16.0.2/24
-        node: h2
       type: svi
       virtual_interface: true
       vlan:
@@ -236,7 +297,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management1
+      ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:00:00:03
     module:
@@ -245,19 +306,27 @@ nodes:
     - vrf
     name: s1
     vlan:
-      max_bridge_group: 1
+      max_bridge_group: 2
     vlans:
+      blue_vlan:
+        bridge_group: 2
+        id: 1001
+        mode: route
+        ospf:
+          cost: 1
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+        vrf: red_vrf
       red_vlan:
         bridge_group: 1
         id: 1000
         mode: irb
         ospf:
-          cost: 1
+          cost: 2
         prefix:
           allocation: id_based
           ipv4: 172.16.0.0/24
-        vlan:
-          mode: route
         vrf: red_vrf
     vrf:
       as: 65000
@@ -280,29 +349,46 @@ nodes:
           af:
             ipv4: true
           area: 0.0.0.0
-          import:
-            connected:
-              auto: true
           interfaces:
-          - bridge_group: 1
+          - bridge_group: 2
             ifindex: 3
+            ifname: eth1.1001
+            ipv4: 172.16.4.3/24
+            name: s1 -> s2
+            neighbors:
+            - ifname: eth3.1001
+              ipv4: 172.16.4.4/24
+              node: s2
+              vrf: red_vrf
+            ospf:
+              area: 0.0.0.0
+              cost: 1
+              network_type: point-to-point
+              passive: false
+            parent_ifindex: 1
+            parent_ifname: eth1
+            type: vlan_member
+            virtual_interface: true
+            vlan:
+              access_id: 1001
+              mode: route
+              name: blue_vlan
+              routed_link: true
+            vrf: red_vrf
+          - bridge_group: 1
+            ifindex: 5
             ifname: Vlan1000
             ipv4: 172.16.0.3/24
-            name: VLAN red_vlan (1000) -> [s2,h1,h2]
+            name: VLAN red_vlan (1000) -> [s2]
             neighbors:
             - ifname: Vlan1000
               ipv4: 172.16.0.4/24
               node: s2
               vrf: red_vrf
-            - ifname: eth1
-              ipv4: 172.16.0.1/24
-              node: h1
-            - ifname: eth1
-              ipv4: 172.16.0.2/24
-              node: h2
             ospf:
               area: 0.0.0.0
-              cost: 1
+              cost: 2
+              network_type: point-to-point
               passive: false
             type: svi
             virtual_interface: true
@@ -328,64 +414,96 @@ nodes:
     af:
       ipv4: true
       vpnv4: true
-    box: arista/veos
-    device: eos
+    box: none
+    device: none
     id: 4
     interfaces:
     - bridge: input_1
+      bridge_group: 1
       ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
+      ipv4: 172.16.2.4/24
       linkindex: 1
-      name: '[Access VLAN red_vlan] s2 -> h1'
+      name: s2 -> h1
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.1/24
+        ipv4: 172.16.2.1/24
         node: h1
+      role: stub
       type: lan
       vlan:
-        access: red_vlan
-        access_id: 1000
+        mode: route
+      vrf: red_vrf
     - bridge: input_2
+      bridge_group: 1
       ifindex: 2
-      ifname: Ethernet2
+      ifname: eth2
+      ipv4: 172.16.3.4/24
       linkindex: 2
-      name: '[Access VLAN red_vlan] s2 -> h2'
+      name: s2 -> h2
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.3.2/24
         node: h2
+      role: stub
       type: lan
       vlan:
-        access: red_vlan
-        access_id: 1000
+        mode: route
+      vrf: red_vrf
     - ifindex: 3
-      ifname: Ethernet3
+      ifname: eth3
       linkindex: 3
       name: s2 -> s1
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         node: s1
+      subif_index: 1
       type: p2p
       vlan:
         trunk:
+          blue_vlan: {}
           red_vlan: {}
         trunk_id:
         - 1000
+    - bridge: input_5
+      ifindex: 4
+      ifname: eth4
+      linkindex: 5
+      name: '[Access VLAN red_vlan] s2 -> stub'
+      neighbors: []
+      type: lan
+      vlan:
+        access: red_vlan
+        access_id: 1000
     - bridge_group: 1
       ifindex: 5
+      ifname: eth3.1001
+      ipv4: 172.16.4.4/24
+      name: s2 -> s1
+      neighbors:
+      - ifname: eth1.1001
+        ipv4: 172.16.4.3/24
+        node: s1
+        vrf: red_vrf
+      parent_ifindex: 3
+      parent_ifname: eth3
+      type: vlan_member
+      virtual_interface: true
+      vlan:
+        access_id: 1001
+        mode: route
+        name: blue_vlan
+        routed_link: true
+      vrf: red_vrf
+    - bridge_group: 2
+      ifindex: 7
       ifname: Vlan1000
       ipv4: 172.16.0.4/24
-      name: VLAN red_vlan (1000) -> [s1,h1,h2]
+      name: VLAN red_vlan (1000) -> [s1]
       neighbors:
       - ifname: Vlan1000
         ipv4: 172.16.0.3/24
         node: s1
-      - ifname: eth1
-        ipv4: 172.16.0.1/24
-        node: h1
-      - ifname: eth1
-        ipv4: 172.16.0.2/24
-        node: h2
       type: svi
       virtual_interface: true
       vlan:
@@ -410,7 +528,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management1
+      ifname: eth0
       ipv4: 192.168.121.104
       mac: 08:4f:a9:00:00:04
     module:
@@ -419,19 +537,27 @@ nodes:
     - vrf
     name: s2
     vlan:
-      max_bridge_group: 1
+      max_bridge_group: 2
     vlans:
-      red_vlan:
+      blue_vlan:
         bridge_group: 1
-        id: 1000
-        mode: irb
+        id: 1001
+        mode: route
         ospf:
           cost: 1
         prefix:
           allocation: id_based
+          ipv4: 172.16.1.0/24
+        vrf: red_vrf
+      red_vlan:
+        bridge_group: 2
+        id: 1000
+        mode: irb
+        ospf:
+          cost: 2
+        prefix:
+          allocation: id_based
           ipv4: 172.16.0.0/24
-        vlan:
-          mode: route
         vrf: red_vrf
     vrf:
       as: 65000
@@ -454,28 +580,87 @@ nodes:
           af:
             ipv4: true
           area: 0.0.0.0
-          import:
-            connected:
-              auto: true
           interfaces:
-          - bridge_group: 1
-            ifindex: 5
-            ifname: Vlan1000
-            ipv4: 172.16.0.4/24
-            name: VLAN red_vlan (1000) -> [s1,h1,h2]
+          - bridge: input_1
+            bridge_group: 1
+            ifindex: 1
+            ifname: eth1
+            ipv4: 172.16.2.4/24
+            linkindex: 1
+            name: s2 -> h1
             neighbors:
-            - ifname: Vlan1000
-              ipv4: 172.16.0.3/24
-              node: s1
             - ifname: eth1
-              ipv4: 172.16.0.1/24
+              ipv4: 172.16.2.1/24
               node: h1
+            ospf:
+              area: 0.0.0.0
+              cost: 1
+              network_type: point-to-point
+              passive: true
+            role: stub
+            type: lan
+            vlan:
+              mode: route
+            vrf: red_vrf
+          - bridge: input_2
+            bridge_group: 1
+            ifindex: 2
+            ifname: eth2
+            ipv4: 172.16.3.4/24
+            linkindex: 2
+            name: s2 -> h2
+            neighbors:
             - ifname: eth1
-              ipv4: 172.16.0.2/24
+              ipv4: 172.16.3.2/24
               node: h2
             ospf:
               area: 0.0.0.0
               cost: 1
+              network_type: point-to-point
+              passive: true
+            role: stub
+            type: lan
+            vlan:
+              mode: route
+            vrf: red_vrf
+          - bridge_group: 1
+            ifindex: 5
+            ifname: eth3.1001
+            ipv4: 172.16.4.4/24
+            name: s2 -> s1
+            neighbors:
+            - ifname: eth1.1001
+              ipv4: 172.16.4.3/24
+              node: s1
+              vrf: red_vrf
+            ospf:
+              area: 0.0.0.0
+              cost: 1
+              network_type: point-to-point
+              passive: false
+            parent_ifindex: 3
+            parent_ifname: eth3
+            type: vlan_member
+            virtual_interface: true
+            vlan:
+              access_id: 1001
+              mode: route
+              name: blue_vlan
+              routed_link: true
+            vrf: red_vrf
+          - bridge_group: 2
+            ifindex: 7
+            ifname: Vlan1000
+            ipv4: 172.16.0.4/24
+            name: VLAN red_vlan (1000) -> [s1]
+            neighbors:
+            - ifname: Vlan1000
+              ipv4: 172.16.0.3/24
+              node: s1
+            ospf:
+              area: 0.0.0.0
+              cost: 2
+              network_type: point-to-point
               passive: false
             type: svi
             virtual_interface: true
@@ -501,30 +686,32 @@ ospf:
   area: 0.0.0.0
 provider: libvirt
 vlans:
-  red_vlan:
-    host_count: 2
-    id: 1000
-    neighbors:
-    - ifname: Vlan1000
-      ipv4: 172.16.0.4/24
-      node: s2
-      vrf: red_vrf
-    - ifname: Vlan1000
-      ipv4: 172.16.0.3/24
-      node: s1
-    - ifname: eth1
-      ipv4: 172.16.0.1/24
-      node: h1
-    - ifname: eth1
-      ipv4: 172.16.0.2/24
-      node: h2
+  blue_vlan:
+    id: 1001
+    mode: route
     ospf:
       cost: 1
     prefix:
       allocation: id_based
+      ipv4: 172.16.1.0/24
+    vrf: red_vrf
+  red_vlan:
+    host_count: 0
+    id: 1000
+    mode: irb
+    neighbors:
+    - ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      node: s1
+    - ifname: Vlan1000
+      ipv4: 172.16.0.4/24
+      node: s2
+      vrf: red_vrf
+    ospf:
+      cost: 2
+    prefix:
+      allocation: id_based
       ipv4: 172.16.0.0/24
-    vlan:
-      mode: route
     vrf: red_vrf
 vrf:
   as: 65000

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -1,0 +1,539 @@
+groups:
+  ce_vlan:
+    members:
+    - red_vlan
+    node_data:
+      ospf:
+        cost: 1
+      vlan:
+        mode: route
+      vrf: red_vrf
+    type: vlan
+  ce_vrf:
+    members:
+    - red_vrf
+    node_data:
+      loopback: true
+    type: vrf
+  ep:
+    device: linux
+    members:
+    - h1
+    - h2
+  sw:
+    device: eos
+    members:
+    - s1
+    - s2
+input:
+- topology/input/groups-vlan-vrf.yml
+- package:topology-defaults.yml
+links:
+- bridge: input_1
+  gateway:
+    ipv4: 172.16.0.4/24
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.1/24
+    node: h1
+  - _vlan_mode: irb
+    ifindex: 1
+    ifname: Ethernet1
+    ipv4: 172.16.0.4/24
+    node: s2
+    vlan:
+      access: red_vlan
+  linkindex: 1
+  node_count: 2
+  ospf:
+    cost: 1
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red_vlan
+    mode: route
+  vrf: red_vrf
+- bridge: input_2
+  gateway:
+    ipv4: 172.16.0.4/24
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.2/24
+    node: h2
+  - _vlan_mode: irb
+    ifindex: 2
+    ifname: Ethernet2
+    ipv4: 172.16.0.4/24
+    node: s2
+    vlan:
+      access: red_vlan
+  linkindex: 2
+  node_count: 2
+  ospf:
+    cost: 1
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red_vlan
+    mode: route
+  vrf: red_vrf
+- interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s1
+    vlan:
+      trunk:
+        red_vlan: {}
+  - ifindex: 3
+    ifname: Ethernet3
+    node: s2
+    vlan:
+      trunk:
+        red_vlan: {}
+  linkindex: 3
+  node_count: 2
+  prefix: {}
+  type: p2p
+  vlan:
+    trunk:
+      red_vlan: {}
+module:
+- vlan
+- ospf
+- vrf
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 1
+    interfaces:
+    - bridge: input_1
+      gateway:
+        ipv4: 172.16.0.4/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.1/24
+      linkindex: 1
+      name: h1 -> [s2,s1,h2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.4/24
+        node: s2
+        vrf: red_vrf
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    name: h1
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: generic/ubuntu2004
+    device: linux
+    id: 2
+    interfaces:
+    - bridge: input_2
+      gateway:
+        ipv4: 172.16.0.4/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.2/24
+      linkindex: 2
+      name: h2 -> [s2,s1,h1]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.4/24
+        node: s2
+        vrf: red_vrf
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: h1
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    name: h2
+    role: host
+  s1:
+    af:
+      ipv4: true
+      vpnv4: true
+    box: arista/veos
+    device: eos
+    id: 3
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 3
+      name: s1 -> s2
+      neighbors:
+      - ifname: Ethernet3
+        node: s2
+      type: p2p
+      vlan:
+        trunk:
+          red_vlan: {}
+        trunk_id:
+        - 1000
+    - bridge_group: 1
+      ifindex: 3
+      ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      name: VLAN red_vlan (1000) -> [s2,h1,h2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.4/24
+        node: s2
+        vrf: red_vrf
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red_vlan
+      vrf: red_vrf
+    - ifindex: 10001
+      ifname: Loopback1
+      ipv4: 10.2.0.1/32
+      name: VRF Loopback red_vrf
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+      vrf: red_vrf
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.3/32
+      neighbors: []
+      ospf:
+        area: 0.0.0.0
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    module:
+    - vlan
+    - ospf
+    - vrf
+    name: s1
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red_vlan:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        ospf:
+          cost: 1
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        vlan:
+          mode: route
+        vrf: red_vrf
+    vrf:
+      as: 65000
+    vrfs:
+      red_vrf:
+        af:
+          ipv4: true
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        loopback: true
+        loopback_address:
+          ipv4: 10.2.0.1/32
+        networks:
+        - ipv4: 10.2.0.1/32
+        ospf:
+          active: true
+          af:
+            ipv4: true
+          area: 0.0.0.0
+          import:
+            connected:
+              auto: true
+          interfaces:
+          - bridge_group: 1
+            ifindex: 3
+            ifname: Vlan1000
+            ipv4: 172.16.0.3/24
+            name: VLAN red_vlan (1000) -> [s2,h1,h2]
+            neighbors:
+            - ifname: Vlan1000
+              ipv4: 172.16.0.4/24
+              node: s2
+              vrf: red_vrf
+            - ifname: eth1
+              ipv4: 172.16.0.1/24
+              node: h1
+            - ifname: eth1
+              ipv4: 172.16.0.2/24
+              node: h2
+            ospf:
+              area: 0.0.0.0
+              cost: 1
+              passive: false
+            type: svi
+            virtual_interface: true
+            vlan:
+              mode: irb
+              name: red_vlan
+            vrf: red_vrf
+          - ifindex: 10001
+            ifname: Loopback1
+            ipv4: 10.2.0.1/32
+            name: VRF Loopback red_vrf
+            neighbors: []
+            ospf:
+              area: 0.0.0.0
+              passive: false
+            type: loopback
+            virtual_interface: true
+            vrf: red_vrf
+          router_id: 10.0.0.3
+        rd: '65000:1'
+        vrfidx: 100
+  s2:
+    af:
+      ipv4: true
+      vpnv4: true
+    box: arista/veos
+    device: eos
+    id: 4
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: '[Access VLAN red_vlan] s2 -> h1'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: h1
+      type: lan
+      vlan:
+        access: red_vlan
+        access_id: 1000
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      name: '[Access VLAN red_vlan] s2 -> h2'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h2
+      type: lan
+      vlan:
+        access: red_vlan
+        access_id: 1000
+    - ifindex: 3
+      ifname: Ethernet3
+      linkindex: 3
+      name: s2 -> s1
+      neighbors:
+      - ifname: Ethernet1
+        node: s1
+      type: p2p
+      vlan:
+        trunk:
+          red_vlan: {}
+        trunk_id:
+        - 1000
+    - bridge_group: 1
+      ifindex: 5
+      ifname: Vlan1000
+      ipv4: 172.16.0.4/24
+      name: VLAN red_vlan (1000) -> [s1,h1,h2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.3/24
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red_vlan
+      vrf: red_vrf
+    - ifindex: 10001
+      ifname: Loopback1
+      ipv4: 10.2.0.2/32
+      name: VRF Loopback red_vrf
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+      vrf: red_vrf
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.4/32
+      neighbors: []
+      ospf:
+        area: 0.0.0.0
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    module:
+    - vlan
+    - ospf
+    - vrf
+    name: s2
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red_vlan:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        ospf:
+          cost: 1
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        vlan:
+          mode: route
+        vrf: red_vrf
+    vrf:
+      as: 65000
+    vrfs:
+      red_vrf:
+        af:
+          ipv4: true
+        export:
+        - '65000:1'
+        id: 1
+        import:
+        - '65000:1'
+        loopback: true
+        loopback_address:
+          ipv4: 10.2.0.2/32
+        networks:
+        - ipv4: 10.2.0.2/32
+        ospf:
+          active: true
+          af:
+            ipv4: true
+          area: 0.0.0.0
+          import:
+            connected:
+              auto: true
+          interfaces:
+          - bridge_group: 1
+            ifindex: 5
+            ifname: Vlan1000
+            ipv4: 172.16.0.4/24
+            name: VLAN red_vlan (1000) -> [s1,h1,h2]
+            neighbors:
+            - ifname: Vlan1000
+              ipv4: 172.16.0.3/24
+              node: s1
+            - ifname: eth1
+              ipv4: 172.16.0.1/24
+              node: h1
+            - ifname: eth1
+              ipv4: 172.16.0.2/24
+              node: h2
+            ospf:
+              area: 0.0.0.0
+              cost: 1
+              passive: false
+            type: svi
+            virtual_interface: true
+            vlan:
+              mode: irb
+              name: red_vlan
+            vrf: red_vrf
+          - ifindex: 10001
+            ifname: Loopback1
+            ipv4: 10.2.0.2/32
+            name: VRF Loopback red_vrf
+            neighbors: []
+            ospf:
+              area: 0.0.0.0
+              passive: false
+            type: loopback
+            virtual_interface: true
+            vrf: red_vrf
+          router_id: 10.0.0.4
+        rd: '65000:1'
+        vrfidx: 100
+ospf:
+  area: 0.0.0.0
+provider: libvirt
+vlans:
+  red_vlan:
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: Vlan1000
+      ipv4: 172.16.0.4/24
+      node: s2
+      vrf: red_vrf
+    - ifname: Vlan1000
+      ipv4: 172.16.0.3/24
+      node: s1
+    - ifname: eth1
+      ipv4: 172.16.0.1/24
+      node: h1
+    - ifname: eth1
+      ipv4: 172.16.0.2/24
+      node: h2
+    ospf:
+      cost: 1
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24
+    vlan:
+      mode: route
+    vrf: red_vrf
+vrf:
+  as: 65000
+vrfs:
+  red_vrf:
+    export:
+    - '65000:1'
+    id: 1
+    import:
+    - '65000:1'
+    loopback: true
+    rd: '65000:1'

--- a/tests/topology/input/groups-vlan-vrf.yml
+++ b/tests/topology/input/groups-vlan-vrf.yml
@@ -1,0 +1,37 @@
+---
+module: [ vlan, vrf, ospf ]
+
+groups:
+  _auto_create: True
+  ce_vlan:
+    members: [ red_vlan ]
+    type: vlan
+    ospf.cost: 1
+    vlan.mode: route
+    vrf: red_vrf
+  ce_vrf:
+    members: [ red_vrf ]
+    type: vrf
+    loopback: True
+  sw:
+    device: eos
+    members: [ s1, s2 ]
+  ep:
+    device: linux
+    members: [ h1, h2 ]
+
+vlans:
+  red_vlan:
+
+nodes: [ h1, h2 ]
+
+links:
+- h1:
+  s2:
+  vlan.access: red_vlan
+- h2:
+  s2:
+  vlan.access: red_vlan
+- s1:
+  s2:
+  vlan.trunk: [ red_vlan ]

--- a/tests/topology/input/groups-vlan-vrf.yml
+++ b/tests/topology/input/groups-vlan-vrf.yml
@@ -4,17 +4,17 @@ module: [ vlan, vrf, ospf ]
 groups:
   _auto_create: True
   ce_vlan:
-    members: [ red_vlan ]
+    members: [ red_vlan, blue_vlan ]
     type: vlan
     ospf.cost: 1
-    vlan.mode: route
+    mode: route
     vrf: red_vrf
   ce_vrf:
     members: [ red_vrf ]
     type: vrf
     loopback: True
   sw:
-    device: eos
+    device: none
     members: [ s1, s2 ]
   ep:
     device: linux
@@ -22,16 +22,19 @@ groups:
 
 vlans:
   red_vlan:
+    ospf.cost: 2
+    links: [ s1, s2 ]
+    mode: irb
 
 nodes: [ h1, h2 ]
 
 links:
 - h1:
   s2:
-  vlan.access: red_vlan
+  vlan.access: blue_vlan
 - h2:
   s2:
-  vlan.access: red_vlan
+  vlan.access: blue_vlan
 - s1:
   s2:
-  vlan.trunk: [ red_vlan ]
+  vlan.trunk: [ red_vlan, blue_vlan ]


### PR DESCRIPTION
This PR generalizes "node groups" into "object groups" and adds VLAN and VRF groups.
The new group types are identified with the **type** attribute, whereas a group with no
**type** attribute is assumed to be a node group.