### PR TITLE
cumulus_nvue: Fix ospf dict merging

### DIFF
--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -46,7 +46,7 @@
 {% endmacro %}
 
 {% if ospf is defined %}
-{% set _lo = (loopback + { 'ospf': { 'area': ospf.area|default('0.0.0.0') } }) if 'ipv4' in loopback else {} %}
+{% set _lo = dict( { 'ospf': { 'area': ospf.area|default('0.0.0.0') } }, **loopback ) if 'ipv4' in loopback else {} %}
 {% set _ospf_intfs = [_lo] + interfaces|default([])|selectattr('ospf','defined')|list %}
-{{ vrf_ospf("default", { 'ospf': ospf + { 'interfaces': _ospf_intfs } } ) }}
+{{ vrf_ospf("default", { 'ospf': dict( { 'interfaces': _ospf_intfs }, **ospf) } ) }}
 {% endif %}

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,11 +1,11 @@
 description: Cumulus VX 5.x configured with NVUE
 interface_name: swp{ifindex}
 lag_interface_name: "bond{lag.ifindex}"
-loopback_interface_name: lo{ifindex}         # Can assign multiple IPs to 'lo' interface, name ignored by template
+loopback_interface_name: lo{ifindex if ifindex else ""}     # Can assign multiple IPs to 'lo' interface, ifindex ignored by template
 mgmt_if: eth0
-mtu: 1500                                    # Set default MTU for all providers the same
+mtu: 1500                                                   # Set default MTU for all providers the same
 libvirt:
-  image: CumulusCommunity/cumulus-vx:5.10.0  # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
+  image: CumulusCommunity/cumulus-vx:5.10.0                 # Latest as of November 2024, supports PVRST+ on single vlan-aware bridge
 virtualbox:
   image: CumulusCommunity/cumulus-vx:5.10.0
 group_vars:


### PR DESCRIPTION
Fix loopback interface name to be 'lo' instead of 'lo0'

Fixes #1584 