### PR TITLE
STP: Add stp.port_type configuration for Cumulus 4.x/NVUE, EOS and Dell OS10

### DIFF
--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -31,7 +31,7 @@ MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
 ## Global Parameters
 
 * **stp.protocol** (one of stp, mstp, rstp or pvrst) -- Global STP flavor to run on supporting nodes, default **stp**
-* **stp.stub_port_type** (one of 'normal','edge','network','auto' or 'none') -- Port type to configure on ports with only hosts connected, default **'edge'**
+* **stp.stub_port_type** (one of 'normal','edge','network','auto' or 'none') -- Port type to configure on ports with only hosts connected, default **'none'**
 
 ## Global, Node, Link, Interface, and VLAN Parameters
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -44,7 +44,7 @@ You can set the **‌stp.enable** parameter in the **‌vlans** dictionary to en
 ## Node Parameters (global or per VLAN)
 
 * **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default, all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
-* **stp.port_type** (one of 'normal','edge','network' or 'auto') -- STP port type for all interfaces connected to this link
+* **stp.port_type** (one of 'normal','edge','network' or 'auto') -- STP port type for all interfaces connected to this node
 
 ## Interface Parameters
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -13,9 +13,10 @@ The following table describes per-platform support of individual STP features:
 | ------------------ |:---:|:---:|:---:|:---:|:---:|
 | Arista EOS[^EOS]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Aruba AOS-CX[^AOSCX] | ❗  | ✅  | ❌  | ✅ |  ✅ |
-| Cumulus Linux[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
-| Dell OS10[^OS10]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
-| FRR[^FRR]          | ✅  |  ❌  |  ❌  |  ✅ | ❌   |
+| Cumulus Linux 4.x[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |  ✅ |    
+| Cumulus 5.x (NVUE)[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |  ✅ |  
+| Dell OS10[^OS10]   | ✅  | ✅  | ✅  | ✅ |  ✅ |  ✅ |
+| FRR[^FRR]          | ✅  |  ❌  |  ❌  |  ✅ | ❌   | ❌   |
 
 [^EOS]: MSTP is enabled by default
 [^AOSCX]: MSTP is enabled by default; STP is stated as not supported, but it is configured as MSTP (see tip below).
@@ -30,7 +31,7 @@ MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
 ## Global Parameters
 
 * **stp.protocol** (one of stp, mstp, rstp or pvrst) -- Global STP flavor to run on supporting nodes, default **stp**
-* **stp.host_edge_port** (bool) -- Configure ports with only hosts connected as 'edge' port_type on platforms that support it, default **True**
+* **stp.stub_port_type** (one of 'normal','edge','network','auto' or 'none') -- Port type to configure on ports with only hosts connected, default **'edge'**
 
 ## Global, Node, Link, Interface, and VLAN Parameters
 
@@ -43,9 +44,9 @@ You can set the **‌stp.enable** parameter in the **‌vlans** dictionary to en
 ## Node Parameters (global or per VLAN)
 
 * **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default, all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
-* **stp.port_type** (one of 'normal','edge','network') -- STP port type for all interfaces connected to this link
+* **stp.port_type** (one of 'normal','edge','network' or 'auto') -- STP port type for all interfaces connected to this link
 
 ## Interface Parameters
 
 * **stp.port_priority** (int 0..15) -- STP port priority for selecting between multiple ports; ports are blocked based on priority (lower value = higher priority). The priority is sent over the wire (4 bits) as the most significant part of the port ID; it is used by the node *receiving* it (!) to decide which port(s) to unblock. Note that on many platforms, the value that ends up in the configuration is a multiple (x16) of this attribute
-* **stp.port_type** (one of 'normal','edge','network') -- STP port type for this interface, default 'normal'
+* **stp.port_type** (one of 'normal','edge','network' or 'auto') -- STP port type for this interface, default 'normal'

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -30,6 +30,7 @@ MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
 ## Global Parameters
 
 * **stp.protocol** (one of stp, mstp, rstp or pvrst) -- Global STP flavor to run on supporting nodes, default **stp**
+* **stp.host_edge_port** (bool) -- Configure ports with only hosts connected as 'edge' port_type on platforms that support it, default **True**
 
 ## Global, Node, Link, Interface, and VLAN Parameters
 
@@ -42,8 +43,9 @@ You can set the **‌stp.enable** parameter in the **‌vlans** dictionary to en
 ## Node Parameters (global or per VLAN)
 
 * **stp.priority** (int 0..61440 in increments of 1024) -- STP priority for root election, by default, all nodes have equal priority 32656.  In case of equal priority, the bridge with the lowest MAC address becomes root; note that MAC addresses are assigned randomly in Netlab
+* **stp.port_type** (one of 'normal','edge','network') -- STP port type for all interfaces connected to this link
 
 ## Interface Parameters
 
 * **stp.port_priority** (int 0..15) -- STP port priority for selecting between multiple ports; ports are blocked based on priority (lower value = higher priority). The priority is sent over the wire (4 bits) as the most significant part of the port ID; it is used by the node *receiving* it (!) to decide which port(s) to unblock. Note that on many platforms, the value that ends up in the configuration is a multiple (x16) of this attribute
-
+* **stp.port_type** (one of 'normal','edge','network') -- STP port type for this interface, default 'normal'

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -38,7 +38,7 @@ iface {{ ifdata.ifname }}
 {%  endif %}
 {%  set port_type = ifdata.stp.port_type|default("normal") %}
  mstpctl-portadminedge {{ 'yes' if port_type=='edge' else 'no' }}
- mstpctl-portautoedge {{ 'yes' if port_type=='normal' else 'no' }}
+ mstpctl-portautoedge {{ 'yes' if port_type in ['normal','auto'] else 'no' }}
 {% endfor %}
 CONFIG
 

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -36,9 +36,11 @@ iface {{ ifdata.ifname }}
 # Newer versions 5.x support mstpctl-port-vlan-priority <vlan id>={{ ifdata.stp.port_priority }}
 #
 {%  endif %}
-{%  set port_type = ifdata.stp.port_type|default("normal") %}
+{%  if ifdata.stp.port_type is defined %}
+{%    set port_type = ifdata.stp.port_type %}
  mstpctl-portadminedge {{ 'yes' if port_type=='edge' else 'no' }}
  mstpctl-portautoedge {{ 'yes' if port_type in ['normal','auto'] else 'no' }}
+{%  endif %}
 {% endfor %}
 CONFIG
 

--- a/netsim/ansible/templates/stp/cumulus.j2
+++ b/netsim/ansible/templates/stp/cumulus.j2
@@ -36,6 +36,9 @@ iface {{ ifdata.ifname }}
 # Newer versions 5.x support mstpctl-port-vlan-priority <vlan id>={{ ifdata.stp.port_priority }}
 #
 {%  endif %}
+{%  set port_type = ifdata.stp.port_type|default("normal") %}
+ mstpctl-portadminedge {{ 'yes' if port_type=='edge' else 'no' }}
+ mstpctl-portautoedge {{ 'yes' if port_type=='normal' else 'no' }}
 {% endfor %}
 CONFIG
 

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -45,9 +45,11 @@
                   '{{ ifdata.vlan.access_id|default(1) }}':
                     priority: {{ ifdata.stp.port_priority * 16 }}
 {%   endif %}
-{%   set port_type = ifdata.stp.port_type|default("normal") %}
+{%   if ifdata.stp.port_type is defined %}
+{%     set port_type = ifdata.stp.port_type %}
                 admin-edge: {{ 'on' if port_type=='edge' else 'off' }}
                 auto-edge: {{ 'on' if port_type in ['normal','auto'] else 'off' }}
+{%   endif %}
 {%  elif ifdata.vlan.trunk_id is defined %}
 {%   for id in ifdata.vlan.trunk_id %}
 {%    if loop.first %}

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -47,7 +47,7 @@
 {%   endif %}
 {%   set port_type = ifdata.stp.port_type|default("normal") %}
                 admin-edge: {{ 'on' if port_type=='edge' else 'off' }}
-                auto-edge: {{ 'on' if port_type=='normal' else 'off' }}
+                auto-edge: {{ 'on' if port_type in ['normal','auto'] else 'off' }}
 {%  elif ifdata.vlan.trunk_id is defined %}
 {%   for id in ifdata.vlan.trunk_id %}
 {%    if loop.first %}

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -45,6 +45,9 @@
                   '{{ ifdata.vlan.access_id|default(1) }}':
                     priority: {{ ifdata.stp.port_priority * 16 }}
 {%   endif %}
+{%   set port_type = ifdata.stp.port_type|default("normal") %}
+                admin-edge: {{ 'on' if port_type=='edge' else 'off' }}
+                auto-edge: {{ 'on' if port_type=='normal' else 'off' }}
 {%  elif ifdata.vlan.trunk_id is defined %}
 {%   for id in ifdata.vlan.trunk_id %}
 {%    if loop.first %}

--- a/netsim/ansible/templates/stp/dellos10.j2
+++ b/netsim/ansible/templates/stp/dellos10.j2
@@ -28,6 +28,8 @@ spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
 {%  for ifdata in interfaces if 'stp' in ifdata or ifdata.vlan.trunk|default({})|dict2items|map(attribute='value')|selectattr('stp','defined') %}
 interface {{ ifdata.ifname }}
 {%   if 'stp' in ifdata %}
+{%    set _no = "" if ifdata.stp.port_type|default("")=='edge' else "no " %}
+ {{ _no }}spanning-tree port type edge
 {%    if not ifdata.stp.enable|default(True) %}
  spanning-tree disable
 {%    elif 'port_priority' in ifdata.stp %}

--- a/netsim/ansible/templates/stp/dellos10.j2
+++ b/netsim/ansible/templates/stp/dellos10.j2
@@ -28,7 +28,7 @@ spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
 {%  for ifdata in interfaces if 'stp' in ifdata or ifdata.vlan.trunk|default({})|dict2items|map(attribute='value')|selectattr('stp','defined') %}
 interface {{ ifdata.ifname }}
 {%   if 'stp' in ifdata %}
-{%    set _no = "" if ifdata.stp.port_type|default("")=='edge' else "no " %}
+{%    set _no = "" if ifdata.stp.port_type|default("normal")=='edge' else "no " %}
  {{ _no }}spanning-tree port type edge
 {%    if not ifdata.stp.enable|default(True) %}
  spanning-tree disable

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -36,5 +36,5 @@ interface {{ ifdata.ifname }}
 #
 {%    endif %} 
 {%   endif %}
- spanning-tree portfast {{ ifdata.stp.port_type|default('auto') }}
+ spanning-tree portfast {{ ifdata.stp.port_type|default('normal') }}
 {% endfor %}

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -36,5 +36,7 @@ interface {{ ifdata.ifname }}
 #
 {%    endif %} 
 {%   endif %}
- spanning-tree portfast {{ ifdata.stp.port_type|default('normal') }}
+{%   if ifdata.stp.port_type is defined %}
+ spanning-tree portfast {{ ifdata.stp.port_type }}
+{%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/stp/eos.j2
+++ b/netsim/ansible/templates/stp/eos.j2
@@ -36,4 +36,5 @@ interface {{ ifdata.ifname }}
 #
 {%    endif %} 
 {%   endif %}
+ spanning-tree portfast {{ ifdata.stp.port_type|default('auto') }}
 {% endfor %}

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -102,6 +102,7 @@ features:
     # Platform supports pvrst too, but current implementation based on single VLAN-aware bridge
     # does not in current (old) version
     enable_per_port: True
+    port_type: True
   vlan:
     model: switch
     svi_interface_name: "vlan{vlan}"

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -36,6 +36,7 @@ features:
   stp:
     supported_protocols: [ stp, rstp, pvrst ]  # PVRST requires release 5.6.0 or higher
     enable_per_port: True
+    port_type: True
   vlan:
     model: switch
     svi_interface_name: "vlan{vlan}"

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -34,6 +34,7 @@ features:
   stp:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
+    port_type: True
   vlan:
     model: switch
     svi_interface_name: virtual-network{vlan}

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -88,6 +88,7 @@ features:
     # See https://www.arista.com/assets/data/pdf/Whitepapers/STPInteroperabilitywithCisco.pdf
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
+    port_type: True
   vlan:
     model: l3-switch
     native_routed: true

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -66,6 +66,10 @@ features:
       inter_vrf: True
   sr: True
   srv6: True
+  stp:
+    supported_protocols: [ stp, rstp, mstp, pvrst ]
+    enable_per_port: True
+    port_type: True
   vlan:
     model: l3-switch
     svi_interface_name: Vlan{vlan}

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -55,12 +55,12 @@ class STP(_Module):
             f'node {node.name}: Cannot apply STP to L3 interface ({intf.ifname})',
             log.IncorrectAttr,
             'stp')
-        elif 'enable' in intf.stp and not features.get('stp.enable_per_port',False):
+        if 'enable' in intf.stp and not features.get('stp.enable_per_port',False):
           log.error(
             f'node {node.name} (device {node.device}) does not support enabling/disabling STP only on a specific port ({intf.ifname})',
             log.IncorrectValue,
             'stp')
-        elif 'port_type' in intf.stp and not features.get('stp.port_type',False):
+        if 'port_type' in intf.stp and not features.get('stp.port_type',False):
           log.error(
             f'node {node.name} (device {node.device}) does not support configuration of STP port_type on ({intf.ifname})',
             log.IncorrectValue,

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -16,7 +16,6 @@ def supports_stp(intf: Box) -> bool:
     return False
   if 'virtual_interface' in intf:                                            # Skip virtual interfaces
     return False
-  print(f"intf {intf} supports STP")
   return True
 
 """
@@ -55,7 +54,7 @@ class STP(_Module):
             log.IncorrectValue,
             'stp')
 
-    stub_port_type = topology.get('stp.stub_port_type','edge') if features.get('stp.port_type',False) else 'none'
+    stub_port_type = topology.get('stp.stub_port_type','none')
     for intf in node.get('interfaces',[]):
       if 'stp' in intf:
         if 'ipv4' in intf or 'ipv6' in intf:
@@ -73,8 +72,9 @@ class STP(_Module):
             f'node {node.name} (device {node.device}) does not support configuration of STP port_type on ({intf.ifname})',
             log.IncorrectValue,
             'stp')
+      if not features.get('stp.port_type',False):                   # If the device doesn't support it, move on
+        continue
       stp_port_type = intf.get('stp.port_type',None)
-      print(stp_port_type)
       if stp_port_type is None and supports_stp(intf):
         if stub_port_type != 'none':
           if configure_stub_port_type(intf,stub_port_type,topology):
@@ -88,7 +88,7 @@ class STP(_Module):
               continue
         stp_port_type = node.get('stp.port_type',None)              # Apply node level setting to ports that support it
         if stp_port_type is not None:
-          intf.stp.port_type = stp_port_type                   # Conditional copy
+          intf.stp.port_type = stp_port_type                        # Conditional copy
       
     # Check if per-VLAN priority is being used
     for vname,vdata in node.get('vlans',{}).items():

--- a/netsim/modules/stp.py
+++ b/netsim/modules/stp.py
@@ -65,7 +65,7 @@ class STP(_Module):
             f'node {node.name} (device {node.device}) does not support configuration of STP port_type on ({intf.ifname})',
             log.IncorrectValue,
             'stp')
-      if set_host_edge_port:
+      if set_host_edge_port and not intf.get('stp.port_type',None):
         configure_host_edge_port(intf,topology)
       
     # Check if per-VLAN priority is being used

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -4,16 +4,16 @@
 requires: [ vlan ]  # Perhaps not on all platforms
 transform_after: [ vlan ]
 config_after: [ vlan ]
-no_propagate: [ host_edge_port ]
+no_propagate: [ stub_port_type ]
 
 enable: True           # By default, enable STP on all devices where this module is activated
 protocol: "stp"        # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
-host_edge_port: True   # Whether to auto-configure port_type as 'edge' for ports with only hosts connected, default True
+stub_port_type: "edge" # Port type to configure on ports with only hosts connected, default 'edge'
 
 attributes:
   global:
     enable: bool
-    host_edge_port: bool
+    stub_port_type: { type: str, valid_values: [ 'normal', 'edge', 'network', 'auto', 'none' ] }
     protocol: { type: str, valid_values: [ stp, rstp, mstp, pvrst ] }
     # mstp = IEEE 802.1s, pvrst = Per-VLAN Rapid Spanning Tree (802.1w)
   node:
@@ -25,13 +25,13 @@ attributes:
   link:
     enable:
       copy: global
-    port_type: { type: str, valid_values: [ normal, edge, network ] } # Apply this port_type to all connected interfaces
+    port_type: { type: str, valid_values: [ normal, edge, network, auto ] } # Apply this port_type to all connected interfaces
 
   intf_to_neighbor: False # By default, do not include STP attributes in neighbors
   interface:
     enable: bool
     port_priority: { type: int, min_value: 0, max_value: 15 }         # 4-bit value, default '8' if not set
-    port_type: { type: str, valid_values: [ normal, edge, network ] }
+    port_type: { type: str, valid_values: [ normal, edge, network, auto ] }
 
 _top:               # Modification of global defaults
   attributes:

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -28,7 +28,7 @@ attributes:
   link:
     enable:
       copy: global
-    port_type:
+    port_type:                 # Also applies to VLANs (?)
       copy: global
 
   intf_to_neighbor: False # By default, do not include STP attributes in neighbors
@@ -43,9 +43,9 @@ _top:               # Modification of global defaults
       stp.priority: { type: int, min_value: 0, max_value: 61440 }
       # Per-VLAN STP priority for this node, implies pvrst
 
-    vlan:
-      port_type:
-        copy: global
+    # vlan:
+    #   port_type:
+    #     copy: global
 
 
 features:

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -8,16 +8,19 @@ no_propagate: [ stub_port_type ]
 
 enable: True           # By default, enable STP on all devices where this module is activated
 protocol: "stp"        # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
-stub_port_type: "edge" # Port type to configure on ports with only hosts connected, default 'edge'
+stub_port_type: "none" # Port type to configure on ports with only hosts connected, default 'none' (disabled)
 
 attributes:
   global:
     enable: bool
     stub_port_type: { type: str, valid_values: [ 'normal', 'edge', 'network', 'auto', 'none' ] }
+    port_type: { type: str, valid_values: [ normal, edge, network, auto ] } # Apply this port_type globally
     protocol: { type: str, valid_values: [ stp, rstp, mstp, pvrst ] }
     # mstp = IEEE 802.1s, pvrst = Per-VLAN Rapid Spanning Tree (802.1w)
   node:
     enable:
+      copy: global
+    port_type:
       copy: global
     priority: { type: int, min_value: 0, max_value: 61440 }
     # Increments of 4096, default 32768, lower value = higher priority
@@ -25,7 +28,8 @@ attributes:
   link:
     enable:
       copy: global
-    port_type: { type: str, valid_values: [ normal, edge, network, auto ] } # Apply this port_type to all connected interfaces
+    port_type:
+      copy: global
 
   intf_to_neighbor: False # By default, do not include STP attributes in neighbors
   interface:
@@ -38,6 +42,11 @@ _top:               # Modification of global defaults
     node_vlan:
       stp.priority: { type: int, min_value: 0, max_value: 61440 }
       # Per-VLAN STP priority for this node, implies pvrst
+
+    vlan:
+      port_type:
+        copy: global
+
 
 features:
   supported_protocols: Subset of supported STP variants

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -4,14 +4,16 @@
 requires: [ vlan ]  # Perhaps not on all platforms
 transform_after: [ vlan ]
 config_after: [ vlan ]
-# no_propagate: [ protocol ]
+no_propagate: [ host_edge_port ]
 
-enable: True        # By default, enable STP everywhere (on all bridges created by Netlab) when this module is used
-protocol: "stp"     # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
+enable: True           # By default, enable STP on all devices where this module is activated
+protocol: "stp"        # Default to basic 802.1D STP protocol, users may explicitly enable fancier newer flavors
+host_edge_port: True   # Whether to auto-configure port_type as 'edge' for ports with only hosts connected, default True
 
 attributes:
   global:
     enable: bool
+    host_edge_port: bool
     protocol: { type: str, valid_values: [ stp, rstp, mstp, pvrst ] }
     # mstp = IEEE 802.1s, pvrst = Per-VLAN Rapid Spanning Tree (802.1w)
   node:
@@ -23,11 +25,13 @@ attributes:
   link:
     enable:
       copy: global
+    port_type: { type: str, valid_values: [ normal, edge, network ] } # Apply this port_type to all connected interfaces
 
   intf_to_neighbor: False # By default, do not include STP attributes in neighbors
   interface:
     enable: bool
-    port_priority: { type: int, min_value: 0, max_value: 15 }  # 4-bit value, default '8' if not set
+    port_priority: { type: int, min_value: 0, max_value: 15 }         # 4-bit value, default '8' if not set
+    port_type: { type: str, valid_values: [ normal, edge, network ] }
 
 _top:               # Modification of global defaults
   attributes:

--- a/tests/errors/stp-on-l3-intf.log
+++ b/tests/errors/stp-on-l3-intf.log
@@ -1,3 +1,3 @@
-IncorrectAttr in stp: node r1: Cannot apply STP to L3 interface (ethernet1/1/1)
-IncorrectAttr in stp: node r2: Cannot apply STP to L3 interface (ethernet1/1/1)
+IncorrectAttr in stp: node r1: Cannot apply STP to L3 interface (r1 -> r2)
+IncorrectAttr in stp: node r2: Cannot apply STP to L3 interface (r2 -> r1)
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/integration/stp/08-stp-port-type.yml
+++ b/tests/integration/stp/08-stp-port-type.yml
@@ -7,7 +7,9 @@ message: |
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
 
-stp.enable: True
+stp:
+  enable: True
+  stub_port_type: edge           # auto-configure host ports as 'edge'
 
 groups:
   _auto_create: True
@@ -16,7 +18,7 @@ groups:
     device: linux
     provider: clab
   switches:
-    members: [ s1,s2 ]
+    members: [ s1,s2,s3 ]
     module: [ vlan, stp ]
 
 vlans:
@@ -25,13 +27,27 @@ vlans:
     links: [ s1-h1, s2-h2 ]
   blue:
     mode: bridge
-    links: [ s1-h3, s2-h4 ]
+    links: [ s1-h3 ]
+  green:
+    mode: bridge
+    stp.port_type: normal # Test: VLAN port_type
+    links: [ s2-h4 ]
+
+nodes:
+  s3:
+    stp.port_type: edge   # Test: node-level stp port_type
 
 links:
 - s1:
   s2:
   vlan.trunk: [red,blue]
   stp.port_type: network
+
+- s1-s3  # IP interface, module should not apply STP port_type setting here
+
+- s2:
+  s3:
+  vlan.access: green # Should both get 'normal' stp.port_type
 
 validate:
   ping_red:

--- a/tests/integration/stp/08-stp-port-type.yml
+++ b/tests/integration/stp/08-stp-port-type.yml
@@ -1,0 +1,50 @@
+---
+message: |
+  The devices under test form a server cluster connected to a pair of ToR switches.
+  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is manually configured as 'network'
+
+  * h1 and h2 should be able to ping each other
+  * h3 and h4 should be able to ping each other
+  * h1 should not be able to reach h3
+
+stp.enable: True
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h1, h2, h3, h4 ]  # Devices with role: host
+    device: linux
+    provider: clab
+  switches:
+    members: [ s1,s2 ]
+    module: [ vlan, stp ]
+
+vlans:
+  red:
+    mode: bridge
+    links: [ s1-h1, s2-h2 ]
+  blue:
+    mode: bridge
+    links: [ s1-h3, s2-h4 ]
+
+links:
+- s1:
+  s2:
+  vlan.trunk: [red,blue]
+  stp.port_type: network
+
+validate:
+  ping_red:
+    description: Ping-based reachability test in VLAN red
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')
+  ping_blue:
+    description: Ping-based reachability test in VLAN blue
+    nodes: [ h3 ]
+    plugin: ping('h4')
+  inter_vlan:
+    description: Ping-based reachability test between blue and red VLANs
+    nodes: [ h1 ]
+    plugin: ping('h3',expect='fail')

--- a/tests/integration/stp/08-stp-port-type.yml
+++ b/tests/integration/stp/08-stp-port-type.yml
@@ -1,7 +1,7 @@
 ---
 message: |
   The devices under test form a server cluster connected to a pair of ToR switches.
-  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is 
+  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is
   manually configured as 'network'
 
   * h1 and h2 should be able to ping each other
@@ -41,14 +41,14 @@ nodes:
 links:
 - s1:
   s2:
-  vlan.trunk: [red,blue]
+  vlan.trunk: [ red, blue ]
   stp.port_type: network
 
 - s1-s3  # IP interface, module should not apply STP port_type setting here
 
 - s2:
   s3:
-  vlan.access: green # Should both get 'normal' stp.port_type, on vlan
+  vlan.access: green # Should both get 'normal' stp.port_type, on the interface
 
 validate:
   ping_red:

--- a/tests/integration/stp/08-stp-port-type.yml
+++ b/tests/integration/stp/08-stp-port-type.yml
@@ -1,7 +1,8 @@
 ---
 message: |
   The devices under test form a server cluster connected to a pair of ToR switches.
-  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is manually configured as 'network'
+  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is 
+  manually configured as 'network'
 
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
@@ -18,7 +19,7 @@ groups:
     device: linux
     provider: clab
   switches:
-    members: [ s1,s2,s3 ]
+    members: [ s1, s2, s3 ]
     module: [ vlan, stp ]
 
 vlans:

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -395,8 +395,6 @@ nodes:
       neighbors:
       - ifname: Ethernet1
         node: s2
-        stp:
-          port_type: network
       stp:
         port_type: network
       type: p2p
@@ -432,8 +430,6 @@ nodes:
       neighbors:
       - ifname: Ethernet4
         node: s3
-        stp:
-          port_type: auto
       type: p2p
     - bridge: input_6
       ifindex: 5
@@ -547,8 +543,6 @@ nodes:
       neighbors:
       - ifname: Ethernet1
         node: s1
-        stp:
-          port_type: network
       stp:
         port_type: network
       type: p2p

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -1,0 +1,625 @@
+groups:
+  hosts:
+    device: linux
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+    node_data:
+      provider: clab
+  switches:
+    members:
+    - s1
+    - s2
+    - s3
+    module:
+    - vlan
+    - stp
+input:
+- topology/input/stp-port-type.yml
+- package:topology-defaults.yml
+libvirt:
+  providers:
+    clab: true
+links:
+- _linkname: links[1]
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s1
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s3
+    stp:
+      port_type: auto
+  linkindex: 1
+  name: port_type on l2 interface override node
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: vlans.red.links[1]
+  bridge: input_2
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s1
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.2/24
+    node: h1
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- _linkname: vlans.red.links[2]
+  bridge: input_3
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 1
+    ifname: Ethernet1
+    node: s2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h2
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lan
+  vlan:
+    access: red
+- _linkname: vlans.blue.links[1]
+  bridge: input_4
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: Ethernet3
+    node: s1
+    vlan:
+      access: blue
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.1.4/24
+    node: h3
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 4
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.1.0/24
+  type: lan
+  vlan:
+    access: blue
+- _linkname: vlans.green.links[1]
+  bridge: input_5
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s2
+    vlan:
+      access: green
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.2.5/24
+    node: h4
+  libvirt:
+    provider:
+      clab: true
+  linkindex: 5
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.2.0/24
+  type: lan
+  vlan:
+    access: green
+message: 'The devices under test form a server cluster connected to a pair of ToR
+  switches.
+
+  Host facing ports are automatically configured as ''edge'' ports, the inter-switch
+  port is manually configured as ''network''
+
+
+  * h1 and h2 should be able to ping each other
+
+  * h3 and h4 should be able to ping each other
+
+  * h1 should not be able to reach h3
+
+  '
+module:
+- vlan
+- stp
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h1/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h1
+    id: 2
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.2/24
+      linkindex: 2
+      mtu: 1500
+      name: h1 -> [s1,h2,s2]
+      neighbors:
+      - ifname: Vlan1000
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h2
+      - ifname: Vlan1000
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: 08:4f:a9:00:00:02
+    mtu: 1500
+    name: h1
+    provider: clab
+    role: host
+  h2:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h2/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h2
+    id: 3
+    interfaces:
+    - bridge: input_3
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 3
+      mtu: 1500
+      name: h2 -> [h1,s1,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: Vlan1000
+        node: s2
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: 08:4f:a9:00:00:03
+    mtu: 1500
+    name: h2
+    provider: clab
+    role: host
+  h3:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h3/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h3
+    id: 4
+    interfaces:
+    - bridge: input_4
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.1.4/24
+      linkindex: 4
+      mtu: 1500
+      name: h3 -> [s1]
+      neighbors:
+      - ifname: Vlan1001
+        node: s1
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    mtu: 1500
+    name: h3
+    provider: clab
+    role: host
+  h4:
+    af:
+      ipv4: true
+    box: python:3.9-alpine
+    clab:
+      binds:
+      - clab_files/h4/hosts:/etc/hosts
+      config_templates:
+      - hosts:/etc/hosts
+      kind: linux
+    device: linux
+    hostname: clab-input-h4
+    id: 5
+    interfaces:
+    - bridge: input_5
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.2.5/24
+      linkindex: 5
+      mtu: 1500
+      name: h4 -> [s2]
+      neighbors:
+      - ifname: Vlan1002
+        node: s2
+      role: stub
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
+    mtu: 1500
+    name: h4
+    provider: clab
+    role: host
+  s1:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 6
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: port_type on l2 interface override node
+      neighbors:
+      - ifname: Ethernet1
+        node: s3
+        stp:
+          port_type: auto
+      type: p2p
+    - bridge: input_2
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 2
+      name: '[Access VLAN red] s1 -> h1'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h1
+      stp:
+        port_type: edge
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_4
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 4
+      name: '[Access VLAN blue] s1 -> h3'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h3
+      stp:
+        port_type: edge
+      type: lan
+      vlan:
+        access: blue
+        access_id: 1001
+    - bridge_group: 1
+      ifindex: 4
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,h2,s2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h2
+      - ifname: Vlan1000
+        node: s2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 5
+      ifname: Vlan1001
+      name: VLAN blue (1001) -> [h3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.1.4/24
+        node: h3
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: blue
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.6/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.106
+      mac: 08:4f:a9:00:00:06
+    module:
+    - vlan
+    - stp
+    name: s1
+    stp:
+      enable: true
+      protocol: stp
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      blue:
+        bridge_group: 2
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s2:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 7
+    interfaces:
+    - bridge: input_3
+      ifindex: 1
+      ifname: Ethernet1
+      linkindex: 3
+      name: '[Access VLAN red] s2 -> h2'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h2
+      stp:
+        port_type: edge
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_5
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 5
+      name: '[Access VLAN green] s2 -> h4'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.2.5/24
+        node: h4
+      stp:
+        port_type: edge
+      type: lan
+      vlan:
+        access: green
+        access_id: 1002
+    - bridge_group: 1
+      ifindex: 3
+      ifname: Vlan1000
+      name: VLAN red (1000) -> [h1,s1,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: h1
+      - ifname: Vlan1000
+        node: s1
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h2
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: red
+    - bridge_group: 2
+      ifindex: 4
+      ifname: Vlan1002
+      name: VLAN green (1002) -> [h4]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.2.5/24
+        node: h4
+      role: stub
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: green
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.7/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.107
+      mac: 08:4f:a9:00:00:07
+    module:
+    - vlan
+    - stp
+    name: s2
+    stp:
+      enable: true
+      protocol: stp
+    vlan:
+      max_bridge_group: 2
+    vlans:
+      green:
+        bridge_group: 2
+        id: 1002
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.2.0/24
+        stp:
+          port_type: normal
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+  s3:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      linkindex: 1
+      name: port_type on l2 interface override node
+      neighbors:
+      - ifname: Ethernet1
+        node: s1
+      stp:
+        port_type: auto
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.101
+      mac: 08:4f:a9:00:00:01
+    module:
+    - vlan
+    - stp
+    name: s3
+    stp:
+      enable: true
+      port_type: edge
+      protocol: stp
+provider: libvirt
+stp:
+  enable: true
+  protocol: stp
+  stub_port_type: edge
+validate:
+- description: Ping-based reachability test in VLAN red
+  name: ping_red
+  nodes:
+  - h1
+  plugin: ping('h2')
+  wait: 45
+  wait_msg: Waiting for STP to enable the ports
+- description: Ping-based reachability test in VLAN blue
+  name: ping_blue
+  nodes:
+  - h3
+  plugin: ping('h4')
+- description: Ping-based reachability test between blue and red VLANs
+  name: inter_vlan
+  nodes:
+  - h1
+  plugin: ping('h3',expect='fail')
+vlans:
+  blue:
+    host_count: 1
+    id: 1001
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.1.4/24
+      node: h3
+    - ifname: Vlan1001
+      node: s1
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.1.0/24
+  green:
+    host_count: 1
+    id: 1002
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.2.5/24
+      node: h4
+    - ifname: Vlan1002
+      node: s2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.2.0/24
+    stp:
+      port_type: normal
+  red:
+    host_count: 2
+    id: 1000
+    mode: bridge
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.2/24
+      node: h1
+    - ifname: Vlan1000
+      node: s1
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h2
+    - ifname: Vlan1000
+      node: s2
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -28,22 +28,102 @@ links:
   - ifindex: 1
     ifname: Ethernet1
     node: s1
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
   - ifindex: 1
     ifname: Ethernet1
+    node: s2
+    vlan:
+      trunk:
+        blue: {}
+        red: {}
+  linkindex: 1
+  name: port_type network configured on link
+  node_count: 2
+  prefix: {}
+  stp:
+    port_type: network
+  type: p2p
+  vlan:
+    trunk:
+      blue: {}
+      red: {}
+- _linkname: links[2]
+  interfaces:
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 10.1.0.1/30
+    node: s1
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 10.1.0.2/30
+    node: s3
+  linkindex: 2
+  name: no port_type on IP interface
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+- _linkname: links[3]
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    node: s1
+  - ifindex: 2
+    ifname: Ethernet2
+    node: s3
+  linkindex: 3
+  name: Inherit node port_type on L2 interface
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4]
+  bridge: input_4
+  interfaces:
+  - _vlan_mode: bridge
+    ifindex: 2
+    ifname: Ethernet2
+    node: s2
+    vlan:
+      access: green
+  - _vlan_mode: bridge
+    ifindex: 3
+    ifname: Ethernet3
+    node: s3
+    vlan:
+      access: green
+  linkindex: 4
+  name: port_type normal configured on access vlan
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.2.0/24
+  type: lan
+  vlan:
+    access: green
+- _linkname: links[5]
+  interfaces:
+  - ifindex: 4
+    ifname: Ethernet4
+    node: s1
+  - ifindex: 4
+    ifname: Ethernet4
     node: s3
     stp:
       port_type: auto
-  linkindex: 1
+  linkindex: 5
   name: port_type on l2 interface override node
   node_count: 2
   prefix: false
   type: p2p
 - _linkname: vlans.red.links[1]
-  bridge: input_2
+  bridge: input_6
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 2
-    ifname: Ethernet2
+    ifindex: 5
+    ifname: Ethernet5
     node: s1
     vlan:
       access: red
@@ -54,7 +134,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 2
+  linkindex: 6
   node_count: 2
   prefix:
     allocation: id_based
@@ -63,11 +143,11 @@ links:
   vlan:
     access: red
 - _linkname: vlans.red.links[2]
-  bridge: input_3
+  bridge: input_7
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 1
-    ifname: Ethernet1
+    ifindex: 3
+    ifname: Ethernet3
     node: s2
     vlan:
       access: red
@@ -78,7 +158,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 3
+  linkindex: 7
   node_count: 2
   prefix:
     allocation: id_based
@@ -87,11 +167,11 @@ links:
   vlan:
     access: red
 - _linkname: vlans.blue.links[1]
-  bridge: input_4
+  bridge: input_8
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 6
+    ifname: Ethernet6
     node: s1
     vlan:
       access: blue
@@ -102,7 +182,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 4
+  linkindex: 8
   node_count: 2
   prefix:
     allocation: id_based
@@ -111,11 +191,11 @@ links:
   vlan:
     access: blue
 - _linkname: vlans.green.links[1]
-  bridge: input_5
+  bridge: input_9
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 2
-    ifname: Ethernet2
+    ifindex: 4
+    ifname: Ethernet4
     node: s2
     vlan:
       access: green
@@ -126,7 +206,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 5
+  linkindex: 9
   node_count: 2
   prefix:
     allocation: id_based
@@ -138,7 +218,9 @@ message: 'The devices under test form a server cluster connected to a pair of To
   switches.
 
   Host facing ports are automatically configured as ''edge'' ports, the inter-switch
-  port is manually configured as ''network''
+  port is
+
+  manually configured as ''network''
 
 
   * h1 and h2 should be able to ping each other
@@ -167,21 +249,21 @@ nodes:
     hostname: clab-input-h1
     id: 2
     interfaces:
-    - bridge: input_2
+    - bridge: input_6
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24
-      linkindex: 2
+      linkindex: 6
       mtu: 1500
-      name: h1 -> [s1,h2,s2]
+      name: h1 -> [s1,s2,h2]
       neighbors:
       - ifname: Vlan1000
         node: s1
+      - ifname: Vlan1000
+        node: s2
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h2
-      - ifname: Vlan1000
-        node: s2
       type: lan
     mgmt:
       ifname: eth0
@@ -205,11 +287,11 @@ nodes:
     hostname: clab-input-h2
     id: 3
     interfaces:
-    - bridge: input_3
+    - bridge: input_7
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.3/24
-      linkindex: 3
+      linkindex: 7
       mtu: 1500
       name: h2 -> [h1,s1,s2]
       neighbors:
@@ -243,17 +325,18 @@ nodes:
     hostname: clab-input-h3
     id: 4
     interfaces:
-    - bridge: input_4
+    - bridge: input_8
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.4/24
-      linkindex: 4
+      linkindex: 8
       mtu: 1500
-      name: h3 -> [s1]
+      name: h3 -> [s1,s2]
       neighbors:
       - ifname: Vlan1001
         node: s1
-      role: stub
+      - ifname: Vlan1001
+        node: s2
       type: lan
     mgmt:
       ifname: eth0
@@ -277,17 +360,18 @@ nodes:
     hostname: clab-input-h4
     id: 5
     interfaces:
-    - bridge: input_5
+    - bridge: input_9
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.2.5/24
-      linkindex: 5
+      linkindex: 9
       mtu: 1500
-      name: h4 -> [s2]
+      name: h4 -> [s2,s3]
       neighbors:
       - ifname: Vlan1002
         node: s2
-      role: stub
+      - ifname: Vlan1002
+        node: s3
       type: lan
     mgmt:
       ifname: eth0
@@ -307,17 +391,54 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
-      name: port_type on l2 interface override node
+      name: port_type network configured on link
       neighbors:
       - ifname: Ethernet1
+        node: s2
+        stp:
+          port_type: network
+      stp:
+        port_type: network
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
+    - ifindex: 2
+      ifname: Ethernet2
+      ipv4: 10.1.0.1/30
+      linkindex: 2
+      name: no port_type on IP interface
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 10.1.0.2/30
+        node: s3
+      type: p2p
+    - ifindex: 3
+      ifname: Ethernet3
+      linkindex: 3
+      name: Inherit node port_type on L2 interface
+      neighbors:
+      - ifname: Ethernet2
+        node: s3
+      type: p2p
+    - ifindex: 4
+      ifname: Ethernet4
+      linkindex: 5
+      name: port_type on l2 interface override node
+      neighbors:
+      - ifname: Ethernet4
         node: s3
         stp:
           port_type: auto
       type: p2p
-    - bridge: input_2
-      ifindex: 2
-      ifname: Ethernet2
-      linkindex: 2
+    - bridge: input_6
+      ifindex: 5
+      ifname: Ethernet5
+      linkindex: 6
       name: '[Access VLAN red] s1 -> h1'
       neighbors:
       - ifname: eth1
@@ -329,10 +450,10 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_4
-      ifindex: 3
-      ifname: Ethernet3
-      linkindex: 4
+    - bridge: input_8
+      ifindex: 6
+      ifname: Ethernet6
+      linkindex: 8
       name: '[Access VLAN blue] s1 -> h3'
       neighbors:
       - ifname: eth1
@@ -345,32 +466,33 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 9
       ifname: Vlan1000
-      name: VLAN red (1000) -> [h1,h2,s2]
+      name: VLAN red (1000) -> [h1,s2,h2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.2/24
         node: h1
+      - ifname: Vlan1000
+        node: s2
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h2
-      - ifname: Vlan1000
-        node: s2
       type: svi
       virtual_interface: true
       vlan:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 10
       ifname: Vlan1001
-      name: VLAN blue (1001) -> [h3]
+      name: VLAN blue (1001) -> [h3,s2]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.1.4/24
         node: h3
-      role: stub
+      - ifname: Vlan1001
+        node: s2
       type: svi
       virtual_interface: true
       vlan:
@@ -418,10 +540,43 @@ nodes:
     device: eos
     id: 7
     interfaces:
-    - bridge: input_3
-      ifindex: 1
+    - ifindex: 1
       ifname: Ethernet1
-      linkindex: 3
+      linkindex: 1
+      name: port_type network configured on link
+      neighbors:
+      - ifname: Ethernet1
+        node: s1
+        stp:
+          port_type: network
+      stp:
+        port_type: network
+      type: p2p
+      vlan:
+        trunk:
+          blue: {}
+          red: {}
+        trunk_id:
+        - 1000
+        - 1001
+    - bridge: input_4
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 4
+      name: '[Access VLAN green] s2 -> s3'
+      neighbors:
+      - ifname: Ethernet3
+        node: s3
+      stp:
+        port_type: normal
+      type: lan
+      vlan:
+        access: green
+        access_id: 1002
+    - bridge: input_7
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 7
       name: '[Access VLAN red] s2 -> h2'
       neighbors:
       - ifname: eth1
@@ -433,10 +588,10 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_5
-      ifindex: 2
-      ifname: Ethernet2
-      linkindex: 5
+    - bridge: input_9
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 9
       name: '[Access VLAN green] s2 -> h4'
       neighbors:
       - ifname: eth1
@@ -449,7 +604,22 @@ nodes:
         access: green
         access_id: 1002
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 7
+      ifname: Vlan1002
+      name: VLAN green (1002) -> [s3,h4]
+      neighbors:
+      - ifname: Vlan1002
+        node: s3
+      - ifname: eth1
+        ipv4: 172.16.2.5/24
+        node: h4
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: green
+    - bridge_group: 2
+      ifindex: 8
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h2]
       neighbors:
@@ -466,20 +636,21 @@ nodes:
       vlan:
         mode: bridge
         name: red
-    - bridge_group: 2
-      ifindex: 4
-      ifname: Vlan1002
-      name: VLAN green (1002) -> [h4]
+    - bridge_group: 3
+      ifindex: 9
+      ifname: Vlan1001
+      name: VLAN blue (1001) -> [h3,s1]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.2.5/24
-        node: h4
-      role: stub
+        ipv4: 172.16.1.4/24
+        node: h3
+      - ifname: Vlan1001
+        node: s1
       type: svi
       virtual_interface: true
       vlan:
         mode: bridge
-        name: green
+        name: blue
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -499,10 +670,17 @@ nodes:
       enable: true
       protocol: stp
     vlan:
-      max_bridge_group: 2
+      max_bridge_group: 3
     vlans:
+      blue:
+        bridge_group: 3
+        id: 1001
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.1.0/24
       green:
-        bridge_group: 2
+        bridge_group: 1
         id: 1002
         mode: bridge
         prefix:
@@ -511,7 +689,7 @@ nodes:
         stp:
           port_type: normal
       red:
-        bridge_group: 1
+        bridge_group: 2
         id: 1000
         mode: bridge
         prefix:
@@ -526,14 +704,63 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: Ethernet1
-      linkindex: 1
+      ipv4: 10.1.0.2/30
+      linkindex: 2
+      name: no port_type on IP interface
+      neighbors:
+      - ifname: Ethernet2
+        ipv4: 10.1.0.1/30
+        node: s1
+      type: p2p
+    - ifindex: 2
+      ifname: Ethernet2
+      linkindex: 3
+      name: Inherit node port_type on L2 interface
+      neighbors:
+      - ifname: Ethernet3
+        node: s1
+      stp:
+        port_type: edge
+      type: p2p
+    - bridge: input_4
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 4
+      name: '[Access VLAN green] s3 -> s2'
+      neighbors:
+      - ifname: Ethernet2
+        node: s2
+      stp:
+        port_type: normal
+      type: lan
+      vlan:
+        access: green
+        access_id: 1002
+    - ifindex: 4
+      ifname: Ethernet4
+      linkindex: 5
       name: port_type on l2 interface override node
       neighbors:
-      - ifname: Ethernet1
+      - ifname: Ethernet4
         node: s1
       stp:
         port_type: auto
       type: p2p
+    - bridge_group: 1
+      ifindex: 5
+      ifname: Vlan1002
+      name: VLAN green (1002) -> [s2,h4]
+      neighbors:
+      - ifname: Vlan1002
+        node: s2
+      - ifname: eth1
+        ipv4: 172.16.2.5/24
+        node: h4
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: bridge
+        name: green
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -553,6 +780,18 @@ nodes:
       enable: true
       port_type: edge
       protocol: stp
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      green:
+        bridge_group: 1
+        id: 1002
+        mode: bridge
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.2.0/24
+        stp:
+          port_type: normal
 provider: libvirt
 stp:
   enable: true
@@ -587,6 +826,8 @@ vlans:
       node: h3
     - ifname: Vlan1001
       node: s1
+    - ifname: Vlan1001
+      node: s2
     prefix:
       allocation: id_based
       ipv4: 172.16.1.0/24
@@ -595,11 +836,13 @@ vlans:
     id: 1002
     mode: bridge
     neighbors:
+    - ifname: Vlan1002
+      node: s2
+    - ifname: Vlan1002
+      node: s3
     - ifname: eth1
       ipv4: 172.16.2.5/24
       node: h4
-    - ifname: Vlan1002
-      node: s2
     prefix:
       allocation: id_based
       ipv4: 172.16.2.0/24
@@ -615,11 +858,11 @@ vlans:
       node: h1
     - ifname: Vlan1000
       node: s1
+    - ifname: Vlan1000
+      node: s2
     - ifname: eth1
       ipv4: 172.16.0.3/24
       node: h2
-    - ifname: Vlan1000
-      node: s2
     prefix:
       allocation: id_based
       ipv4: 172.16.0.0/24

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -408,6 +408,8 @@ nodes:
       - ifname: eth1
         ipv4: 172.16.0.3/24
         node: h1
+      stp:
+        port_type: edge
       type: lan
       vlan:
         access: red
@@ -433,6 +435,8 @@ nodes:
       - ifname: eth1
         ipv4: 172.16.1.5/24
         node: h3
+      stp:
+        port_type: edge
       type: lan
       vlan:
         access: blue
@@ -575,6 +579,8 @@ nodes:
       - ifname: eth1
         ipv4: 172.16.0.4/24
         node: h2
+      stp:
+        port_type: edge
       type: lan
       vlan:
         access: red
@@ -709,6 +715,8 @@ nodes:
       - ifname: eth1
         ipv4: 172.16.1.6/24
         node: h4
+      stp:
+        port_type: edge
       type: lan
       vlan:
         access: blue

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -812,6 +812,7 @@ provider: libvirt
 stp:
   enable: true
   protocol: pvrst
+  stub_port_type: edge
 vlans:
   blue:
     host_count: 2

--- a/tests/topology/input/stp-port-type.yml
+++ b/tests/topology/input/stp-port-type.yml
@@ -20,7 +20,7 @@ groups:
     device: linux
     provider: clab
   switches:
-    members: [ s1,s2,s3 ]
+    members: [ s1, s2, s3 ]
     module: [ vlan, stp ]
 
 vlans:

--- a/tests/topology/input/stp-port-type.yml
+++ b/tests/topology/input/stp-port-type.yml
@@ -7,6 +7,8 @@ message: |
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
 
+defaults.device: eos
+
 stp:
   enable: True
   stub_port_type: edge           # auto-configure host ports as 'edge'
@@ -38,16 +40,31 @@ nodes:
     stp.port_type: edge   # Test: node-level stp port_type
 
 links:
-- s1:
+- name: port_type network configured on link
+  s1:
   s2:
   vlan.trunk: [red,blue]
   stp.port_type: network
 
-- s1-s3  # IP interface, module should not apply STP port_type setting here
+- name: no port_type on IP interface
+  s1:
+  s3: # IP interface, module should not apply STP port_type setting here
 
-- s2:
+- name: Inherit node port_type on L2 interface
+  s1:
   s3:
-  vlan.access: green # Should both get 'normal' stp.port_type, on vlan
+  prefix: False
+
+- name: port_type normal configured on access vlan
+  s2:
+  s3:
+  vlan.access: green # Should both get 'normal' stp.port_type, on vlan interface
+
+- name: port_type on l2 interface override node
+  s1:
+  s3:
+    stp.port_type: auto
+  prefix: False
 
 validate:
   ping_red:

--- a/tests/topology/input/stp-port-type.yml
+++ b/tests/topology/input/stp-port-type.yml
@@ -1,7 +1,8 @@
 ---
 message: |
   The devices under test form a server cluster connected to a pair of ToR switches.
-  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is manually configured as 'network'
+  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is
+  manually configured as 'network'
 
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
@@ -43,7 +44,7 @@ links:
 - name: port_type network configured on link
   s1:
   s2:
-  vlan.trunk: [red,blue]
+  vlan.trunk: [ red, blue ]
   stp.port_type: network
 
 - name: no port_type on IP interface

--- a/tests/topology/input/stp.yml
+++ b/tests/topology/input/stp.yml
@@ -1,6 +1,8 @@
 ---
 defaults.device: eos
-stp.protocol: pvrst  # Topology requires running STP per VLAN
+stp:
+  protocol: pvrst      # Topology requires running STP per VLAN
+  stub_port_type: edge # Configure all host-only ports as 'edge'
 
 addressing:
   p2p:


### PR DESCRIPTION
* Option to auto-configure stp.port_type as 'edge' for ports with only hosts connected, default disabled
* Feature flag stp.port_type (not supported by FRR)