### PR TITLE
Dell OS10: Disable ipv6 on ipv4-only interfaces

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -74,6 +74,8 @@ interface {{ l.ifname }}
 {%   else %}
 ! Invalid IPv6 address {{ l.ipv6 }}
 {%   endif %}
+{% elif 'ipv4' in l %}
+ no ipv6 enable
 {% endif %}
 !
 {% endfor %}


### PR DESCRIPTION
Dell OS10 enables ipv6 unless told not to. On ipv4-only interfaces it should be disabled