### PR TITLE
Cumulus nvue multiple loopback support

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -204,7 +204,7 @@ The following interface parameters are configured on supported network operating
 | Cisco IOS XRv         | ✅  | ✅ [❗](caveats-iosxr) | ✅ |  ❌  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ |  ❌ |  ❌  |
+| Cumulus Linux 5.0 (NVUE) | ✅ | ❌ | ✅  | ✅  |
 | Dell OS10             | ✅  |  ❌  | ✅  | ✅  |
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
@@ -311,11 +311,12 @@ These devices support additional control-plane protocols or BGP address families
 (platform-layer-2-support)=
 The layer-2 control plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
 
-| Operating system      | [Spanning<br>Tree Protocol](module/stp.md) | [Link Aggregation<br>Groups](module/lag.md) |
-| --------------------- |:--:|:--:|
-| Arista EOS            | ✅ | ✅ |
-| Cumulus Linux         | ✅ | ✅ |
-| FRR                   | ✅ | ✅ |
+| Operating system          | [Spanning<br>Tree Protocol](module/stp.md) | [Link Aggregation<br>Groups](module/lag.md) |
+| ------------------------- |:--:|:--:|
+| Arista EOS                | ✅ | ✅ |
+| Cumulus Linux             | ✅ | ✅ |
+| Cumulus Linux 5.0 (NVUE)  | ✅ | ✅ |
+| FRR                       | ✅ | ✅ |
 
 (platform-dataplane-support)=
 The data plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
@@ -329,7 +330,7 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Cisco IOSv/IOSvL2     | ✅ | ✅ |  ❌ | ✅ |  ❌ |  ❌ |
 | Cisco Nexus OS        | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | Cumulus Linux         | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
-| Cumulus Linux 5.0 (NVUE) | ❌ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
+| Cumulus Linux 5.0 (NVUE) | ✅ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
 | Dell OS10             | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | FRR                   | ✅ | ✅ | ✅ | ✅ | ✅ |  ❌ | 
 | Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ | 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -25,7 +25,7 @@
 | Cisco IOS XRv  [❗](caveats-iosxr)        | iosxr              |
 | Cisco Nexus 9300v [❗](caveats-nxos)      | nxos               |
 | Cumulus Linux 4.x/5.x [❗](caveats-cumulus) | cumulus            |
-| Cumulus Linux 5.0 (NVUE) [❗](caveats-cumulus-nvue)                            | cumulus_nvue           |
+| Cumulus Linux 5.x (NVUE) [❗](caveats-cumulus-nvue)                            | cumulus_nvue           |
 | Dell OS10 [❗](caveats-os10)              | dellos10           |
 | Fortinet FortiOS [❗](caveats-fortios)    | fortios            |
 | FRRouting (FRR) [❗](caveats-frr)         | frr                |
@@ -83,7 +83,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Cisco IOS XRv      | [✅](build-iosxr) |  ❌  | ✅  |
 | Cisco Nexus 9300v  | [✅](build-nxos) | ✅  |  ✅[❗](clab-vrnetlab)  |
 | Cumulus Linux      | ✅  | ✅  | ✅[❗](caveats-cumulus) |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ | ✅[❗](caveats-cumulus) |
+| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅[❗](caveats-cumulus) |
 | Dell OS10          | [✅](build-dellos10)  |  ❌  | ✅  |
 | Fortinet FortiOS   | ✅  |  ❌  |  ❌  |
 | FRR | ✅[❗](caveats-frr) | ✅[❗](caveats-frr) | ✅ |
@@ -117,7 +117,7 @@ Configuration files for Virtualbox and KVM/libvirt environments specify the numb
 | Cisco IOS XRv              | iosxr              |    2 |    8192 | e1000                     |
 | Cisco Nexus 9300v          | nxos               |    2 |   6144 [❗](caveats-nxos)| e1000 |
 | Cumulus Linux              | cumulus            |    2 |   1024 | virtio |
-| Cumulus Linux 5.0 (NVUE)   | cumulus_nvue       |    2 |   1024 | virtio |
+| Cumulus Linux 5.x (NVUE)   | cumulus_nvue       |    2 |   1024 | virtio |
 | Dell OS10                  | dellos10           |    2 |   2048 | e1000                      |
 | Fortinet FortiOS           | fortios            |    1 |   1024 | virtio |
 | FRR                        | frr                |    1 |   1024 | virtio |
@@ -177,7 +177,7 @@ The following system-wide features are configured on supported network operating
 | Cisco IOS XRv            | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Cisco Nexus OS           | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux            | ✅  | ✅ [^HIF]  | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Cumulus Linux 5.x (NVUE) | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Dell OS10                | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Fortinet FortiOS         | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | FRR                      | ✅  | ✅ [^HIF]  |  ❌  | ✅  | ✅  |
@@ -204,7 +204,7 @@ The following interface parameters are configured on supported network operating
 | Cisco IOS XRv         | ✅  | ✅ [❗](caveats-iosxr) | ✅ |  ❌  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ❌ | ✅  | ✅  |
+| Cumulus Linux 5.x (NVUE) | ✅ | ❌ | ✅  | ✅  |
 | Dell OS10             | ✅  |  ❌  | ✅  | ✅  |
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
@@ -230,7 +230,7 @@ The following interface addresses are supported on various platforms:
 | Cisco IOS XRv         | ✅  | ✅  | ✅  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ | ✅ |
+| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅ |
 | Dell OS10             | ✅  | ✅  |  ❌  |
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  |
@@ -264,7 +264,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Cisco IOS XRv         | ✅   |  ✅  |   ❌  |  ✅  |   ❌  |
 | Cisco Nexus OS        | ✅   |  ✅  |  ✅  |  ✅  |   ❌  |
 | Cumulus Linux         | ✅   |   ❌  |   ❌  |  ✅  |  ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ |  ❌  |   ❌   | ✅ [❗](caveats-cumulus-nvue)  |  ❌  |
+| Cumulus Linux 5.x (NVUE) | ✅ |  ❌  |   ❌   | ✅ [❗](caveats-cumulus-nvue)  |  ❌  |
 | Dell OS10             | ✅ [❗](caveats-os10) |   ❌   |   ❌   | ✅  |  ❌  |
 | Fortinet FortiOS      | ✅ [❗](caveats-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |
 | FRR                   | ✅   |  ✅   |   ❌  | ✅  |  ✅  |
@@ -315,7 +315,7 @@ The layer-2 control plane [configuration modules](module-reference.md) are suppo
 | ------------------------- |:--:|:--:|
 | Arista EOS                | ✅ | ✅ |
 | Cumulus Linux             | ✅ | ✅ |
-| Cumulus Linux 5.0 (NVUE)  | ✅ | ✅ |
+| Cumulus Linux 5.x (NVUE)  | ✅ | ✅ |
 | FRR                       | ✅ | ✅ |
 
 (platform-dataplane-support)=
@@ -330,7 +330,7 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Cisco IOSv/IOSvL2     | ✅ | ✅ |  ❌ | ✅ |  ❌ |  ❌ |
 | Cisco Nexus OS        | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | Cumulus Linux         | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
-| Cumulus Linux 5.0 (NVUE) | ✅ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
+| Cumulus Linux 5.x (NVUE) | ✅ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
 | Dell OS10             | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | FRR                   | ✅ | ✅ | ✅ | ✅ | ✅ |  ❌ | 
 | Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ | 
@@ -376,7 +376,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Cisco IOS XE[^18v]    |          ✅          |   ✅    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cisco Nexus OS        |          ✅          |   ❌    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cumulus Linux         |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
-| Cumulus Linux 5.0 (NVUE)        |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
+| Cumulus Linux 5.x (NVUE)        |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Dell OS10             |          ✅          |   ✅    |    ❌     |         ❌          |        ✅         |    ❌    |
 | Fortinet FortiOS      |          ✅          |   ❌    |    ❌     |         ❌          |        ❌         |    ❌    |
 | FRR                   |          ✅          |   ✅    |    ✅     |         ❌          |        ✅         |    ❌    |

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -2,9 +2,9 @@
       {{ i.ifname }}:
         type: {{ 'svi' if i.type=='svi' else 'bond' if i.type=='lag' else 'swp' }}
         link:
-{%  if i.mtu is defined %}
+{%    if i.mtu is defined %}
           mtu: {{ i.mtu }}
-{%  endif %}
+{%    endif %}
           state:
             up: {}
 {%  if i.name is defined %}
@@ -14,6 +14,9 @@
 {%  endif %}
 {%  if i.ipv4 is defined or i.ipv6 is defined %}
         ip:
+{%    if i.vrf is defined %}
+          vrf: {{ i.vrf }}
+{%    endif %}
           address:
 {%    if i.ipv4 is defined %}
 {%      if i.ipv4 == True %}
@@ -22,12 +25,18 @@
             {{ i.ipv4 }}: {}
 {%      endif %}
 {%    endif %}
-{%    if i.vrf is defined %}
-          vrf: {{ i.vrf }}
-{%    endif %}
 {%    if i.ipv6 is defined %}
-{%      if i.ipv6 is string %}
+{%      if i.ipv6 is string and i.ipv6|ipv6 %}
             {{ i.ipv6 }}: {}
+          ipv6:
+            forward: on
+{%        if 'ipv6' not in i.dhcp.client|default({}) %}
+          neighbor-discovery:
+            enable: on
+            router-advertisement:
+              enable: off # Major bug in NVUE - any non-"on" value will *enable* (no suppress) RA...
+              interval: 5000
+{%        endif %}
 {%      endif %}
 {%    else %}
           ipv6:
@@ -50,21 +59,29 @@
           address:
             dhcp: {}
         type: eth
+{# Put all loopback IPs on the 'lo' interface #}
+{% set loopbacks = netlab_interfaces|selectattr('type','eq','loopback')|list %}
+{% set lo_ipv4s = loopbacks|selectattr('ipv4','defined')|map(attribute='ipv4')|list %}
+{% set lo_ipv6s = loopbacks|selectattr('ipv6','defined')|map(attribute='ipv6')|list %}
       lo:
         ip:
           address:
-{% if 'ipv4' in loopback %}
-            {{ loopback.ipv4 }}: {}
+{% if lo_ipv4s %}
+{%   for ip in lo_ipv4s %}
+            {{ ip }}: {}
+{%   endfor %}
 {% else %}
             127.0.0.1: {}
 {% endif %}
-{% if 'ipv6' in loopback %}
-            {{ loopback.ipv6 }}: {}
+{% if lo_ipv6s %}
+{%   for ip in lo_ipv6s %}
+            {{ ip }}: {}
+{%   endfor %}
 {% else %}
           ipv6:
             enable: off
 {% endif %}
         type: loopback
-{% for l in interfaces|default([]) if l.type in ['lan','p2p','stub','svi','lag'] %}
+{% for l in interfaces|default([]) if l.type!='loopback' %}
 {{      decl_interface(l) }}
 {% endfor %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -2,9 +2,9 @@
       {{ i.ifname }}:
         type: {{ 'svi' if i.type=='svi' else 'bond' if i.type=='lag' else 'swp' }}
         link:
-{%    if i.mtu is defined %}
+{%  if i.mtu is defined %}
           mtu: {{ i.mtu }}
-{%    endif %}
+{%  endif %}
           state:
             up: {}
 {%  if i.name is defined %}
@@ -59,29 +59,49 @@
           address:
             dhcp: {}
         type: eth
-{# Put all loopback IPs on the 'lo' interface #}
-{% set loopbacks = netlab_interfaces|selectattr('type','eq','loopback')|list %}
-{% set lo_ipv4s = loopbacks|selectattr('ipv4','defined')|map(attribute='ipv4')|list %}
-{% set lo_ipv6s = loopbacks|selectattr('ipv6','defined')|map(attribute='ipv6')|list %}
-      lo:
-        ip:
-          address:
-{% if lo_ipv4s %}
-{%   for ip in lo_ipv4s %}
-            {{ ip }}: {}
-{%   endfor %}
-{% else %}
-            127.0.0.1: {}
-{% endif %}
-{% if lo_ipv6s %}
-{%   for ip in lo_ipv6s %}
-            {{ ip }}: {}
-{%   endfor %}
-{% else %}
-          ipv6:
-            enable: off
-{% endif %}
-        type: loopback
 {% for l in interfaces|default([]) if l.type!='loopback' %}
 {{      decl_interface(l) }}
+{% endfor %}
+
+{% for lb in netlab_interfaces if lb.type=='loopback' %}
+- set:
+{%   if lb.vrf is not defined %}
+    interface:
+      lo:
+        type: loopback
+{%     if lb.mtu is defined %}
+        link:
+          mtu: {{ lb.mtu }}
+{%     endif %}
+        ip:
+          address:
+{%     if 'ipv4' in lb %}
+            {{ lb.ipv4 }}: {}
+{%     else %}
+            127.0.0.1/8: {}
+{%     endif %}
+{%     if 'ipv6' in lb %}
+            {{ lb.ipv6 }}: {}
+{%     else %}
+          ipv6:
+            enable: off
+{%     endif %}
+{%   else %}
+    vrf:
+      {{ lb.vrf }}:
+        loopback:
+          ip:
+            address:
+{%     if 'ipv4' in lb %}
+              {{ lb.ipv4 }}: {}
+{%     else %}
+              127.0.0.1/8: {}
+{%     endif %}
+{%     if 'ipv6' in lb %}
+              {{ lb.ipv6 }}: {}
+{%     else %}
+            ipv6:
+              enable: off
+{%     endif %}
+{%   endif %}
 {% endfor %}

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -76,7 +76,8 @@ def get_device_name(node: Box, type: str, defaults: Box, ifdata: Box) -> typing.
   lbname = features.get(f'{full_type}.interface_name',None)
   if not lbname:
     if log.debug_active('deprecated'):
-      log.info(f"Deprecated: device {node.device} does not provide '{full_type}.interface_name'")
+      log.error(f"Deprecated - device {node.device} does not provide '{full_type}.interface_name' in features",
+                module="initial",category=Warning)
     lbname = get_device_attribute(node,f'{type}_interface_name',defaults)
     if not lbname:
       return None

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -64,7 +64,7 @@ def get_device_features(node: Box, defaults: Box) -> Box:
 Get device loopback name (built-in loopback if ifindex == 0 else an additional loopback)
 """
 def get_loopback_name(node: Box, defaults: Box, ifindex: int = 0) -> typing.Optional[str]:
-  return get_device_name(node,'loopback',defaults,{'ifindex':ifindex})
+  return get_device_name(node,'loopback',defaults,Box({'ifindex':ifindex}))
 
 """
 get_device_name - get platform specific formatted device name for the given type and ifindex

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -67,7 +67,7 @@ def get_loopback_name(node: Box, defaults: Box, ifindex: int = 0) -> typing.Opti
   return get_device_name(node,'loopback',defaults,Box({'ifindex':ifindex}))
 
 """
-get_device_name - get platform specific formatted device name for the given type and ifindex
+get_device_name - get platform specific formatted device name for the given type and (other) ifdata
 """
 def get_device_name(node: Box, type: str, defaults: Box, ifdata: Box) -> typing.Optional[str]:
   # First try updated attribute name

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -288,9 +288,9 @@ def create_virtual_interface(node: Box, ifdata: Box, defaults: Box) -> None:
   # ifindex. For example, loopback interfaces have ifindex starting with 10001, but
   # the interface names start with Loopback1
   #
-  ifname_format  = devices.get_device_attribute(node,f'{devtype}_interface_name',defaults)
-  if ifname_format:
-    ifdata.ifname = strings.eval_format(ifname_format,ifdata + { 'ifindex': ifdata.ifindex - devtype_offset })
+  ifname = devices.get_device_name(node,devtype,defaults,ifdata + { 'ifindex': ifdata.ifindex - devtype_offset })
+  if ifname:
+    ifdata.ifname = ifname
     return
 
   # We could not find the relevant interface name template. Report an error
@@ -811,7 +811,7 @@ def set_link_loopback_type(link: Box, nodes: Box, defaults: Box) -> None:
 
   # If we don't know how to create loopbacks on this device, it makes no sense to proceed
   #
-  lb_name = devices.get_device_attribute(ndata,'loopback_interface_name',defaults)
+  lb_name = devices.get_loopback_name(ndata,defaults)
   if not lb_name:
     return
 

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -341,7 +341,7 @@ def loopback_interface(n: Box, pools: Box, topology: Box) -> None:
   n.loopback.type = 'loopback'
   n.loopback.neighbors = []
   n.loopback.virtual_interface = True
-  lbname = devices.get_loopback_name(n,topology)
+  lbname = devices.get_loopback_name(n,topology.defaults)
   if lbname:
     n.loopback.ifname = lbname
     n.loopback.ifindex = 0

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -27,7 +27,7 @@ def parser_add_debug(parser: argparse.ArgumentParser) -> None:
                   choices=sorted([
                     'all','addr','cli','links','libvirt','clab','modules','plugin','template',
                     'vlan','vrf','quirks','validate','addressing','groups','status',
-                    'external','defaults','lag']),
+                    'external','defaults','lag','deprecated']),
                   help=argparse.SUPPRESS)
   parser.add_argument('--test', dest='test', action='store',nargs='*',
                   choices=['errors'],

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,6 +1,5 @@
 description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
-lag_interface_name: "bond{lag.ifindex}"
 mgmt_if: eth0
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
@@ -18,12 +17,14 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    loopback.interface_name: lo  # Can assign multiple IPs to this interface
   bgp:
     ipv6_lla: True
     rfc8950: True
     activate_af: True
   lag:
     passive: False
+    interface_name: "bond{lag.ifindex}"
   ospf:
     unnumbered: True
   stp:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -17,7 +17,7 @@ features:
       unnumbered: True
     ipv6:
       lla: True
-    loopback.interface_name: lo  # Can assign multiple IPs to this interface
+    loopback.interface_name: lo{ifindex}  # Can assign multiple IPs to 'lo' interface, name ignored by template
   bgp:
     ipv6_lla: True
     rfc8950: True

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -305,9 +305,9 @@ def fix_vrf_unnumbered(node: Box, vrfname: str, lbdata: Box) -> None:
     intf._parent_ipv4 = lbdata.ipv4                             # ... IPv4 unnumbereds
 
 def vrf_loopbacks(node : Box, topology: Box) -> None:
-  loopback_name = devices.get_device_attribute(node,'loopback_interface_name',topology.defaults)
+  loopback_name = devices.get_loopback_name(node,topology.defaults)
 
-  if not loopback_name:                                                        # pragma: no cover -- hope we got device settings right ;)
+  if not loopback_name:                                               # pragma: no cover -- hope we got device settings right ;)
     log.print_verbose(f'Device {node.device} used by {node.name} does not support VRF loopback interfaces - skipping assignment.')
     return
 

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -96,7 +96,7 @@ def assign_vni(toponode: Box, obj_path: str, topology: Box) -> None:
 def node_set_vtep(node: Box, topology: Box) -> bool:
   # default vtep interface & interface name
   vtep_interface = node.loopback
-  loopback_name = devices.get_loopback_name(node,topology)
+  loopback_name = devices.get_loopback_name(node,topology.defaults)
   if not loopback_name:
     log.fatal("Can't find the loopback name of VXLAN-capable device {node.device}",module="vxlan",header=True)
 


### PR DESCRIPTION
* Puts additional ipv4/6 loopback addresses on 'lo' interface (only supported device name)
* Fix IPv6 ND/RA
* Remove check on most interface types (except 'loopback' which is still special)
* Moves interface_name under ```features.<module>.interface_name```
* Enables gradual migration to new interface_name layout, adding ```deprecated``` debug flag to call out remaining legacy settings

Tested:
integration/initial/02-loopbacks (Cumulus_nvue and FRR)
integration/lag/01-l3-lag (Cumulus_nvue and FRR)

(PS - if you prefer to move all platforms to the new scheme in 1 PR, we can do that too. I simply cannot test all of them personally)

Note: May need additional fixes for loopbacks in vrfs (didn't test those yet), let me know if you'd like to include those