### PR TITLE
Dell OS10: Fix test cases 33-vrf-common-ospf and 34- by redistributing imported OSPF routes too

### DIFF
--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -1,14 +1,14 @@
 {% from "templates/ospf/dellos10.macro.j2" import configure_ospf_interface %}
 
 router ospf {{ vdata.vrfidx }} vrf {{ vname }}
-  router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
-  redistribute connected
-  redistribute imported-ospf-routes
+ router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
+ redistribute connected
+ redistribute imported-ospf-routes
 {% if bgp.as is defined %}
-  redistribute bgp {{ bgp.as }}
+ redistribute bgp {{ bgp.as }}
 {% endif %}
-{% if ospf.reference_bandwidth is defined %}
-  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+{% if vdata.ospf.reference_bandwidth is defined %}
+ auto-cost reference-bandwidth {{ vdata.ospf.reference_bandwidth }}
 {% endif %}
 !
 {% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -3,6 +3,7 @@
 router ospf {{ vdata.vrfidx }} vrf {{ vname }}
   router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
   redistribute connected
+  redistribute imported-ospf-routes
 {% if bgp.as is defined %}
   redistribute bgp {{ bgp.as }}
 {% endif %}


### PR DESCRIPTION
Might be related to https://github.com/ipspace/netlab/issues/1135

Fixes both 33-vrf-common-ospf and 34-vrf-common-mixed integration test cases

Technically this flag is only required if there are multiple VRFs running OSPF and they import from each other - but I think it's safe to enable whenever OSPF is used in VRFs

Note: Also fixes reference_bandwidth attribute