### PR TITLE
Linux: Update libvirt image to debian/bookworm64 with Python 3.11

### DIFF
--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -10,11 +10,11 @@ features:
     server: true
     relay: true
 libvirt:
-  image: generic/ubuntu2004
+  image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
     netlab_linux_distro: ubuntu
 virtualbox:
-  image: generic/ubuntu2004
+  image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
     netlab_linux_distro: ubuntu
 group_vars:
@@ -27,7 +27,7 @@ group_vars:
   netlab_lldp_enable: False
   netlab_net_tools: False
 clab:
-  image: python:3.9-alpine
+  image: python:3.11-alpine # Matches Python version in debian/bookworm64
   mtu: 1500
   kmods:
   node:


### PR DESCRIPTION
Also update Containerlab image to match Python version