### PR TITLE
Fix: retain _linkname attribute

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -1181,5 +1181,5 @@ def cleanup(topology: Box) -> None:
   if not 'links' in topology:
     return
 
-  for link in topology.links:
-    link.pop('_linkname',None)
+#  for link in topology.links:
+#    link.pop('_linkname',None)

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -51,7 +51,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 172.31.0.1/24
@@ -69,7 +70,8 @@ links:
     ipv6: 2001:db8:2::/64
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 172.31.1.1/24
@@ -87,7 +89,8 @@ links:
     ipv6: 2001:db8:2:1::/64
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.2/30
@@ -101,7 +104,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -23,7 +23,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -47,7 +48,8 @@ links:
   prefix:
     ipv6: 2001:db8:1::/64
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv6: 2001:db8:2::1/64
@@ -62,7 +64,8 @@ links:
   prefix:
     ipv6: 2001:db8:2::/64
   type: p2p
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
@@ -82,7 +85,8 @@ links:
   prefix:
     ipv6: 2001:db8:1:1::/64
   type: lan
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: GigabitEthernet0/4
     ipv6: 2001:db8:2:1::1/64

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -23,7 +23,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -43,7 +44,8 @@ links:
   prefix:
     ipv6: 2001:db8:1::/64
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv6: 2001:db8:2::2/127
@@ -59,7 +61,8 @@ links:
     ipv6: 2001:db8:2::2/127
     prefix6: 127
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv6: 2001:db8:2::4/127

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/addressing-lan.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet2
@@ -22,7 +23,8 @@ links:
   prefix:
     ipv6: 2001:db8:1::/64
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet3
@@ -44,7 +46,8 @@ links:
   prefix:
     ipv4: true
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 4
     ifname: GigabitEthernet4
@@ -63,7 +66,8 @@ links:
   node_count: 3
   pool: unnumbered
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 5
     ifname: GigabitEthernet5
@@ -84,7 +88,8 @@ links:
   prefix:
     ipv4: 1.2.3.0/29
   type: lan
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 6
     ifname: GigabitEthernet6
@@ -105,7 +110,8 @@ links:
   prefix:
     ipv6: 2001:db8:2::/64
   type: lan
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - ifindex: 7
     ifname: GigabitEthernet7
@@ -131,7 +137,8 @@ links:
     ipv4: 172.17.0.0/25
     ipv6: 2001:db8:3::/64
   type: lan
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   interfaces:
   - ifindex: 8
     ifname: GigabitEthernet8
@@ -147,7 +154,8 @@ links:
   node_count: 3
   pool: l2only
   type: lan
-- bridge: input_8
+- _linkname: links[8]
+  bridge: input_8
   interfaces:
   - ifindex: 9
     ifname: GigabitEthernet9
@@ -172,7 +180,8 @@ links:
     ipv4: 172.17.0.128/25
     ipv6: 2001:db8:3:1::/64
   type: lan
-- bridge: input_9
+- _linkname: links[9]
+  bridge: input_9
   interfaces:
   - ifindex: 10
     ifname: GigabitEthernet10
@@ -197,7 +206,8 @@ links:
     ipv4: 172.17.1.0/25
     ipv6: 2001:db8:3:2::/64
   type: lan
-- bridge: input_10
+- _linkname: links[10]
+  bridge: input_10
   interfaces:
   - ifindex: 11
     ifname: GigabitEthernet11
@@ -214,7 +224,8 @@ links:
   node_count: 3
   pool: l2only
   type: lan
-- bridge: input_11
+- _linkname: links[11]
+  bridge: input_11
   interfaces:
   - ifindex: 12
     ifname: GigabitEthernet12
@@ -231,7 +242,8 @@ links:
   node_count: 3
   prefix: false
   type: lan
-- bridge: input_12
+- _linkname: links[12]
+  bridge: input_12
   interfaces:
   - ifindex: 13
     ifname: GigabitEthernet13
@@ -251,7 +263,8 @@ links:
   prefix:
     ipv4: 172.42.42.0/24
   type: lan
-- bridge: input_13
+- _linkname: links[13]
+  bridge: input_13
   interfaces:
   - ifindex: 14
     ifname: GigabitEthernet14
@@ -275,7 +288,8 @@ links:
     ipv4: 172.42.32.0/22
     ipv6: 2001:db8:42:42::/64
   type: lan
-- interfaces:
+- _linkname: links[14]
+  interfaces:
   - ifindex: 15
     ifname: GigabitEthernet15
     ipv4: true
@@ -293,7 +307,8 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:43::/64
   type: p2p
-- interfaces:
+- _linkname: links[15]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet3
     ipv4: 172.18.0.1/28
@@ -310,7 +325,8 @@ links:
     allocation: sequential
     ipv4: 172.18.0.0/28
   type: p2p
-- bridge: input_16
+- _linkname: links[16]
+  bridge: input_16
   interfaces:
   - ifindex: 20000
     ifname: Tunnel0

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/addressing-p2p.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet2
     ipv4: true
@@ -17,7 +18,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet3
     ipv4: 10.42.42.18/32
@@ -33,7 +35,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 4
     ifname: GigabitEthernet4
     ipv4: true
@@ -47,7 +50,8 @@ links:
   node_count: 2
   pool: unnumbered
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 5
     ifname: GigabitEthernet5
     ipv6: 2001:db8:2::1/64
@@ -63,7 +67,8 @@ links:
   prefix:
     ipv6: 2001:db8:2::/64
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 6
     ifname: GigabitEthernet6
     ipv4: 172.17.0.1/29
@@ -82,7 +87,8 @@ links:
     ipv4: 172.17.0.0/29
     ipv6: 2001:db8:3::/64
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 7
     ifname: GigabitEthernet7
     node: r1
@@ -94,7 +100,8 @@ links:
   node_count: 2
   pool: l2only
   type: p2p
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 8
     ifname: GigabitEthernet8
     ipv4: 172.17.0.11/29
@@ -113,7 +120,8 @@ links:
     ipv4: 172.17.0.8/29
     ipv6: 2001:db8:3:1::/64
   type: p2p
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 9
     ifname: GigabitEthernet9
     ipv4: true
@@ -132,7 +140,8 @@ links:
     ipv4: 172.17.0.16/29
     ipv6: 2001:db8:3:2::/64
   type: p2p
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 10
     ifname: GigabitEthernet10
     ipv4: 10.0.0.1/30
@@ -145,7 +154,8 @@ links:
   node_count: 2
   pool: l2only
   type: p2p
-- interfaces:
+- _linkname: links[10]
+  interfaces:
   - ifindex: 11
     ifname: GigabitEthernet11
     node: r1
@@ -158,7 +168,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[11]
+  interfaces:
   - ifindex: 12
     ifname: GigabitEthernet12
     ipv4: 172.42.42.1/28
@@ -173,7 +184,8 @@ links:
   prefix:
     ipv4: 172.42.42.0/28
   type: p2p
-- interfaces:
+- _linkname: links[12]
+  interfaces:
   - ifindex: 13
     ifname: GigabitEthernet13
     ipv4: 172.42.42.128/31
@@ -188,7 +200,8 @@ links:
   prefix:
     ipv4: 172.42.42.128/31
   type: p2p
-- interfaces:
+- _linkname: links[13]
+  interfaces:
   - ifindex: 14
     ifname: GigabitEthernet14
     ipv4: 172.42.42.17/28
@@ -206,7 +219,8 @@ links:
     ipv4: 172.42.42.16/28
     ipv6: 2001:db8:42:42::/64
   type: p2p
-- interfaces:
+- _linkname: links[14]
+  interfaces:
   - ifindex: 15
     ifname: GigabitEthernet15
     ipv4: true
@@ -224,7 +238,8 @@ links:
     ipv4: true
     ipv6: 2001:db8:42:43::/64
   type: p2p
-- interfaces:
+- _linkname: links[15]
+  interfaces:
   - ifindex: 16
     ifname: GigabitEthernet16
     ipv4: 10.42.42.18/32

--- a/tests/topology/expected/addressing-prefix.yml
+++ b/tests/topology/expected/addressing-prefix.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/addressing-prefix.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -18,7 +19,8 @@ links:
     ipv6: 2001:db8:1::/64
   role: stub
   type: stub
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -35,7 +37,8 @@ links:
     ipv6: 2001:db8:1:1::/64
   role: stub
   type: stub
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: eth3
@@ -49,7 +52,8 @@ links:
     ipv4: 10.1.0.0/30
   role: stub
   type: stub
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 4
     ifname: eth4
@@ -63,7 +67,8 @@ links:
     ipv6: 2001:db8:2::/64
   role: stub
   type: stub
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 5
     ifname: eth5
@@ -78,7 +83,8 @@ links:
     ipv4: 192.168.42.0/24
   role: stub
   type: stub
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - _vlan_mode: irb
     ifindex: 6

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -26,7 +26,8 @@ input:
 - topology/input/anycast-gateway.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -62,7 +63,8 @@ links:
   prefix:
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -94,7 +96,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -126,7 +129,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -153,7 +157,8 @@ links:
     ipv4: 10.42.42.0/28
   role: stub
   type: lan
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -180,7 +185,8 @@ links:
     ipv4: 10.42.42.0/29
   role: stub
   type: lan
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   gateway:
     anycast:
       mac: 0200.cafe.00ff

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -27,7 +27,8 @@ input:
 - topology/input/bgp-af-rt-929.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
@@ -39,7 +40,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: stub
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -17,7 +17,8 @@ input:
 - topology/input/bgp-anycast.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -42,7 +42,8 @@ input:
 - topology/input/bgp-autogroup.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
@@ -56,7 +57,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
@@ -70,7 +72,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.10/30
@@ -84,7 +87,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
@@ -99,7 +103,8 @@ links:
     ipv4: 10.1.0.12/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.18/30
@@ -114,7 +119,8 @@ links:
     ipv4: 10.1.0.16/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.22/30

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -18,7 +18,8 @@ input:
 - topology/input/bgp-community.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
@@ -32,7 +33,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - bgp:
       local_as: 65002
     ifindex: 1

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -23,7 +23,8 @@ input:
 - topology/input/bgp-ibgp.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
     ipv4: true
@@ -35,7 +36,8 @@ links:
   linkindex: 1
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: true
@@ -47,7 +49,8 @@ links:
   linkindex: 2
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
     ipv4: true
@@ -59,7 +62,8 @@ links:
   linkindex: 3
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: true

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -18,7 +18,8 @@ input:
 - topology/input/bgp-interface-disable.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
@@ -34,7 +35,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- bgp: false
+- _linkname: links[2]
+  bgp: false
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -51,7 +53,8 @@ links:
     ipv4: 10.1.0.4/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - bgp: false
     ifindex: 3
     ifname: GigabitEthernet0/3

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -37,7 +37,8 @@ input:
 - topology/input/bgp-members.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
@@ -51,7 +52,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
@@ -65,7 +67,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.10/30
@@ -79,7 +82,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
@@ -93,7 +97,8 @@ links:
   prefix:
     ipv4: 10.1.0.12/30
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.18/30
@@ -108,7 +113,8 @@ links:
     ipv4: 10.1.0.16/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.22/30

--- a/tests/topology/expected/bgp-rs-2as.yml
+++ b/tests/topology/expected/bgp-rs-2as.yml
@@ -24,7 +24,8 @@ input:
 - topology/input/bgp-rs-2as.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -26,7 +26,8 @@ input:
 - topology/input/bgp-sessions.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.2/30
@@ -44,7 +45,8 @@ links:
     ipv6: 2001:db8:1::/64
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -27,7 +27,8 @@ input:
 - topology/input/bgp-unnumbered-dual-stack.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: swp1
     ipv4: true
@@ -43,7 +44,8 @@ links:
   role: external
   type: p2p
   unnumbered: true
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: swp2
     ipv4: true
@@ -58,7 +60,8 @@ links:
     ipv4: true
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: swp3
     ipv4: true
@@ -76,7 +79,8 @@ links:
     ipv6: true
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: swp4
     ipv6: true
@@ -91,7 +95,8 @@ links:
     ipv6: true
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 5
     ifname: swp5
     ipv4: 172.31.1.1/24
@@ -109,7 +114,8 @@ links:
     ipv6: true
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 6
     ifname: swp6
     ipv4: true

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -31,7 +31,8 @@ input:
 - topology/input/bgp-unnumbered.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: swp1
     ipv4: true
@@ -46,7 +47,8 @@ links:
   node_count: 2
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: swp2
     ipv4: 10.10.10.1/24

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -21,7 +21,8 @@ input:
 - topology/input/bgp-vrf-local-as.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: r1
@@ -45,7 +46,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: r2
@@ -69,7 +71,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - _vlan_mode: route
     bgp:
       local_as: 65001

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -25,7 +25,8 @@ input:
 - topology/input/bgp.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
@@ -42,7 +43,8 @@ links:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
@@ -59,7 +61,8 @@ links:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.10/30
@@ -76,7 +79,8 @@ links:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
@@ -93,7 +97,8 @@ links:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 172.31.0.2/30
@@ -108,7 +113,8 @@ links:
     ipv4: 172.31.0.0/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 172.31.0.6/30
@@ -123,7 +129,8 @@ links:
     ipv4: 172.31.0.4/30
   role: external
   type: p2p
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   interfaces:
   - bgp:
       advertise: true
@@ -137,7 +144,8 @@ links:
     ipv6: 2001:db8:2::/64
   role: stub
   type: stub
-- bridge: input_8
+- _linkname: links[8]
+  bridge: input_8
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -149,7 +157,8 @@ links:
     ipv6: 2001:db8:2:1::/64
   role: stub
   type: stub
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 172.16.0.6/24
@@ -159,7 +168,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: loopback
-- interfaces:
+- _linkname: links[10]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.17/30

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -78,7 +78,8 @@ input:
 - topology/input/components.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30
@@ -93,7 +94,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.5/30
@@ -108,7 +110,8 @@ links:
     ipv4: 10.1.0.4/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.9/30
@@ -123,7 +126,8 @@ links:
     ipv4: 10.1.0.8/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.13/30
@@ -138,7 +142,8 @@ links:
     ipv4: 10.1.0.12/30
   role: external
   type: p2p
-- bridge: input_5
+- _linkname: pod_1_l1_components.tor.links[1]
+  bridge: input_5
   gateway:
     ipv4: 172.16.0.4/24
   interfaces:
@@ -156,7 +161,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: lan
-- bridge: input_6
+- _linkname: pod_1_l2_components.tor.links[1]
+  bridge: input_6
   gateway:
     ipv4: 172.16.1.6/24
   interfaces:
@@ -174,7 +180,8 @@ links:
     ipv4: 172.16.1.0/24
   role: stub
   type: lan
-- interfaces:
+- _linkname: pod_1_components.pod.links[1]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.17/30
@@ -188,7 +195,8 @@ links:
   prefix:
     ipv4: 10.1.0.16/30
   type: p2p
-- interfaces:
+- _linkname: pod_1_components.pod.links[2]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     ipv4: 10.1.0.21/30
@@ -202,7 +210,8 @@ links:
   prefix:
     ipv4: 10.1.0.20/30
   type: p2p
-- interfaces:
+- _linkname: pod_1_components.pod.links[3]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.25/30
@@ -216,7 +225,8 @@ links:
   prefix:
     ipv4: 10.1.0.24/30
   type: p2p
-- interfaces:
+- _linkname: pod_1_components.pod.links[4]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     ipv4: 10.1.0.29/30
@@ -230,7 +240,8 @@ links:
   prefix:
     ipv4: 10.1.0.28/30
   type: p2p
-- bridge: input_11
+- _linkname: pod_2_l1_components.tor.links[1]
+  bridge: input_11
   gateway:
     ipv4: 172.16.2.10/24
   interfaces:
@@ -248,7 +259,8 @@ links:
     ipv4: 172.16.2.0/24
   role: stub
   type: lan
-- bridge: input_12
+- _linkname: pod_2_l2_components.tor.links[1]
+  bridge: input_12
   gateway:
     ipv4: 172.16.3.12/24
   interfaces:
@@ -266,7 +278,8 @@ links:
     ipv4: 172.16.3.0/24
   role: stub
   type: lan
-- interfaces:
+- _linkname: pod_2_components.pod.links[1]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.33/30
@@ -280,7 +293,8 @@ links:
   prefix:
     ipv4: 10.1.0.32/30
   type: p2p
-- interfaces:
+- _linkname: pod_2_components.pod.links[2]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     ipv4: 10.1.0.37/30
@@ -294,7 +308,8 @@ links:
   prefix:
     ipv4: 10.1.0.36/30
   type: p2p
-- interfaces:
+- _linkname: pod_2_components.pod.links[3]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.41/30
@@ -308,7 +323,8 @@ links:
   prefix:
     ipv4: 10.1.0.40/30
   type: p2p
-- interfaces:
+- _linkname: pod_2_components.pod.links[4]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     ipv4: 10.1.0.45/30

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -17,7 +17,8 @@ input:
 - topology/input/device-module-defaults.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/device-node-defaults.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -20,7 +21,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.1.1/24
   interfaces:

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -13,7 +13,8 @@ libvirt:
   providers:
     clab: true
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   dhcp:
     client:
       ipv4: true

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -36,7 +36,8 @@ libvirt:
   providers:
     clab: true
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 192.168.42.2/24
   interfaces:
@@ -59,7 +60,8 @@ links:
     ipv4: 192.168.42.0/24
     ipv6: 2001:db8:cafe:d001::/64
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   dhcp:
     subnet:
       ipv4: true
@@ -99,7 +101,8 @@ links:
   type: lan
   vlan:
     access: blue
-- bridge: input_3
+- _linkname: vlans.red.links[1]
+  bridge: input_3
   dhcp:
     client:
       ipv4: true
@@ -130,7 +133,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_4
+- _linkname: vlans.red.links[2]
+  bridge: input_4
   dhcp:
     client:
       ipv4: true

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/dual-stack.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -35,7 +36,8 @@ links:
     ipv4: 10.2.0.0/26
     ipv6: 2001:db8:1::/64
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.2/30
@@ -49,7 +51,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: c-to-a
+- _linkname: links[3]
+  bridge: c-to-a
   interfaces:
   - ifindex: 2
     ifname: Ethernet2

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -48,7 +48,8 @@ input:
 - topology/input/ebgp.utils.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -63,7 +64,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- bgp:
+- _linkname: links[2]
+  bgp:
     password: SomethingElse
   interfaces:
   - ifindex: 2
@@ -82,7 +84,8 @@ links:
     ipv4: 10.1.0.4/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: 10.1.0.9/30
@@ -96,7 +99,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- bgp:
+- _linkname: vrfs.red.links[1]
+  bgp:
     password: InVrf
   interfaces:
   - bgp:

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -4,7 +4,8 @@ input:
 - topology/input/eigrp-feature-test.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
     ipv4: 10.1.0.2/30
@@ -18,7 +19,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.6/30
@@ -32,7 +34,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
@@ -56,7 +59,8 @@ links:
     ipv6: 2008:db8:1::/64
   role: passive
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 3
     ifname: Ethernet1/3
@@ -68,7 +72,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: stub
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 4
     ifname: GigabitEthernet4
@@ -80,7 +85,8 @@ links:
     ipv4: 172.16.1.0/24
   role: stub
   type: stub
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - ifindex: 4
     ifname: GigabitEthernet0/4
@@ -92,7 +98,8 @@ links:
     ipv4: 172.16.2.0/24
   role: stub
   type: stub
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   interfaces:
   - ifindex: 4
     ifname: Ethernet1/4

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -42,7 +42,8 @@ input:
 - topology/input/evpn-asymmetric-irb-ospf.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -64,7 +65,8 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
   vrf: tenant
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.1.2/24
   interfaces:
@@ -86,7 +88,8 @@ links:
     ipv4: 172.16.1.0/24
   type: lan
   vrf: tenant
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.2.1/24
   interfaces:
@@ -108,7 +111,8 @@ links:
     ipv4: 172.16.2.0/24
   type: lan
   vrf: tenant
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.3.2/24
   interfaces:
@@ -130,7 +134,8 @@ links:
     ipv4: 172.16.3.0/24
   type: lan
   vrf: tenant
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -23,7 +23,8 @@ input:
 - topology/input/evpn-hub-spoke.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -22,7 +22,8 @@ input:
 - topology/input/evpn-l3vni-only.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30
@@ -36,7 +37,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: input_2
+- _linkname: vrfs.red.links[1]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -49,7 +51,8 @@ links:
   role: stub
   type: stub
   vrf: red
-- bridge: input_3
+- _linkname: vrfs.red.links[2]
+  bridge: input_3
   interfaces:
   - ifindex: 2
     ifname: eth2

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -21,7 +21,8 @@ input:
 - topology/input/evpn-node-vrf.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -19,7 +19,8 @@ input:
 - topology/input/evpn-vlan-attr.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -36,7 +36,8 @@ input:
 - topology/input/evpn-vxlan.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -57,7 +58,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.1.1/24
   interfaces:
@@ -78,7 +80,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.0.2/24
   interfaces:
@@ -99,7 +102,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.1.3/24
   interfaces:

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/extra-attr-link.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
@@ -16,7 +17,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv6: 2001:db8:cafe:1::1/64
@@ -30,7 +32,8 @@ links:
   prefix:
     ipv6: 2001:db8:cafe:1::/64
   type: p2p
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -45,7 +48,8 @@ links:
   prefix:
     ipv4: 192.168.22.0/24
   type: lan
-- dmz: 100000
+- _linkname: links[4]
+  dmz: 100000
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -57,7 +57,8 @@ input:
 - topology/input/fabric-ebgp.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.2/30
@@ -72,7 +73,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.6/30
@@ -87,7 +89,8 @@ links:
     ipv4: 10.1.0.4/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.10/30
@@ -102,7 +105,8 @@ links:
     ipv4: 10.1.0.8/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.14/30
@@ -117,7 +121,8 @@ links:
     ipv4: 10.1.0.12/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.18/30
@@ -132,7 +137,8 @@ links:
     ipv4: 10.1.0.16/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.22/30
@@ -147,7 +153,8 @@ links:
     ipv4: 10.1.0.20/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.26/30
@@ -162,7 +169,8 @@ links:
     ipv4: 10.1.0.24/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.30/30
@@ -177,7 +185,8 @@ links:
     ipv4: 10.1.0.28/30
   role: external
   type: p2p
-- bridge: input_9
+- _linkname: links[9]
+  bridge: input_9
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -195,7 +204,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: lan
-- bridge: input_10
+- _linkname: links[10]
+  bridge: input_10
   gateway:
     ipv4: 172.16.1.2/24
   interfaces:

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -20,7 +20,8 @@ input:
 - topology/input/group-data-vlan.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: r1
@@ -43,7 +44,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: r1

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -18,7 +18,8 @@ input:
 - topology/input/group-data-vrf.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -41,7 +41,8 @@ input:
 - topology/input/groups-hierarchy.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: swp1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -29,7 +29,8 @@ input:
 - topology/input/groups-vlan-vrf.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.2.4/24
   interfaces:
@@ -57,7 +58,8 @@ links:
     access: blue_vlan
     mode: route
   vrf: red_vrf
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.3.4/24
   interfaces:
@@ -85,7 +87,8 @@ links:
     access: blue_vlan
     mode: route
   vrf: red_vrf
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: s1
@@ -108,7 +111,8 @@ links:
     trunk:
       blue_vlan: {}
       red_vlan: {}
-- bridge: input_4
+- _linkname: vlans.red_vlan.links[1]
+  bridge: input_4
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -128,7 +132,8 @@ links:
   vlan:
     access: red_vlan
   vrf: red_vrf
-- bridge: input_5
+- _linkname: vlans.red_vlan.links[2]
+  bridge: input_5
   interfaces:
   - _vlan_mode: irb
     ifindex: 4

--- a/tests/topology/expected/id.yml
+++ b/tests/topology/expected/id.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/id.yml
 - package:topology-defaults.yml
 links:
-- bridge: b1
+- _linkname: links[1]
+  bridge: b1
   interfaces:
   - ifindex: 1
     ifname: swp1
@@ -17,7 +18,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: swp2
     ipv4: 10.1.0.5/30
@@ -31,7 +33,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 2
     ifname: swp2
     ipv4: 10.1.0.10/30

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -8,7 +8,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: true
@@ -22,7 +23,8 @@ links:
   linkindex: 1
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: true
@@ -36,7 +38,8 @@ links:
   linkindex: 2
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: true
@@ -50,7 +53,8 @@ links:
   linkindex: 3
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: true
@@ -64,7 +68,8 @@ links:
   linkindex: 4
   node_count: 2
   type: p2p
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -76,7 +81,8 @@ links:
     ipv6: 2001:db8:1::/64
   role: stub
   type: stub
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 10.2.0.1/32

--- a/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
+++ b/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
@@ -8,7 +8,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
@@ -23,7 +24,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- eigrp: false
+- _linkname: links[2]
+  eigrp: false
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -41,7 +43,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - eigrp: false
     ifindex: 3
     ifname: GigabitEthernet0/3

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -12,7 +12,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
@@ -32,7 +33,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.1/30
@@ -50,7 +52,8 @@ links:
     ipv4: 10.1.0.0/30
     ipv6: 2001:db8:1::/64
   type: p2p
-- bfd: false
+- _linkname: links[3]
+  bfd: false
   interfaces:
   - ifindex: 3
     ifname: Ethernet3
@@ -69,7 +72,8 @@ links:
     ipv4: 10.1.0.4/30
     ipv6: 2001:db8:1:1::/64
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: Ethernet4
     ipv4: 10.1.0.9/30
@@ -89,7 +93,8 @@ links:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 5
     ifname: Ethernet5
     ipv4: 10.1.0.13/30
@@ -108,7 +113,8 @@ links:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 6
     ifname: Ethernet6
     ipv4: 10.1.0.17/30
@@ -130,7 +136,8 @@ links:
     ipv4: 10.1.0.16/30
     ipv6: 2001:db8:1:4::/64
   type: p2p
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 7
     ifname: Ethernet7
     ipv4: 10.1.0.21/30
@@ -152,7 +159,8 @@ links:
     ipv4: 10.1.0.20/30
     ipv6: 2001:db8:1:5::/64
   type: p2p
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 8
     ifname: Ethernet8
     ipv4: 10.42.42.1/24
@@ -169,7 +177,8 @@ links:
   prefix:
     ipv4: 10.42.42.0/24
   type: p2p
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 9
     ifname: Ethernet9
     ipv6: 2001:db8:42:1::1/64
@@ -184,7 +193,8 @@ links:
   prefix:
     ipv6: 2001:db8:42:1::/64
   type: p2p
-- interfaces:
+- _linkname: links[10]
+  interfaces:
   - ifindex: 10
     ifname: Ethernet10
     ipv4: 10.42.43.1/24
@@ -205,7 +215,8 @@ links:
   prefix:
     ipv4: 10.42.43.0/24
   type: p2p
-- interfaces:
+- _linkname: links[11]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.25/30

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -6,7 +6,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
@@ -37,7 +38,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
@@ -51,7 +53,8 @@ links:
     ipv6: 2008:db8:1::/64
   role: stub
   type: stub
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet3
@@ -65,7 +68,8 @@ links:
     ipv6: 2008:db8:1:1::/64
   role: stub
   type: stub
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -79,7 +83,8 @@ links:
     ipv6: 2008:db8:1:2::/64
   role: stub
   type: stub
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 1
     ifname: ge-0/0/1
@@ -93,7 +98,8 @@ links:
     ipv6: 2008:db8:1:3::/64
   role: stub
   type: stub
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - ifindex: 3
     ifname: Ethernet1/3
@@ -125,7 +131,8 @@ links:
     ipv6: 2008:db8:1:4::/64
   role: stub
   type: lan
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   interfaces:
   - ifindex: 4
     ifname: Ethernet1/4
@@ -149,7 +156,8 @@ links:
     ipv4: 172.16.1.0/24
   role: external
   type: lan
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 5
     ifname: Ethernet1/5
     ipv4: true
@@ -161,7 +169,8 @@ links:
   linkindex: 8
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 6
     ifname: Ethernet1/6
     ipv4: true
@@ -173,7 +182,8 @@ links:
   linkindex: 9
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[10]
+  interfaces:
   - ifindex: 7
     ifname: Ethernet1/7
     ipv6: true
@@ -187,7 +197,8 @@ links:
   prefix:
     ipv6: true
   type: p2p
-- interfaces:
+- _linkname: links[11]
+  interfaces:
   - ifindex: 6
     ifname: Ethernet6
     ipv6: true
@@ -201,7 +212,8 @@ links:
   prefix:
     ipv6: true
   type: p2p
-- interfaces:
+- _linkname: links[12]
+  interfaces:
   - ifindex: 7
     ifname: Ethernet7
     ipv4: true
@@ -213,7 +225,8 @@ links:
   linkindex: 12
   node_count: 2
   type: p2p
-- interfaces:
+- _linkname: links[13]
+  interfaces:
   - ifindex: 8
     ifname: GigabitEthernet8
     ipv6: true
@@ -227,7 +240,8 @@ links:
   prefix:
     ipv6: true
   type: p2p
-- interfaces:
+- _linkname: links[14]
+  interfaces:
   - ifindex: 8
     ifname: Ethernet1/8
     node: c_nxos

--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -6,7 +6,8 @@ lag:
   lacp_mode: active
   mode: 802.3ad
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 30000
     ifname: port-channel1
@@ -23,7 +24,8 @@ links:
   stp:
     enable: false
   type: lag
-- interfaces:
+- _linkname: links[1].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: r1
@@ -37,7 +39,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: r1

--- a/tests/topology/expected/lag-l3-access-vlan.yml
+++ b/tests/topology/expected/lag-l3-access-vlan.yml
@@ -6,7 +6,8 @@ lag:
   lacp_mode: active
   mode: 802.3ad
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - _vlan_mode: irb
     ifindex: 30000
@@ -33,7 +34,8 @@ links:
   type: lag
   vlan:
     access: v1
-- interfaces:
+- _linkname: links[1].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: r1
@@ -46,7 +48,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: r1
@@ -59,7 +62,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[3]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     node: r2

--- a/tests/topology/expected/lag-l3-vlan-trunk.yml
+++ b/tests/topology/expected/lag-l3-vlan-trunk.yml
@@ -6,7 +6,8 @@ lag:
   lacp_mode: active
   mode: 802.3ad
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 30000
     ifname: bond1
@@ -32,7 +33,8 @@ links:
     trunk:
       v1: {}
       v2: {}
-- interfaces:
+- _linkname: links[1].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: r1
@@ -45,7 +47,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: r1
@@ -58,7 +61,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[3]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     node: r1

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -6,7 +6,8 @@ lag:
   lacp_mode: active
   mode: 802.3ad
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 30000
     ifname: port-channel1
@@ -23,7 +24,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: lag
-- interfaces:
+- _linkname: links[1].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: ethernet1/1/1
     node: r1
@@ -36,7 +38,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[1].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: ethernet1/1/2
     node: r1

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -17,7 +17,8 @@ lag:
   lacp_mode: active
   mode: 802.3ad
 links:
-- interfaces:
+- _linkname: links[1].peerlink[1]
+  interfaces:
   - ifindex: 1
     ifname: ethernet1/1/1
     node: s1
@@ -31,7 +32,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: irb
     ifindex: 30000
@@ -70,7 +72,8 @@ links:
   type: lag
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - _vlan_mode: irb
     ifindex: 30000
@@ -109,7 +112,8 @@ links:
   type: lag
   vlan:
     access: red
-- interfaces:
+- _linkname: links[1].peerlink[2]
+  interfaces:
   - ifindex: 2
     ifname: ethernet1/1/2
     node: s2
@@ -122,7 +126,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[2].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: h1
@@ -135,7 +140,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[2].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: h1
@@ -148,7 +154,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[2].lag[3]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     node: h1
@@ -161,7 +168,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[2].lag[4]
+  interfaces:
   - ifindex: 4
     ifname: eth4
     node: h1
@@ -174,7 +182,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[3].lag[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: h2
@@ -187,7 +196,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[3].lag[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: h2
@@ -200,7 +210,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[3].lag[3]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     node: h2
@@ -213,7 +224,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- interfaces:
+- _linkname: links[3].lag[4]
+  interfaces:
   - ifindex: 4
     ifname: eth4
     node: h2

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -20,7 +20,8 @@ libvirt:
   providers:
     clab: true
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -44,7 +45,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.1/30
@@ -58,7 +60,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
@@ -76,7 +79,8 @@ links:
   prefix:
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.2.3/24
   interfaces:
@@ -97,7 +101,8 @@ links:
     ipv4: 172.16.2.0/24
   role: stub
   type: lan
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   gateway:
     ipv4: 172.16.3.3/24
   interfaces:

--- a/tests/topology/expected/link-bw.yml
+++ b/tests/topology/expected/link-bw.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-bw.yml
 - package:topology-defaults.yml
 links:
-- bandwidth: 100000
+- _linkname: links[1]
+  bandwidth: 100000
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-formats.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30
@@ -16,7 +17,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -35,7 +37,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
@@ -54,7 +57,8 @@ links:
   prefix:
     ipv4: 172.16.1.0/24
   type: lan
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: GigabitEthernet0/4
     ipv4: 10.1.0.5/30
@@ -71,7 +75,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 5
     ifname: GigabitEthernet0/5
@@ -91,7 +96,8 @@ links:
   prefix:
     ipv4: 172.16.2.0/24
   type: lan
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 6
     ifname: GigabitEthernet0/6
     ipv4: 10.1.0.9/30
@@ -106,7 +112,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 7
     ifname: GigabitEthernet0/7
     ipv4: 10.1.0.13/30
@@ -123,7 +130,8 @@ links:
   prefix:
     ipv4: 10.1.0.12/30
   type: p2p
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 8
     ifname: GigabitEthernet0/8
     ipv4: 10.1.0.17/30
@@ -138,7 +146,8 @@ links:
   prefix:
     ipv4: 10.1.0.16/30
   type: p2p
-- bridge: input_9
+- _linkname: links[9]
+  bridge: input_9
   interfaces:
   - ifindex: 10
     ifname: GigabitEthernet0/10

--- a/tests/topology/expected/link-group.yml
+++ b/tests/topology/expected/link-group.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-group.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[core][1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -18,7 +19,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[core][2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30
@@ -34,7 +36,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[core][3]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.9/30
@@ -50,7 +53,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- bridge: input_4
+- _linkname: links[stub][1]
+  bridge: input_4
   interfaces:
   - ifindex: 3
     ifname: Ethernet3
@@ -64,7 +68,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: stub
-- bridge: input_5
+- _linkname: links[stub][2]
+  bridge: input_5
   interfaces:
   - ifindex: 3
     ifname: Ethernet3
@@ -78,7 +83,8 @@ links:
     ipv4: 172.16.1.0/24
   role: stub
   type: stub
-- bridge: input_6
+- _linkname: links[stub][3]
+  bridge: input_6
   interfaces:
   - ifindex: 3
     ifname: Ethernet3

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-loopback.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -14,7 +15,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 172.16.1.1/24
@@ -24,7 +26,8 @@ links:
   prefix:
     ipv4: 172.16.1.0/24
   type: loopback
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -36,7 +39,8 @@ links:
     ipv4: 172.16.2.0/24
   role: stub
   type: stub
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 10.1.0.1/32
@@ -46,7 +50,8 @@ links:
   prefix:
     ipv4: 172.16.3.0/24
   type: loopback
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 10002
     ifname: Loopback2
     ipv4: 10.1.0.2/32
@@ -56,7 +61,8 @@ links:
   prefix:
     ipv4: 10.1.0.2/32
   type: loopback
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 10003
     ifname: Loopback3
     ipv4: 10.2.0.1/32

--- a/tests/topology/expected/link-tunnel.yml
+++ b/tests/topology/expected/link-tunnel.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-tunnel.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 20000
     ifname: Tunnel13
@@ -21,7 +22,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: tunnel
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 20001
     ifname: Tunnel1
@@ -36,7 +38,8 @@ links:
   prefix:
     ipv4: 172.16.1.0/24
   type: tunnel
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 20002
     ifname: Tunnel2
@@ -48,7 +51,8 @@ links:
     ipv4: 172.16.2.0/24
   role: stub
   type: tunnel
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/link-without-prefix.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -16,7 +17,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -35,7 +37,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     node: r1
@@ -46,7 +49,8 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 4
     ifname: Ethernet4

--- a/tests/topology/expected/links-as-dict.yml
+++ b/tests/topology/expected/links-as-dict.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/links-as-dict.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links.g1[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30
@@ -16,7 +17,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links.g2[1]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.5/30
@@ -30,7 +32,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links.g3
+  interfaces:
   - ifindex: 2
     ifname: eth2
     ipv4: 10.1.0.10/30

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -16,7 +16,8 @@ input:
 - topology/input/module-node-global-params.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -16,7 +16,8 @@ input:
 - topology/input/module-node-params.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -21,7 +21,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet2
     ipv4: 10.1.0.2/30
@@ -35,7 +36,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet3
     ipv4: 10.1.0.6/30
@@ -49,7 +51,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.10/30
@@ -63,7 +66,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.14/30

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -21,7 +21,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30
@@ -35,7 +36,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- bridge: input_2
+- _linkname: vrfs.red.links[1]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -48,7 +50,8 @@ links:
   role: stub
   type: stub
   vrf: red
-- bridge: input_3
+- _linkname: vrfs.red.links[2]
+  bridge: input_3
   interfaces:
   - ifindex: 2
     ifname: eth2

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -24,7 +24,8 @@ input:
 - topology/input/mpls.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.2/30
@@ -42,7 +43,8 @@ links:
     ipv6: 2001:db8:1::/64
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.6/30
@@ -60,7 +62,8 @@ links:
     ipv6: 2001:db8:1:1::/64
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.10/30
@@ -77,7 +80,8 @@ links:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
     ipv4: 10.1.0.14/30
@@ -94,7 +98,8 @@ links:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
     ipv4: 10.1.0.18/30

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -20,7 +20,8 @@ input:
 - topology/input/null-vrfs.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -5,7 +5,8 @@ input:
 - topology/input/ospf-bfd-test.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -25,7 +26,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- bfd: false
+- _linkname: links[2]
+  bfd: false
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -41,7 +43,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.5/30
@@ -58,7 +61,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: GigabitEthernet0/4
     ipv4: 10.1.0.9/30

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/ospf.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
@@ -36,7 +37,8 @@ links:
     ipv4: 172.19.0.0/24
     ipv6: 2001:db8:1::/64
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: true
@@ -53,7 +55,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet1/3
     ipv4: true
@@ -72,7 +75,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: Ethernet1/4
     ipv4: true
@@ -89,7 +93,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: true
@@ -106,7 +111,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 4
     ifname: Ethernet4
     ipv4: true
@@ -123,7 +129,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 5
     ifname: GigabitEthernet5
     ipv4: true
@@ -140,7 +147,8 @@ links:
   prefix:
     ipv4: true
   type: p2p
-- bridge: input_8
+- _linkname: links[8]
+  bridge: input_8
   interfaces:
   - ifindex: 5
     ifname: Ethernet1/5
@@ -155,7 +163,8 @@ links:
     ipv6: 2001:db8:1:1::/64
   role: edge
   type: stub
-- bridge: input_9
+- _linkname: links[9]
+  bridge: input_9
   interfaces:
   - ifindex: 5
     ifname: Ethernet5
@@ -169,7 +178,8 @@ links:
     ipv6: 2001:db8:1:2::/64
   role: edge
   type: stub
-- bridge: input_10
+- _linkname: links[10]
+  bridge: input_10
   interfaces:
   - ifindex: 6
     ifname: Ethernet1/6

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -20,7 +20,8 @@ input:
 - topology/input/rp-aspath-numbers.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - bgp:
       policy:
         in: rp1

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -8,7 +8,8 @@ input:
 - topology/input/rt-vlan-anycast.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway: true
   interfaces:
   - ifindex: 1
@@ -25,7 +26,8 @@ links:
     ipv4: 172.16.1.0/24
   role: stub
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway: true
   interfaces:
   - ifindex: 2
@@ -47,7 +49,8 @@ links:
   type: lan
   vlan:
     access: blue
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     node: s1

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/rt-vlan-mode-link-route.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.3.2/24
   interfaces:
@@ -28,7 +29,8 @@ links:
   vlan:
     access: red
     mode: route
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -49,7 +51,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: eth3
@@ -70,7 +73,8 @@ links:
   type: lan
   vlan:
     access: red
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: sw
@@ -97,7 +101,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3
@@ -120,7 +125,8 @@ links:
   type: lan
   vlan:
     access: red
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 4
     ifname: eth4
     node: sw
@@ -150,7 +156,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - _vlan_mode: route
     ifindex: 5
     ifname: eth5
@@ -175,7 +182,8 @@ links:
   vlan:
     access: red
     mode: route
-- interfaces:
+- _linkname: links[8]
+  interfaces:
   - ifindex: 6
     ifname: eth6
     node: sw
@@ -202,7 +210,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: rt
@@ -229,7 +238,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- bridge: input_10
+- _linkname: links[10]
+  bridge: input_10
   interfaces:
   - _vlan_mode: route
     ifindex: 3

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/rt-vlan-native-routed.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - _vlan_mode: irb
     ifindex: 1

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -14,7 +14,8 @@ input:
 - topology/input/rt-vlan-no-gateway.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -32,7 +33,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -6,7 +6,8 @@ input:
 - topology/input/rt-vlan-role-unnumbered.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     node: leaf

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/rt-vlan-trunk-partial-overlap.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/stp-pvrst.yml
+++ b/tests/topology/expected/stp-pvrst.yml
@@ -23,7 +23,8 @@ libvirt:
   providers:
     clab: true
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: s2
@@ -46,7 +47,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_2
+- _linkname: vlans.red.links[1]
+  bridge: input_2
   interfaces:
   - _vlan_mode: bridge
     ifindex: 1
@@ -69,7 +71,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: vlans.red.links[2]
+  bridge: input_3
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -92,7 +95,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_4
+- _linkname: vlans.red.links[3]
+  bridge: input_4
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -114,7 +118,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_5
+- _linkname: vlans.blue.links[1]
+  bridge: input_5
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3
@@ -137,7 +142,8 @@ links:
   type: lan
   vlan:
     access: blue
-- bridge: input_6
+- _linkname: vlans.blue.links[2]
+  bridge: input_6
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -160,7 +166,8 @@ links:
   type: lan
   vlan:
     access: blue
-- bridge: input_7
+- _linkname: vlans.blue.links[3]
+  bridge: input_7
   interfaces:
   - _vlan_mode: bridge
     ifindex: 4

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/unmanaged-device.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.2/30
@@ -17,7 +18,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/unnumbered.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
@@ -30,7 +31,8 @@ links:
     ipv4: 172.19.0.0/24
     ipv6: 2001:db8:1::/64
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: true
@@ -45,7 +47,8 @@ links:
   node_count: 2
   pool: core
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: true
@@ -60,7 +63,8 @@ links:
   node_count: 2
   pool: core
   type: p2p
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet1/3
     ipv4: true

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vbox.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1/1
@@ -21,7 +22,8 @@ links:
   prefix:
     ipv4: 172.16.0.0/24
   type: lan
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: 10.1.0.2/30

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-access-links.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: vlans.red.links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.2/24
   interfaces:
@@ -27,7 +28,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_2
+- _linkname: vlans.red.links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -53,7 +55,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: vlans.red.links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.0.3/24
   interfaces:

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -18,7 +18,8 @@ input:
 - topology/input/vlan-access-neighbors.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
@@ -37,7 +38,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -15,7 +15,8 @@ input:
 - topology/input/vlan-access-node.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -36,7 +37,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
@@ -55,7 +57,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.1.2/24
   interfaces:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-access-single.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.2/24
   interfaces:
@@ -25,7 +26,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -51,7 +53,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.0.3/24
   interfaces:
@@ -74,7 +77,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - _vlan_mode: irb
     ifindex: 3

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -19,7 +19,8 @@ input:
 - topology/input/vlan-bridge-trunk-router.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: s1
@@ -42,7 +43,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -60,7 +62,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -78,7 +81,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 1
     ifname: GigabitEthernet0/1
@@ -96,7 +100,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-coverage.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.2/24
   interfaces:
@@ -23,7 +24,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -47,7 +49,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.0.3/24
   interfaces:
@@ -68,7 +71,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3
@@ -86,7 +90,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-mode-priority.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - _vlan_mode: vl_irb
     ifindex: 1
@@ -26,7 +27,8 @@ links:
   type: lan
   vlan:
     access: red
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: eth2
     node: s1
@@ -52,7 +54,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: eth3
     node: s1

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-native-routed.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.3.1/24
   interfaces:

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-routed-access.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - _vlan_mode: route
     ifindex: 1
@@ -28,7 +29,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -53,7 +55,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 3
     ifname: Ethernet3

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -5,7 +5,8 @@ libvirt:
   providers:
     clab: true
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -10,7 +10,8 @@ input:
 - topology/input/vlan-routed-vrf.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -30,7 +31,8 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
   vrf: red
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   interfaces:
   - _vlan_mode: bridge
     ifindex: 1
@@ -49,7 +51,8 @@ links:
     ipv4: 172.16.1.0/24
   type: lan
   vrf: blue
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -71,7 +74,8 @@ links:
     ipv6: true
   type: lan
   vrf: green
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: s1
@@ -97,7 +101,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     node: s1
@@ -124,7 +129,8 @@ links:
       blue: {}
       green: {}
       red: {}
-- interfaces:
+- _linkname: links[6]
+  interfaces:
   - ifindex: 4
     ifname: eth4
     node: s2

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-routed.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.1.1/24
   interfaces:
@@ -26,7 +27,8 @@ links:
   type: lan
   vlan:
     mode: route
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.2.1/24
   interfaces:

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -16,7 +16,8 @@ input:
 - topology/input/vlan-router-stick.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: s1
@@ -39,7 +40,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: s2
@@ -62,7 +64,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
@@ -82,7 +85,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 1
     ifname: Ethernet1

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vlan-trunk-native.yml
 - package:topology-defaults.yml
 links:
-- bridge: input_1
+- _linkname: links[1]
+  bridge: input_1
   gateway:
     ipv4: 172.16.0.1/24
   interfaces:
@@ -25,7 +26,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_2
+- _linkname: links[2]
+  bridge: input_2
   gateway:
     ipv4: 172.16.1.1/24
   interfaces:
@@ -46,7 +48,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.0.2/24
   interfaces:
@@ -69,7 +72,8 @@ links:
     allocation: id_based
     ipv4: 172.16.0.0/24
   type: lan
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.1.2/24
   interfaces:
@@ -90,7 +94,8 @@ links:
     allocation: id_based
     ipv4: 172.16.1.0/24
   type: lan
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   gateway:
     ipv4: 172.16.2.2/24
   interfaces:
@@ -111,7 +116,8 @@ links:
     allocation: id_based
     ipv4: 172.16.2.0/24
   type: lan
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   gateway:
     ipv4: 172.16.2.2/24
   interfaces:
@@ -148,7 +154,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   interfaces:
   - _vlan_mode: irb
     ifindex: 4

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -19,7 +19,8 @@ input:
 - topology/input/vlan-vrf-lite.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: r1
@@ -42,7 +43,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     node: r2
@@ -65,7 +67,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   gateway:
     ipv4: 172.16.2.1/24
   interfaces:
@@ -90,7 +93,8 @@ links:
   vlan:
     mode: route
   vrf: red
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.3.1/24
   interfaces:
@@ -115,7 +119,8 @@ links:
   vlan:
     mode: route
   vrf: blue
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   gateway:
     ipv4: 172.16.4.2/24
   interfaces:
@@ -140,7 +145,8 @@ links:
   vlan:
     mode: route
   vrf: red
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   gateway:
     ipv4: 172.16.5.2/24
   interfaces:
@@ -165,7 +171,8 @@ links:
   vlan:
     mode: route
   vrf: blue
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -22,7 +22,8 @@ input:
 - topology/input/vlan-vrrp.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: s1
@@ -45,7 +46,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- bridge: input_2
+- _linkname: vlans.red.links[1]
+  bridge: input_2
   gateway:
     anycast:
       mac: 0200.cafe.00ff
@@ -81,7 +83,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_3
+- _linkname: vlans.red.links[2]
+  bridge: input_3
   gateway:
     anycast:
       mac: 0200.cafe.00ff

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -24,7 +24,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -39,7 +40,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30
@@ -55,7 +57,8 @@ links:
     ipv4: 10.1.0.4/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: true
@@ -70,7 +73,8 @@ links:
     ipv4: true
   type: p2p
   vrf: blue
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: 10.1.0.9/30
@@ -87,7 +91,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -100,7 +105,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: stub
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - ifindex: 3
     ifname: Ethernet3

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -2,7 +2,8 @@ input:
 - topology/input/vrf-leaking-loop.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: eth1
     name: Global side

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -18,7 +18,8 @@ input:
 - topology/input/vrf-links.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: vrfs.red.links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -33,7 +34,8 @@ links:
     ipv4: 10.1.0.0/30
   type: p2p
   vrf: red
-- interfaces:
+- _linkname: vrfs.red.links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30
@@ -48,7 +50,8 @@ links:
     ipv4: 10.1.0.4/30
   type: p2p
   vrf: red
-- interfaces:
+- _linkname: vrfs.red.links[3]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 172.16.0.1/24
@@ -59,7 +62,8 @@ links:
     ipv4: 172.16.0.0/24
   type: loopback
   vrf: red
-- interfaces:
+- _linkname: vrfs.blue.links[1]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.9/30
@@ -74,7 +78,8 @@ links:
     ipv4: 10.1.0.8/30
   type: p2p
   vrf: blue
-- interfaces:
+- _linkname: vrfs.blue.links[2]
+  interfaces:
   - ifindex: 10001
     ifname: Loopback1
     ipv4: 172.16.1.3/24

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -24,7 +24,8 @@ isis:
   instance: Gandalf
   type: level-2
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -38,7 +39,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30
@@ -54,7 +56,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: 10.1.0.9/30
@@ -72,7 +75,8 @@ links:
     ipv4: 10.1.0.8/30
   type: p2p
   vrf: o_1
-- interfaces:
+- _linkname: links[4]
+  interfaces:
   - ifindex: 4
     ifname: Ethernet4
     ipv4: 10.1.0.13/30
@@ -89,7 +93,8 @@ links:
     ipv4: 10.1.0.12/30
   type: p2p
   vrf: o_1
-- interfaces:
+- _linkname: links[5]
+  interfaces:
   - ifindex: 5
     ifname: Ethernet5
     ipv4: 10.1.0.17/30
@@ -105,7 +110,8 @@ links:
     ipv4: 10.1.0.16/30
   type: p2p
   vrf: o_2
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   interfaces:
   - ifindex: 6
     ifname: Ethernet6
@@ -119,7 +125,8 @@ links:
   role: stub
   type: stub
   vrf: o_3
-- interfaces:
+- _linkname: links[7]
+  interfaces:
   - ifindex: 7
     ifname: Ethernet7
     ipv4: 10.1.0.21/30
@@ -135,7 +142,8 @@ links:
   role: external
   type: p2p
   vrf: b_1
-- bgp: false
+- _linkname: links[8]
+  bgp: false
   interfaces:
   - ifindex: 8
     ifname: Ethernet8
@@ -152,7 +160,8 @@ links:
   role: external
   type: p2p
   vrf: b_1
-- interfaces:
+- _linkname: links[9]
+  interfaces:
   - ifindex: 9
     ifname: Ethernet9
     ipv4: 10.1.0.29/30

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -19,7 +19,8 @@ input:
 - topology/input/vrf.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -35,7 +36,8 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.5/30
@@ -50,7 +52,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- bridge: input_3
+- _linkname: links[3]
+  bridge: input_3
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
@@ -63,7 +66,8 @@ links:
     ipv4: 172.16.0.0/24
   role: stub
   type: stub
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   interfaces:
   - ifindex: 2
     ifname: Ethernet2

--- a/tests/topology/expected/vrrp-interface-granularity.yml
+++ b/tests/topology/expected/vrrp-interface-granularity.yml
@@ -9,7 +9,8 @@ input:
 - topology/input/vrrp-interface-granularity.yml
 - package:topology-defaults.yml
 links:
-- gateway:
+- _linkname: links[1]
+  gateway:
     anycast:
       mac: 0200.cafe.00ff
       unicast: true
@@ -35,7 +36,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/27
   type: p2p
-- gateway:
+- _linkname: links[2]
+  gateway:
     anycast:
       mac: 0200.cafe.00ff
       unicast: true
@@ -61,7 +63,8 @@ links:
   prefix:
     ipv4: 10.1.0.32/27
   type: p2p
-- gateway:
+- _linkname: links[3]
+  gateway:
     anycast:
       mac: 0200.cafe.00ff
       unicast: true

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -14,7 +14,8 @@ input:
 - topology/input/vxlan-router-stick.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     node: s1
@@ -37,7 +38,8 @@ links:
     trunk:
       blue: {}
       red: {}
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 2
     ifname: Ethernet2
     ipv4: 10.1.0.2/30
@@ -51,7 +53,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: 10.1.0.6/30

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -19,7 +19,8 @@ input:
 - topology/input/vxlan-static.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.1/30
@@ -33,7 +34,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.5/30
@@ -47,7 +49,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- bridge: input_3
+- _linkname: vlans.red.links[1]
+  bridge: input_3
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -67,7 +70,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_4
+- _linkname: vlans.red.links[2]
+  bridge: input_4
   interfaces:
   - _vlan_mode: bridge
     ifindex: 2
@@ -87,7 +91,8 @@ links:
   type: lan
   vlan:
     access: red
-- bridge: input_5
+- _linkname: vlans.blue.links[1]
+  bridge: input_5
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3
@@ -107,7 +112,8 @@ links:
   type: lan
   vlan:
     access: blue
-- bridge: input_6
+- _linkname: vlans.blue.links[2]
+  bridge: input_6
   interfaces:
   - _vlan_mode: bridge
     ifindex: 3

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -46,7 +46,8 @@ input:
 - topology/input/vxlan-vrf-lite.yml
 - package:topology-defaults.yml
 links:
-- interfaces:
+- _linkname: links[1]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.2/30
@@ -60,7 +61,8 @@ links:
   prefix:
     ipv4: 10.1.0.0/30
   type: p2p
-- interfaces:
+- _linkname: links[2]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.6/30
@@ -74,7 +76,8 @@ links:
   prefix:
     ipv4: 10.1.0.4/30
   type: p2p
-- interfaces:
+- _linkname: links[3]
+  interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.10/30
@@ -88,7 +91,8 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-- bridge: input_4
+- _linkname: links[4]
+  bridge: input_4
   gateway:
     ipv4: 172.16.2.6/24
   interfaces:
@@ -107,7 +111,8 @@ links:
   role: stub
   type: lan
   vrf: red
-- bridge: input_5
+- _linkname: links[5]
+  bridge: input_5
   gateway:
     ipv4: 172.16.3.7/24
   interfaces:
@@ -126,7 +131,8 @@ links:
   role: stub
   type: lan
   vrf: red
-- bridge: input_6
+- _linkname: links[6]
+  bridge: input_6
   gateway:
     ipv4: 172.16.4.8/24
   interfaces:
@@ -145,7 +151,8 @@ links:
   role: stub
   type: lan
   vrf: red
-- bridge: input_7
+- _linkname: links[7]
+  bridge: input_7
   gateway:
     ipv4: 172.16.5.6/24
   interfaces:
@@ -164,7 +171,8 @@ links:
   role: stub
   type: lan
   vrf: blue
-- bridge: input_8
+- _linkname: links[8]
+  bridge: input_8
   gateway:
     ipv4: 172.16.6.7/24
   interfaces:


### PR DESCRIPTION
We need _linkname attribute to display meaningful error messages in provider-specific code. As that code is executed at the very end of the transformation process, we should not remove the _linkname attribute during the link cleanup processing.