### PR TITLE
Linux: Update libvirt image to debian/bookworm64 and clab image to python:3.11-alpine

### DIFF
--- a/netsim/ansible/templates/initial/linux/debian.j2
+++ b/netsim/ansible/templates/initial/linux/debian.j2
@@ -1,6 +1,25 @@
 echo -n 'Starting initial config ' && date
 
+# Set persistent hostname
+hostnamectl set-hostname {{ inventory_hostname }}
+
+# Update APT and install netplan
+apt-get update -qq
+apt-get install -qq nplan
+
 # (Overwrite resolved config to remove DNS stuff)
+cat <<SCRIPT >/etc/netplan/01-netcfg.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp6: false
+      optional: true
+SCRIPT
+netplan apply
+
 # cat <<SCRIPT > /etc/systemd/resolved.conf 
 # [Resolve]
 # DNS=
@@ -11,13 +30,6 @@ echo -n 'Starting initial config ' && date
 # DNSStubListener=yes
 # SCRIPT
 # systemctl restart systemd-resolved
-
-# Set persistent hostname
-hostnamectl set-hostname {{ inventory_hostname }}
-
-# Update APT and install netplan
-apt-get update -qq
-apt-get install -qq nplan
 
 {% if netlab_net_tools|default(False) %}
 #
@@ -72,7 +84,7 @@ net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
 SCRIPT
 sysctl -p /etc/sysctl.d/10-netsim.conf
 
-# Loopback addressing, JvB commented out
+# Loopback addressing
 {% if loopback.ipv4 is defined or loopback.ipv6 is defined %}
 cat <<SCRIPT > /etc/netplan/02-loopback.yaml
 network:

--- a/netsim/ansible/templates/initial/linux/debian.j2
+++ b/netsim/ansible/templates/initial/linux/debian.j2
@@ -1,0 +1,140 @@
+echo -n 'Starting initial config ' && date
+
+# (Overwrite resolved config to remove DNS stuff)
+# cat <<SCRIPT > /etc/systemd/resolved.conf 
+# [Resolve]
+# DNS=
+# FallbackDNS=
+# Domains=
+# DNSOverTLS=no
+# Cache=yes
+# DNSStubListener=yes
+# SCRIPT
+# systemctl restart systemd-resolved
+
+# Set persistent hostname
+hostnamectl set-hostname {{ inventory_hostname }}
+
+# Update APT and install netplan
+apt-get update -qq
+apt-get install -qq nplan
+
+{% if netlab_net_tools|default(False) %}
+#
+# Install net-tools (arp, route...)
+#
+if which arp; then
+  echo "net-tools already installed"
+else
+  apt-get install -qq net-tools
+fi
+if which traceroute; then
+  echo "traceroute already installed"
+else
+  apt-get install -qq traceroute
+fi
+{% endif %}
+{% if netlab_lldp_enable|default(False) %}
+#
+# Enable LLDP
+#
+if systemctl is-active --quiet lldpd.service; then
+  echo "LLDP already installed"
+else
+  apt-get install -qq lldpd
+fi
+
+cat <<CONFIG >/etc/lldpd.d/system.conf
+configure lldp tx-interval 30
+configure lldp tx-hold 3
+configure system interface pattern *,!eth0,eth*
+CONFIG
+systemctl enable lldpd
+systemctl restart lldpd
+{% endif %}
+
+# Sysctl settings: IPv4/IPv6 forwarding, IPv6 LLA
+#
+{% set pkt_fwd = "1" if role|default("host") == "router" else "0" %}
+cat <<SCRIPT > /etc/sysctl.d/10-netsim.conf
+net.ipv4.ip_forward={{ pkt_fwd }}
+net.ipv6.conf.all.forwarding={{ pkt_fwd }}
+
+{%   if loopback.ipv6 is defined %}
+net.ipv6.conf.lo.disable_ipv6=0
+{%   endif %}
+{% for l in interfaces|default([]) %}
+{%   if l.ipv6 is defined %}
+net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
+{%   endif %}
+{% endfor %}
+
+SCRIPT
+sysctl -p /etc/sysctl.d/10-netsim.conf
+
+# Loopback addressing, JvB commented out
+{% if loopback.ipv4 is defined or loopback.ipv6 is defined %}
+cat <<SCRIPT > /etc/netplan/02-loopback.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    lo:
+      addresses:
+{%   if 'ipv4' in loopback %}
+        - {{ loopback.ipv4 }}
+{%   endif %}
+{%   if 'ipv6' in loopback %}
+        - {{ loopback.ipv6 }}
+{%   endif %}
+SCRIPT
+{% endif %}
+
+# Interface addressing
+{% for l in interfaces|default([]) if (l.ipv4 is defined or l.ipv6 is defined or l.dhcp is defined)%}
+cat <<SCRIPT > /etc/netplan/03-eth-{{ l.ifname }}.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ l.ifname }}:
+{%   if l.dhcp.client.ipv4|default(False) %}
+      dhcp4: true
+{%   endif %}
+{%   if l.dhcp.client.ipv6|default(False) %}
+      dhcp6: true
+{%   endif %}
+{%   for af in ('ipv4','ipv6') if af in l %}
+{%     if loop.first %}
+      addresses:
+{%     endif %}
+        - {{ l[af] }}
+{%   endfor %}
+{%   if l.mtu is defined %}
+      mtu: {{ l.mtu }}
+{%   endif %}
+SCRIPT
+{% endfor %}
+
+# Add routes to IPv4 address pools pointing to the first neighbor on the first link
+{% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
+cat <<SCRIPT > /etc/netplan/04-routes-{{ ifdata.ifname }}.yaml
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    {{ ifdata.ifname }}:
+      routes:
+{%   for name,pool in pools.items()|default({}) %}
+{%     for af,pfx in pool.items() if af == 'ipv4' and name != 'mgmt' and name != 'router_id' %}
+        - to: {{ pfx }}
+          via: {{ ifdata.gateway.ipv4|ipaddr('address') }}
+{%     endfor %}
+{%   endfor %}
+SCRIPT
+{% endfor  %}
+
+echo -n 'Starting netplan generate ' && date
+netplan generate
+echo -n 'Starting netplan apply ' && date
+nohup netplan apply &

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -103,7 +103,9 @@ def ssh_connect(
   if data.netlab_ssh_args:
     c_args.extend(data.netlab_ssh_args.split(' '))
 
-  if data.ansible_ssh_pass:
+  if data.ansible_ssh_private_key_file:
+    c_args.extend(['-i', strings.eval_format(data.ansible_ssh_private_key_file,{'name': data.host})])
+  elif data.ansible_ssh_pass:
     c_args = ['sshpass','-p',data.ansible_ssh_pass ] + c_args
 
   if data.ansible_port:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -12,16 +12,15 @@ features:
 libvirt:
   image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
-    netlab_linux_distro: ubuntu
+    netlab_linux_distro: debian
 virtualbox:
   image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
-    netlab_linux_distro: ubuntu
+    netlab_linux_distro: debian
 group_vars:
   ansible_network_os: linux
   ansible_connection: paramiko
   ansible_user: vagrant
-  ansible_ssh_pass: vagrant
   docker_shell: sh -il
   ansible_python_interpreter: auto_silent
   netlab_lldp_enable: False

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -10,11 +10,11 @@ features:
     server: true
     relay: true
 libvirt:
-  image: generic/ubuntu2004
+  image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
     netlab_linux_distro: ubuntu
 virtualbox:
-  image: generic/ubuntu2004
+  image: debian/bookworm64 # generic/ubuntu2004
   group_vars:
     netlab_linux_distro: ubuntu
 group_vars:
@@ -27,7 +27,7 @@ group_vars:
   netlab_lldp_enable: False
   netlab_net_tools: False
 clab:
-  image: python:3.9-alpine
+  image: python:3.11-alpine # Matches Python version in debian/bookworm64
   mtu: 1500
   kmods:
   node:

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -18,10 +18,10 @@ from ..data import global_vars,append_to_list
 
 forwarded_port_name = { 'ssh': 'ansible_port', }
 
-def copy_provider_inventory(host: Box, p_data: Box) -> None:
+def copy_provider_inventory(host: Box, p_data: Box, node: Box) -> None:
   if 'inventory' in p_data:
     for k,v in p_data.inventory.items():
-      host[k] = v
+      host[k] = strings.eval_format(v,node)
 
   if 'inventory_port_map' in p_data and 'forwarded' in p_data:
     for k,v in p_data.inventory_port_map.items():
@@ -42,7 +42,7 @@ def provider_inventory_settings(host: Box, node: Box, topology: Box) -> None:
   node_provider = devices.get_provider(node,topology)
   p_data = defaults.providers[node_provider]
   if p_data:
-    copy_provider_inventory(host,p_data)
+    copy_provider_inventory(host,p_data,node)
 
   if 'provider' in node:                                              # Is the node using a secondary provider?
     copy_device_provider_group_vars(host,node,topology)

--- a/netsim/providers/libvirt.yml
+++ b/netsim/providers/libvirt.yml
@@ -41,3 +41,6 @@ attributes:
     uplink: str
   global:
     providers:
+
+inventory:
+  ansible_ssh_private_key_file: .vagrant/machines/{ name }/libvirt/private_key

--- a/netsim/templates/provider/libvirt/Vagrantfile.j2
+++ b/netsim/templates/provider/libvirt/Vagrantfile.j2
@@ -1,6 +1,7 @@
 VAGRANT_COMMAND = ARGV[0]
 
 Vagrant.configure("2") do |config|
+  config.ssh.insert_key = true
   config.vm.provider :libvirt do |libvirt|
 {% if addressing.mgmt._network|default(False) %}
     libvirt.management_network_name = "{{ addressing.mgmt._network }}"

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -227,7 +227,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -284,7 +284,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -341,7 +341,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:
@@ -381,7 +381,7 @@ nodes:
     af:
       ipv4: true
       ipv6: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 13
     interfaces:

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -657,7 +657,7 @@ nodes:
   pod_1_l1_srv:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/srv/hosts:/etc/hosts
@@ -815,7 +815,7 @@ nodes:
   pod_1_l2_srv:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/srv/hosts:/etc/hosts
@@ -1229,7 +1229,7 @@ nodes:
   pod_2_l1_srv:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/srv/hosts:/etc/hosts
@@ -1387,7 +1387,7 @@ nodes:
   pod_2_l2_srv:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/srv/hosts:/etc/hosts

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -47,7 +47,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -83,7 +83,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -109,7 +109,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -243,7 +243,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:
@@ -280,7 +280,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -317,7 +317,7 @@ nodes:
   h3:
     af:
       ipv6: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -165,7 +165,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:
@@ -195,7 +195,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -225,7 +225,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -253,7 +253,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -135,7 +135,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -167,7 +167,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -199,7 +199,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:
@@ -231,7 +231,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 7
     interfaces:

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -480,7 +480,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 7
     interfaces:
@@ -507,7 +507,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 8
     interfaces:

--- a/tests/topology/expected/group-ansible-variables.yml
+++ b/tests/topology/expected/group-ansible-variables.yml
@@ -19,7 +19,7 @@ nodes:
   h1:
     af: {}
     ansible_connection: ac
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces: []
@@ -33,7 +33,7 @@ nodes:
   h2:
     af: {}
     ansible_connection: ac
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts
@@ -56,7 +56,7 @@ nodes:
   h3:
     af: {}
     ansible_connection: ac3
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h3/hosts:/etc/hosts

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -162,7 +162,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:
@@ -190,7 +190,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -134,7 +134,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -191,7 +191,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -79,7 +79,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -78,7 +78,7 @@ nodes:
   h:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -628,7 +628,7 @@ nodes:
   h:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -59,7 +59,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:
@@ -86,7 +86,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:

--- a/tests/topology/expected/stp-pvrst.yml
+++ b/tests/topology/expected/stp-pvrst.yml
@@ -197,7 +197,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -237,7 +237,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts
@@ -277,7 +277,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h3/hosts:/etc/hosts
@@ -317,7 +317,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h4/hosts:/etc/hosts

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -42,7 +42,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -89,7 +89,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -131,7 +131,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -86,7 +86,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:
@@ -113,7 +113,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -110,7 +110,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -154,7 +154,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.9-alpine
+    box: python:3.11-alpine
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -126,7 +126,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:
@@ -156,7 +156,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -112,7 +112,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:
@@ -144,7 +144,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -54,7 +54,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -59,7 +59,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:
@@ -86,7 +86,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -199,7 +199,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:
@@ -250,7 +250,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -282,7 +282,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -314,7 +314,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:
@@ -346,7 +346,7 @@ nodes:
   h5:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 7
     interfaces:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -202,7 +202,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -230,7 +230,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -258,7 +258,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:
@@ -286,7 +286,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 7
     interfaces:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -128,7 +128,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -177,7 +177,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -142,7 +142,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -170,7 +170,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -198,7 +198,7 @@ nodes:
   h3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 6
     interfaces:
@@ -226,7 +226,7 @@ nodes:
   h4:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 7
     interfaces:

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -201,7 +201,7 @@ nodes:
   bh1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 4
     interfaces:
@@ -230,7 +230,7 @@ nodes:
   bh2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 5
     interfaces:
@@ -329,7 +329,7 @@ nodes:
   rh1:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 1
     interfaces:
@@ -358,7 +358,7 @@ nodes:
   rh2:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 2
     interfaces:
@@ -387,7 +387,7 @@ nodes:
   rh3:
     af:
       ipv4: true
-    box: generic/ubuntu2004
+    box: debian/bookworm64
     device: linux
     id: 3
     interfaces:


### PR DESCRIPTION
* Update Python to version 3.11, match across providers
* Fix SSH private key handling for Libvirt provider (set ```ansible_ssh_private_key_file``` in inventory)
* Update ```netlab_linux_distro``` to debian, add custom init script

I commented out the DNS fixes for systemd resolvd, not sure if those are still needed. We may want to refactor ```netplan``` init into its own script - I copied the Ubuntu bits
