### PR TITLE
Install FRR during 'vagrant up' processing

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -262,7 +262,7 @@ We're not testing Fortinet implementation as part of the regular integration tes
 ## FRRouting
 
 * Many FRR configuration templates are not idempotent -- you cannot run **netlab initial** multiple times. Non-idempotent templates include VLAN and VRF configurations.
-* VM version of FRR is an Ubuntu VM. The FRR package is downloaded and installed during the initial configuration process.
+* The VM version of FRR is a Debian VM. The FRR package is downloaded and installed during **vagrant up** processing in the libvirt environment and during the initial configuration process (**netlab initial**) in the VirtualBox environment. To postpone the FRR installation to the initial configuration process, set the node variable **netlab_quick_start** to `true`.
 * You can change the FRR default profile with the **netlab_frr_defaults** node parameter (`traditional` or `datacenter`, default is `datacenter`).
 * **netlab collect** downloads FRR configuration but not Linux interface configuration.
 * FRR containers need host kernel modules (drivers) to implement the data-plane functionality of *vrf*, *mpls*, and *vxlan* netlab modules. The kernel modules are automatically loaded (when available) during the **netlab up** processing.

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -34,7 +34,7 @@ sysctl -w net.ipv6.conf.all.forwarding=1
 if which /usr/lib/frr/frrinit.sh; then
   echo "FRR already installed, skipping installation"
 else
-  curl -s https://deb.frrouting.org/frr/keys.asc | apt-key add -
+  curl -s https://deb.frrouting.org/frr/keys.asc >/etc/apt/trusted.gpg.d/frr.asc
   FRRVER="frr-stable"
   echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER > /etc/apt/sources.list.d/frr.list
   apt-get update -qq && apt-get install -qq frr frr-pythontools bridge-utils ethtool

--- a/netsim/templates/provider/libvirt/frr-domain.j2
+++ b/netsim/templates/provider/libvirt/frr-domain.j2
@@ -10,6 +10,24 @@ sed -i -e "s#PasswordAuthentication no#PasswordAuthentication yes#" /etc/ssh/ssh
 service sshd restart
     SCRIPT
 
+    $frr_install_script = <<-SCRIPT
+set -e
+if which /usr/lib/frr/frrinit.sh; then
+  echo "FRR already installed, skipping installation"
+else
+  export DEBIAN_FRONTEND=noninteractive
+  echo "Installing GPG and curl"
+  apt-get update -qq >/dev/null
+  apt-get install -qq curl gnupg >/dev/null
+  echo "Installing FRR -- set 'netlab_quick_start' node variable to True to skip this step"
+  curl -s https://deb.frrouting.org/frr/keys.asc >/etc/apt/trusted.gpg.d/frr.asc
+  FRRVER="frr-stable"
+  echo deb https://deb.frrouting.org/frr $(lsb_release -s -c) $FRRVER > /etc/apt/sources.list.d/frr.list
+  apt-get update -qq >/dev/null
+  apt-get install -qq frr frr-pythontools bridge-utils ethtool >/dev/null
+  echo "Installation complete"
+fi
+    SCRIPT
 {% endif %}
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
 
@@ -20,4 +38,5 @@ service sshd restart
 
     # Run debian-specific provisioning script
     #
-    {{ name }}.vm.provision :shell , :inline => $frr_script
+    {{ name }}.vm.provision :shell, :inline => $frr_script{% 
+      if not (n.netlab_quick_start|default(False)) %} + $frr_install_script {% endif +%}


### PR DESCRIPTION
Installing FRR during 'vagrant up' processing should result in reduced overall start time as other VMs usually take longer to boot.

In labs using only fast-start VMs it might be better to postpone the FRR installation, in particular if you use --fast-config option. Setting netlab_quick_start node variable postpones FRR installation until the initial configuration process.

Closes #1596