### PR TITLE
BGP: Define behavior in case of ipv6 with unnumbered ipv4 as IPv4+6 AF over ipv6 session (only)

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -308,7 +308,7 @@ See the [Simple BGP](bgp_example/simple.md) and [EBGP Data Center Fabric](bgp_ex
 
 Unnumbered EBGP sessions are supported on a few platforms. *netlab* creates an IPv6 LLA EBGP session when the **unnumbered** link- or interface attribute is set, or when **ipv6** interface address or link prefix is set to *True* (IPv6 LLA).
 
-*netlab* can use an IPv6 LLA EBGP session to transport IPv4 address family with IPv6 next hops (RFC 8950) -- the functionality commonly used to implement *unnumbered EBGP sessions*. *netlab* will enable IPv4 AF over IPv6 LLA EBGP session when the **unnumbered** link- or interface attribute is set, or when **ipv4** interface address or link prefix is set to *True*.
+*netlab* can use an IPv6 EBGP session (either regular or LLA) to transport IPv4 address family with IPv6 next hops (RFC 8950) -- the functionality commonly used to implement *unnumbered EBGP sessions*. *netlab* will enable IPv4 AF over an IPv6 EBGP session when the **unnumbered** link- or interface attribute is set, or when **ipv4** interface address or link prefix is set to *True*.
 
 ## IPv6 Support
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -275,7 +275,7 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
       rfc8950  = l.get('unnumbered',None) is True and ngb_ifdata.get('unnumbered',None) is True
       ipv4_unnum = l.get('ipv4',None) is True and ngb_ifdata.get('ipv4',None) is True
 #      print(f'EBGP node {node.name} neighbor {ngb_name} lla {ipv6_lla} v6num {ipv6_num} v4unnum {ipv4_unnum} rfc8950 {unnumbered}')
-      if ipv4_unnum:
+      if ipv4_unnum and (ipv6_lla or ipv6_num):
         rfc8950 = True                                                # Unnumbered IPv4 over IPv6 ==> IPv6 nexthops + RFC 8950 IPv4 AF
         if ipv6_num:
           extra_data.ipv4 = True                                      # Do activate the IPv4 AF (over IPv6)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -274,8 +274,11 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
       rfc8950  = l.get('unnumbered',None) is True and ngb_ifdata.get('unnumbered',None) is True
       ipv4_unnum = l.get('ipv4',None) is True and ngb_ifdata.get('ipv4',None) is True
 #      print(f'EBGP node {node.name} neighbor {ngb_name} lla {ipv6_lla} v6num {ipv6_num} v4unnum {ipv4_unnum} rfc8950 {unnumbered}')
-      if ipv4_unnum and not ipv6_num:                                 # Unnumbered IPv4 w/o IPv6 ==> IPv6 LLA + RFC 8950 IPv4 AF
-        rfc8950 = True
+      if ipv4_unnum:
+        if not ipv6_num:
+          rfc8950 = True                                              # Unnumbered IPv4 w/o IPv6 ==> IPv6 LLA + RFC 8950 IPv4 AF
+        else:
+          sessions.pop('ipv4',None)                                   # Unnumbered IPv4 with IPv6 ==> remove IPv4 session
 
 #      print(f'... unnumbered {unnumbered}')
       if ipv6_lla or rfc8950:

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -279,8 +279,8 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
         rfc8950 = True                                                # Unnumbered IPv4 over IPv6 ==> IPv6 nexthops + RFC 8950 IPv4 AF
         if ipv6_num:
           extra_data.ipv4 = True                                      # Do activate the IPv4 AF (over IPv6)
-          l.pop('ipv4',None)                                          # ...but remove the IPv4 session
-          ngb_ifdata.pop('ipv4',None)
+          ngb_ifdata.pop('ipv4',None)                                 # ...but remove the IPv4 session
+          l.pop('ipv4',None)                                          # ...and the unnumbered IPv4 address from the interface
 
 #      print(f'... unnumbered {unnumbered}')
       if ipv6_lla or rfc8950:

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -277,10 +277,10 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
 #      print(f'EBGP node {node.name} neighbor {ngb_name} lla {ipv6_lla} v6num {ipv6_num} v4unnum {ipv4_unnum} rfc8950 {unnumbered}')
       if ipv4_unnum and (ipv6_lla or ipv6_num):
         rfc8950 = True                                                # Unnumbered IPv4 over IPv6 ==> IPv6 nexthops + RFC 8950 IPv4 AF
-        if ipv6_num:
-          extra_data.ipv4 = True                                      # Do activate the IPv4 AF (over IPv6)
+        if not l.get('_parent_ipv4',None):                            # If the user did not explicitly ask for ipv4 unnumbered
+          extra_data.ipv4 = True                                      # Activate the IPv4 AF (over IPv6)
           ngb_ifdata.pop('ipv4',None)                                 # ...but remove the IPv4 session
-          l.pop('ipv4',None)                                          # ...and the unnumbered IPv4 address from the interface
+          l.pop('ipv4',None)                                          # ...remove the unnumbered IPv4 address from the interface
 
 #      print(f'... unnumbered {unnumbered}')
       if ipv6_lla or rfc8950:

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -111,8 +111,6 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, sessions: Box, extra_data: typin
         elif isinstance(intf[af],bool):
           if intf[af] is True:
             ngb[af] = True
-          else:
-            intf.pop(af,None)                     # Remove flag when value is 'False'
         else:
           ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
 
@@ -343,6 +341,8 @@ def activate_bgp_default_af(node: Box, activate: Box, topology: Box) -> None:
     for af in ('ipv4','ipv6'):
       if af in ngb:
         ngb.activate[af] = node.bgp.get(af) and af in activate and ngb.type in activate[af]
+        if ngb[af] is False:
+          ngb.pop(af,None)                # Cleanup False values
 
 """
 Build BGP route reflector clusters

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -110,10 +110,7 @@ def bgp_neighbor(n: Box, intf: Box, ctype: str, sessions: Box, extra_data: typin
         if "unnumbered" in ngb and ngb.unnumbered == True:
           ngb[af] = True
         elif isinstance(intf[af],bool):
-          if intf[af] is True:
-            ngb[af] = True
-          else:
-            intf.pop(af,None)
+          ngb[af] = intf[af]
         else:
           ngb[af] = str(netaddr.IPNetwork(intf[af]).ip)
 
@@ -281,8 +278,9 @@ def build_ebgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
       if ipv4_unnum:
         rfc8950 = True                                                # Unnumbered IPv4 over IPv6 ==> IPv6 nexthops + RFC 8950 IPv4 AF
         if ipv6_num:
-          extra_data.ipv4 = True
-          ngb_ifdata.ipv4 = False                                     # Remove the IPv4 session, activate IPv4 over IPv6 session
+          extra_data.ipv4 = True                                      # Do activate the IPv4 AF (over IPv6)
+          l.pop('ipv4',None)                                          # ...but remove the IPv4 session
+          ngb_ifdata.pop('ipv4',None)
 
 #      print(f'... unnumbered {unnumbered}')
       if ipv6_lla or rfc8950:

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -302,6 +302,7 @@ nodes:
       name: test -> x4
       neighbors:
       - ifname: swp2
+        ipv4: false
         ipv6: 2001:db8:1::2/64
         node: x4
       role: external
@@ -625,6 +626,7 @@ nodes:
       name: x4 -> test
       neighbors:
       - ifname: swp6
+        ipv4: false
         ipv6: 2001:db8:1::1/64
         node: test
       role: external

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -202,6 +202,13 @@ nodes:
         local_if: swp5
         name: x4
         type: ebgp
+      - activate:
+          ipv6: true
+        as: 65004
+        ifindex: 6
+        ipv6: 2001:db8:1::2
+        name: x4
+        type: ebgp
       next_hop_self: true
       router_id: 10.0.0.1
     box: CumulusCommunity/cumulus-vx:4.4.5
@@ -578,11 +585,9 @@ nodes:
         name: test
         type: ebgp
       - activate:
-          ipv4: true
           ipv6: true
         as: 65000
         ifindex: 2
-        ipv4: true
         ipv6: 2001:db8:1::1
         name: test
         type: ebgp

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -169,8 +169,6 @@ nodes:
         as: 65001
         ifindex: 2
         ipv4: true
-        ipv4_rfc8950: true
-        local_if: swp2
         name: x1
         type: ebgp
       - activate:
@@ -241,7 +239,6 @@ nodes:
       ifindex: 2
       ifname: swp2
       ipv4: true
-      ipv6: true
       linkindex: 2
       mtu: 1500
       name: test -> x1
@@ -361,8 +358,6 @@ nodes:
         as: 65000
         ifindex: 2
         ipv4: true
-        ipv4_rfc8950: true
-        local_if: swp2
         name: test
         type: ebgp
       next_hop_self: true
@@ -393,7 +388,6 @@ nodes:
       ifindex: 2
       ifname: swp2
       ipv4: true
-      ipv6: true
       linkindex: 2
       mtu: 1500
       name: x1 -> test

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -206,7 +206,9 @@ nodes:
           ipv6: true
         as: 65004
         ifindex: 6
+        ipv4_rfc8950: true
         ipv6: 2001:db8:1::2
+        local_if: swp6
         name: x4
         type: ebgp
       next_hop_self: true
@@ -300,7 +302,6 @@ nodes:
       name: test -> x4
       neighbors:
       - ifname: swp2
-        ipv4: true
         ipv6: 2001:db8:1::2/64
         node: x4
       role: external
@@ -588,7 +589,9 @@ nodes:
           ipv6: true
         as: 65000
         ifindex: 2
+        ipv4_rfc8950: true
         ipv6: 2001:db8:1::1
+        local_if: swp2
         name: test
         type: ebgp
       next_hop_self: true
@@ -622,7 +625,6 @@ nodes:
       name: x4 -> test
       neighbors:
       - ifname: swp6
-        ipv4: true
         ipv6: 2001:db8:1::1/64
         node: test
       role: external

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -202,15 +202,6 @@ nodes:
         local_if: swp5
         name: x4
         type: ebgp
-      - activate:
-          ipv4: true
-          ipv6: true
-        as: 65004
-        ifindex: 6
-        ipv4: true
-        ipv6: 2001:db8:1::2
-        name: x4
-        type: ebgp
       next_hop_self: true
       router_id: 10.0.0.1
     box: CumulusCommunity/cumulus-vx:4.4.5

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -294,12 +294,14 @@ nodes:
       _parent_ipv4: 10.0.0.1/32
       ifindex: 6
       ifname: swp6
+      ipv4: true
       ipv6: 2001:db8:1::1/64
       linkindex: 6
       mtu: 1500
       name: test -> x4
       neighbors:
       - ifname: swp2
+        ipv4: true
         ipv6: 2001:db8:1::2/64
         node: x4
       role: external
@@ -615,12 +617,14 @@ nodes:
       _parent_ipv4: 10.0.0.5/32
       ifindex: 2
       ifname: swp2
+      ipv4: true
       ipv6: 2001:db8:1::2/64
       linkindex: 6
       mtu: 1500
       name: x4 -> test
       neighbors:
       - ifname: swp6
+        ipv4: true
         ipv6: 2001:db8:1::1/64
         node: test
       role: external

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -203,9 +203,11 @@ nodes:
         name: x4
         type: ebgp
       - activate:
+          ipv4: true
           ipv6: true
         as: 65004
         ifindex: 6
+        ipv4: true
         ipv4_rfc8950: true
         ipv6: 2001:db8:1::2
         local_if: swp6
@@ -302,7 +304,6 @@ nodes:
       name: test -> x4
       neighbors:
       - ifname: swp2
-        ipv4: false
         ipv6: 2001:db8:1::2/64
         node: x4
       role: external
@@ -587,9 +588,11 @@ nodes:
         name: test
         type: ebgp
       - activate:
+          ipv4: true
           ipv6: true
         as: 65000
         ifindex: 2
+        ipv4: true
         ipv4_rfc8950: true
         ipv6: 2001:db8:1::1
         local_if: swp2
@@ -626,7 +629,6 @@ nodes:
       name: x4 -> test
       neighbors:
       - ifname: swp6
-        ipv4: false
         ipv6: 2001:db8:1::1/64
         node: test
       role: external

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -297,7 +297,6 @@ nodes:
       _parent_ipv4: 10.0.0.1/32
       ifindex: 6
       ifname: swp6
-      ipv4: true
       ipv6: 2001:db8:1::1/64
       linkindex: 6
       mtu: 1500
@@ -622,7 +621,6 @@ nodes:
       _parent_ipv4: 10.0.0.5/32
       ifindex: 2
       ifname: swp2
-      ipv4: true
       ipv6: 2001:db8:1::2/64
       linkindex: 6
       mtu: 1500

--- a/tests/topology/input/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/input/bgp-unnumbered-dual-stack.yml
@@ -25,7 +25,7 @@ links:
 - test:
   x1:
   unnumbered: True
-# interface 2 - activate only IPv4 AF over IPv6 LLA
+# interface 2 - activate only IPv4 AF over IPv4 unnumbered session, no IPv6
 - test:
   x1:
   prefix:
@@ -36,7 +36,7 @@ links:
   prefix:
     ipv4: True
     ipv6: True
-# interface 4 - IPv6 AF over IPv6 LLA
+# interface 4 - IPv6 AF over IPv6 LLA, no IPv4
 - test:
   x3:
   prefix:
@@ -47,7 +47,7 @@ links:
   prefix:
     ipv4: 172.31.1.0/24
     ipv6: True
-# interface 6 - IPv6 AF over IPv6 numbered, no IPv4 session/AF
+# interface 6 - IPv4+IPv6 AF over IPv6 numbered, no IPv4 session
 - test:
   x4:
   prefix:


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1562

This PR modifies 2 test cases from https://github.com/ipspace/netlab/blob/dev/tests/topology/input/bgp-unnumbered-dual-stack.yml:
```
# interface 2 - activate only IPv4 AF over IPv4 unnumbered session, no IPv6
- test:
  x1:
  prefix:
    ipv4: True
```
In this case, there should be no IPv6 nor RFC8950 behavior

```
# interface 6 - IPv4+IPv6 AF over IPv6 numbered, no IPv4 session
- test:
  x4:
  prefix:
    ipv4: True
    ipv6: 2001:db8:1::/64
```
Previously undefined, now defined as:
1. Enable RFC8950 feature to advertise ipv4 prefixes over an ipv6 session
2. Activate ipv4 and ipv6 address families over ipv6 session
3. Remove ipv4 bgp session
4. Remove ipv4 flag from the interface (as there is no ```_parent_ipv4``` defined)

Documentation updated; note that RFC8950 seems oblivious to numbered or unnumbered IPv6, either should work
