### PR TITLE
Refactor EBGP IPv6 LLA/RFC 8950 code

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -315,7 +315,7 @@ Use the **netlab show module --module bgp --feature ipv6_lla** command to displa
 (bgp-ebgp-rfc8950)=
 **EBGP Sessions on Unnumbered IPv4 Links**
 
-*netlab* can use an IPv6 EBGP sessions to transport IPv4 address family with IPv6 next hops (RFC 8950) -- the functionality commonly used to implement *interface EBGP sessions*. *netlab* will enable IPv4 AF over IPv6 LLA EBGP session when the **unnumbered** link- or interface attribute is set, or when **ipv4** interface address or link prefix is set to *True*.
+*netlab* can use IPv6 EBGP sessions to transport IPv4 address family with IPv6 next hops (RFC 8950) -- the functionality commonly used to implement *interface EBGP sessions*. *netlab* will enable IPv4 AF over IPv6 LLA EBGP sessions when the **unnumbered** link- or interface attribute is set, or when **ipv4** interface address or link prefix is set to *True*.
 
 Use the **netlab show module --module bgp --feature ipv6_lla** command to display devices on which you can use the IPv4 address family on IPv6 LLA EBGP sessions and the **netlab show module --module bgp --feature rfc8950** command to display devices on which you can use the IPv4 address family on regular IPv6 EBGP sessions.
 

--- a/docs/plugins/bgp.domain.md
+++ b/docs/plugins/bgp.domain.md
@@ -1,3 +1,4 @@
+(plugin-bgp-domain)=
 # BGP Domains Plugin
 
 The **bgp.domain** plugin allows you to create multiple independent copies of the same autonomous system, for example, when testing MPLS/VPN topologies in which all customer sites use the same AS number.

--- a/docs/plugins/ebgp.utils.md
+++ b/docs/plugins/ebgp.utils.md
@@ -1,3 +1,0 @@
-# EBGP Utilities Plugin
-
-This plugin has been renamed to [](bgp.session.md) in release 1.7.0.

--- a/docs/release.md
+++ b/docs/release.md
@@ -139,7 +139,7 @@ This release contains only [bug fixes](bug-fixes-1.7.2) and [documentation fixes
 **[Release 1.6.3](release-1.6.3) (2023-10-06)**
 
 * [EBGP multihop sessions](plugins/ebgp.multihop.md)
-* [ebgp.utils plugin](plugins/ebgp.utils.md) supports TCP-AO, configurable BGP timers, and Generic TTL Security Mechanism (TTL session protection)
+* [ebgp.utils plugin](plugin-bgp-session) supports TCP-AO, configurable BGP timers, and Generic TTL Security Mechanism (TTL session protection)
 * [OSPF reports](module/ospf.md)
 * Shorter version of [BGP neighbor report](module/bgp.md)
 * [BFD on Cumulus Linux](bfd-platform)

--- a/docs/release/1.3.md
+++ b/docs/release/1.3.md
@@ -44,7 +44,7 @@ Release 1.3.3 is a bug fix release. New functionality will be added in release 1
 * IS-IS on VyOS
 * VLAN and VRF on Cisco Nexus OS
 * VRF support for Nokia SR Linux
-* [Default route origination on EBGP sessions](../plugins/ebgp.utils.md)
+* [Default route origination on EBGP sessions](plugin-bgp-session)
 * [gRPC installation script](../netlab/install.md) -- install all the dependencies needed to configure Nokia SR Linux with a single command
 * Device-specific module requirements (example: VXLAN on Nokia SR Linux works only with EVPN)
 * Complete implementation of VLAN interface on Nokia SR Linux

--- a/docs/release/1.6.md
+++ b/docs/release/1.6.md
@@ -52,7 +52,7 @@
 ### Release 1.6.3
 
 * [EBGP multihop sessions](../plugins/ebgp.multihop.md) in the global routing table. Implemented on Arista EOS, Cisco IOSv, Cisco IOS-XE, FRR and Cumulus Linux 4.x.
-* [ebgp.utils plugin](../plugins/ebgp.utils.md) supports TCP-AO, configurable BGP timers, and Generic TTL Security Mechanism (TTL session protection)
+* [ebgp.utils plugin](plugin-bgp-session) supports TCP-AO, configurable BGP timers, and Generic TTL Security Mechanism (TTL session protection)
 * [OSPF reports](../module/ospf.md): areas/routers/interfaces in md/html/text format
 * Shorter version of [BGP neighbor report](../module/bgp.md)
 * Specify [minimum netlab version](topology-reference-extra-elements) in lab topology

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -43,7 +43,6 @@ features:
   bfd: True
   bgp:
     ipv6_lla: True
-    rfc8950: True
     activate_af: True
     local_as: True
     vrf_local_as: True

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -22,7 +22,6 @@ features:
       lla: True
   bgp:
     ipv6_lla: True
-    rfc8950: True
     activate_af: True
   lag:
     passive: False
@@ -39,7 +38,7 @@ features:
     ospfv2: True
 clab:
   kmods:
-   initial: [ ebtables ]
+    initial: [ ebtables ]
   node:
     kind: cvx
     runtime: docker

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -15,7 +15,6 @@ features:
     activate_af: true
     ipv6_lla: true
     local_as: true
-    rfc8950: true
     vrf_local_as: true
   evpn:
     asymmetrical_irb: true
@@ -25,9 +24,9 @@ features:
   lag:
     reserved_ifindex_range: [1000]
     mlag:
-     peer:
-      mac: 0200.01a9.0000  # Base to generate a virtual MAC
-      ip: loopback.ipv4    # Use loopback.ipv4 for peer IP address
+      peer:
+        mac: 0200.01a9.0000  # Base to generate a virtual MAC
+        ip: loopback.ipv4    # Use loopback.ipv4 for peer IP address
     passive: True
   ospf: true
   stp:

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -25,7 +25,6 @@ features:
     ipv6_lla: true
     local_as: true
     local_as_ibgp: true
-    rfc8950: true
     vrf_local_as: true
     import: [ ospf, isis, ripv2, connected, vrf ]
     community:
@@ -53,10 +52,10 @@ features:
     import: [ bgp, ospf, ripv2, connected, vrf ]
   lag:
     mlag:
-     peer:
-      vlan: 4094              # Use this vlan
-      ifindex: 4094           # Use this port-channel
-      ip: 169.254.127.0/31    # Use this subnet
+      peer:
+        vlan: 4094              # Use this vlan
+        ifindex: 4094           # Use this port-channel
+        ip: 169.254.127.0/31    # Use this subnet
     passive: True
   mpls:
     6pe: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -53,7 +53,6 @@ features:
     ipv6_lla: true
     local_as: true
     local_as_ibgp: true
-    rfc8950: true
     vrf_local_as: true
     import: [ ospf, ripv2, isis, connected, vrf ]
     community:

--- a/netsim/devices/sonic.yml
+++ b/netsim/devices/sonic.yml
@@ -30,7 +30,6 @@ features:
     ipv6_lla: true
     local_as: true
     local_as_ibgp: true
-    rfc8950: true
     vrf_local_as: true
     community:
       standard: [ standard, large ]

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -44,7 +44,6 @@ features:
     local_as_ibgp: True
     activate_af: True
     ipv6_lla: True
-    rfc8950: True
     import: [ ospf, isis, connected, vrf, no_policy ]
   evpn:
     irb: True

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -30,7 +30,6 @@ features:
     local_as_ibgp: True
     activate_af: True
     ipv6_lla: True
-    rfc8950: False            # Not implemented yet, may be possible
   evpn:
     irb: True
     asymmetrical_irb: True

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -22,7 +22,6 @@ features:
     activate_af: true
     ipv6_lla: true
     local_as: true
-    rfc8950: true
     vrf_local_as: true
     import: [ ospf, ripv2, connected, vrf ]
   evpn:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -87,7 +87,7 @@ features:
   local_as_ibgp: Can use local-as to create IBGP sesssion
   activate_af: Can control activation of individual address families
   ipv6_lla: Can run EBGP sessions over IPv6 link-local addresses
-  rfc8950: Can run IPv4 AF over IPv6 LLA EBGP session
+  rfc8950: Can run IPv4 AF over regular IPv6 EBGP session
   community: Granular BGP community propagation
   import: Import routes from other routing protocols
 warnings:

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -30,12 +30,12 @@ links:
 - _linkname: links[1]
   interfaces:
   - ifindex: 1
-    ifname: swp1
+    ifname: eth1
     ipv4: true
     ipv6: true
     node: test
   - ifindex: 1
-    ifname: swp1
+    ifname: eth1
     ipv4: true
     ipv6: true
     node: x1
@@ -47,11 +47,11 @@ links:
 - _linkname: links[2]
   interfaces:
   - ifindex: 2
-    ifname: swp2
+    ifname: eth2
     ipv4: true
     node: test
   - ifindex: 2
-    ifname: swp2
+    ifname: eth2
     ipv4: true
     node: x1
   linkindex: 2
@@ -63,12 +63,12 @@ links:
 - _linkname: links[3]
   interfaces:
   - ifindex: 3
-    ifname: swp3
+    ifname: eth3
     ipv4: true
     ipv6: true
     node: test
   - ifindex: 1
-    ifname: swp1
+    ifname: eth1
     ipv4: true
     ipv6: true
     node: x2
@@ -82,11 +82,11 @@ links:
 - _linkname: links[4]
   interfaces:
   - ifindex: 4
-    ifname: swp4
+    ifname: eth4
     ipv6: true
     node: test
   - ifindex: 1
-    ifname: swp1
+    ifname: eth1
     ipv6: true
     node: x3
   linkindex: 4
@@ -98,12 +98,12 @@ links:
 - _linkname: links[5]
   interfaces:
   - ifindex: 5
-    ifname: swp5
+    ifname: eth5
     ipv4: 172.31.1.1/24
     ipv6: true
     node: test
   - ifindex: 1
-    ifname: swp1
+    ifname: eth1
     ipv4: 172.31.1.2/24
     ipv6: true
     node: x4
@@ -117,12 +117,12 @@ links:
 - _linkname: links[6]
   interfaces:
   - ifindex: 6
-    ifname: swp6
+    ifname: eth6
     ipv4: true
     ipv6: 2001:db8:1::1/64
     node: test
   - ifindex: 2
-    ifname: swp2
+    ifname: eth2
     ipv4: true
     ipv6: 2001:db8:1::2/64
     node: x4
@@ -147,14 +147,11 @@ nodes:
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         ibgp_localas:
         - standard
-        - large
         - extended
       ipv4: true
       ipv6: true
@@ -167,7 +164,7 @@ nodes:
         ipv4: true
         ipv4_rfc8950: true
         ipv6: true
-        local_if: swp1
+        local_if: eth1
         name: x1
         type: ebgp
       - activate:
@@ -176,7 +173,7 @@ nodes:
         ifindex: 2
         ipv4: true
         ipv4_rfc8950: true
-        local_if: swp2
+        local_if: eth2
         name: x1
         type: ebgp
       - activate:
@@ -187,7 +184,7 @@ nodes:
         ipv4: true
         ipv4_rfc8950: true
         ipv6: true
-        local_if: swp3
+        local_if: eth3
         name: x2
         type: ebgp
       - activate:
@@ -195,7 +192,7 @@ nodes:
         as: 65003
         ifindex: 4
         ipv6: true
-        local_if: swp4
+        local_if: eth4
         name: x3
         type: ebgp
       - activate:
@@ -205,7 +202,7 @@ nodes:
         ifindex: 5
         ipv4: 172.31.1.2
         ipv6: true
-        local_if: swp5
+        local_if: eth5
         name: x4
         type: ebgp
       - activate:
@@ -214,100 +211,95 @@ nodes:
         as: 65004
         ifindex: 6
         ipv4: true
+        ipv4_rfc8950: true
         ipv6: 2001:db8:1::2
         name: x4
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.1
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: none
+    device: none
     id: 1
     interfaces:
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.1/32
       ifindex: 1
-      ifname: swp1
+      ifname: eth1
       ipv4: true
       ipv6: true
       linkindex: 1
-      mtu: 1500
       name: test -> x1
       neighbors:
-      - ifname: swp1
+      - ifname: eth1
         ipv4: true
         ipv6: true
         node: x1
       role: external
       type: p2p
       unnumbered: true
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.1/32
       ifindex: 2
-      ifname: swp2
+      ifname: eth2
       ipv4: true
       ipv6: true
       linkindex: 2
-      mtu: 1500
       name: test -> x1
       neighbors:
-      - ifname: swp2
+      - ifname: eth2
         ipv4: true
         node: x1
       role: external
       type: p2p
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.1/32
       ifindex: 3
-      ifname: swp3
+      ifname: eth3
       ipv4: true
       ipv6: true
       linkindex: 3
-      mtu: 1500
       name: test -> x2
       neighbors:
-      - ifname: swp1
+      - ifname: eth1
         ipv4: true
         ipv6: true
         node: x2
       role: external
       type: p2p
     - ifindex: 4
-      ifname: swp4
+      ifname: eth4
       ipv6: true
       linkindex: 4
-      mtu: 1500
       name: test -> x3
       neighbors:
-      - ifname: swp1
+      - ifname: eth1
         ipv6: true
         node: x3
       role: external
       type: p2p
     - ifindex: 5
-      ifname: swp5
+      ifname: eth5
       ipv4: 172.31.1.1/24
       ipv6: true
       linkindex: 5
-      mtu: 1500
       name: test -> x4
       neighbors:
-      - ifname: swp1
+      - ifname: eth1
         ipv4: 172.31.1.2/24
         ipv6: true
         node: x4
       role: external
       type: p2p
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.1/32
       ifindex: 6
-      ifname: swp6
+      ifname: eth6
       ipv4: true
       ipv6: 2001:db8:1::1/64
       linkindex: 6
-      mtu: 1500
       name: test -> x4
       neighbors:
-      - ifname: swp2
+      - ifname: eth2
         ipv4: true
         ipv6: 2001:db8:1::2/64
         node: x4
@@ -315,7 +307,7 @@ nodes:
       type: p2p
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.1/32
       ipv6: 2001:db8:0:1::1/64
       neighbors: []
@@ -327,7 +319,6 @@ nodes:
       mac: 08:4f:a9:00:00:01
     module:
     - bgp
-    mtu: 1500
     name: test
   x1:
     af:
@@ -339,14 +330,11 @@ nodes:
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         ibgp_localas:
         - standard
-        - large
         - extended
       ipv4: true
       ipv6: true
@@ -359,7 +347,7 @@ nodes:
         ipv4: true
         ipv4_rfc8950: true
         ipv6: true
-        local_if: swp1
+        local_if: eth1
         name: test
         type: ebgp
       - activate:
@@ -368,50 +356,48 @@ nodes:
         ifindex: 2
         ipv4: true
         ipv4_rfc8950: true
-        local_if: swp2
+        local_if: eth2
         name: test
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.2
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: none
+    device: none
     id: 2
     interfaces:
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.2/32
       ifindex: 1
-      ifname: swp1
+      ifname: eth1
       ipv4: true
       ipv6: true
       linkindex: 1
-      mtu: 1500
       name: x1 -> test
       neighbors:
-      - ifname: swp1
+      - ifname: eth1
         ipv4: true
         ipv6: true
         node: test
       role: external
       type: p2p
       unnumbered: true
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.2/32
       ifindex: 2
-      ifname: swp2
+      ifname: eth2
       ipv4: true
       ipv6: true
       linkindex: 2
-      mtu: 1500
       name: x1 -> test
       neighbors:
-      - ifname: swp2
+      - ifname: eth2
         ipv4: true
         node: test
       role: external
       type: p2p
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.2/32
       ipv6: 2001:db8:0:2::1/64
       neighbors: []
@@ -423,7 +409,6 @@ nodes:
       mac: 08:4f:a9:00:00:02
     module:
     - bgp
-    mtu: 1500
     name: x1
   x2:
     af:
@@ -435,14 +420,11 @@ nodes:
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         ibgp_localas:
         - standard
-        - large
         - extended
       ipv4: true
       ipv6: true
@@ -455,26 +437,25 @@ nodes:
         ipv4: true
         ipv4_rfc8950: true
         ipv6: true
-        local_if: swp1
+        local_if: eth1
         name: test
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.3
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: none
+    device: none
     id: 3
     interfaces:
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.3/32
       ifindex: 1
-      ifname: swp1
+      ifname: eth1
       ipv4: true
       ipv6: true
       linkindex: 3
-      mtu: 1500
       name: x2 -> test
       neighbors:
-      - ifname: swp3
+      - ifname: eth3
         ipv4: true
         ipv6: true
         node: test
@@ -482,7 +463,7 @@ nodes:
       type: p2p
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.3/32
       ipv6: 2001:db8:0:3::1/64
       neighbors: []
@@ -494,7 +475,6 @@ nodes:
       mac: 08:4f:a9:00:00:03
     module:
     - bgp
-    mtu: 1500
     name: x2
   x3:
     af:
@@ -506,14 +486,11 @@ nodes:
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         ibgp_localas:
         - standard
-        - large
         - extended
       ipv4: true
       ipv6: true
@@ -523,30 +500,29 @@ nodes:
         as: 65000
         ifindex: 1
         ipv6: true
-        local_if: swp1
+        local_if: eth1
         name: test
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.4
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: none
+    device: none
     id: 4
     interfaces:
     - ifindex: 1
-      ifname: swp1
+      ifname: eth1
       ipv6: true
       linkindex: 4
-      mtu: 1500
       name: x3 -> test
       neighbors:
-      - ifname: swp4
+      - ifname: eth4
         ipv6: true
         node: test
       role: external
       type: p2p
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.4/32
       ipv6: 2001:db8:0:4::1/64
       neighbors: []
@@ -558,7 +534,6 @@ nodes:
       mac: 08:4f:a9:00:00:04
     module:
     - bgp
-    mtu: 1500
     name: x3
   x4:
     af:
@@ -570,14 +545,11 @@ nodes:
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         ibgp_localas:
         - standard
-        - large
         - extended
       ipv4: true
       ipv6: true
@@ -589,7 +561,7 @@ nodes:
         ifindex: 1
         ipv4: 172.31.1.1
         ipv6: true
-        local_if: swp1
+        local_if: eth1
         name: test
         type: ebgp
       - activate:
@@ -598,40 +570,39 @@ nodes:
         as: 65000
         ifindex: 2
         ipv4: true
+        ipv4_rfc8950: true
         ipv6: 2001:db8:1::1
         name: test
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.5
-    box: CumulusCommunity/cumulus-vx:4.4.5
-    device: cumulus
+    box: none
+    device: none
     id: 5
     interfaces:
     - ifindex: 1
-      ifname: swp1
+      ifname: eth1
       ipv4: 172.31.1.2/24
       ipv6: true
       linkindex: 5
-      mtu: 1500
       name: x4 -> test
       neighbors:
-      - ifname: swp5
+      - ifname: eth5
         ipv4: 172.31.1.1/24
         ipv6: true
         node: test
       role: external
       type: p2p
-    - _parent_intf: lo
+    - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.5/32
       ifindex: 2
-      ifname: swp2
+      ifname: eth2
       ipv4: true
       ipv6: 2001:db8:1::2/64
       linkindex: 6
-      mtu: 1500
       name: x4 -> test
       neighbors:
-      - ifname: swp6
+      - ifname: eth6
         ipv4: true
         ipv6: 2001:db8:1::1/64
         node: test
@@ -639,7 +610,7 @@ nodes:
       type: p2p
     loopback:
       ifindex: 0
-      ifname: lo
+      ifname: Loopback0
       ipv4: 10.0.0.5/32
       ipv6: 2001:db8:0:5::1/64
       neighbors: []
@@ -651,6 +622,5 @@ nodes:
       mac: 08:4f:a9:00:00:05
     module:
     - bgp
-    mtu: 1500
     name: x4
 provider: libvirt

--- a/tests/topology/input/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/input/bgp-unnumbered-dual-stack.yml
@@ -1,5 +1,5 @@
 module: [ bgp ]
-defaults.device: cumulus
+defaults.device: none
 
 addressing:
   loopback:
@@ -53,4 +53,3 @@ links:
   prefix:
     ipv4: True
     ipv6: 2001:db8:1::/64
-


### PR DESCRIPTION
The EBGP session creation code was a bit of a mess (including references to non-existent interface 'unnumbered' attribute). With the redefinition of ipv6_lla and rfc8950 feature flags triggered by #1562 and #1565 a refactoring was overdue (hopefully making the code easier to read):

* All references to 'unnumbered' attribute or AF were removed. The link transformation module turns them into 'ipv4: True' and 'ipv6: True' anyway.
* The ipv6_lla feature flag now means 'the box supports IPv6 LLA sessions and RFC 8950 IPv4 AF over those sessions'. We found no device that would support IPv6 LLA EBGP sessions without RFC 8950 IPv4 next hops, so it made no sense to keep two feature flags. If such a device ever appears, the exception will be handled as a device quirk.
* The rfc8950 feature flag means 'the device can do RFC 8950 IPv4 next hops over regular IPv6 EBGP session'. This feature flag is not implemented on any device yet.
* The EBGP session code got sanity checks for matching address paradigm (unnumbered/LLA) on both ends of the link.

Finally, the transformation test case uses the 'none' device to test the RFC8950 behavior over regular IPv6 EBGP session.

Related documentation fixes:

* Rewrote the 'IPv6 LLA' and 'Unnumbered IPv4' parts of EBGP sessions documentation
* Cleaned up the rest of the BGP module documentation as suggested by Grammarly AI ;)
* Updated the list of related BGP plugins (because I stumbled upon it), which triggered the removal of obsolete ebgp.utils plugin documentation and a change in all references to it.