### PR TITLE
Dell OS10: Add lag support

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -31,7 +31,7 @@ interface {{ mgmt.ifname|default('mgmt1/1/1') }}
 {% for l in interfaces|default([]) %}
 interface {{ l.ifname }}
  no shutdown
-{%   if l.virtual_interface is not defined %}
+{%   if l.virtual_interface is not defined or l.type=='lag' %}
  no switchport
 {%   endif %}
 {% if l.vrf is defined %}

--- a/netsim/ansible/templates/lag/dellos10.j2
+++ b/netsim/ansible/templates/lag/dellos10.j2
@@ -1,0 +1,12 @@
+{% for intf in interfaces if intf.type == 'lag' %}
+{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
+!
+{%     set _lag_mode = 
+         'on' if intf.lag.lacp|default('') == 'off' else
+         'active' if intf.lag.lacp_mode|default('') == 'active' else 
+         'passive' %}
+interface {{ ch.ifname }}
+  channel-group {{ intf.lag.ifindex }} mode {{ _lag_mode }}
+  lacp rate {{ 'fast' if intf.lag.lacp|default('') == 'fast' else 'normal' }}
+{%   endfor %}
+{% endfor %}

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -3,6 +3,7 @@ description: Dell OS10
 interface_name: ethernet1/1/{ifindex}
 mgmt_if: mgmt1/1/1
 loopback_interface_name: loopback{ifindex}
+lag_interface_name: "port-channel{lag.ifindex}"
 features:
   initial:
     ipv4:
@@ -21,6 +22,8 @@ features:
     irb: true
   gateway:
     protocol: [ anycast, vrrp ]
+  lag:
+    passive: True
   ospf: true
   stp:
     supported_protocols: [ stp, rstp, mstp, pvrst ]

--- a/tests/integration/lag/03-l3-lag-passive.yml
+++ b/tests/integration/lag/03-l3-lag-passive.yml
@@ -1,0 +1,26 @@
+---
+message: |
+  The device under test is a router with a L3 LAG link connected to a FRR device. The
+  devices should be able to establish an OSPF adjacency, with the DUT in passive mode for LACP.
+
+groups:
+  switches:
+    members: [ dut, xr ]
+    module: [ lag, ospf ]
+
+nodes:
+  dut:
+    lag.lacp_mode: passive
+  xr:
+    device: frr
+
+links:
+- lag.members: [ dut-xr, dut-xr ]
+
+validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: 50
+    nodes: [ xr ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)


### PR DESCRIPTION
Adds passive mode test

TODO: Could rename ```lag_interface_name``` to ```features.lag.interface_name``` for consistency with vlan module