### PR TITLE
lag: Assign unique lag.ifindex

### DIFF
--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -187,7 +187,7 @@ def create_lag_member_links(l: Box, topology: Box) -> None:
             lag_ifindex = _n._lag_ifindex
           else:
             lag_ifindex = 1                       # Start at 1
-          _n._lag_ifindex = lag_ifindex + 1
+          _n._lag_ifindex = lag_ifindex + 1       # Track next ifindex to assign, per node
           i.lag.ifindex = lag_ifindex             # In time to derive interface name from it
 
 """
@@ -327,7 +327,6 @@ class LAG(_Module):
   """
   def node_post_transform(self, node: Box, topology: Box) -> None:
     features = devices.get_device_features(node,topology.defaults)
-    lag_ifindex = 1
     for i in node.interfaces:
       if i.get('lag.mlag.peergroup',None):  # Fill in peer loopback IP and vMAC for MLAG peer links
         populate_mlag_peer(node,i,topology)
@@ -339,3 +338,5 @@ class LAG(_Module):
             category=log.IncorrectAttr,
             module='lag',
             hint='lag')
+
+    node.pop('_lag_ifindex',None)           # Cleanup

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -179,7 +179,16 @@ def create_lag_member_links(l: Box, topology: Box) -> None:
       if i.node!=mlag_1_side:
         if not check_mlag_support(i.node,l._linkname,mlag_device):
           return
-        i.lag.mlag = True                       # Put 'mlag' flag on M-side (only)
+        i.lag.mlag = True                         # Put 'mlag' flag on M-side (only)
+      else:
+        if 'ifindex' not in i.lag:                # else assign lag.ifindex if not provided
+          _n = topology.nodes[i.node]
+          if '_lag_ifindex' in _n:
+            lag_ifindex = _n._lag_ifindex
+          else:
+            lag_ifindex = 1                       # Start at 1
+          _n._lag_ifindex = lag_ifindex + 1
+          i.lag.ifindex = lag_ifindex             # In time to derive interface name from it
 
 """
 create_peer_links -- creates and configures physical link(s) for given peer link
@@ -330,8 +339,3 @@ class LAG(_Module):
             category=log.IncorrectAttr,
             module='lag',
             hint='lag')
-
-        if not i.get('lag.mlag',False):     # For regular lags or the 1-side of MLAGs
-          if 'ifindex' not in i.lag:        # Unless the user chose otherwise
-            i.lag.ifindex = lag_ifindex     # Assign sequential lag.ifindex
-            lag_ifindex = lag_ifindex + 1

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -39,8 +39,6 @@ links:
     ifindex: 30000
     ifname: bond1
     ipv4: 172.16.0.3/24
-    lag:
-      ifindex: 1
     node: h1
     vlan:
       access: red
@@ -77,10 +75,8 @@ links:
   interfaces:
   - _vlan_mode: irb
     ifindex: 30000
-    ifname: bond1
+    ifname: bond2
     ipv4: 172.16.0.4/24
-    lag:
-      ifindex: 1
     node: h2
     vlan:
       access: red
@@ -112,6 +108,44 @@ links:
   type: lag
   vlan:
     access: red
+- _linkname: links[4]
+  bridge: input_4
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 30001
+    ifname: bond3
+    ipv4: 172.16.0.4/24
+    node: h2
+    vlan:
+      access: red
+  - _vlan_mode: irb
+    ifindex: 30002
+    ifname: port-channel3
+    ipv4: 172.16.0.1/24
+    lag:
+      mlag: true
+    node: s1
+    vlan:
+      access: red
+  - _vlan_mode: irb
+    ifindex: 30002
+    ifname: port-channel3
+    ipv4: 172.16.0.2/24
+    lag:
+      mlag: true
+    node: s2
+    vlan:
+      access: red
+  lag:
+    ifindex: 3
+  linkindex: 4
+  node_count: 3
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lag
+  vlan:
+    access: red
 - _linkname: links[1].peerlink[2]
   interfaces:
   - ifindex: 2
@@ -122,7 +156,7 @@ links:
     node: s1
   lag:
     _parentindex: 1
-  linkindex: 4
+  linkindex: 5
   node_count: 2
   prefix: false
   type: p2p
@@ -136,7 +170,7 @@ links:
     node: s1
   lag:
     _parentindex: 2
-  linkindex: 5
+  linkindex: 6
   node_count: 2
   prefix: false
   type: p2p
@@ -150,7 +184,7 @@ links:
     node: s1
   lag:
     _parentindex: 2
-  linkindex: 6
+  linkindex: 7
   node_count: 2
   prefix: false
   type: p2p
@@ -164,7 +198,7 @@ links:
     node: s2
   lag:
     _parentindex: 2
-  linkindex: 7
+  linkindex: 8
   node_count: 2
   prefix: false
   type: p2p
@@ -178,7 +212,7 @@ links:
     node: s2
   lag:
     _parentindex: 2
-  linkindex: 8
+  linkindex: 9
   node_count: 2
   prefix: false
   type: p2p
@@ -192,7 +226,7 @@ links:
     node: s1
   lag:
     _parentindex: 3
-  linkindex: 9
+  linkindex: 10
   node_count: 2
   prefix: false
   type: p2p
@@ -206,7 +240,7 @@ links:
     node: s1
   lag:
     _parentindex: 3
-  linkindex: 10
+  linkindex: 11
   node_count: 2
   prefix: false
   type: p2p
@@ -220,7 +254,7 @@ links:
     node: s2
   lag:
     _parentindex: 3
-  linkindex: 11
+  linkindex: 12
   node_count: 2
   prefix: false
   type: p2p
@@ -234,7 +268,35 @@ links:
     node: s2
   lag:
     _parentindex: 3
-  linkindex: 12
+  linkindex: 13
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[1]
+  interfaces:
+  - ifindex: 5
+    ifname: eth5
+    node: h2
+  - ifindex: 7
+    ifname: ethernet1/1/7
+    node: s1
+  lag:
+    _parentindex: 4
+  linkindex: 14
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[2]
+  interfaces:
+  - ifindex: 6
+    ifname: eth6
+    node: h2
+  - ifindex: 7
+    ifname: ethernet1/1/7
+    node: s2
+  lag:
+    _parentindex: 4
+  linkindex: 15
   node_count: 2
   prefix: false
   type: p2p
@@ -285,7 +347,7 @@ nodes:
       ifname: eth1
       lag:
         _parentindex: 2
-      linkindex: 5
+      linkindex: 6
       mtu: 1500
       name: h1 -> s1
       neighbors:
@@ -296,7 +358,7 @@ nodes:
       ifname: eth2
       lag:
         _parentindex: 2
-      linkindex: 6
+      linkindex: 7
       mtu: 1500
       name: h1 -> s1
       neighbors:
@@ -307,7 +369,7 @@ nodes:
       ifname: eth3
       lag:
         _parentindex: 2
-      linkindex: 7
+      linkindex: 8
       mtu: 1500
       name: h1 -> s2
       neighbors:
@@ -318,7 +380,7 @@ nodes:
       ifname: eth4
       lag:
         _parentindex: 2
-      linkindex: 8
+      linkindex: 9
       mtu: 1500
       name: h1 -> s2
       neighbors:
@@ -392,9 +454,9 @@ nodes:
     id: 4
     interfaces:
     - ifindex: 30000
-      ifname: bond1
+      ifname: bond2
       lag:
-        ifindex: 1
+        ifindex: 2
         lacp: fast
         lacp_mode: active
         mode: 802.3ad
@@ -413,11 +475,33 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+    - ifindex: 30001
+      ifname: bond3
+      lag:
+        ifindex: 3
+        lacp: fast
+        lacp_mode: active
+        mode: 802.3ad
+      linkindex: 4
+      mtu: 1500
+      name: '[Access VLAN red] h2 -> [s1,s2]'
+      neighbors:
+      - ifname: port-channel3
+        ipv4: 172.16.0.1/24
+        node: s1
+      - ifname: port-channel3
+        ipv4: 172.16.0.2/24
+        node: s2
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
     - ifindex: 1
       ifname: eth1
       lag:
         _parentindex: 3
-      linkindex: 9
+      linkindex: 10
       mtu: 1500
       name: h2 -> s1
       neighbors:
@@ -428,7 +512,7 @@ nodes:
       ifname: eth2
       lag:
         _parentindex: 3
-      linkindex: 10
+      linkindex: 11
       mtu: 1500
       name: h2 -> s1
       neighbors:
@@ -439,7 +523,7 @@ nodes:
       ifname: eth3
       lag:
         _parentindex: 3
-      linkindex: 11
+      linkindex: 12
       mtu: 1500
       name: h2 -> s2
       neighbors:
@@ -450,15 +534,37 @@ nodes:
       ifname: eth4
       lag:
         _parentindex: 3
-      linkindex: 12
+      linkindex: 13
       mtu: 1500
       name: h2 -> s2
       neighbors:
       - ifname: ethernet1/1/6
         node: s2
       type: p2p
+    - ifindex: 5
+      ifname: eth5
+      lag:
+        _parentindex: 4
+      linkindex: 14
+      mtu: 1500
+      name: h2 -> s1
+      neighbors:
+      - ifname: ethernet1/1/7
+        node: s1
+      type: p2p
+    - ifindex: 6
+      ifname: eth6
+      lag:
+        _parentindex: 4
+      linkindex: 15
+      mtu: 1500
+      name: h2 -> s2
+      neighbors:
+      - ifname: ethernet1/1/7
+        node: s2
+      type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 7
       ifname: vlan1000
       ipv4: 172.16.0.4/24
       name: VLAN red (1000) -> [h1,s2,s1]
@@ -568,10 +674,33 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
-      - ifname: bond1
+      - ifname: bond2
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel2
+        ipv4: 172.16.0.2/24
+        node: s2
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
+    - ifindex: 30002
+      ifname: port-channel3
+      lag:
+        ifindex: 3
+        lacp: fast
+        lacp_mode: active
+        mlag: true
+        mode: 802.3ad
+      linkindex: 4
+      mtu: 1500
+      name: '[Access VLAN red] s1 -> [h2,s2]'
+      neighbors:
+      - ifname: bond3
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: port-channel3
         ipv4: 172.16.0.2/24
         node: s2
       type: lag
@@ -585,7 +714,7 @@ nodes:
       ifname: ethernet1/1/2
       lag:
         _parentindex: 1
-      linkindex: 4
+      linkindex: 5
       mtu: 1500
       name: s1 -> s2
       neighbors:
@@ -598,7 +727,7 @@ nodes:
       ifname: ethernet1/1/3
       lag:
         _parentindex: 2
-      linkindex: 5
+      linkindex: 6
       mtu: 1500
       name: s1 -> h1
       neighbors:
@@ -611,7 +740,7 @@ nodes:
       ifname: ethernet1/1/4
       lag:
         _parentindex: 2
-      linkindex: 6
+      linkindex: 7
       mtu: 1500
       name: s1 -> h1
       neighbors:
@@ -624,7 +753,7 @@ nodes:
       ifname: ethernet1/1/5
       lag:
         _parentindex: 3
-      linkindex: 9
+      linkindex: 10
       mtu: 1500
       name: s1 -> h2
       neighbors:
@@ -637,15 +766,28 @@ nodes:
       ifname: ethernet1/1/6
       lag:
         _parentindex: 3
-      linkindex: 10
+      linkindex: 11
       mtu: 1500
       name: s1 -> h2
       neighbors:
       - ifname: eth2
         node: h2
       type: p2p
-    - bridge_group: 1
+    - clab:
+        name: eth7
       ifindex: 7
+      ifname: ethernet1/1/7
+      lag:
+        _parentindex: 4
+      linkindex: 14
+      mtu: 1500
+      name: s1 -> h2
+      neighbors:
+      - ifname: eth5
+        node: h2
+      type: p2p
+    - bridge_group: 1
+      ifindex: 8
       ifname: virtual-network1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,s2,h2]
@@ -755,10 +897,33 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
-      - ifname: bond1
+      - ifname: bond2
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel2
+        ipv4: 172.16.0.1/24
+        node: s1
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
+    - ifindex: 30002
+      ifname: port-channel3
+      lag:
+        ifindex: 3
+        lacp: fast
+        lacp_mode: active
+        mlag: true
+        mode: 802.3ad
+      linkindex: 4
+      mtu: 1500
+      name: '[Access VLAN red] s2 -> [h2,s1]'
+      neighbors:
+      - ifname: bond3
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: port-channel3
         ipv4: 172.16.0.1/24
         node: s1
       type: lag
@@ -772,7 +937,7 @@ nodes:
       ifname: ethernet1/1/2
       lag:
         _parentindex: 1
-      linkindex: 4
+      linkindex: 5
       mtu: 1500
       name: s2 -> s1
       neighbors:
@@ -785,7 +950,7 @@ nodes:
       ifname: ethernet1/1/3
       lag:
         _parentindex: 2
-      linkindex: 7
+      linkindex: 8
       mtu: 1500
       name: s2 -> h1
       neighbors:
@@ -798,7 +963,7 @@ nodes:
       ifname: ethernet1/1/4
       lag:
         _parentindex: 2
-      linkindex: 8
+      linkindex: 9
       mtu: 1500
       name: s2 -> h1
       neighbors:
@@ -811,7 +976,7 @@ nodes:
       ifname: ethernet1/1/5
       lag:
         _parentindex: 3
-      linkindex: 11
+      linkindex: 12
       mtu: 1500
       name: s2 -> h2
       neighbors:
@@ -824,15 +989,28 @@ nodes:
       ifname: ethernet1/1/6
       lag:
         _parentindex: 3
-      linkindex: 12
+      linkindex: 13
       mtu: 1500
       name: s2 -> h2
       neighbors:
       - ifname: eth4
         node: h2
       type: p2p
-    - bridge_group: 1
+    - clab:
+        name: eth7
       ifindex: 7
+      ifname: ethernet1/1/7
+      lag:
+        _parentindex: 4
+      linkindex: 15
+      mtu: 1500
+      name: s2 -> h2
+      neighbors:
+      - ifname: eth6
+        node: h2
+      type: p2p
+    - bridge_group: 1
+      ifindex: 8
       ifname: virtual-network1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s1,h2]

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -39,6 +39,8 @@ links:
     ifindex: 30000
     ifname: bond1
     ipv4: 172.16.0.3/24
+    lag:
+      ifindex: 1
     node: h1
     vlan:
       access: red
@@ -75,8 +77,10 @@ links:
   interfaces:
   - _vlan_mode: irb
     ifindex: 30000
-    ifname: bond2
+    ifname: bond1
     ipv4: 172.16.0.4/24
+    lag:
+      ifindex: 1
     node: h2
     vlan:
       access: red
@@ -113,8 +117,10 @@ links:
   interfaces:
   - _vlan_mode: irb
     ifindex: 30001
-    ifname: bond3
+    ifname: bond2
     ipv4: 172.16.0.4/24
+    lag:
+      ifindex: 2
     node: h2
     vlan:
       access: red
@@ -306,6 +312,7 @@ module:
 name: input
 nodes:
   h1:
+    _lag_ifindex: 2
     af:
       ipv4: true
     box: quay.io/frrouting/frr:10.0.1
@@ -438,6 +445,7 @@ nodes:
           allocation: id_based
           ipv4: 172.16.0.0/24
   h2:
+    _lag_ifindex: 3
     af:
       ipv4: true
     box: quay.io/frrouting/frr:10.0.1
@@ -454,9 +462,9 @@ nodes:
     id: 4
     interfaces:
     - ifindex: 30000
-      ifname: bond2
+      ifname: bond1
       lag:
-        ifindex: 2
+        ifindex: 1
         lacp: fast
         lacp_mode: active
         mode: 802.3ad
@@ -476,9 +484,9 @@ nodes:
         access: red
         access_id: 1000
     - ifindex: 30001
-      ifname: bond3
+      ifname: bond2
       lag:
-        ifindex: 3
+        ifindex: 2
         lacp: fast
         lacp_mode: active
         mode: 802.3ad
@@ -674,7 +682,7 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
-      - ifname: bond2
+      - ifname: bond1
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel2
@@ -697,7 +705,7 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
-      - ifname: bond3
+      - ifname: bond2
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel3
@@ -897,7 +905,7 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
-      - ifname: bond2
+      - ifname: bond1
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel2
@@ -920,7 +928,7 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
-      - ifname: bond3
+      - ifname: bond2
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel3

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -312,7 +312,6 @@ module:
 name: input
 nodes:
   h1:
-    _lag_ifindex: 2
     af:
       ipv4: true
     box: quay.io/frrouting/frr:10.0.1
@@ -445,7 +444,6 @@ nodes:
           allocation: id_based
           ipv4: 172.16.0.0/24
   h2:
-    _lag_ifindex: 3
     af:
       ipv4: true
     box: quay.io/frrouting/frr:10.0.1

--- a/tests/topology/input/lag-mlag.yml
+++ b/tests/topology/input/lag-mlag.yml
@@ -30,3 +30,7 @@ links:
    members: [ h2-s1,h2-s1,h2-s2,h2-s2 ]
    mlag: True
   vlan.access: red
+- lag:
+   members: [ h2-s1,h2-s2 ]              # A second lag should get a unique ifindex, not overlapping with the first one
+   mlag: True
+  vlan.access: red


### PR DESCRIPTION
Corrects an issue with duplicate ```lag.ifindex``` assignment, due to restarting the count for each link

Adds a test case for multiple lag links between the same pair of nodes