### PR TITLE
Cumulus_nvue: Use password variable instead of hardcoded string, declare container image unsupported

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -34,7 +34,11 @@
           neighbor-discovery:
             enable: on
             router-advertisement:
+{%          if 'CumulusCommunity/cumulus-vx' in box %}
+              enable: on
+{%          else %}
               enable: off # Major bug in NVUE - any non-"on" value will *enable* (no suppress) RA...
+{%          endif %}
               interval: 5000
 {%        endif %}
 {%      endif %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -34,10 +34,10 @@
           neighbor-discovery:
             enable: on
             router-advertisement:
-{%          if 'CumulusCommunity/cumulus-vx' in box %}
-              enable: on
-{%          else %}
+{%          if 'networkop/cx:' in box %}
               enable: off # Major bug in NVUE - any non-"on" value will *enable* (no suppress) RA...
+{%          else %}
+              enable: on
 {%          endif %}
               interval: 5000
 {%        endif %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -34,11 +34,7 @@
           neighbor-discovery:
             enable: on
             router-advertisement:
-{%          if 'networkop/cx:' in box %}
-              enable: off # Major bug in NVUE - any non-"on" value will *enable* (no suppress) RA...
-{%          else %}
               enable: on
-{%          endif %}
               interval: 5000
 {%        endif %}
 {%      endif %}

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -20,7 +20,7 @@ clab:
     config_templates:
       interfaces: /etc/network/interfaces
       hosts: /etc/hosts
-  image: networkop/cx:4.4.0
+  image: networkop/cx:4.4.0                         # Note: dated and known to have issues, unsupported
   group_vars:
     ansible_connection: docker
     ansible_user: root

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -42,7 +42,7 @@ clab:
   node:
     kind: cvx
     runtime: docker
-  image: networkop/cx:5.3.0                    # Note: dated and known to have issues, use with caution
+  image: networkop/cx:5.3.0                    # Note: dated and known to have issues, unsupported
   group_vars:
     ansible_connection: docker
     ansible_user: root

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -42,7 +42,7 @@ clab:
   node:
     kind: cvx
     runtime: docker
-  image: networkop/cx:5.3.0
+  image: networkop/cx:5.3.0                    # Note: dated and known to have issues, use with caution
   group_vars:
     ansible_connection: docker
     ansible_user: root

--- a/netsim/templates/provider/libvirt/cumulus_nvue-domain.j2
+++ b/netsim/templates/provider/libvirt/cumulus_nvue-domain.j2
@@ -1,9 +1,10 @@
     $cumulus_script = <<-SCRIPT
 
 function set_cumulus_password(){
-    echo "### Setting cumulus user password to 'cumulus' ###"
+{% set _password = defaults.devices.cumulus_nvue.group_vars.ansible_ssh_pass %}
+    echo "### Setting cumulus user password to '{{ _password }}' ###"
     echo "cumulus ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/10_cumulus
-    echo "cumulus:GetLost1!" | chpasswd
+    echo "cumulus:{{ _password }}" | chpasswd
     mkdir /home/cumulus/.ssh/
     cat /home/vagrant/.ssh/authorized_keys >> /home/cumulus/.ssh/authorized_keys
     chown -R cumulus:cumulus /home/cumulus/.ssh/


### PR DESCRIPTION
* Use variable for cumulus password provisioned into the box
* Declare Cumulus container images unsupported (warning to be added)