### PR TITLE
Cumulus_nvue: basic lag support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
     entry: tests/run-tests.sh ci
     language: script
     types_or: [ yaml, python3 ]
+
+  - id: jinjalint
+    name: jinjalint
+    description: This hook runs jinjalint on .j2 files
+    entry: jinjalint
+    types: [ file ]  # restore the default `types` matching
+    language: script
+    files: \.(j2)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,8 @@ repos:
     types_or: [ yaml, python3 ]
 
   - id: j2lint
-    name: j2lint
-    description: This hook runs j2lint on .j2 files
+    name: Check for Linting error on Jinja2 templates
     entry: j2lint
-    types: [ file ]  # restore the default `types` matching
-    language: script
-    files: \.(j2)$
+    language: python
+    types: [jinja]
+    require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
     language: script
     types_or: [ yaml, python3 ]
 
-  - id: jinjalint
-    name: jinjalint
-    description: This hook runs jinjalint on .j2 files
-    entry: jinjalint
+  - id: j2lint
+    name: j2lint
+    description: This hook runs j2lint on .j2 files
+    entry: j2lint
     types: [ file ]  # restore the default `types` matching
     language: script
     files: \.(j2)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,3 @@ repos:
     entry: tests/run-tests.sh ci
     language: script
     types_or: [ yaml, python3 ]
-
-  - id: j2lint
-    name: Check for Linting error on Jinja2 templates
-    entry: j2lint
-    language: python
-    types: [jinja]
-    require_serial: true

--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -9,7 +9,7 @@ LAG is currently supported on these platforms:
 | Operating system      | LACP | Static | Passive<br>LACP |
 | --------------------- |:--:|:--:|:--:|
 | Arista EOS [❗](caveats-eos) | ✅ | ✅ | ✅ |
-| Cumulus Linux         | ✅ | ✅ | ❌  |
+| Cumulus Linux 4.x/5.x | ✅ | ✅ | ❌  |
 | FRR                   | ✅ | ✅ | ❌  |
 
 ## Parameters

--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -9,7 +9,8 @@ LAG is currently supported on these platforms:
 | Operating system      | LACP | Static | Passive<br>LACP |
 | --------------------- |:--:|:--:|:--:|
 | Arista EOS [❗](caveats-eos) | ✅ | ✅ | ✅ |
-| Cumulus Linux 4.x/5.x | ✅ | ✅ | ❌  |
+| Cumulus Linux 4.x     | ✅ | ✅ | ❌  |
+| Cumulus 5.x (NVUE)    | ✅ | ✅ | ❌  |
 | FRR                   | ✅ | ✅ | ❌  |
 
 ## Parameters

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -1,7 +1,9 @@
+- set_fact:
+    nvue_config_file: "/tmp/nvue_config_{{ netsim_action }}.yaml"
 - name: "copy the cumulus nvue YAML {{ netsim_action }} config file to switch (generated from {{ config_template }})"
   template:
     src: "{{ config_template }}"
-    dest: /tmp/nvue_config.yaml
+    dest: "{{ nvue_config_file }}"
     mode: 0644
 
 - block:
@@ -11,10 +13,10 @@
 
   - name: "Wait for nvued to start"
     service_facts:
-    register: svc
-    until: svc.ansible_facts.services['nvued.service'].state == 'running'
+    until: services['nvued.service'].state == 'running'
     retries: 15
     delay: 5
+    no_log: True
 
   when: nvue_service_running is not defined
 
@@ -22,8 +24,8 @@
     nvue_service_running: 1 
 
 - name: "execute on cumulus: 'nv config patch' for {{ netsim_action }} config"
-  command: nv config patch /tmp/nvue_config.yaml
+  command: nv config patch {{ nvue_config_file }}
 
-- name: "execute on cumulus: 'nv config apply' for {{ netsim_action }} config"
+- name: "execute on cumulus: 'nv config apply -y' for {{ netsim_action }} config"
   command: nv config apply -y
   tags: [ print_action, always ]

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -14,25 +14,24 @@
 {%  if i.ipv4 is defined or i.ipv6 is defined %}
         ip:
           address:
-{%   if i.ipv4 is defined %}
-{%    if i.ipv4 == True %}
+{%    if i.ipv4 is defined %}
+{%      if i.ipv4 == True %}
             {{ loopback.ipv4 }}: {}
-{%    else %}
+{%      else %}
             {{ i.ipv4 }}: {}
+{%      endif %}
 {%    endif %}
-{%   endif %}
-{%     if i.vrf is defined %}
+{%    if i.vrf is defined %}
           vrf: {{ i.vrf }}
-{%  endif %}
-{%  if i.ipv6 is defined %}
-{%   if i.ipv6 == True %}
-{%   else %}
+{%    endif %}
+{%    if i.ipv6 is defined %}
+{%      if i.ipv6 is string %}
             {{ i.ipv6 }}: {}
-{%   endif %}
-{%   else %}
+{%      endif %}
+{%    else %}
           ipv6:
             enable: off
-{%   endif %}
+{%    endif %}
 {%  endif %}
 {% endmacro %}
 

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -1,3 +1,40 @@
+{% macro decl_interface(i) %}
+      {{ i.ifname }}:
+        link:
+{%  if i.mtu is defined %}
+          mtu: {{ i.mtu }}
+{%  endif %}
+          state:
+            up: {}
+{%  if i.name is defined %}
+        description: "{{ i.name }}{{ " ["+i.role+"]" if i.role is defined else "" }}"
+{%  elif i.type|default("") == "stub" %}
+        description: Stub interface
+{%  endif %}
+{%  if i.ipv4 is defined or i.ipv6 is defined %}
+        ip:
+          address:
+{%   if i.ipv4 is defined %}
+{%    if i.ipv4 == True %}
+            {{ loopback.ipv4 }}: {}
+{%    else %}
+            {{ i.ipv4 }}: {}
+{%    endif %}
+{%   endif %}
+{%     if i.vrf is defined %}
+          vrf: {{ i.vrf }}
+{%  endif %}
+{%  if i.ipv6 is defined %}
+{%   if i.ipv6 == True %}
+{%   else %}
+            {{ i.ipv6 }}: {}
+{%   endif %}
+{%   else %}
+          ipv6:
+            enable: off
+{%   endif %}
+{%  endif %}
+{% endmacro %}
 
 - set:
     system:
@@ -19,40 +56,12 @@
 {% endif %}
 {% if 'ipv6' in loopback %}
             {{ loopback.ipv6 }}: {}
+{% else %}
+          ipv6:
+            enable: off
 {% endif %}
         type: loopback
 {% for l in interfaces|default([]) if l.type in ['lan','p2p','stub','svi'] %}
-      {{ l.ifname }}:
-        link:
-{%  if l.mtu is defined %}
-          mtu: {{ l.mtu }}
-{%  endif %}
-          state:
-            up: {}
+{{      decl_interface(l) }}
         type: {{ 'svi' if l.type=='svi' else 'swp' }}
-{%   if l.name is defined %}
-        description: "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}"
-{%   elif l.type|default("") == "stub" %}
-        description:  Stub interface
-{%   endif %}
-{%   if (l.ipv4 is defined and l.ipv4) or l.ipv6 is string %}
-        ip:
-          address:
-{%     if l.ipv4 is defined %}
-{%      if l.ipv4 == True %}
-            {{ loopback.ipv4 }}: {}
-{%       else %}
-            {{ l.ipv4 }}: {}
-{%       endif %}
-{%     endif %}
-{%     if l.vrf is defined %}
-          vrf: {{ l.vrf }}
-{%     endif %}
-{%     if l.ipv6 is defined %}
-{%       if l.ipv6 == True %}
-{%       else %}
-            {{ l.ipv6 }}: {}
-{%       endif %}
-{%     endif %}
-{%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -1,5 +1,6 @@
 {% macro decl_interface(i) %}
       {{ i.ifname }}:
+        type: {{ 'svi' if i.type=='svi' else 'bond' if i.type=='lag' else 'swp' }}
         link:
 {%  if i.mtu is defined %}
           mtu: {{ i.mtu }}
@@ -31,7 +32,11 @@
 {%    else %}
           ipv6:
             enable: off
-{%    endif %}
+{%    endif %}            
+{%  elif i.type=='lag' %}
+        bridge:
+          domain:
+            br_default: {}
 {%  endif %}
 {% endmacro %}
 
@@ -60,7 +65,6 @@
             enable: off
 {% endif %}
         type: loopback
-{% for l in interfaces|default([]) if l.type in ['lan','p2p','stub','svi'] %}
+{% for l in interfaces|default([]) if l.type in ['lan','p2p','stub','svi','lag'] %}
 {{      decl_interface(l) }}
-        type: {{ 'svi' if l.type=='svi' else 'swp' }}
 {% endfor %}

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -1,12 +1,9 @@
-{% from "initial/cumulus_nvue.j2" import decl_interface with context %}
-
 {% for i in interfaces if i.type == 'lag' %}
 {%  if loop.first %}
 - set:
     interface:
 {%  endif %}
-{{      decl_interface(i) }}
-        type: bond
+      {{ i.ifname }}:
         bond:
 {%  set _lacp = i.lag.lacp|default(lag.lacp) %}
 {%  if _lacp=='slow' %}
@@ -18,9 +15,4 @@
 {%  for c in interfaces if c.lag._parentindex|default(False) == i.linkindex %}
             {{ c.ifname }}: {}
 {%  endfor %}
-{%  if 'ipv4' not in i and 'ipv6' not in i %}
-        bridge:
-          domain:
-            br_default: {}
-{%  endif %}
 {% endfor %}

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -5,6 +5,12 @@
 {{      decl_interface(i) }}
         type: bond
         bond:
+{%  set _lacp = i.lag.lacp|default(lag.lacp) %}
+{%  if _lacp=='slow' %}
+          lacp-rate: slow
+{%  elif _lacp=='off' or i.lag.mode|default(lag.mode)=="balance-xor" %}
+          mode: static
+{%  endif %}
           member:
 {%  for c in interfaces if c.lag._parentindex|default(False) == i.linkindex %}
             {{ c.ifname }}: {}

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -1,0 +1,17 @@
+{% from "initial/cumulus_nvue.j2" import decl_interface with context %}
+- set:
+    interface:
+{% for i in interfaces if i.type == 'lag' %}
+{{      decl_interface(i) }}
+        type: bond
+        bond:
+          member:
+{%  for c in interfaces if c.lag._parentindex|default(False) == i.linkindex %}
+            {{ c.ifname }}: {}
+{%  endfor %}
+{%  if 'ipv4' not in i and 'ipv6' not in i %}
+        bridge:
+          domain:
+            br_default: {}
+{%  endif %}
+{% endfor %}

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -1,7 +1,10 @@
 {% from "initial/cumulus_nvue.j2" import decl_interface with context %}
+
+{% for i in interfaces if i.type == 'lag' %}
+{%  if loop.first %}
 - set:
     interface:
-{% for i in interfaces if i.type == 'lag' %}
+{%  endif %}
 {{      decl_interface(i) }}
         type: bond
         bond:

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -13,8 +13,10 @@
 {%  endfor %}
 {% endif %}
 
-    interface:
 {% for i in interfaces if i.vlan is defined and (i.virtual_interface is not defined or i.type=="lag") %}
+{%   if loop.first %}
+    interface:
+{%   endif %}
      {{ i.ifname }}:
         bridge:
           domain:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,5 +1,6 @@
 description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
+lag_interface_name: "bond{lag.ifindex}"
 mgmt_if: eth0
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
@@ -21,6 +22,8 @@ features:
     ipv6_lla: True
     rfc8950: True
     activate_af: True
+  lag:
+    passive: False
   ospf:
     unnumbered: True
   stp:

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -15,6 +15,7 @@ nodes:
 
 links:
 - lag.members: [ dut-xr, dut-xr ]
+  mtu: 1500
 
 validate:
   adj:


### PR DESCRIPTION
* Enables bonded interfaces with dynamic (LACP) or static modes
* Refactor IP address config as macro; used only in 'initial' script
* Explicitly disable ipv6 when not configured
* Define MTU in lag OSPF test such that it works on libvirt too

Note: Fixes ipv6-only unnumbered config, would have been skipped prior to this PR