### PR TITLE
OSPF: Enable global default passive

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -144,6 +144,7 @@ OSPF routing daemons support these interface-level features:
 
 * **ospf.reference_bandwidth** sets the OSPF auto-cost reference bandwidth (in Mbps) for all devices in the network.
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
+* **ospf.passive** sets the global default for passive (default: False)
 
 ## Node Parameters
 
@@ -155,6 +156,7 @@ OSPF routing daemons support these interface-level features:
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.
 * **ospf.router_id** -- set [static router ID](routing_router_id).
+* **ospf.passive** -- per node setting for passive interfaces (default: False)
 
 You can specify most node parameters as global values (top-level topology elements) or within individual nodes (see [example](#example) for details).
 

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -59,7 +59,7 @@ attributes:
     cost: { type: int, min_value: 1, max_value: 65534 }
     area: { type: ipv4, use: id }
     bfd: bool
-    passive: { copy: global }
+    passive: bool
     network_type: { type: str, valid_values: [ point-to-point, point-to-multipoint, broadcast, non-broadcast ] }
 
 features:

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -12,6 +12,7 @@ attributes:
       ipv4: bool
       ipv6: bool
     area: { type: ipv4, use: id }
+    passive: bool
     process: { type: int, min_value: 1 }
     reference_bandwidth: { type: int, min_value: 1 }
     bfd:
@@ -23,6 +24,7 @@ attributes:
   node:
     af:
     area:
+    passive:
     process:
     reference_bandwidth:
     bfd:
@@ -37,7 +39,7 @@ attributes:
         cost: int
         type: { type: str, valid_values: [ e1, e2 ] }
 
-  node_copy: [ area ]
+  node_copy: [ area, passive ]
   vrf_aware: [ area ]
   vrf_copy: [ area, router_id, reference_bandwidth ]
   vrf:
@@ -57,7 +59,7 @@ attributes:
     cost: { type: int, min_value: 1, max_value: 65534 }
     area: { type: ipv4, use: id }
     bfd: bool
-    passive: bool
+    passive: { copy: global }
     network_type: { type: str, valid_values: [ point-to-point, point-to-multipoint, broadcast, non-broadcast ] }
 
 features:

--- a/netsim/validate/ospf/frr.py
+++ b/netsim/validate/ospf/frr.py
@@ -10,14 +10,14 @@ from netsim.utils import log
 from .. import _common
 from . import OSPF_PREFIX_NAMES
 
-def show_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> str:
+def show_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default', count: int = 0) -> str:
   try:
     netaddr.IPAddress(id)
   except:
     raise Exception(f'OSPF router ID {id} is not a valid IP address')
   return f'ip ospf ' + (f'vrf {vrf} ' if vrf != 'default' else '') + f'neighbor {id} json'
 
-def valid_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> bool:
+def valid_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default', count: int = 0) -> bool:
   _result = global_vars.get_result_dict('_result')
 
   if vrf in _result:
@@ -27,7 +27,10 @@ def valid_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> 
     if not present:
       return True
     raise Exception(f'There is no OSPF neighbor {id}')
-  
+
+  if count and len(_result[id])!=count:
+    raise Exception(f'Expecting {count} adjacencies for {id}, but found {len(_result[id])}')
+
   n_state = _result[id][0]
   if not present:
     raise Exception(f'Unexpected neighbor {id} in state {n_state.nbrState}')

--- a/tests/integration/ospf/ospfv2/06-default-passive.yml
+++ b/tests/integration/ospf/ospfv2/06-default-passive.yml
@@ -1,0 +1,84 @@
+---
+message: |
+  This lab tests whether OSPF interfaces can be configured as 'passive' by default, enabling only 1 VLAN in a trunk to setup an OSPF adjacency.
+  Without this, OSPF would create adjacencies on all VLANs and the route table ends up with duplicate routes via nexthops that are different VLANs 
+  on the same physical node
+
+  Using FRR
+  1. Deploy lab without OSPF passive: netlab up integration/ospf/ospfv2/06-default-passive.yml -d frr -v -p clab -s ospf.passive=False
+  2. netlab exec dut vtysh -c 'show ip ospf neigh'
+  3. netlab validate -> should fail
+  4. Teardown lab: netlab down --cleanup
+  5. Bring up with OSPF passive: netlab up integration/ospf/ospfv2/06-default-passive.yml -d frr -v -p clab
+  6. netlab validate -> now succeeds
+
+module: [ ospf, vlan ]
+
+ospf.passive: True # Configure OSPF interfaces as passive by default
+
+vlans:
+ active:
+  prefix.ipv4: 10.42.1.0/24
+  ospf.passive: False
+  ospf.cost: 100
+ passive1:
+ passive2:
+
+groups:
+  probes:
+    device: frr
+    provider: clab
+    members: [ x1, x2 ]
+
+nodes:
+  dut:
+  x1:
+  x2:
+
+links:
+- dut:
+  x1:
+  ospf.cost: 10
+  mtu: 1500
+  vlan.trunk: [active,passive1,passive2]
+
+- dut:
+  x2:
+  mtu: 1500
+  vlan.access: active
+
+- x1:
+  x2:
+  ospf.cost: 100
+  ospf.passive: False
+  mtu: 1500
+
+- dut:
+  prefix.ipv4: 10.42.2.0/24
+  ospf.cost: 25
+  mtu: 1500
+
+validate:
+  adj_x1:
+    description: Is DUT a neigbor of X1?
+    wait: 30
+    wait_msg: Waiting for OSPF adjacency process to complete
+    pass: OK, X1 has DUT as a neighbor
+    nodes: [ x1 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id,count=1)
+  wait:
+    description: Wait extra 15 seconds just to be on the safe side ;)
+    wait: 15
+  adj_x2:
+    description: Is DUT a neigbor of X2?
+    nodes: [ x2 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id,present=True,count=1)
+    pass: OK, X2 can see DUT as a neighbor
+  c_p1:
+    description: Check cost of IPv4 prefix on access VLAN interface on DUT
+    nodes: [ x1 ]
+    plugin: ospf_prefix('10.42.1.0/24',cost=100)
+  c_x2:
+    description: Check cost of IPv4 prefix on stub interface on DUT
+    nodes: [ x1 ]
+    plugin: ospf_prefix('10.42.2.0/24',cost=125)


### PR DESCRIPTION
* Allow ```ospf.passive``` to be set globally or per node
* Extend OSPFv2 validation plugin for FRR with a ```count``` parameter that checks the number of adjacencies
* Add integration test case to test OSPF passive