### PR TITLE
Consistently replace '_' with '-' in hostnames

### DIFF
--- a/netsim/ansible/templates/initial/arcos.j2
+++ b/netsim/ansible/templates/initial/arcos.j2
@@ -1,4 +1,4 @@
-system hostname {{ inventory_hostname }}
+system hostname {{ inventory_hostname.replace('_','-') }}
 !
 !
 interface loopback0

--- a/netsim/ansible/templates/initial/asa.j2
+++ b/netsim/ansible/templates/initial/asa.j2
@@ -1,4 +1,4 @@
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname.replace('_','-') }}
 domain-name lab.local
 !
 {% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) %}

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -50,7 +50,7 @@
 
 - set:
     system:
-      hostname: {{ inventory_hostname }}
+      hostname: {{ inventory_hostname.replace("_","-") }}
     interface:
       eth0:
         ip:

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -24,7 +24,7 @@ SCRIPT
 #
 # Configure system defaults on Ubuntu
 #
-hostnamectl set-hostname {{ inventory_hostname }}
+hostnamectl set-hostname {{ inventory_hostname.replace('_','-') }}
 sysctl -w net.ipv4.ip_forward=1
 sysctl -w net.ipv6.conf.all.forwarding=1
 #
@@ -107,7 +107,7 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 # Rest of initial configuration done through VTYSH
 #
 cat >/tmp/config <<CONFIG
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname.replace('_','-') }}
 !
 {% if clab is defined and netlab_mgmt_vrf|default(False) %}
 vrf mgmt

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -1,4 +1,4 @@
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname.replace('_','-') }}
 !
 no ip domain lookup
 !

--- a/netsim/ansible/templates/initial/iosxr.j2
+++ b/netsim/ansible/templates/initial/iosxr.j2
@@ -1,4 +1,4 @@
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname.replace('_','-') }}
 !
 domain lookup disable
 !

--- a/netsim/ansible/templates/initial/junos.j2
+++ b/netsim/ansible/templates/initial/junos.j2
@@ -1,5 +1,5 @@
 system {
-  host-name {{ inventory_hostname }};
+  host-name {{ inventory_hostname.replace('_','-') }};
   static-host-mapping {
 {% for k,v in hostvars.items() if k != inventory_hostname %}
 {%   if v.loopback.ipv4 is defined %}

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -31,7 +31,7 @@ SCRIPT
 systemctl restart systemd-resolved
 
 # Set persistent hostname
-hostnamectl set-hostname {{ inventory_hostname }}
+hostnamectl set-hostname {{ inventory_hostname.replace('_','-') }}
 
 NEED_APT_UPDATE=YES
 {% if netlab_net_tools|default(False) %}

--- a/netsim/ansible/templates/initial/nxos.j2
+++ b/netsim/ansible/templates/initial/nxos.j2
@@ -1,7 +1,7 @@
 {#
   NXOS hates single-character hostnames. Prepend 'nxos-' to hostname if it's too short
 #}
-hostname {{ 'nxos-' if inventory_hostname|length == 1 else '' }}{{ inventory_hostname }}
+hostname {{ 'nxos-' if inventory_hostname|length == 1 else '' }}{{ inventory_hostname.replace('_','-') }}
 !
 no ip domain-lookup
 !
@@ -10,7 +10,7 @@ feature lldp
 username vagrant password vagrant
 !
 {% for hname,hdata in hosts.items() if 'ipv4' in hdata and hname != inventory_hostname %}
-ip host {{ hname }} {{ hdata.ipv4[0] }}
+ip host {{ hname.replace('_','') }} {{ hdata.ipv4[0] }}
 {% endfor %}
 !
 {% if vlans is defined %}

--- a/netsim/ansible/templates/initial/routeros.j2
+++ b/netsim/ansible/templates/initial/routeros.j2
@@ -1,5 +1,5 @@
 
-/system identity set name="{{ inventory_hostname }}"
+/system identity set name="{{ inventory_hostname.replace('_','-') }}"
 
 /interface bridge add name=loopback protocol-mode=none
 

--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -1,5 +1,5 @@
 
-/system identity set name="{{ inventory_hostname }}"
+/system identity set name="{{ inventory_hostname.replace('_','-') }}"
 
 /interface bridge add name=loopback protocol-mode=none
 

--- a/netsim/ansible/templates/initial/sonic.j2
+++ b/netsim/ansible/templates/initial/sonic.j2
@@ -63,7 +63,7 @@ fi
 # And now let's configure the interfaces
 #
 cat >/etc/sonic/frr/do_config <<CONFIG
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname.replace('_','-') }}
 !
 {% if 'ipv6' in af %}
 ipv6 forwarding

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -7,7 +7,7 @@ ipv6 unicast-routing
 !
 router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
   log-adjacency-changes
-  is-hostname {{ inventory_hostname }}
+  is-hostname {{ inventory_hostname.replace('_','-') }}
   is-type {{ isis.type }}
 {% if isis.net is defined %}
   net {{ isis.net }}


### PR DESCRIPTION
It is not a valid FQDN character, and some platforms (like Cumulus NVUE) fail with an error

We could consider restricting node names to be valid FQDNs (of at most 16 characters), and/or apply the 'replace' normalization in Python rather than all templates (either define a ```node.hostname``` property and use that everywhere instead of ```inventory_hostname```, or change ```inventory_hostname``` (and issue an error when troublesome node names are used)