### PR TITLE
Cumulus_nvue: add stp support (including PVRST)

### DIFF
--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -11,7 +11,7 @@ cat >/etc/network/interfaces.d/53-stp.intf <<CONFIG
 auto bridge
 iface bridge
  bridge-stp {{ 'on' if stp.enable|default(True) else 'off' }}
- mstpctl-forcevers {{ stp.protocol }} {# options are stp, rstp or mstp #}
+ mstpctl-forcevers {{ 'rstp' if stp.protocol=='pvrst' else stp.protocol }} {# options are stp, rstp or mstp +#}
  #
  # Newer versions 5.x support 'mstpctl-pvrst-mode yes' to enable PVRST
  #

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -1,0 +1,7 @@
+- set:
+    bridge:
+      domain:
+        br_default:
+          stp:
+            state:
+              {{ 'up' if stp.enable|default(True) else 'down' }}: {}

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -28,7 +28,7 @@
             burst: 7200
             rate: 7200
 {% endif %}
-{% for ifdata in interfaces if 'stp' in ifdata  %}
+{% for ifdata in interfaces if 'stp' in ifdata or ifdata.vlan.trunk|default({})|dict2items|map(attribute='value')|selectattr('stp','defined') %}
 {%  if loop.first %}
     interface:
 {%  endif %}
@@ -37,11 +37,25 @@
           domain:
             br_default:
               stp:
-{%  if not ifdata.stp.enable|default(True) %}
+{%  if 'stp' in ifdata %}
+{%   if not ifdata.stp.enable|default(True) %}
                 bpdu-filter: on
-{%  elif 'port_priority' in ifdata.stp %}
+{%   elif 'port_priority' in ifdata.stp %}
                 vlan:
                   '{{ ifdata.vlan.access_id|default(1) }}':
                     priority: {{ ifdata.stp.port_priority * 16 }}
+{%   endif %}
+{%  elif ifdata.vlan.trunk_id is defined %}
+{%   for id in ifdata.vlan.trunk_id %}
+{%    if loop.first %}
+                vlan:
+{%    endif %}
+{%    for vname,vdata in vlans.items() if vdata.id==id %}
+{%     if vname in ifdata.vlan.trunk and ifdata.vlan.trunk[vname].stp.port_priority is defined %}
+                  '{{ id }}':
+                    priority: {{ ifdata.vlan.trunk[vname].stp.port_priority * 16 }}
+{%     endif %}
+{%    endfor %}
+{%   endfor %}
 {%  endif %}
 {% endfor %}

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -3,5 +3,45 @@
       domain:
         br_default:
           stp:
+            mode: {{ 'pvrst' if stp.protocol=='pvrst' else 'rstp' }}
             state:
               {{ 'up' if stp.enable|default(True) else 'down' }}: {}
+{% if 'priority' in stp %}
+            priority: {{ stp.priority }}
+{% endif %}
+{% if vlans is defined %}
+{%  for vname,vdata in vlans.items() if vdata.stp.priority is defined %}
+{%   if loop.first %}
+            vlan:
+{%   endif %}
+             '{{ vdata.id }}':
+               bridge-priority: {{ vdata.stp.priority }}
+{%  endfor %}
+{% endif %}
+
+# When using PVRST, NVidia recommends to increase from default 2000 pps
+{% if stp.protocol=='pvrst' %}
+    system:
+      control-plane:
+        policer:
+          rpvst:
+            burst: 7200
+            rate: 7200
+{% endif %}
+{% for ifdata in interfaces if 'stp' in ifdata  %}
+{%  if loop.first %}
+    interface:
+{%  endif %}
+      {{ ifdata.ifname }}:
+        bridge:
+          domain:
+            br_default:
+              stp:
+{%  if not ifdata.stp.enable|default(True) %}
+                bpdu-filter: on
+{%  elif 'port_priority' in ifdata.stp %}
+                vlan:
+                  '{{ ifdata.vlan.access_id|default(1) }}':
+                    priority: {{ ifdata.stp.port_priority * 16 }}
+{%  endif %}
+{% endfor %}

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -2,6 +2,7 @@
     bridge:
       domain:
         br_default:
+          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" # The default 'auto' setting picks the same MAC for multiple instances!
           untagged: 1
 {% if vlans is defined %}
 {%  for vname,vdata in vlans.items() %}

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -3,7 +3,7 @@
 #
 from box import Box
 
-from . import _Quirks, report_quirk
+from . import _Quirks
 from ..utils import log
 from ..augment import devices
 

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -15,25 +15,6 @@ def check_ospf_vrf_default(node: Box) -> None:
         category=log.IncorrectType,
         module='quirks')
 
-def nvue_check_stp_features(node: Box, topology: Box) -> None:
-  err_data = []
-  stp_protocol = topology.get('stp.protocol','stp')
-  for i in node.interfaces:
-    if 'stp' not in i:
-      continue
-    if 'port_priority' in i.stp:  # AttributeNotImplemented("mstpctl-treeportprio") in NVUE
-      if 'vlan' not in i:
-        err_data.append(f'Non-VLAN interface {i.ifname}')
-      elif stp_protocol!='pvrst':
-        err_data.append(f'VLAN interface without PVRST {i.ifname}')
-  
-  if err_data:
-    report_quirk(
-      f'node {node.name} does not support STP port_priority on non-VLAN interfaces or without PVRST ({stp_protocol})',
-      quirk='stp_port_priority',
-      more_data=err_data,
-      node=node)
-
 class Cumulus(_Quirks):
 
   @classmethod
@@ -41,8 +22,3 @@ class Cumulus(_Quirks):
     mods = node.get('module',[])
     if 'ospf' in mods and 'vrfs' in node:
       check_ospf_vrf_default(node)
-    
-    # NVUE specific quirks
-    if node.device == "cumulus_nvue":
-      if 'stp' in mods:
-        nvue_check_stp_features(node,topology)

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -15,18 +15,6 @@ def check_ospf_vrf_default(node: Box) -> None:
         category=log.IncorrectType,
         module='quirks')
 
-"""
-Checks whether any node VLAN is in the (changeable) reserved range
-"""
-def check_reserved_vlan_range(node: Box) -> None:
-  for vname,vdata in node.get('vlans',{}).items():
-    vid = vdata.get('id',0)
-    if vid>=3725 and vid <=3999:
-      log.error(
-        f"VLAN id {vid} is in the reserved range 3725-3999 on Cumulus Linux (node {node.name}, vlan {vname})",
-        category=log.IncorrectValue,
-        module='quirks')
-
 class Cumulus(_Quirks):
 
   @classmethod
@@ -34,5 +22,3 @@ class Cumulus(_Quirks):
     mods = node.get('module',[])
     if 'ospf' in mods and 'vrfs' in node:
       check_ospf_vrf_default(node)
-    if 'vlan' in mods and 'vlans' in node:
-      check_reserved_vlan_range(node)

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -15,6 +15,18 @@ def check_ospf_vrf_default(node: Box) -> None:
         category=log.IncorrectType,
         module='quirks')
 
+"""
+Checks whether any node VLAN is in the (changeable) reserved range
+"""
+def check_reserved_vlan_range(node: Box) -> None:
+  for vname,vdata in node.get('vlans',{}).items():
+    vid = vdata.get('id',0)
+    if vid>=3725 and vid <=3999:
+      log.error(
+        f"VLAN id {vid} is in the reserved range 3725-3999 on Cumulus Linux (node {node.name}, vlan {vname})",
+        category=log.IncorrectValue,
+        module='quirks')
+
 class Cumulus(_Quirks):
 
   @classmethod
@@ -22,3 +34,5 @@ class Cumulus(_Quirks):
     mods = node.get('module',[])
     if 'ospf' in mods and 'vrfs' in node:
       check_ospf_vrf_default(node)
+    if 'vlan' in mods and 'vlans' in node:
+      check_reserved_vlan_range(node)

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -3,7 +3,7 @@
 #
 from box import Box
 
-from . import _Quirks
+from . import _Quirks, report_quirk
 from ..utils import log
 from ..augment import devices
 
@@ -15,6 +15,25 @@ def check_ospf_vrf_default(node: Box) -> None:
         category=log.IncorrectType,
         module='quirks')
 
+def nvue_check_stp_features(node: Box, topology: Box) -> None:
+  err_data = []
+  stp_protocol = topology.get('stp.protocol','stp')
+  for i in node.interfaces:
+    if 'stp' not in i:
+      continue
+    if 'port_priority' in i.stp:  # AttributeNotImplemented("mstpctl-treeportprio") in NVUE
+      if 'vlan' not in i:
+        err_data.append(f'Non-VLAN interface {i.ifname}')
+      elif stp_protocol!='pvrst':
+        err_data.append(f'VLAN interface without PVRST {i.ifname}')
+  
+  if err_data:
+    report_quirk(
+      f'node {node.name} does not support STP port_priority on non-VLAN interfaces or without PVRST ({stp_protocol})',
+      quirk='stp_port_priority',
+      more_data=err_data,
+      node=node)
+
 class Cumulus(_Quirks):
 
   @classmethod
@@ -22,3 +41,8 @@ class Cumulus(_Quirks):
     mods = node.get('module',[])
     if 'ospf' in mods and 'vrfs' in node:
       check_ospf_vrf_default(node)
+    
+    # NVUE specific quirks
+    if node.device == "cumulus_nvue":
+      if 'stp' in mods:
+        nvue_check_stp_features(node,topology)

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -1,0 +1,42 @@
+#
+# Arista EOS quirks
+#
+from box import Box
+
+from . import _Quirks, report_quirk
+# from .cumulus import Cumulus  # This causes Cumulus_Nvue to get skipped
+from .cumulus import check_ospf_vrf_default
+from ..utils import log
+from ..augment import devices
+
+def nvue_check_stp_features(node: Box, topology: Box) -> None:
+  err_data = []
+  stp_protocol = topology.get('stp.protocol','stp')
+  for i in node.interfaces:
+    if 'stp' not in i:
+      continue
+    if 'port_priority' in i.stp:  # AttributeNotImplemented("mstpctl-treeportprio") in NVUE
+      if 'vlan' not in i:
+        err_data.append(f'Non-VLAN interface {i.ifname}')
+      elif stp_protocol!='pvrst':
+        err_data.append(f'VLAN interface without PVRST {i.ifname}')
+  
+  if err_data:
+    report_quirk(
+      f'node {node.name} does not support STP port_priority on non-VLAN interfaces or without PVRST ({stp_protocol})',
+      quirk='stp_port_priority',
+      more_data=err_data,
+      node=node)
+
+class Cumulus_Nvue(_Quirks):
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    # Cumulus.device_quirks(node,topology)
+    mods = node.get('module',[])
+    if 'ospf' in mods and 'vrfs' in node:
+      check_ospf_vrf_default(node)
+
+    # NVUE specific quirks
+    if 'stp' in mods:
+      nvue_check_stp_features(node,topology)

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -20,7 +20,16 @@ def nvue_check_stp_features(node: Box, topology: Box) -> None:
         err_data.append(f'Non-VLAN interface {i.ifname}')
       elif stp_protocol!='pvrst':
         err_data.append(f'VLAN interface without PVRST {i.ifname}')
-  
+
+  if stp_protocol!='pvrst':
+    for i in node.interfaces:
+      if not i.get('vlan.trunk',{}):
+        continue
+      for vname,vdata in i.vlan.trunk.items():
+        if 'stp' in vdata and 'port_priority' in vdata.stp:  # AttributeNotImplemented("mstpctl-treeportprio") in NVUE
+          err_data.append(f'Trunk VLAN {vname} interface without PVRST {i.ifname}({i.get("name","?")})')
+
+
   if err_data:
     report_quirk(
       f'node {node.name} does not support STP port_priority on non-VLAN interfaces or without PVRST ({stp_protocol})',

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -1,5 +1,5 @@
 #
-# Arista EOS quirks
+# Cumulus NVUE quirks
 #
 from box import Box
 

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -2,7 +2,7 @@ description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
 mgmt_if: eth0
 libvirt:
-  image: CumulusCommunity/cumulus-vx:5.10.0
+  image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
 virtualbox:
   image: CumulusCommunity/cumulus-vx:5.10.0
 group_vars:
@@ -33,7 +33,7 @@ features:
   vrf: True
 clab:
   mtu: 1500
-  kmods: 
+  kmods:
    initial: [ ebtables ]
   node:
     kind: cvx

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -2,9 +2,9 @@ description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
 mgmt_if: eth0
 libvirt:
-  image: CumulusCommunity/cumulus-vx:5.2.0
+  image: CumulusCommunity/cumulus-vx:5.10.0
 virtualbox:
-  image: CumulusCommunity/cumulus-vx:5.2.0
+  image: CumulusCommunity/cumulus-vx:5.10.0
 group_vars:
   ansible_user: cumulus
   ansible_ssh_pass: GetLost1!
@@ -23,6 +23,9 @@ features:
     activate_af: True
   ospf:
     unnumbered: True
+  stp:
+    supported_protocols: [ stp, rstp, pvrst ]  # PVRST requires release 5.6.0 or higher
+    enable_per_port: True
   vlan:
     model: switch
     svi_interface_name: "vlan{vlan}"

--- a/tests/integration/stp/02-vlan-loop-multiple.yml
+++ b/tests/integration/stp/02-vlan-loop-multiple.yml
@@ -5,44 +5,58 @@ message: |
   If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do.
   Per-VLAN priority settings should make S1 root for red, and S2 for blue VLAN
 
-  * h1 and h2 should be able to ping each other
-  * h3 and h4 should be able to ping each other
-  * h1 should not be able to reach h3
+  * h1, h2 and h3 should be able to ping each other
+  * h4, h5 and h6 should be able to ping each other
+  * h1,h2,h3 should not be able to reach h4,h5,h6
 
   For FRR, use
   ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` and
-  ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001``` and
+  ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001```
+
+  For Cumulus NVUE:
+  ```netlab exec "s*" nv show bridge domain br_default stp vlan```
 
 stp.protocol: pvrst # Topology requires running STP per VLAN
 
 groups:
   _auto_create: True
+  switches:
+    members: [ s1, s2, s3 ]
+    module: [ vlan, stp ]
   hosts:
-    members: [ h1, h2, h3, h4 ]
+    members: [ h1, h2, h3, h4, h5, h6 ]
     device: linux
     provider: clab
-  switches:
-    members: [ s1,s2,s3 ]
-    module: [ vlan, stp ]
 
 vlans:
   red:
     mode: bridge
-    links: [ s1-h1, s2-h2, s1-s2 ]  # NOT s1-s3
+    links: [ s1-h1, s2-h2, s3-h3 ]  # NOT s1-s3
   blue:
     mode: bridge
-    links: [ s1-h3, s3-h4, s1-s3 ]  # NOT s1-s2
+    links: [ s1-h4, s2-h5, s3-h6 ]  # NOT s1-s2
 
 links:
+# For platforms using a single Linux bridge these need to be trunk ports, not access ports,
+# and the native vlan must be defined on all inter-switch links
+- s1:
+  s2:
+  vlan.trunk: [ red ]
+  vlan.native: red
+- s1:
+  s3:
+  vlan.trunk: [ blue ]
+  vlan.native: blue
 - s2:
   s3:
-  # vlan.trunk: [ red, blue ]
-  vlan.access: red
+  vlan.trunk: [ red, blue ]
+  vlan.native: red
+  # vlan.access: red
 
-- s2:
-  s3:
-  # vlan.trunk: [ red, blue ]
-  vlan.access: blue
+#- s2:
+#  s3:
+#  # vlan.trunk: [ red, blue ]
+#  vlan.access: blue
 
 nodes:
  s1:
@@ -52,18 +66,38 @@ nodes:
 
 validate:
   ping_red:
-    description: Ping-based reachability test in VLAN red
+    description: Ping-based reachability test in VLAN red h1->h2
     nodes: [ h1 ]
     wait_msg: Waiting for STP to enable the ports
     wait: 45
     plugin: ping('h2')
+  ping_red2:
+    description: Ping-based reachability test in VLAN red h1->h3
+    nodes: [ h1 ]
+    plugin: ping('h3')
+  ping_red3:
+    description: Ping-based reachability test in VLAN red h2->h3
+    nodes: [ h2 ]
+    plugin: ping('h3')
   ping_blue:
-    description: Ping-based reachability test in VLAN blue
-    nodes: [ h3 ]
+    description: Ping-based reachability test in VLAN blue h4->h5
+    nodes: [ h4 ]
     wait_msg: Waiting for STP to enable the ports
     wait: 20
-    plugin: ping('h4')
+    plugin: ping('h5')
+  ping_blue2:
+    description: Ping-based reachability test in VLAN blue h4->h6
+    nodes: [ h4 ]
+    plugin: ping('h6')
+  ping_blue3:
+    description: Ping-based reachability test in VLAN blue h5->h6
+    nodes: [ h5 ]
+    plugin: ping('h6')
   inter_vlan:
-    description: Ping-based reachability test between blue and red VLANs
+    description: Ping-based reachability test between blue and red VLANs h1->h4
     nodes: [ h1 ]
-    plugin: ping('h3',expect='fail')
+    plugin: ping('h4',expect='fail')
+  inter_vlan2:
+    description: Ping-based reachability test between blue and red VLANs h1->h5
+    nodes: [ h1 ]
+    plugin: ping('h5',expect='fail')

--- a/tests/integration/stp/02b-vlan-loop-trunk.yml
+++ b/tests/integration/stp/02b-vlan-loop-trunk.yml
@@ -1,0 +1,63 @@
+---
+message: |
+  The devices under test form a connected triangle (loop) with 2 VLANs. 
+  
+  If STP is enabled, this topology requires per-VLAN STP (PVRST); the VLANs themselves don't form a loop, but the links do.
+  Per-VLAN priority settings should make S1 root for red, and S2 for blue VLAN
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+
+  For FRR, use
+  ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` and
+  ```docker exec -it clab-stp-s2 /usr/sbin/brctl showstp vlan1001``` and
+
+stp.protocol: pvrst # Topology requires running STP per VLAN
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2,s3 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2, s1-s2 ]  # NOT s1-s3
+  blue:
+    mode: bridge
+    links: [ s1-h3, s3-h4, s1-s3 ]  # NOT s1-s2
+
+links:
+- s2:
+  s3:
+  vlan.trunk: [ red, blue ]
+
+nodes:
+ s1:
+  vlans.red.stp.priority: 4096   # Test per-VLAN priority, it becomes 4096 + vlan ID = 5096
+ s2:
+  vlans.blue.stp.priority: 4096
+
+validate:
+  ping_red:
+    description: Ping-based reachability test in VLAN red
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping_blue:
+    description: Ping-based reachability test in VLAN blue
+    nodes: [ h3 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 20
+    plugin: ping('h4')
+  inter_vlan:
+    description: Ping-based reachability test between blue and red VLANs
+    nodes: [ h1 ]
+    plugin: ping('h3',expect='fail')

--- a/tests/integration/stp/03-vlan-multi-link.yml
+++ b/tests/integration/stp/03-vlan-multi-link.yml
@@ -49,13 +49,13 @@ message: |
 
 groups:
   _auto_create: True
+  switches:
+    members: [ s1, s2 ]
+    module: [ vlan, stp ]
   hosts:
     members: [ h1, h2 ]
     device: linux
     provider: clab
-  switches:
-    members: [ s1, s2 ]
-    module: [ vlan, stp ]
 
 nodes:
  s2:
@@ -67,13 +67,21 @@ vlans:
     links:
     - s1-h1
     - s2-h2
-    # Dual link between s1/s2
+    # Dual access link between s1/s2
     - s1:
       s2:
        stp.port_priority: 2  # Backup link (lower priority)
     - s1:
       s2:
        stp.port_priority: 1  # Sent to S1 which should cause it to select this link as root port
+
+links:
+- s1:
+  s2:
+   vlan.trunk:
+    red:
+     stp.port_priority: 3    # Test port priority on trunk vlan
+  vlan.trunk: [red]
 
 validate:
   ping:

--- a/tests/integration/stp/03c-vlan-trunk-priority.yml
+++ b/tests/integration/stp/03c-vlan-trunk-priority.yml
@@ -1,0 +1,92 @@
+---
+message: |
+  The devices under test have multiple links between them which form a loop unless STP blocks all but one
+
+  h1 and h2 should be able to ping each other, and no forwarding loop should occur
+
+  The bridge with the highest priority (s2) should become the root, all but one port should get blocked by S1 in order of port priority
+  For FRR, use ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` to verify
+  Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
+  cEOS: ```docker exec -it clab-stp-s2 Cli -c "show spanning-tree"```
+  Dell OS10: ```sshpass -padmin ssh admin@clab-stp-s1 "show spanning-tree vlan 1000"```
+
+  Sample cEOS output:
+  user@host:~/Projects/netlab/tests/integration/stp$ docker exec -it clab-stp-s1 Cli -c "show spanning-tree"
+  MST0
+  Spanning tree enabled protocol rstp
+  Root ID    Priority    4096
+             Address     001c.735d.832c
+             Cost        20000 (Ext) 0 (Int)
+             Port        3 (Ethernet3)
+             Hello Time  2.000 sec  Max Age 20 sec  Forward Delay 15 sec
+
+  Bridge ID  Priority    32768  (priority 32768 sys-id-ext 0)
+             Address     001c.73e5.fda9
+             Hello Time  2.000 sec  Max Age 20 sec  Forward Delay 15 sec
+
+  Interface        Role       State      Cost      Prio.Nbr Type
+  ---------------- ---------- ---------- --------- -------- --------------------
+  Et1              designated forwarding 20000     128.1    P2p Edge                      
+  Et2              alternate  discarding 20000     128.2    P2p            <-- selected to discard due to priority Et3 received from s2
+  Et3              root       forwarding 20000     128.3    P2p                           
+  
+  user@host:~/Projects/netlab/tests/integration/stp$ docker exec -it clab-stp-s2 Cli -c "show spanning-tree"
+  MST0
+  Spanning tree enabled protocol rstp
+  Root ID    Priority    4096
+             Address     001c.735d.832c
+             This bridge is the root
+
+  Bridge ID  Priority     4096  (priority 4096 sys-id-ext 0)
+             Address     001c.735d.832c
+             Hello Time  2.000 sec  Max Age 20 sec  Forward Delay 15 sec
+
+  Interface        Role       State      Cost      Prio.Nbr Type
+  ---------------- ---------- ---------- --------- -------- --------------------
+  Et1              designated forwarding 20000     128.1    P2p Edge        <-- default '8'*16 = 128              
+  Et2              designated forwarding 20000      32.2    P2p                           
+  Et3              designated forwarding 20000      16.3    P2p             <-- configured '1' => *16     
+
+groups:
+  _auto_create: True
+  switches:
+    members: [ s1, s2 ]
+    module: [ vlan, stp ]
+  hosts:
+    members: [ h1, h2 ]
+    device: linux
+    provider: clab
+
+nodes:
+ s2:
+  stp.priority: 4096  # High STP bridge priority (low value) -> becomes root
+
+vlans:
+  red:
+    mode: bridge
+    links:
+    - s1-h1
+    - s2-h2
+
+links:
+- s1:
+  s2:
+   vlan.trunk:
+    red:
+     stp.port_priority: 1    # Test port priority on trunk vlan
+  vlan.trunk: [red]
+
+- s1:
+  s2:
+   vlan.trunk:
+    red:
+     stp.port_priority: 2    # Backup port
+  vlan.trunk: [red]
+
+validate:
+  ping:
+    description: Pinging H2 from H1
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')

--- a/tests/integration/stp/07-pvrst-interop.yml
+++ b/tests/integration/stp/07-pvrst-interop.yml
@@ -1,0 +1,61 @@
+---
+message: |
+  The different vendor devices under test use per-VLAN STP with a different root bridge on each VLAN
+  To check the status:
+  netlab exec "s*" show spanning-tree vlan 1000
+  netlab exec "s*" show spanning-tree vlan 1001
+  netlab exec "l*" nv show bridge domain br_default stp vlan
+
+provider: clab
+
+module: [vlan,stp]
+
+stp.protocol: pvrst
+
+# Dell OS10 can't run STP on virtual networks -> use custom template
+defaults.devices.dellos10:
+ features.vlan.svi_interface_name: vlan{vlan}
+
+vlans:
+ red:
+ blue:
+
+groups:
+ _auto_create: True
+ spines:
+  members: [s1,s2]
+  device: dellos10
+ leaves:
+  members: [l1,l2]
+  device: cumulus_nvue
+  provider: libvirt
+
+nodes:
+ s1:
+  vlans:
+   red:
+    stp.priority: 4096
+
+ s2:
+  vlans:
+   blue:
+    stp.priority: 8192
+
+links:
+- s1:
+  s2:
+  vlan.trunk: [red,blue]
+- s1:
+  l1:
+  vlan.trunk: [red,blue]
+- s2:
+  l2:
+   vlan.trunk:
+    red:
+     stp.port_priority: 1
+    blue:
+     stp.port_priority: 15
+  vlan.trunk: [red,blue]
+- l1:
+  l2:
+  vlan.trunk: [red,blue]

--- a/tests/integration/stp/templates/vlan/dellos10.j2
+++ b/tests/integration/stp/templates/vlan/dellos10.j2
@@ -1,0 +1,33 @@
+! First of all, create association VLAN<->Virtual-Network -> commented out for STP interop test
+{% if vlans is defined %}
+{%   for vlan_name, vlan in vlans.items() %}
+! virtual-network {{ vlan.id }}
+!   exit
+interface vlan {{ vlan.id }}
+  description "VLAN {{ vlan_name }}"
+!  virtual-network {{ vlan.id }}
+  exit
+{%   endfor %}
+{% endif %}
+!
+{% for ifdata in interfaces if ifdata.vlan is defined %}
+!
+interface {{ ifdata.ifname }}
+{%   if ifdata.vlan.access_id is defined %}
+ switchport mode access
+ switchport access vlan {{ ifdata.vlan.access_id }}
+{%   endif %}
+{%   if ifdata.vlan.trunk_id is defined %}
+ switchport mode trunk
+
+{%     set vid_list = [] %}
+{%     for vid in ifdata.vlan.trunk_id if vid != ifdata.vlan.access_id|default(0) %}
+{{       vid_list.append(vid) }}
+{%     endfor %}
+
+ switchport trunk allowed vlan {{ vid_list|join(",") }}
+{%     if ifdata.vlan.native is defined %}
+ switchport access vlan {{ ifdata.vlan.access_id }}
+{%     endif %}
+{%   endif %}
+{% endfor +%}


### PR DESCRIPTION
Cumulus 5.6 introduced support for PVRST on VLAN-aware bridges. This PR adds support for that in Netlab

* Fixes a critical issue with NVUE auto-generating the same MAC for each br_default (not sure why...)
* Configures per-VLAN port priority (including on VLAN trunks, which is somewhat convoluted)
* PR includes a PVRST interop test between Dell OS10 and Cumulus NVUE; correct root bridges are elected
* Update Cumulus NVUE libvirt image to 5.10

Open issues:
* Configured per-vlan port priorities do not appear on the wire - could be a bug in Cumulus. Unable to solve that here
* PVRST seems to work best when using trunk vlans between switches, not access vlans (per-VLAN tagging gets lost)
   Could add a quirk warning about this combination
   
   Note: the cumulus.j2 change doesn't really belong in this PR, but it fixes an issue with the 'pvrst' string which should never appear in that stanza and which we'd likely forget about