### PR TITLE
Fix node.clone 'count' attribute

### DIFF
--- a/netsim/extra/node.clone/defaults.yml
+++ b/netsim/extra/node.clone/defaults.yml
@@ -6,6 +6,6 @@ clone:
 
   attributes:
     node:
-      clone: { type: int, min_value: 1, _required: True }  # Create N copies of this node anywhere it's used in groups or links
+      count: { type: int, min_value: 1, _required: True }  # Create N copies of this node anywhere it's used in groups or links
       start: int                                           # Optional ID to start with, default 1
       step: int                                            # Optional increment between clones, default 1


### PR DESCRIPTION
Not sure how this got changed, and strangely it doesn't affect the topology tests so attributes aren't getting validated as one would expect