### PR TITLE
Fix: Generate a single instance of Vagrant provisioning script

### DIFF
--- a/netsim/templates/provider/libvirt/Vagrantfile.j2
+++ b/netsim/templates/provider/libvirt/Vagrantfile.j2
@@ -1,5 +1,6 @@
 VAGRANT_COMMAND = ARGV[0]
 
+{% set _vagrant_scripts = namespace() %}
 Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |libvirt|
 {% if addressing.mgmt._network|default(False) %}

--- a/netsim/templates/provider/libvirt/cumulus_nvue-domain.j2
+++ b/netsim/templates/provider/libvirt/cumulus_nvue-domain.j2
@@ -1,3 +1,6 @@
+{% if _vagrant_scripts.cumulus_nvue is not defined %}
+{%   set _vagrant_scripts.cumulus_nvue = True %}
+
     $cumulus_script = <<-SCRIPT
 
 function set_cumulus_password(){
@@ -24,6 +27,7 @@ fi
 
     SCRIPT
 
+{% endif %}
     {{ name }}.ssh.insert_key = false
     if VAGRANT_COMMAND == "ssh" or VAGRANT_COMMAND == "scp"
         {{ name }}.ssh.username = 'cumulus'

--- a/netsim/templates/provider/libvirt/frr-domain.j2
+++ b/netsim/templates/provider/libvirt/frr-domain.j2
@@ -1,9 +1,16 @@
+{% if _vagrant_scripts.frr is not defined %}
+{%   set _vagrant_scripts.frr = True %}
+
     $frr_script = <<-SCRIPT
+echo "Setting password for user Vagrant"
 echo vagrant:{{ n.ansible_ssh_pass }} | chpasswd
+
+echo "Enabling SSH password authentication"
 sed -i -e "s#PasswordAuthentication no#PasswordAuthentication yes#" /etc/ssh/sshd_config
 service sshd restart
     SCRIPT
 
+{% endif %}
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
 
     {{ name }}.vm.provider :libvirt do |domain|


### PR DESCRIPTION
Several devices (frr, cumulus_nvue) need a custom Vagrant provisioning script. That script resides in device-specific template and was included with every device instance. This fix makes sure the script appears in Vagrantfile only once.

Fixes #1597