### PR TITLE
Draft: Improve multiprovider p2p links by removing Linux bridge

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -50,7 +50,7 @@
 
 - set:
     system:
-      hostname: {{ inventory_hostname }}
+      hostname: {{ inventory_hostname | replace("_","-") }}
     interface:
       eth0:
         ip:

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -311,6 +311,9 @@ class Libvirt(_Provider):
   def pre_output_transform(self, topology: Box) -> None:
     _Provider.pre_output_transform(self,topology)
 
+    """
+    libvirt_ifname - define an interface name to use, must be <16 characters long
+    """
     def libvirt_ifname(node_id: int, intf:Box) -> str:
       _vifprefix = topology.defaults.get('providers.libvirt.vifprefix',"")
       return f"{_vifprefix}{'_' if _vifprefix else ''}n{node_id}_{intf.ifindex}"
@@ -355,7 +358,6 @@ class Libvirt(_Provider):
         #  continue
 
         if len(link.interfaces) == 2: # and link.type == 'p2p':     # Also 'lag' type links, and really any type with 2 nodes
-          print(f"JvB: P2P link provider(s)={link.provider}")
           if len(link.provider) == 1:
             intf.libvirt.type = "tunnel"                            # ... found a true libvirt-only P2P link, set type to tunnel
             intf.libvirt.ifname = libvirt_ifname(node.id,intf)

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -357,20 +357,16 @@ class Libvirt(_Provider):
         # if len(link.provider) > 1:                                  # Skip multi-provider links
         #  continue
 
+        if node.provider=='libvirt':
+          intf.libvirt.ifname = libvirt_ifname(node.id,intf)
+
         if len(link.interfaces) == 2: # and link.type == 'p2p':     # Also 'lag' type links, and really any type with 2 nodes
           if len(link.provider) == 1:
             intf.libvirt.type = "tunnel"                            # ... found a true libvirt-only P2P link, set type to tunnel
-            intf.libvirt.ifname = libvirt_ifname(node.id,intf)
           else:                                                     # else found a multi-provider P2P link
             if node.provider=='libvirt':
-              intf.libvirt.ifname = libvirt_ifname(node.id,intf)
+              link.clab.uplink = intf.libvirt.ifname                # Connect Clab directly to the vif created by Libvirt (using Macvlan)
               link.libvirt.delete_bridge = True                     # Delete the bridge after Vagrant creates it
-            else:
-              _other = [ i.node for i in link.interfaces if i.node!=node.name ]
-              _node = topology.nodes[ _other[0] ]
-              link.clab.uplink = libvirt_ifname(_node.id,intf)      # Tell clab to attach as macvlan uplink to libvirt.ifname
-        elif node.provider=='libvirt':
-          intf.libvirt.ifname = libvirt_ifname(node.id,intf)
 
         if intf.get('libvirt.type') != 'tunnel':                    # The current link is not a tunnel link, move on
           continue

--- a/netsim/templates/provider/libvirt/libvirt-bridge.j2
+++ b/netsim/templates/provider/libvirt/libvirt-bridge.j2
@@ -1,7 +1,7 @@
 {#
   Bridge-based private network
 #}
-{% set ifname = defaults.providers.libvirt.vifprefix + "_" + name + "_" + l.ifindex|string %}
+{% set ifname = l.libvirt.ifname %}
 {% set pubnet = l.libvirt.public|default('') if 'libvirt' in l else '' %}
 {% if pubnet %}
     {{ name }}.vm.network :public_network,
@@ -11,7 +11,6 @@
 {%   endif %}
 {% else %}
     {{ name }}.vm.network :private_network,
-
                   :libvirt__network_name => "{{ l.bridge }}",
                   :libvirt__forward_mode => "veryisolated",
                   :libvirt__dhcp_enabled => false,
@@ -21,6 +20,8 @@
 {% endif -%}
 {% if ifname|length < 16 %}
                   :libvirt__iface_name => "{{ ifname }}",
+{% else %}
+# l.libvirt.ifname too long: {{ ifname }}
 {% endif %}
                   :autostart => true,
                   :auto_config => false

--- a/netsim/templates/provider/libvirt/libvirt-tunnel.j2
+++ b/netsim/templates/provider/libvirt/libvirt-tunnel.j2
@@ -7,5 +7,5 @@
                   :libvirt__tunnel_local_port => "{{ 10000 + l.ifindex }}",
                   :libvirt__tunnel_ip => "127.1.{{ defaults.providers.libvirt.tunnel_id }}.{{ l.remote_id }}",
                   :libvirt__tunnel_port => "{{ 10000 + l.remote_ifindex }}",
-                  :libvirt__iface_name => "{{ defaults.providers.libvirt.vifprefix }}_{{ vm_name }}_{{ l.ifindex }}",
-                  auto_config: false
+                  :libvirt__iface_name => "{{ l.libvirt.ifname }}",
+                  :auto_config => false

--- a/netsim/utils/linuxbridge.py
+++ b/netsim/utils/linuxbridge.py
@@ -1,5 +1,34 @@
 from . import log
-from ..cli import external_commands
+from ..cli import external_commands, is_dry_run
+
+def create_linux_bridge( brname: str ) -> bool:
+  if external_commands.run_command(
+       ['brctl','show',brname],check_result=True,ignore_errors=True) and not is_dry_run():
+    log.print_verbose(f'Linux bridge {brname} already exists, skipping')
+    return True
+
+  status = external_commands.run_command(
+      ['sudo','ip','link','add','name',brname,'type','bridge'],check_result=True,return_stdout=True)
+  if status is False:
+    return False
+  log.print_verbose( f"Created Linux bridge '{brname}': {status}" )
+
+  status = external_commands.run_command(
+      ['sudo','ip','link','set','dev',brname,'up'],check_result=True,return_stdout=True)
+  if status is False:
+    return False
+  log.print_verbose( f"Enable Linux bridge '{brname}': {status}" )
+
+  status = configure_bridge_forwarding(brname)
+  return status
+
+def destroy_linux_bridge( brname: str ) -> bool:
+  status = external_commands.run_command(
+      ['sudo','ip','link','del','dev',brname],check_result=True,return_stdout=True)
+  if status is False:
+    return False
+  log.print_verbose( f"Delete Linux bridge '{brname}': {status}" )
+  return True
 
 """
 configure_bridge_forwarding - Enables LLDP (and some other L2 protocols) forwarding on the given Linux bridge

--- a/tests/integration/initial/05-multi-provider-links.yml
+++ b/tests/integration/initial/05-multi-provider-links.yml
@@ -16,36 +16,39 @@ groups:
   _auto_create: True
 
   libvirt:
-    members: [libvirt_a,libvirt_b]
+    members: [libvirt-a,libvirt-b]
     device: cumulus
 
   clab:
-    members: [clab_a,clab_b]
+    members: [clab-a,clab-b]
     device: frr
     provider: clab
 
 links: 
-- libvirt_a-libvirt_b  # libvirt-libvirt: p2p tunnel
-- clab_a-clab_b        # clab-clab: veth pair
-- libvirt_a-clab_a     # libvirt-clab p2p: macvlan to tap interface, bridge deleted after Vagrant creates it
-- libvirt_b:           # 3-node LAN: Linux bridge created by libvirt, external to clab in this case
-  clab_a:
-  clab_b:
+- libvirt-a:
+  libvirt-b:           # libvirt-libvirt: p2p tunnel
+- clab-a:
+  clab-b:              # clab-clab: veth pair
+- libvirt-a:
+  clab-a:              # libvirt-clab p2p: macvlan to tap interface, bridge deleted after Vagrant creates it
+- libvirt-b:           # 3-node LAN: Linux bridge created by libvirt, external to clab in this case
+  clab-a:
+  clab-b:
 
 validate:
  ping_libv_libv:
-    description: IPv4 ping libvirt_a => libvirt_b on loopback, depends on OSPF
+    description: IPv4 ping libvirt-a => libvirt-b on loopback, depends on OSPF
     wait: 20
     wait_msg: Wait for IPv4 interfaces to become operational
-    nodes: [ libvirt_a ]
-    plugin: ping('libvirt_b')
+    nodes: [ libvirt-a ]
+    plugin: ping('libvirt-b')
 
  ping_clab_clab:
-    description: IPv4 ping clab_a => clab_b on loopback, depends on OSPF
-    nodes: [ clab_a ]
-    plugin: ping('clab_b')
+    description: IPv4 ping clab-a => clab-b on loopback, depends on OSPF
+    nodes: [ clab-a ]
+    plugin: ping('clab-b')
 
  ping_libv_clab:
-    description: IPv4 ping libvirt_a => clab_a on loopback, depends on OSPF
-    nodes: [ libvirt_a ]
-    plugin: ping('clab_a')
+    description: IPv4 ping libvirt-a => clab-a on loopback, depends on OSPF
+    nodes: [ libvirt-a ]
+    plugin: ping('clab-a')

--- a/tests/integration/initial/05-multi-provider-links.yml
+++ b/tests/integration/initial/05-multi-provider-links.yml
@@ -17,7 +17,7 @@ groups:
 
   libvirt:
     members: [libvirt_a,libvirt_b]
-    device: cumulus_nvue
+    device: cumulus
 
   clab:
     members: [clab_a,clab_b]

--- a/tests/integration/initial/05-multi-provider-links.yml
+++ b/tests/integration/initial/05-multi-provider-links.yml
@@ -36,10 +36,15 @@ links:
   clab-b:
 
 validate:
+ ospf_adj:
+    description: Check OSPF adjacencies
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: 30
+    nodes: [ clab-a, clab-b ]
+    plugin: ospf_neighbor(nodes['libvirt-b'].ospf.router_id)
+
  ping_libv_libv:
     description: IPv4 ping libvirt-a => libvirt-b on loopback, depends on OSPF
-    wait: 20
-    wait_msg: Wait for IPv4 interfaces to become operational
     nodes: [ libvirt-a ]
     plugin: ping('libvirt-b')
 
@@ -52,3 +57,8 @@ validate:
     description: IPv4 ping libvirt-a => clab-a on loopback, depends on OSPF
     nodes: [ libvirt-a ]
     plugin: ping('clab-a')
+
+ ping_clab_lan_bridge:
+    description: IPv4 ping clab-a/b => libvirt-b on loopback, depends on OSPF
+    nodes: [ clab-a, clab-b ]
+    plugin: ping('libvirt-b')

--- a/tests/integration/initial/05-multi-provider-links.yml
+++ b/tests/integration/initial/05-multi-provider-links.yml
@@ -1,0 +1,31 @@
+---
+message: |
+  This scenario tests all possible multi-provider link scenarios. There are 4 main cases:
+  1. Libvirt-libvirt => P2P UDP tunnel
+  2. Clab-clab => P2P veth pair
+  3. Libvirt-Clab => (NEW) tap interface connected to macvlan device from Clab
+  4. 3 nodes or more => Linux bridge (slight variation in who creates it: all Clab->Clab, else Libvirt)
+
+  The reason for introducing a new multi-provider interconnect construct, is that a Linux bridge (as currently used) blocks STP and LACP
+
+provider: libvirt
+
+groups:
+  _auto_create: True
+
+  libvirt:
+    members: [libvirt_a,libvirt_b]
+    device: cumulus_nvue
+
+  clab:
+    members: [clab_a,clab_b]
+    device: frr
+    provider: clab
+
+links: 
+- libvirt_a-libvirt_b  # libvirt-libvirt: p2p tunnel
+- clab_a-clab_b        # clab-clab: veth pair
+- libvirt_a-clab_a     # libvirt-clab p2p: macvlan to tap interface  ## FAILS ##
+- libvirt_a:           # 3-node LAN: Linux bridge created by libvirt, external to clab in this case
+  clab_a:
+  clab_b:

--- a/tests/integration/initial/05-multi-provider-links.yml
+++ b/tests/integration/initial/05-multi-provider-links.yml
@@ -10,6 +10,8 @@ message: |
 
 provider: libvirt
 
+module: [ ospf ]       # Use OSPF to distribute loopback routes
+
 groups:
   _auto_create: True
 
@@ -25,7 +27,25 @@ groups:
 links: 
 - libvirt_a-libvirt_b  # libvirt-libvirt: p2p tunnel
 - clab_a-clab_b        # clab-clab: veth pair
-- libvirt_a-clab_a     # libvirt-clab p2p: macvlan to tap interface  ## FAILS ##
-- libvirt_a:           # 3-node LAN: Linux bridge created by libvirt, external to clab in this case
+- libvirt_a-clab_a     # libvirt-clab p2p: macvlan to tap interface, bridge deleted after Vagrant creates it
+- libvirt_b:           # 3-node LAN: Linux bridge created by libvirt, external to clab in this case
   clab_a:
   clab_b:
+
+validate:
+ ping_libv_libv:
+    description: IPv4 ping libvirt_a => libvirt_b on loopback, depends on OSPF
+    wait: 20
+    wait_msg: Wait for IPv4 interfaces to become operational
+    nodes: [ libvirt_a ]
+    plugin: ping('libvirt_b')
+
+ ping_clab_clab:
+    description: IPv4 ping clab_a => clab_b on loopback, depends on OSPF
+    nodes: [ clab_a ]
+    plugin: ping('clab_b')
+
+ ping_libv_clab:
+    description: IPv4 ping libvirt_a => clab_a on loopback, depends on OSPF
+    nodes: [ libvirt_a ]
+    plugin: ping('clab_a')

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -65,11 +65,11 @@ links:
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
-    ipv4: 172.16.1.2/24
+    ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.1.3/24
+    ipv4: 10.1.0.6/30
     node: r3
   libvirt:
     provider:
@@ -77,20 +77,20 @@ links:
   linkindex: 3
   node_count: 2
   prefix:
-    ipv4: 172.16.1.0/24
-  type: lan
+    ipv4: 10.1.0.4/30
+  type: p2p
 - _linkname: links[4]
   bridge: input_4
   gateway:
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
     node: r3
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.2.5/24
+    ipv4: 172.16.1.5/24
     node: h2
   libvirt:
     provider:
@@ -98,25 +98,25 @@ links:
   linkindex: 4
   node_count: 2
   prefix:
-    ipv4: 172.16.2.0/24
+    ipv4: 172.16.1.0/24
   role: stub
   type: lan
 - _linkname: links[5]
   bridge: input_5
   gateway:
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
   interfaces:
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.4/24
+    ipv4: 172.16.2.4/24
     node: h1
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
     node: r3
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.5/24
+    ipv4: 172.16.2.5/24
     node: h2
   libvirt:
     provider:
@@ -124,7 +124,7 @@ links:
   linkindex: 5
   node_count: 3
   prefix:
-    ipv4: 172.16.3.0/24
+    ipv4: 172.16.2.0/24
   role: stub
   type: lan
 module:
@@ -167,16 +167,16 @@ nodes:
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.4/24
+      ipv4: 172.16.2.4/24
       linkindex: 5
       mtu: 1500
       name: h1 -> [r3,h2]
       neighbors:
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       role: stub
       type: lan
@@ -206,32 +206,32 @@ nodes:
     interfaces:
     - bridge: input_4
       gateway:
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.2.5/24
+      ipv4: 172.16.1.5/24
       linkindex: 4
       mtu: 1500
       name: h2 -> r3
       neighbors:
       - ifname: Ethernet2
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
         node: r3
       role: stub
       type: lan
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.5/24
+      ipv4: 172.16.2.5/24
       linkindex: 5
       mtu: 1500
       name: h2 -> [h1,r3]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       role: stub
       type: lan
@@ -343,18 +343,18 @@ nodes:
     - bridge: input_3
       ifindex: 3
       ifname: GigabitEthernet0/3
-      ipv4: 172.16.1.2/24
+      ipv4: 10.1.0.5/30
       linkindex: 3
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.1.3/24
+        ipv4: 10.1.0.6/30
         node: r3
       ospf:
         area: 0.0.0.0
         network_type: point-to-point
         passive: false
-      type: lan
+      type: p2p
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -396,29 +396,29 @@ nodes:
         name: et1
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 172.16.1.3/24
+      ipv4: 10.1.0.6/30
       linkindex: 3
       name: r3 -> r2
       neighbors:
       - ifname: GigabitEthernet0/3
-        ipv4: 172.16.1.2/24
+        ipv4: 10.1.0.5/30
         node: r2
       ospf:
         area: 0.0.0.0
         network_type: point-to-point
         passive: false
-      type: lan
+      type: p2p
     - bridge: input_4
       clab:
         name: et2
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 172.16.2.3/24
+      ipv4: 172.16.1.3/24
       linkindex: 4
       name: r3 -> h2
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.2.5/24
+        ipv4: 172.16.1.5/24
         node: h2
       ospf:
         area: 0.0.0.0
@@ -431,15 +431,15 @@ nodes:
         name: et3
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 172.16.3.3/24
+      ipv4: 172.16.2.3/24
       linkindex: 5
       name: r3 -> [h1,h2]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -28,7 +28,7 @@ links:
   linkindex: 1
   node_count: 2
   prefix: {}
-  type: lan
+  type: p2p
   vlan:
     trunk:
       blue: {}
@@ -53,7 +53,7 @@ nodes:
       - ifname: eth1
         node: s
       subif_index: 2
-      type: lan
+      type: p2p
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
@@ -146,7 +146,7 @@ nodes:
       - ifname: Ethernet1
         node: r
       subif_index: 2
-      type: lan
+      type: p2p
     - ifindex: 2
       ifname: eth1.1001
       name: '[SubIf VLAN blue] s -> r'


### PR DESCRIPTION
As observed, Linux bridges don't work well with STP or LACP, posing challenges especially in multi-provider topologies

This draft PR proposes a workaround: Implement Libvirt-Clab P2P links (i.e. links having 2 nodes) without a bridge by connecting the clab Macvlan device directly to the Libvirt virtual interface (deleting the Linux bridge created by Vagrant)

A PR like this obviously needs thorough testing, it is not ready to be merged. But before I spend more time doing that, I'd like to get some feedback

Rather than marking multi-provider links as 'lan', this PR annotates the links to orchestrate a different implementation of the underlying connectivity. It never made sense that P2P links suddenly get IPs from a different pool when a different provider is selected, and as a side benefit, this also allows us to keep the 'lag' type links.

It is nicer if both STP and lag can work in multi-provider scenarios, as some platforms only come as containers and others only as Vagrant box

Fixes https://github.com/ipspace/netlab/issues/1581