### PR TITLE
Cumulus_nvue: Add loopback and VRF support, fix IPv6

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -25,7 +25,7 @@
 | Cisco IOS XRv  [❗](caveats-iosxr)        | iosxr              |
 | Cisco Nexus 9300v [❗](caveats-nxos)      | nxos               |
 | Cumulus Linux 4.x/5.x [❗](caveats-cumulus) | cumulus            |
-| Cumulus Linux 5.0 (NVUE) [❗](caveats-cumulus-nvue)                            | cumulus_nvue           |
+| Cumulus Linux 5.x (NVUE) [❗](caveats-cumulus-nvue)                            | cumulus_nvue           |
 | Dell OS10 [❗](caveats-os10)              | dellos10           |
 | Fortinet FortiOS [❗](caveats-fortios)    | fortios            |
 | FRRouting (FRR) [❗](caveats-frr)         | frr                |
@@ -83,7 +83,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Cisco IOS XRv      | [✅](build-iosxr) |  ❌  | ✅  |
 | Cisco Nexus 9300v  | [✅](build-nxos) | ✅  |  ✅[❗](clab-vrnetlab)  |
 | Cumulus Linux      | ✅  | ✅  | ✅[❗](caveats-cumulus) |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ | ✅[❗](caveats-cumulus) |
+| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅[❗](caveats-cumulus) |
 | Dell OS10          | [✅](build-dellos10)  |  ❌  | ✅  |
 | Fortinet FortiOS   | ✅  |  ❌  |  ❌  |
 | FRR | ✅[❗](caveats-frr) | ✅[❗](caveats-frr) | ✅ |
@@ -117,7 +117,7 @@ Configuration files for Virtualbox and KVM/libvirt environments specify the numb
 | Cisco IOS XRv              | iosxr              |    2 |    8192 | e1000                     |
 | Cisco Nexus 9300v          | nxos               |    2 |   6144 [❗](caveats-nxos)| e1000 |
 | Cumulus Linux              | cumulus            |    2 |   1024 | virtio |
-| Cumulus Linux 5.0 (NVUE)   | cumulus_nvue       |    2 |   1024 | virtio |
+| Cumulus Linux 5.x (NVUE)   | cumulus_nvue       |    2 |   1024 | virtio |
 | Dell OS10                  | dellos10           |    2 |   2048 | e1000                      |
 | Fortinet FortiOS           | fortios            |    1 |   1024 | virtio |
 | FRR                        | frr                |    1 |   1024 | virtio |
@@ -177,7 +177,7 @@ The following system-wide features are configured on supported network operating
 | Cisco IOS XRv            | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Cisco Nexus OS           | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux            | ✅  | ✅ [^HIF]  | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Cumulus Linux 5.x (NVUE) | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Dell OS10                | ✅  | ✅  | ✅  | ✅  | ✅  |
 | Fortinet FortiOS         | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | FRR                      | ✅  | ✅ [^HIF]  |  ❌  | ✅  | ✅  |
@@ -204,7 +204,7 @@ The following interface parameters are configured on supported network operating
 | Cisco IOS XRv         | ✅  | ✅ [❗](caveats-iosxr) | ✅ |  ❌  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ |  ❌ |  ❌  |
+| Cumulus Linux 5.x (NVUE) | ✅ | ❌ | ✅  | ✅  |
 | Dell OS10             | ✅  |  ❌  | ✅  | ✅  |
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
@@ -230,7 +230,7 @@ The following interface addresses are supported on various platforms:
 | Cisco IOS XRv         | ✅  | ✅  | ✅  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ | ✅ | ✅ |
+| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅ |
 | Dell OS10             | ✅  | ✅  |  ❌  |
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  |
@@ -264,7 +264,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Cisco IOS XRv         | ✅   |  ✅  |   ❌  |  ✅  |   ❌  |
 | Cisco Nexus OS        | ✅   |  ✅  |  ✅  |  ✅  |   ❌  |
 | Cumulus Linux         | ✅   |   ❌  |   ❌  |  ✅  |  ✅  |
-| Cumulus Linux 5.0 (NVUE) | ✅ |  ❌  |   ❌   | ✅ [❗](caveats-cumulus-nvue)  |  ❌  |
+| Cumulus Linux 5.x (NVUE) | ✅ |  ❌  |   ❌   | ✅ [❗](caveats-cumulus-nvue)  |  ❌  |
 | Dell OS10             | ✅ [❗](caveats-os10) |   ❌   |   ❌   | ✅  |  ❌  |
 | Fortinet FortiOS      | ✅ [❗](caveats-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |
 | FRR                   | ✅   |  ✅   |   ❌  | ✅  |  ✅  |
@@ -311,11 +311,12 @@ These devices support additional control-plane protocols or BGP address families
 (platform-layer-2-support)=
 The layer-2 control plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
 
-| Operating system      | [Spanning<br>Tree Protocol](module/stp.md) | [Link Aggregation<br>Groups](module/lag.md) |
-| --------------------- |:--:|:--:|
-| Arista EOS            | ✅ | ✅ |
-| Cumulus Linux         | ✅ | ✅ |
-| FRR                   | ✅ | ✅ |
+| Operating system          | [Spanning<br>Tree Protocol](module/stp.md) | [Link Aggregation<br>Groups](module/lag.md) |
+| ------------------------- |:--:|:--:|
+| Arista EOS                | ✅ | ✅ |
+| Cumulus Linux             | ✅ | ✅ |
+| Cumulus Linux 5.x (NVUE)  | ✅ | ✅ |
+| FRR                       | ✅ | ✅ |
 
 (platform-dataplane-support)=
 The data plane [configuration modules](module-reference.md) are supported on these devices[^NSM]:
@@ -329,7 +330,7 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Cisco IOSv/IOSvL2     | ✅ | ✅ |  ❌ | ✅ |  ❌ |  ❌ |
 | Cisco Nexus OS        | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | Cumulus Linux         | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
-| Cumulus Linux 5.0 (NVUE) | ❌ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
+| Cumulus Linux 5.x (NVUE) | ✅ |[❗](module-vrf-platform-support)| ❌ | ❌ | ❌ | ❌ |
 | Dell OS10             | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ | 
 | FRR                   | ✅ | ✅ | ✅ | ✅ | ✅ |  ❌ | 
 | Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ | 
@@ -375,7 +376,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Cisco IOS XE[^18v]    |          ✅          |   ✅    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cisco Nexus OS        |          ✅          |   ❌    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cumulus Linux         |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
-| Cumulus Linux 5.0 (NVUE)        |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
+| Cumulus Linux 5.x (NVUE)        |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Dell OS10             |          ✅          |   ✅    |    ❌     |         ❌          |        ✅         |    ❌    |
 | Fortinet FortiOS      |          ✅          |   ❌    |    ❌     |         ❌          |        ❌         |    ❌    |
 | FRR                   |          ✅          |   ✅    |    ✅     |         ❌          |        ✅         |    ❌    |

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -99,9 +99,6 @@
 {%     endif %}
 {%     if 'ipv6' in lb %}
               {{ lb.ipv6 }}: {}
-{%     else %}
-            ipv6:
-              enable: off
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -14,6 +14,9 @@
 {%  endif %}
 {%  if i.ipv4 is defined or i.ipv6 is defined %}
         ip:
+{%    if i.vrf is defined %}
+          vrf: {{ i.vrf }}
+{%    endif %}
           address:
 {%    if i.ipv4 is defined %}
 {%      if i.ipv4 == True %}
@@ -22,12 +25,18 @@
             {{ i.ipv4 }}: {}
 {%      endif %}
 {%    endif %}
-{%    if i.vrf is defined %}
-          vrf: {{ i.vrf }}
-{%    endif %}
 {%    if i.ipv6 is defined %}
-{%      if i.ipv6 is string %}
+{%      if i.ipv6 is string and i.ipv6|ipv6 %}
             {{ i.ipv6 }}: {}
+          ipv6:
+            forward: on
+{%        if 'ipv6' not in i.dhcp.client|default({}) %}
+          neighbor-discovery:
+            enable: on
+            router-advertisement:
+              enable: off # Major bug in NVUE - any non-"on" value will *enable* (no suppress) RA...
+              interval: 5000
+{%        endif %}
 {%      endif %}
 {%    else %}
           ipv6:
@@ -50,21 +59,49 @@
           address:
             dhcp: {}
         type: eth
+{% for l in interfaces|default([]) if l.type!='loopback' %}
+{{      decl_interface(l) }}
+{% endfor %}
+
+{% for lb in netlab_interfaces if lb.type=='loopback' %}
+- set:
+{%   if lb.vrf is not defined %}
+    interface:
       lo:
+        type: loopback
+{%     if lb.mtu is defined %}
+        link:
+          mtu: {{ lb.mtu }}
+{%     endif %}
         ip:
           address:
-{% if 'ipv4' in loopback %}
-            {{ loopback.ipv4 }}: {}
-{% else %}
-            127.0.0.1: {}
-{% endif %}
-{% if 'ipv6' in loopback %}
-            {{ loopback.ipv6 }}: {}
-{% else %}
+{%     if 'ipv4' in lb %}
+            {{ lb.ipv4 }}: {}
+{%     else %}
+            127.0.0.1/8: {}
+{%     endif %}
+{%     if 'ipv6' in lb %}
+            {{ lb.ipv6 }}: {}
+{%     else %}
           ipv6:
             enable: off
-{% endif %}
-        type: loopback
-{% for l in interfaces|default([]) if l.type in ['lan','p2p','stub','svi','lag'] %}
-{{      decl_interface(l) }}
+{%     endif %}
+{%   else %}
+    vrf:
+      {{ lb.vrf }}:
+        loopback:
+          ip:
+            address:
+{%     if 'ipv4' in lb %}
+              {{ lb.ipv4 }}: {}
+{%     else %}
+              127.0.0.1/8: {}
+{%     endif %}
+{%     if 'ipv6' in lb %}
+              {{ lb.ipv6 }}: {}
+{%     else %}
+            ipv6:
+              enable: off
+{%     endif %}
+{%   endif %}
 {% endfor %}

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,5 +1,7 @@
 description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
+lag_interface_name: "bond{lag.ifindex}"
+loopback_interface_name: lo{ifindex}         # Can assign multiple IPs to 'lo' interface, name ignored by template
 mgmt_if: eth0
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
@@ -17,14 +19,12 @@ features:
       unnumbered: True
     ipv6:
       lla: True
-    loopback.interface_name: lo{ifindex}  # Can assign multiple IPs to 'lo' interface, name ignored by template
   bgp:
     ipv6_lla: True
     rfc8950: True
     activate_af: True
   lag:
     passive: False
-    interface_name: "bond{lag.ifindex}"
   ospf:
     unnumbered: True
   stp:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,8 +1,6 @@
 description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
-lag_interface_name: "bond{lag.ifindex}"
 mgmt_if: eth0
-mtu: 1500 # Set default MTU for all providers the same
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
 virtualbox:
@@ -19,12 +17,14 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    loopback.interface_name: lo{ifindex}  # Can assign multiple IPs to 'lo' interface, name ignored by template
   bgp:
     ipv6_lla: True
     rfc8950: True
     activate_af: True
   lag:
     passive: False
+    interface_name: "bond{lag.ifindex}"
   ospf:
     unnumbered: True
   stp:
@@ -36,6 +36,7 @@ features:
     subif_name: "{ifname}.{vlan.access_id}"
   vrf: True
 clab:
+  mtu: 1500
   kmods:
    initial: [ ebtables ]
   node:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -3,6 +3,7 @@ interface_name: swp{ifindex}
 lag_interface_name: "bond{lag.ifindex}"
 loopback_interface_name: lo{ifindex}         # Can assign multiple IPs to 'lo' interface, name ignored by template
 mgmt_if: eth0
+mtu: 1500                                    # Set default MTU for all providers the same
 libvirt:
   image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
 virtualbox:
@@ -36,7 +37,6 @@ features:
     subif_name: "{ifname}.{vlan.access_id}"
   vrf: True
 clab:
-  mtu: 1500
   kmods:
    initial: [ ebtables ]
   node:


### PR DESCRIPTION
* Removes interface ```type``` test
* Puts interfaces in the correct VRF
* Fixes IPv6 to send out router-advertisements ( "off" means enable them ... )
* Updates docs (note I could not find ```bandwidth``` setting in NVUE)

Note that Cumulus supports multiple loopbacks by putting multiple IPs on a single loopback device; ```set``` commands are cumulative and don't replace existing addresses

This also means applying Netlab configs to a system that already has some existing configs won't replace those; this would require an 'unset' command