### PR TITLE
lag: Avoid picking overlapping lag.ifindex in mixed scenarios

### DIFF
--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -11,12 +11,15 @@ links:
   interfaces:
   - ifindex: 30000
     ifname: port-channel1
+    lag:
+      ifindex: 1
     node: r1
   - ifindex: 30000
     ifname: port-channel1
+    lag:
+      ifindex: 1
     node: r2
-  lag:
-    ifindex: 1
+  lag: {}
   linkindex: 1
   mtu: 1600
   node_count: 2

--- a/tests/topology/expected/lag-l3-access-vlan.yml
+++ b/tests/topology/expected/lag-l3-access-vlan.yml
@@ -13,6 +13,8 @@ links:
     ifindex: 30000
     ifname: bond1
     ipv4: 172.16.0.1/24
+    lag:
+      ifindex: 1
     node: r1
     vlan:
       access: v1
@@ -20,11 +22,12 @@ links:
     ifindex: 30000
     ifname: bond1
     ipv4: 172.16.0.2/24
+    lag:
+      ifindex: 1
     node: r2
     vlan:
       access: v1
   lag:
-    ifindex: 1
     lacp: 'off'
   linkindex: 1
   node_count: 2

--- a/tests/topology/expected/lag-l3-vlan-trunk.yml
+++ b/tests/topology/expected/lag-l3-vlan-trunk.yml
@@ -11,6 +11,8 @@ links:
   interfaces:
   - ifindex: 30000
     ifname: bond1
+    lag:
+      ifindex: 1
     node: r1
     vlan:
       trunk:
@@ -18,13 +20,14 @@ links:
         v2: {}
   - ifindex: 30000
     ifname: bond1
+    lag:
+      ifindex: 1
     node: r2
     vlan:
       trunk:
         v1: {}
         v2: {}
-  lag:
-    ifindex: 1
+  lag: {}
   linkindex: 1
   node_count: 2
   prefix: {}

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -12,13 +12,16 @@ links:
   - ifindex: 30000
     ifname: port-channel1
     ipv4: 10.1.0.1/30
+    lag:
+      ifindex: 1
     node: r1
   - ifindex: 30000
     ifname: port-channel1
     ipv4: 10.1.0.2/30
+    lag:
+      ifindex: 1
     node: r2
-  lag:
-    ifindex: 1
+  lag: {}
   linkindex: 1
   node_count: 2
   prefix:

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -75,52 +75,30 @@ links:
 - _linkname: links[3]
   bridge: input_3
   interfaces:
+  - ifindex: 30001
+    ifname: bond2
+    lag:
+      ifindex: 2
+    node: h1
+  - ifindex: 30001
+    ifname: port-channel2
+    lag:
+      ifindex: 2
+    node: s1
+  lag: {}
+  linkindex: 3
+  node_count: 2
+  pool: l2only
+  type: lag
+- _linkname: links[4]
+  bridge: input_4
+  interfaces:
   - _vlan_mode: irb
     ifindex: 30000
     ifname: bond1
     ipv4: 172.16.0.4/24
     lag:
       ifindex: 1
-    node: h2
-    vlan:
-      access: red
-  - _vlan_mode: irb
-    ifindex: 30001
-    ifname: port-channel2
-    ipv4: 172.16.0.1/24
-    lag:
-      _mlag: true
-    node: s1
-    vlan:
-      access: red
-  - _vlan_mode: irb
-    ifindex: 30001
-    ifname: port-channel2
-    ipv4: 172.16.0.2/24
-    lag:
-      _mlag: true
-    node: s2
-    vlan:
-      access: red
-  lag:
-    ifindex: 2
-  linkindex: 3
-  node_count: 3
-  prefix:
-    allocation: id_based
-    ipv4: 172.16.0.0/24
-  type: lag
-  vlan:
-    access: red
-- _linkname: links[4]
-  bridge: input_4
-  interfaces:
-  - _vlan_mode: irb
-    ifindex: 30001
-    ifname: bond2
-    ipv4: 172.16.0.4/24
-    lag:
-      ifindex: 2
     node: h2
     vlan:
       access: red
@@ -134,7 +112,7 @@ links:
     vlan:
       access: red
   - _vlan_mode: irb
-    ifindex: 30002
+    ifindex: 30001
     ifname: port-channel3
     ipv4: 172.16.0.2/24
     lag:
@@ -152,6 +130,46 @@ links:
   type: lag
   vlan:
     access: red
+- _linkname: links[5]
+  bridge: input_5
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 30001
+    ifname: bond2
+    ipv4: 172.16.0.4/24
+    lag:
+      ifindex: 2
+    node: h2
+    vlan:
+      access: red
+  - _vlan_mode: irb
+    ifindex: 30003
+    ifname: port-channel4
+    ipv4: 172.16.0.1/24
+    lag:
+      _mlag: true
+    node: s1
+    vlan:
+      access: red
+  - _vlan_mode: irb
+    ifindex: 30002
+    ifname: port-channel4
+    ipv4: 172.16.0.2/24
+    lag:
+      _mlag: true
+    node: s2
+    vlan:
+      access: red
+  lag:
+    ifindex: 4
+  linkindex: 5
+  node_count: 3
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  type: lag
+  vlan:
+    access: red
 - _linkname: links[1].peerlink[2]
   interfaces:
   - ifindex: 2
@@ -162,7 +180,7 @@ links:
     node: s1
   lag:
     _parentindex: 1
-  linkindex: 5
+  linkindex: 6
   node_count: 2
   prefix: false
   type: p2p
@@ -176,7 +194,7 @@ links:
     node: s1
   lag:
     _parentindex: 2
-  linkindex: 6
+  linkindex: 7
   node_count: 2
   prefix: false
   type: p2p
@@ -190,7 +208,7 @@ links:
     node: s1
   lag:
     _parentindex: 2
-  linkindex: 7
+  linkindex: 8
   node_count: 2
   prefix: false
   type: p2p
@@ -204,7 +222,7 @@ links:
     node: s2
   lag:
     _parentindex: 2
-  linkindex: 8
+  linkindex: 9
   node_count: 2
   prefix: false
   type: p2p
@@ -218,31 +236,17 @@ links:
     node: s2
   lag:
     _parentindex: 2
-  linkindex: 9
+  linkindex: 10
   node_count: 2
   prefix: false
   type: p2p
 - _linkname: links[3].lag[1]
   interfaces:
-  - ifindex: 1
-    ifname: eth1
-    node: h2
+  - ifindex: 5
+    ifname: eth5
+    node: h1
   - ifindex: 5
     ifname: ethernet1/1/5
-    node: s1
-  lag:
-    _parentindex: 3
-  linkindex: 10
-  node_count: 2
-  prefix: false
-  type: p2p
-- _linkname: links[3].lag[2]
-  interfaces:
-  - ifindex: 2
-    ifname: eth2
-    node: h2
-  - ifindex: 6
-    ifname: ethernet1/1/6
     node: s1
   lag:
     _parentindex: 3
@@ -250,7 +254,49 @@ links:
   node_count: 2
   prefix: false
   type: p2p
-- _linkname: links[3].lag[3]
+- _linkname: links[3].lag[2]
+  interfaces:
+  - ifindex: 6
+    ifname: eth6
+    node: h1
+  - ifindex: 6
+    ifname: ethernet1/1/6
+    node: s1
+  lag:
+    _parentindex: 3
+  linkindex: 12
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[1]
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    node: h2
+  - ifindex: 7
+    ifname: ethernet1/1/7
+    node: s1
+  lag:
+    _parentindex: 4
+  linkindex: 13
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[2]
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    node: h2
+  - ifindex: 8
+    ifname: ethernet1/1/8
+    node: s1
+  lag:
+    _parentindex: 4
+  linkindex: 14
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[3]
   interfaces:
   - ifindex: 3
     ifname: eth3
@@ -259,12 +305,12 @@ links:
     ifname: ethernet1/1/5
     node: s2
   lag:
-    _parentindex: 3
-  linkindex: 12
+    _parentindex: 4
+  linkindex: 15
   node_count: 2
   prefix: false
   type: p2p
-- _linkname: links[3].lag[4]
+- _linkname: links[4].lag[4]
   interfaces:
   - ifindex: 4
     ifname: eth4
@@ -273,26 +319,26 @@ links:
     ifname: ethernet1/1/6
     node: s2
   lag:
-    _parentindex: 3
-  linkindex: 13
+    _parentindex: 4
+  linkindex: 16
   node_count: 2
   prefix: false
   type: p2p
-- _linkname: links[4].lag[1]
+- _linkname: links[5].lag[1]
   interfaces:
   - ifindex: 5
     ifname: eth5
     node: h2
-  - ifindex: 7
-    ifname: ethernet1/1/7
+  - ifindex: 9
+    ifname: ethernet1/1/9
     node: s1
   lag:
-    _parentindex: 4
-  linkindex: 14
+    _parentindex: 5
+  linkindex: 17
   node_count: 2
   prefix: false
   type: p2p
-- _linkname: links[4].lag[2]
+- _linkname: links[5].lag[2]
   interfaces:
   - ifindex: 6
     ifname: eth6
@@ -301,8 +347,8 @@ links:
     ifname: ethernet1/1/7
     node: s2
   lag:
-    _parentindex: 4
-  linkindex: 15
+    _parentindex: 5
+  linkindex: 18
   node_count: 2
   prefix: false
   type: p2p
@@ -349,11 +395,27 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+    - ifindex: 30001
+      ifname: bond2
+      lag:
+        ifindex: 2
+        lacp: fast
+        lacp_mode: active
+        mode: 802.3ad
+      linkindex: 3
+      mtu: 1500
+      name: h1 -> s1
+      neighbors:
+      - ifname: port-channel2
+        node: s1
+      pool: l2only
+      type: lag
+      virtual_interface: true
     - ifindex: 1
       ifname: eth1
       lag:
         _parentindex: 2
-      linkindex: 6
+      linkindex: 7
       mtu: 1500
       name: h1 -> s1
       neighbors:
@@ -364,7 +426,7 @@ nodes:
       ifname: eth2
       lag:
         _parentindex: 2
-      linkindex: 7
+      linkindex: 8
       mtu: 1500
       name: h1 -> s1
       neighbors:
@@ -375,7 +437,7 @@ nodes:
       ifname: eth3
       lag:
         _parentindex: 2
-      linkindex: 8
+      linkindex: 9
       mtu: 1500
       name: h1 -> s2
       neighbors:
@@ -386,15 +448,37 @@ nodes:
       ifname: eth4
       lag:
         _parentindex: 2
-      linkindex: 9
+      linkindex: 10
       mtu: 1500
       name: h1 -> s2
       neighbors:
       - ifname: ethernet1/1/4
         node: s2
       type: p2p
+    - ifindex: 5
+      ifname: eth5
+      lag:
+        _parentindex: 3
+      linkindex: 11
+      mtu: 1500
+      name: h1 -> s1
+      neighbors:
+      - ifname: ethernet1/1/5
+        node: s1
+      type: p2p
+    - ifindex: 6
+      ifname: eth6
+      lag:
+        _parentindex: 3
+      linkindex: 12
+      mtu: 1500
+      name: h1 -> s1
+      neighbors:
+      - ifname: ethernet1/1/6
+        node: s1
+      type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 7
       ifname: vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [s2,s1,h2]
@@ -466,28 +550,6 @@ nodes:
         lacp: fast
         lacp_mode: active
         mode: 802.3ad
-      linkindex: 3
-      mtu: 1500
-      name: '[Access VLAN red] h2 -> [s1,s2]'
-      neighbors:
-      - ifname: port-channel2
-        ipv4: 172.16.0.1/24
-        node: s1
-      - ifname: port-channel2
-        ipv4: 172.16.0.2/24
-        node: s2
-      type: lag
-      virtual_interface: true
-      vlan:
-        access: red
-        access_id: 1000
-    - ifindex: 30001
-      ifname: bond2
-      lag:
-        ifindex: 2
-        lacp: fast
-        lacp_mode: active
-        mode: 802.3ad
       linkindex: 4
       mtu: 1500
       name: '[Access VLAN red] h2 -> [s1,s2]'
@@ -503,33 +565,55 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+    - ifindex: 30001
+      ifname: bond2
+      lag:
+        ifindex: 2
+        lacp: fast
+        lacp_mode: active
+        mode: 802.3ad
+      linkindex: 5
+      mtu: 1500
+      name: '[Access VLAN red] h2 -> [s1,s2]'
+      neighbors:
+      - ifname: port-channel4
+        ipv4: 172.16.0.1/24
+        node: s1
+      - ifname: port-channel4
+        ipv4: 172.16.0.2/24
+        node: s2
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
     - ifindex: 1
       ifname: eth1
       lag:
-        _parentindex: 3
-      linkindex: 10
+        _parentindex: 4
+      linkindex: 13
       mtu: 1500
       name: h2 -> s1
       neighbors:
-      - ifname: ethernet1/1/5
+      - ifname: ethernet1/1/7
         node: s1
       type: p2p
     - ifindex: 2
       ifname: eth2
       lag:
-        _parentindex: 3
-      linkindex: 11
+        _parentindex: 4
+      linkindex: 14
       mtu: 1500
       name: h2 -> s1
       neighbors:
-      - ifname: ethernet1/1/6
+      - ifname: ethernet1/1/8
         node: s1
       type: p2p
     - ifindex: 3
       ifname: eth3
       lag:
-        _parentindex: 3
-      linkindex: 12
+        _parentindex: 4
+      linkindex: 15
       mtu: 1500
       name: h2 -> s2
       neighbors:
@@ -539,8 +623,8 @@ nodes:
     - ifindex: 4
       ifname: eth4
       lag:
-        _parentindex: 3
-      linkindex: 13
+        _parentindex: 4
+      linkindex: 16
       mtu: 1500
       name: h2 -> s2
       neighbors:
@@ -550,19 +634,19 @@ nodes:
     - ifindex: 5
       ifname: eth5
       lag:
-        _parentindex: 4
-      linkindex: 14
+        _parentindex: 5
+      linkindex: 17
       mtu: 1500
       name: h2 -> s1
       neighbors:
-      - ifname: ethernet1/1/7
+      - ifname: ethernet1/1/9
         node: s1
       type: p2p
     - ifindex: 6
       ifname: eth6
       lag:
-        _parentindex: 4
-      linkindex: 15
+        _parentindex: 5
+      linkindex: 18
       mtu: 1500
       name: h2 -> s2
       neighbors:
@@ -671,26 +755,19 @@ nodes:
     - ifindex: 30001
       ifname: port-channel2
       lag:
-        _mlag: true
         ifindex: 2
         lacp: fast
         lacp_mode: active
         mode: 802.3ad
       linkindex: 3
       mtu: 1500
-      name: '[Access VLAN red] s1 -> [h2,s2]'
+      name: s1 -> h1
       neighbors:
-      - ifname: bond1
-        ipv4: 172.16.0.4/24
-        node: h2
-      - ifname: port-channel2
-        ipv4: 172.16.0.2/24
-        node: s2
+      - ifname: bond2
+        node: h1
+      pool: l2only
       type: lag
       virtual_interface: true
-      vlan:
-        access: red
-        access_id: 1000
     - ifindex: 30002
       ifname: port-channel3
       lag:
@@ -703,10 +780,33 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
-      - ifname: bond2
+      - ifname: bond1
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel3
+        ipv4: 172.16.0.2/24
+        node: s2
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
+    - ifindex: 30003
+      ifname: port-channel4
+      lag:
+        _mlag: true
+        ifindex: 4
+        lacp: fast
+        lacp_mode: active
+        mode: 802.3ad
+      linkindex: 5
+      mtu: 1500
+      name: '[Access VLAN red] s1 -> [h2,s2]'
+      neighbors:
+      - ifname: bond2
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: port-channel4
         ipv4: 172.16.0.2/24
         node: s2
       type: lag
@@ -720,7 +820,7 @@ nodes:
       ifname: ethernet1/1/2
       lag:
         _parentindex: 1
-      linkindex: 5
+      linkindex: 6
       mtu: 1500
       name: s1 -> s2
       neighbors:
@@ -733,7 +833,7 @@ nodes:
       ifname: ethernet1/1/3
       lag:
         _parentindex: 2
-      linkindex: 6
+      linkindex: 7
       mtu: 1500
       name: s1 -> h1
       neighbors:
@@ -746,7 +846,7 @@ nodes:
       ifname: ethernet1/1/4
       lag:
         _parentindex: 2
-      linkindex: 7
+      linkindex: 8
       mtu: 1500
       name: s1 -> h1
       neighbors:
@@ -759,12 +859,12 @@ nodes:
       ifname: ethernet1/1/5
       lag:
         _parentindex: 3
-      linkindex: 10
+      linkindex: 11
       mtu: 1500
-      name: s1 -> h2
+      name: s1 -> h1
       neighbors:
-      - ifname: eth1
-        node: h2
+      - ifname: eth5
+        node: h1
       type: p2p
     - clab:
         name: eth6
@@ -772,12 +872,12 @@ nodes:
       ifname: ethernet1/1/6
       lag:
         _parentindex: 3
-      linkindex: 11
+      linkindex: 12
       mtu: 1500
-      name: s1 -> h2
+      name: s1 -> h1
       neighbors:
-      - ifname: eth2
-        node: h2
+      - ifname: eth6
+        node: h1
       type: p2p
     - clab:
         name: eth7
@@ -785,7 +885,33 @@ nodes:
       ifname: ethernet1/1/7
       lag:
         _parentindex: 4
+      linkindex: 13
+      mtu: 1500
+      name: s1 -> h2
+      neighbors:
+      - ifname: eth1
+        node: h2
+      type: p2p
+    - clab:
+        name: eth8
+      ifindex: 8
+      ifname: ethernet1/1/8
+      lag:
+        _parentindex: 4
       linkindex: 14
+      mtu: 1500
+      name: s1 -> h2
+      neighbors:
+      - ifname: eth2
+        node: h2
+      type: p2p
+    - clab:
+        name: eth9
+      ifindex: 9
+      ifname: ethernet1/1/9
+      lag:
+        _parentindex: 5
+      linkindex: 17
       mtu: 1500
       name: s1 -> h2
       neighbors:
@@ -793,7 +919,7 @@ nodes:
         node: h2
       type: p2p
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 10
       ifname: virtual-network1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,s2,h2]
@@ -892,29 +1018,6 @@ nodes:
         access: red
         access_id: 1000
     - ifindex: 30001
-      ifname: port-channel2
-      lag:
-        _mlag: true
-        ifindex: 2
-        lacp: fast
-        lacp_mode: active
-        mode: 802.3ad
-      linkindex: 3
-      mtu: 1500
-      name: '[Access VLAN red] s2 -> [h2,s1]'
-      neighbors:
-      - ifname: bond1
-        ipv4: 172.16.0.4/24
-        node: h2
-      - ifname: port-channel2
-        ipv4: 172.16.0.1/24
-        node: s1
-      type: lag
-      virtual_interface: true
-      vlan:
-        access: red
-        access_id: 1000
-    - ifindex: 30002
       ifname: port-channel3
       lag:
         _mlag: true
@@ -926,10 +1029,33 @@ nodes:
       mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
-      - ifname: bond2
+      - ifname: bond1
         ipv4: 172.16.0.4/24
         node: h2
       - ifname: port-channel3
+        ipv4: 172.16.0.1/24
+        node: s1
+      type: lag
+      virtual_interface: true
+      vlan:
+        access: red
+        access_id: 1000
+    - ifindex: 30002
+      ifname: port-channel4
+      lag:
+        _mlag: true
+        ifindex: 4
+        lacp: fast
+        lacp_mode: active
+        mode: 802.3ad
+      linkindex: 5
+      mtu: 1500
+      name: '[Access VLAN red] s2 -> [h2,s1]'
+      neighbors:
+      - ifname: bond2
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: port-channel4
         ipv4: 172.16.0.1/24
         node: s1
       type: lag
@@ -943,7 +1069,7 @@ nodes:
       ifname: ethernet1/1/2
       lag:
         _parentindex: 1
-      linkindex: 5
+      linkindex: 6
       mtu: 1500
       name: s2 -> s1
       neighbors:
@@ -956,7 +1082,7 @@ nodes:
       ifname: ethernet1/1/3
       lag:
         _parentindex: 2
-      linkindex: 8
+      linkindex: 9
       mtu: 1500
       name: s2 -> h1
       neighbors:
@@ -969,7 +1095,7 @@ nodes:
       ifname: ethernet1/1/4
       lag:
         _parentindex: 2
-      linkindex: 9
+      linkindex: 10
       mtu: 1500
       name: s2 -> h1
       neighbors:
@@ -981,8 +1107,8 @@ nodes:
       ifindex: 5
       ifname: ethernet1/1/5
       lag:
-        _parentindex: 3
-      linkindex: 12
+        _parentindex: 4
+      linkindex: 15
       mtu: 1500
       name: s2 -> h2
       neighbors:
@@ -994,8 +1120,8 @@ nodes:
       ifindex: 6
       ifname: ethernet1/1/6
       lag:
-        _parentindex: 3
-      linkindex: 13
+        _parentindex: 4
+      linkindex: 16
       mtu: 1500
       name: s2 -> h2
       neighbors:
@@ -1007,8 +1133,8 @@ nodes:
       ifindex: 7
       ifname: ethernet1/1/7
       lag:
-        _parentindex: 4
-      linkindex: 15
+        _parentindex: 5
+      linkindex: 18
       mtu: 1500
       name: s2 -> h2
       neighbors:

--- a/tests/topology/input/lag-mlag.yml
+++ b/tests/topology/input/lag-mlag.yml
@@ -26,6 +26,9 @@ links:
    members: [ h1-s1,h1-s1,h1-s2,h1-s2 ]  # Test multiple links between same pair of nodes
   vlan.access: red
 - lag:
+   members: [ h1-s1, h1-s1 ]             # Regression: MLAG followed by regular lag should not pick overlapping lag.ifindex
+  pool: l2only
+- lag:
    members: [ h2-s1,h2-s1,h2-s2,h2-s2 ]
   vlan.access: red
 - lag:


### PR DESCRIPTION
This PR solves an issue with ```lag.ifindex``` allocation; in an a-typical mixed use case where there are both regular lags and mlags there are cases where overlapping ```lag.ifindex``` values get generated

On the "M" side of mlags the lag.ifindex needs to match, on the "1" side and on regular lags any locally unique value will suffice