### PR TITLE
Replace use of 'netlab_provider' with 'node_provider' in templates

### DIFF
--- a/netsim/ansible/tasks/deploy-config/dellos10.yml
+++ b/netsim/ansible/tasks/deploy-config/dellos10.yml
@@ -1,7 +1,7 @@
 - wait_for_connection:
     timeout: 60
   when: |
-    netlab_provider == 'clab' and ansible_connection == 'network_cli'
+    node_provider == 'clab' and ansible_connection == 'network_cli'
 
 - name: "dellos10_config: deploying {{ netsim_action }} from {{ config_template }}"
   dellemc.os10.os10_config:

--- a/netsim/ansible/tasks/deploy-config/vyos.yml
+++ b/netsim/ansible/tasks/deploy-config/vyos.yml
@@ -6,7 +6,7 @@
       timeout: 120
       path: /tmp/vyos-config-status
   when: |
-    netlab_provider == 'clab' and vyos_booted is not defined
+    node_provider == 'clab' and vyos_booted is not defined
 
 - set_fact:
     vyos_booted: 1

--- a/netsim/ansible/tasks/readiness-check/vsrx.yml
+++ b/netsim/ansible/tasks/readiness-check/vsrx.yml
@@ -2,7 +2,7 @@
   pause:
     minutes: 5
   when: |
-    netlab_provider == 'clab'
+    node_provider == 'clab'
 
 - name: Execute local ssh command to check vSRX readiness
   local_action:

--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -94,7 +94,7 @@ iface {{ l.ifname }} inet6 static
 {%     endif %}
   address {{ l.ipv6 }}
 {%   endif %}
-{%   if l.mtu is defined and provider|default(netlab_provider) == 'clab' %}
+{%   if l.mtu is defined and node_provider == 'clab' %}
 
 iface {{ l.ifname }}
   mtu {{ l.mtu }}

--- a/netsim/ansible/templates/lag/frr.j2
+++ b/netsim/ansible/templates/lag/frr.j2
@@ -2,7 +2,7 @@
 #
 set -e # Exit immediately when any command fails
 #
-{% if netlab_provider != 'clab' %}
+{% if node_provider != 'clab' %}
 modprobe bonding miimon=100 mode=802.3ad lacp_rate=fast
 {% endif %}
 #
@@ -16,7 +16,7 @@ modprobe bonding miimon=100 mode=802.3ad lacp_rate=fast
 {%     set lacp_act = 'off' if _lacp=='off' else 'on' %}
 {%     set lacp_rate = (' lacp_rate ' + _lacp) if _lacp!='off' else '' %}
 {%     set _m = _m + " xmit_hash_policy encap3+4" + lacp_rate %}
-{%     if netlab_provider == 'clab' %}
+{%     if node_provider == 'clab' %}
 {%       set _m = _m + " lacp_active " + lacp_act %}
 {%     endif %}
 {%   endif %}
@@ -27,7 +27,7 @@ ip link set dev {{ l.ifname }} down
 
 {% for l in interfaces if 'lag' in l and l.type != 'lag' %}
 {%   if l.type=='p2p' %}
-{%     if netlab_provider != 'clab' %}
+{%     if node_provider != 'clab' %}
 ethtool -s {{ l.ifname }} autoneg off speed 1000 duplex full
 {%     endif %}
 ip link set dev {{ l.ifname }} master {% 


### PR DESCRIPTION
Needed to fix multi-provider deployments; FRR clab nodes in a libvirt topology currently try to run ```modprobe``` for example