### PR TITLE
Cumulus: Update OSPFv3 support check mark

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -375,7 +375,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Cisco IOSv/IOSvL2     |          ✅          |   ✅    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cisco IOS XE[^18v]    |          ✅          |   ✅    |    ✅     |         ✅          |        ✅         |    ❌    |
 | Cisco Nexus OS        |          ✅          |   ❌    |    ✅     |         ✅          |        ✅         |    ❌    |
-| Cumulus Linux         |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
+| Cumulus Linux         |          ✅          |   ✅    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Cumulus Linux 5.x (NVUE)        |          ✅          |   ❌    |    ✅     |         ❌          |        ✅         |    ❌    |
 | Dell OS10             |          ✅          |   ✅    |    ❌     |         ❌          |        ✅         |    ❌    |
 | Fortinet FortiOS      |          ✅          |   ❌    |    ❌     |         ❌          |        ❌         |    ❌    |


### PR DESCRIPTION
Validated that Cumulus passes the first OSPFv3 integration test