### PR TITLE
STP: Don't include module attributes with each neighbor

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -784,6 +784,11 @@ def create_node_interfaces(link: Box, addr_pools: Box, ndict: Box, defaults: Box
     print(f'... link data: {link}')
     print(f'... interface data: {interfaces}\n')
 
+  # link_to_neighbor returns True iff a given module's attributes should be included with each neighbor
+  def link_to_neighbor(m:str) -> bool:
+    has_if_atts = defaults[m].attributes.get('interface',None) is not None
+    return defaults[m].attributes.get('link_to_neighbor',has_if_atts)
+
   # Second phase: build neighbor list from list of newly-created interfaces
   for node_if in interfaces:
     ifdata = node_if['data']                                      # Get a pointer to interface data
@@ -797,8 +802,7 @@ def create_node_interfaces(link: Box, addr_pools: Box, ndict: Box, defaults: Box
       #
       # Find relevant modules that have interface attributes
       mods_with_attr = set([ m for m in ndict[remote_node].get('module',[])
-                              if defaults[m].attributes.get('interface',None) or
-                                 defaults[m].attributes.get('link_to_neighbor',None) ])
+                              if link_to_neighbor(m) ])
       #
       # Merge neighbor module data + AF with baseline neighbor data
       ngh_data = interface_data(

--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -28,7 +28,9 @@ attributes:
     enable: bool
     port_priority: { type: int, min_value: 0, max_value: 15 }  # 4-bit value, default '8' if not set
 
-_top:               # Modification of global defaults
+  link_to_neighbor: False # Do not include STP attributes in neighbors
+
+_top:                     # Modification of global defaults
   attributes:
     node_vlan:
       stp.priority: { type: int, min_value: 0, max_value: 61440 }

--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -86,8 +86,6 @@ nodes:
       neighbors:
       - ifname: port-channel1
         node: r2
-        stp:
-          enable: false
       stp:
         enable: false
       type: lag
@@ -167,8 +165,6 @@ nodes:
       neighbors:
       - ifname: port-channel1
         node: r1
-        stp:
-          enable: false
       stp:
         enable: false
       type: lag


### PR DESCRIPTION
Interpret ```link_to_neighbor: False``` to mean "don't include interface attributes in neighbors"