### PR TITLE
Cumulus_nvue: Don't try to configure MTU for loopback interfaces

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -69,10 +69,6 @@
     interface:
       lo:
         type: loopback
-{%     if lb.mtu is defined %}
-        link:
-          mtu: {{ lb.mtu }}
-{%     endif %}
         ip:
           address:
 {%     if 'ipv4' in lb %}

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -326,7 +326,7 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
       if not sys_mtu:                           # .. does the device support system MTU?
         ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU
 
-  if ifdata.get('type',None)=='loopback':
+  if ifdata.get('type',None) == 'loopback':
     ifdata.pop('mtu',None)                      # Remove MTU from loopback interfaces
 
   node.interfaces.append(ifdata)

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -326,6 +326,9 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
       if not sys_mtu:                           # .. does the device support system MTU?
         ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU
 
+  if ifdata.get('type',None)=='loopback':
+    ifdata.pop('mtu',None)                      # Remove MTU from loopback interfaces
+
   node.interfaces.append(ifdata)
 
   # Box modifies the dict in place, return a reference to be updated

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -46,6 +46,7 @@ links:
     ipv4: 10.1.0.1/32
     node: r2
   linkindex: 4
+  mtu: 1500
   node_count: 1
   prefix:
     ipv4: 172.16.3.0/24

--- a/tests/topology/input/link-loopback.yml
+++ b/tests/topology/input/link-loopback.yml
@@ -27,6 +27,7 @@ links:
 - r2:
     ipv4: 10.1.0.1/32       # Force a /32 as the node IPv4 address
   type: loopback            # While this one is an explicit loopback
+  mtu: 1500                 # MTU setting should be removed/ignored
 - r1:
   prefix: 10.1.0.2/32       # Use a /32 prefix on an implicit loopback interface
 - r1:


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1583

Also modifies Netlab link augmentation code to remove MTU settings from loopbacks, since they generally don't make sense and might trip over other platform templates