### PR TITLE
Adds NSO Docker as an external tool

### DIFF
--- a/extool/nso.md
+++ b/extool/nso.md
@@ -1,0 +1,21 @@
+(tools-nso)=
+# NSO
+
+NSO is a tool for multi vendor network automation. See https://cisco-tailf.gitbook.io/nso-docs for documentation.
+
+* Add the following lines to the lab topology file to enable NSO.
+
+```
+tools:
+  nso:
+```
+* The URL used to connect to NSO is printed during **netlab up** process. 
+* You can connect to the cli with the **netlab connect nso** command. You can edit the NSO configs this way and access the cisco NSO cli with the following command ncs_cli -C -u admin. Config changes need NSO reloaded with the ncs --reload command.
+* You need to download the docker container and any NEDs from https://software.cisco.com/download/home/286331591/type. You can also use NEDs from 3rd parties or make your own. The download is a 90 Day trial you can also provide your own docker image or add a license following the cisco documentation.
+* The docker container download this was tested with is 6.4 and the Production image, the development image is used for creating NEDs.
+
+
+**Notes:**
+* Data collected by NSO is stored on a lab-specific Docker volume and remains intact across lab runs until you execute the **netlab down --cleanup** command.
+* Username is admin and password is admin.
+* WebUI and Local Authentication have been enabled and NED Package upload has been enabled by the WebUI.

--- a/extools.md
+++ b/extools.md
@@ -1,0 +1,55 @@
+# Integrating External Tools
+
+Some user might want to use _netlab_ with external management tools (example: Graphite, SuzieQ, Prometheus...). _netlab_ can automatically generate the configuration files for these tools and start them as the last step in the **netlab up** process (after the lab has been configured).
+
+The external tools started with _netlab_ can access the management network and the management interfaces of lab devices. If you need access to lab links start your tool as a [Linux container with a custom image](clab-linux).
+
+```{warning}
+* Tools are started as Docker containers. You have to run your labs on a Linux server with Docker to use external tools with _netlab_.[^DI]
+* When using containers as lab devices _netlab_ connects tool containers to the lab management network and they get IPv4 addresses from the beginning of the management IPv4 prefix. Do not change [**addressing.mgmt.start** parameter](addressing.md) to a very low value when using external tools.
+```
+
+[^DI]: You can use **netlab install containerlab** to install Docker on a Ubuntu server.
+
+## Using the External Tools
+
+Adding a tool to the lab is as easy as adding an entry to the **tools** dictionary. For example, to start SuzieQ together with the lab, simple add the following two lines to the lab topology file:
+
+```
+tools:
+  suzieq:
+```
+
+You can configure individual tools using parameters in the tool-specific dictionary. Some of these parameters are system-defined, others are defined by the tool creator. System-defined parameters include:
+
+* **runtime** -- execution environment. The only supported value is *docker* (Docker container dynamically pulled from a container repository). If you want to start the tools on the Linux host, define *local* execution environment ([details](dev/extools.md)).
+
+For the list of tool-specific parameters see the individual tool description.
+
+(tools-enable-default)=
+## Enabling Tools in User Defaults
+
+You can change [user defaults](defaults.md) to start an external tool with every lab topology -- all you have to do is to set the **defaults.tools._toolname_.enabled** attribute to `True`.
+
+For example, to use Graphite GUI with every lab you start, add the following line to `~/.netlab.yml` file:
+
+```
+tools.graphite.enabled: True
+```
+
+(extools-list)=
+## Supported Tools
+
+_netlab_ includes definitions for the following tools:
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+
+   extool/graphite.md
+   extool/suzieq.md
+   extool/edgeshark.md
+   extool/nso.md
+```
+
+It's relatively easy to add your own tools to the **defaults.tools** dictionary. Read [](dev/extools.md) for more details.

--- a/netsim/tools/nso.yml
+++ b/netsim/tools/nso.yml
@@ -1,0 +1,21 @@
+#
+# Graphite tool
+#
+runtime: docker     # Default: start in a Docker container
+docker:
+    up:
+      docker run --rm -itd --name {name}-cisco-nso {sys.docker_net} -v {name}-nso-vol:/nso -v {name}-nso-log-vol:/log -p { 8888 + defaults.multilab.id if defaults.multilab.id else 8888 }:8080 -e ADMIN_USERNAME=admin -e ADMIN_PASSWORD=admin -e EXTRA_ARGS='--with-package-reload --ignore-initial-validation' cisco-nso-prod;
+      docker exec -it {name}-cisco-nso sed -i.original -e "/<webui>/,/<\\/webui>/ {{ /<transport>/,/<\\/transport>/ {{ /<tcp>/,/<\\/tcp>/ {{ /<enabled>/ s/false/true/ }} }} }}" /etc/ncs/ncs.conf;
+      docker exec -it {name}-cisco-nso sed -i.backup -e "/<local-authentication>/{{n;s|<enabled>false</enabled>|<enabled>true</enabled>|}}" /etc/ncs/ncs.conf;
+      docker exec -it {name}-cisco-nso sed -i.backup -e "/<webui>/a <package-upload> <enabled>true</enabled> </package-upload>" /etc/ncs/ncs.conf;
+    message:
+      Open http://{sys.ipaddr}:{ 8888 + defaults.multilab.id if defaults.multilab.id else 8888 } in your browser
+      Use admin/admin for login
+      Use 'netlab connect nso' to start nso CLI and type ncs_cli -C -u admin to acces cisco CLI
+    connect:
+      docker exec -it '{name}-cisco-nso' bash
+    down:
+      docker kill {name}-cisco-nso
+    cleanup:
+      docker volume rm '{name}-nso-vol'
+      docker volume rm '{name}-nso-log-vol'


### PR DESCRIPTION
This PR adds the Cisco NSO Docker container as an external tool to any lab topology. Also have created documentation.

This PR closes #1615