### PR TITLE
Cumulus_nvue: Add quirk to alert user to lack of OSPFv3 support in NVUE

### DIFF
--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -46,7 +46,7 @@
 {% endmacro %}
 
 {% if ospf is defined %}
-{% set _lo = dict( { 'ospf': { 'area': ospf.area|default('0.0.0.0') } }, **loopback ) if 'ipv4' in loopback else {} %}
+{% set _lo = (loopback | combine( { 'ospf': { 'area': ospf.area|default('0.0.0.0') } } )) if 'ipv4' in loopback else {} %}
 {% set _ospf_intfs = [_lo] + interfaces|default([])|selectattr('ospf','defined')|list %}
-{{ vrf_ospf("default", { 'ospf': dict( { 'interfaces': _ospf_intfs }, **ospf) } ) }}
+{{ vrf_ospf("default", { 'ospf': ospf | combine( { 'interfaces': _ospf_intfs } ) } ) }}
 {% endif %}

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -49,14 +49,26 @@ def nvue_check_vrf_route_leaking(node: Box) -> None:
         hint='route leaking')
       return
 
+"""
+Checks for OSPFv3 which is not supported by NVUE configuration command
+"""
+def nvue_check_ospfv3(node: Box) -> None:
+  if node.get('ospf.af.ipv6',False):
+    log.error(f"Node '{node.name}' uses OSPFv3 which cannot be configured through Cumulus NVUE; use a regular 'cumulus' node instead",
+      category=log.FatalError,
+      module='ospf',
+      hint='ospfv3')
+
 class Cumulus_Nvue(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     # Cumulus.device_quirks(node,topology)
     mods = node.get('module',[])
-    if 'ospf' in mods and 'vrfs' in node:
-      check_ospf_vrf_default(node)
+    if 'ospf' in mods:
+      if 'vrfs' in node:
+        check_ospf_vrf_default(node)
+      nvue_check_ospfv3(node)
 
     # NVUE specific quirks
     if 'stp' in mods:


### PR DESCRIPTION
"Fixes" https://github.com/ipspace/netlab/issues/1585

Also cleanup OSPF template using ```combine``` filter instead of **dict expansion