### PR TITLE
Dell OS10: Fix trunk STP port priority

### DIFF
--- a/netsim/ansible/templates/stp/dellos10.j2
+++ b/netsim/ansible/templates/stp/dellos10.j2
@@ -10,12 +10,12 @@ spanning-tree mode {{ mode }}
 spanning-tree rstp force-version stp
 {%  endif %}
 
-{% if 'priority' in stp %}
+{%  if 'priority' in stp %}
 spanning-tree rstp priority {{ stp.priority }}
-{% endif %}
+{%  endif %}
 
 {# Check for per-VLAN enable and priority; implies Rapid-PVST #}
-{% if vlans is defined %}
+{%  if vlans is defined %}
 {%   for vname,vdata in vlans.items() if 'stp' in vdata %}
 {%    if not vdata.stp.enable|default(True) %}
 spanning-tree vlan {{ vdata.id }} disable
@@ -23,11 +23,11 @@ spanning-tree vlan {{ vdata.id }} disable
 spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
 {%    endif %}
 {%   endfor +%}
-{% endif %}
+{%  endif %}
 
-{% for ifdata in interfaces if 'stp' in ifdata %}
-{%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
+{%  for ifdata in interfaces if 'stp' in ifdata or ifdata.vlan.trunk|default({})|dict2items|map(attribute='value')|selectattr('stp','defined') %}
 interface {{ ifdata.ifname }}
+{%   if 'stp' in ifdata %}
 {%    if not ifdata.stp.enable|default(True) %}
  spanning-tree disable
 {%    elif 'port_priority' in ifdata.stp %}
@@ -35,11 +35,20 @@ interface {{ ifdata.ifname }}
 # Use 16x port_priority to get the correct 4-bit value on the wire
 #
 {%     if stp.protocol=='pvrst' %}
- spanning-tree vlan {{ ifdata.vlan.trunk_id|default(ifdata.vlan.access_id) }} priority {{ ifdata.stp.port_priority * 16 }}
+ spanning-tree vlan {{ ifdata.vlan.access_id|default(1) }} priority {{ ifdata.stp.port_priority * 16 }}
 {%     else %}
  spanning-tree rstp priority {{ ifdata.stp.port_priority * 16 }}
 {%     endif %}
 {%    endif %} 
+{%   else %}
+{# Trunk port(s) with STP attributes #}
+{%    for id in ifdata.vlan.trunk_id %}
+{%     for vname,vdata in vlans.items() if vdata.id==id %}
+{%      if vname in ifdata.vlan.trunk and ifdata.vlan.trunk[vname].stp.port_priority is defined %}
+ spanning-tree vlan {{ id }} priority {{ ifdata.vlan.trunk[vname].stp.port_priority * 16 }}
+{%      endif %}
+{%     endfor %}
+{%    endfor %}
 {%   endif %}
-{% endfor %}
+{%  endfor %}
 {% endif %}

--- a/tests/integration/stp/03-vlan-multi-link.yml
+++ b/tests/integration/stp/03-vlan-multi-link.yml
@@ -8,7 +8,7 @@ message: |
   For FRR, use ```docker exec -it clab-stp-s1 /usr/sbin/brctl showstp vlan1000``` to verify
   Cumulus: ```docker exec -it clab-stp-s1 /sbin/brctl showstp bridge```
   cEOS: ```docker exec -it clab-stp-s2 Cli -c "show spanning-tree"```
-  Dell OS10: ```sshpass -padmin ssh admin@clab-stp-s1 "show spanning-tree vlan 1000"```
+  Dell OS10: ```netlab exec "s*" show spanning-tree vlan 1000```
 
   Sample cEOS output:
   user@host:~/Projects/netlab/tests/integration/stp$ docker exec -it clab-stp-s1 Cli -c "show spanning-tree"
@@ -46,6 +46,13 @@ message: |
   Et1              designated forwarding 20000     128.1    P2p Edge        <-- default '8'*16 = 128              
   Et2              designated forwarding 20000      32.2    P2p                           
   Et3              designated forwarding 20000      16.3    P2p             <-- configured '1' => *16     
+
+# Dell OS10 can't run STP on virtual networks -> use custom template
+defaults.devices.dellos10:
+ features.vlan.svi_interface_name: vlan{vlan}
+
+# Per-VLAN port priority requires PVRST
+stp.protocol: pvrst
 
 groups:
   _auto_create: True

--- a/tests/integration/stp/03b-vlan-multi-link-no-stp.yml
+++ b/tests/integration/stp/03b-vlan-multi-link-no-stp.yml
@@ -30,12 +30,14 @@ vlans:
 
 links: # Dual link between s1/s2
 - s1:
-   # stp.port_priority: 1  # S1 uses this link to send to S2, unless it is down
+   vlan.trunk:
+    red:
+     stp.port_priority: 1  # S1 uses this link to send to S2, unless it is down
   s2:
   vlan.trunk: [ untagged, red ]  # Must be a trunk allowing packets on VLAN 1 for this topology to work on Cumulus
   vlan.native: untagged
 - s1:
-   # stp.port_priority: 2
+   stp.port_priority: 2
   s2:
   vlan.trunk: [ untagged, red ]
   vlan.native: untagged


### PR DESCRIPTION
Fixes the configuration of ```stp.port_priority``` on VLAN trunks