### PR TITLE
links: Decouple default address pool from link type

### DIFF
--- a/tests/errors/anycast-prefix.log
+++ b/tests/errors/anycast-prefix.log
@@ -1,11 +1,3 @@
-IncorrectValue in links: Cannot use ipv4 prefix 10.1.0.0/30 to address 2 nodes plus first-hop gateway on links[1]
-... Use "type: lan" or a custom pool on links with default gateways
-... link data: {'_linkname': 'links[1]', 'gateway': {'id': 1, 'protocol': 'anycast',
-... 'anycast': {'mac': '0200.cafe.00ff', 'unicast': True}, 'vrrp': {'group': 1},
-... 'ipv4': '10.1.0.1/30'}, 'interfaces': [{'node': 'r1', 'gateway': {'ipv4':
-... '10.1.0.1/30'}}, {'node': 'r2', 'gateway': {'ipv4': '10.1.0.1/30'}}],
-... 'linkindex': 1, 'node_count': 2, 'type': 'p2p', 'prefix': {'ipv4':
-... '10.1.0.0/30'}}
 IncorrectValue in links: Cannot use ipv4 prefix 192.168.0.8/29 to address 4 nodes plus first-hop gateway on links[2]
 ... link data: {'_linkname': 'links[2]', 'prefix': {'ipv4': '192.168.0.8/29'},
 ... 'gateway': {'id': -4, 'protocol': 'anycast', 'anycast': {'mac':

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -153,11 +153,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.3.1/24
+      ipv4: 10.1.0.5/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.3.2/24
+        ipv4: 10.1.0.6/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -174,11 +174,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.4.1/24
+      ipv4: 10.1.0.9/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.4.2/24
+        ipv4: 10.1.0.10/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -240,7 +240,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 2
-            ipv4: 172.16.3.2
+            ipv4: 10.1.0.6
             name: r2
             type: ebgp
         export:
@@ -260,7 +260,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 3
-            ipv4: 172.16.4.2
+            ipv4: 10.1.0.10
             name: r2
             type: ebgp
         export:
@@ -363,11 +363,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.3.2/24
+      ipv4: 10.1.0.6/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.3.1/24
+        ipv4: 10.1.0.5/30
         node: r1
         vrf: blue
       parent_ifindex: 1
@@ -384,11 +384,11 @@ nodes:
     - bridge_group: 3
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.4.2/24
+      ipv4: 10.1.0.10/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.4.1/24
+        ipv4: 10.1.0.9/30
         node: r1
         vrf: red
       parent_ifindex: 1
@@ -405,11 +405,11 @@ nodes:
     - bridge_group: 2
       ifindex: 7
       ifname: Ethernet2.1
-      ipv4: 172.16.5.2/24
+      ipv4: 10.1.0.13/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.5.3/24
+        ipv4: 10.1.0.14/30
         node: r3
         vrf: blue
       parent_ifindex: 2
@@ -426,11 +426,11 @@ nodes:
     - bridge_group: 3
       ifindex: 8
       ifname: Ethernet2.2
-      ipv4: 172.16.6.2/24
+      ipv4: 10.1.0.17/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.6.3/24
+        ipv4: 10.1.0.18/30
         node: r3
         vrf: red
       parent_ifindex: 2
@@ -505,12 +505,12 @@ nodes:
             type: ebgp
           - as: 65100
             ifindex: 5
-            ipv4: 172.16.3.1
+            ipv4: 10.1.0.5
             name: r1
             type: ebgp
           - as: 65101
             ifindex: 7
-            ipv4: 172.16.5.3
+            ipv4: 10.1.0.14
             name: r3
             type: ebgp
           router_id: 172.32.0.2
@@ -537,12 +537,12 @@ nodes:
             type: ebgp
           - as: 65100
             ifindex: 6
-            ipv4: 172.16.4.1
+            ipv4: 10.1.0.9
             name: r1
             type: ebgp
           - as: 65101
             ifindex: 8
-            ipv4: 172.16.6.3
+            ipv4: 10.1.0.18
             name: r3
             type: ebgp
           router_id: 172.31.0.1
@@ -598,11 +598,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.5.3/24
+      ipv4: 10.1.0.14/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
-        ipv4: 172.16.5.2/24
+        ipv4: 10.1.0.13/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -619,11 +619,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.6.3/24
+      ipv4: 10.1.0.18/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
-        ipv4: 172.16.6.2/24
+        ipv4: 10.1.0.17/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -685,7 +685,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 2
-            ipv4: 172.16.5.2
+            ipv4: 10.1.0.13
             name: r2
             type: ebgp
         export:
@@ -705,7 +705,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 3
-            ipv4: 172.16.6.2
+            ipv4: 10.1.0.17
             name: r2
             type: ebgp
         export:

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -40,36 +40,40 @@ links:
   interfaces:
   - ifindex: 2
     ifname: GigabitEthernet0/2
-    ipv4: 10.1.0.2/30
+    ipv4: 10.3.0.1/31
+    ipv6: 2001:db8:2::2/64
     node: c_ios
   - ifindex: 3
     ifname: GigabitEthernet3
-    ipv4: 10.1.0.1/30
+    ipv4: 10.3.0.0/31
+    ipv6: 2001:db8:2::1/64
     node: c_csr
   linkindex: 2
   node_count: 2
   prefix:
-    ipv4: 10.1.0.0/30
+    ipv4: 10.3.0.0/31
+    ipv6: 2001:db8:2::/64
   type: p2p
 - _linkname: links[3]
   bridge: c-to-a
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
-    ipv4: 10.2.0.68/26
-    ipv6: 2001:db8:1:1::4/64
+    ipv4: 10.2.0.65/26
+    ipv6: 2001:db8:1:1::1/64
     node: a_eos
   - ifindex: 2
     ifname: Ethernet1/2
-    ipv4: 10.2.0.67/26
-    ipv6: 2001:db8:1:1::3/64
+    ipv4: 10.2.0.66/26
+    ipv6: 2001:db8:1:1::2/64
     node: c_nxos
   linkindex: 3
   node_count: 2
+  pool: lan
   prefix:
     ipv4: 10.2.0.64/26
     ipv6: 2001:db8:1:1::/64
-  type: lan
+  type: p2p
 name: input
 nodes:
   a_eos:
@@ -108,16 +112,17 @@ nodes:
     - bridge: c-to-a
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 10.2.0.68/26
-      ipv6: 2001:db8:1:1::4/64
+      ipv4: 10.2.0.65/26
+      ipv6: 2001:db8:1:1::1/64
       linkindex: 3
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
-        ipv4: 10.2.0.67/26
-        ipv6: 2001:db8:1:1::3/64
+        ipv4: 10.2.0.66/26
+        ipv6: 2001:db8:1:1::2/64
         node: c_nxos
-      type: lan
+      pool: lan
+      type: p2p
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -166,12 +171,14 @@ nodes:
       type: lan
     - ifindex: 3
       ifname: GigabitEthernet3
-      ipv4: 10.1.0.1/30
+      ipv4: 10.3.0.0/31
+      ipv6: 2001:db8:2::1/64
       linkindex: 2
       name: c_csr -> c_ios
       neighbors:
       - ifname: GigabitEthernet0/2
-        ipv4: 10.1.0.2/30
+        ipv4: 10.3.0.1/31
+        ipv6: 2001:db8:2::2/64
         node: c_ios
       type: p2p
     loopback:
@@ -223,12 +230,14 @@ nodes:
       type: lan
     - ifindex: 2
       ifname: GigabitEthernet0/2
-      ipv4: 10.1.0.2/30
+      ipv4: 10.3.0.1/31
+      ipv6: 2001:db8:2::2/64
       linkindex: 2
       name: c_ios -> c_csr
       neighbors:
       - ifname: GigabitEthernet3
-        ipv4: 10.1.0.1/30
+        ipv4: 10.3.0.0/31
+        ipv6: 2001:db8:2::1/64
         node: c_csr
       type: p2p
     loopback:
@@ -280,16 +289,17 @@ nodes:
     - bridge: c-to-a
       ifindex: 2
       ifname: Ethernet1/2
-      ipv4: 10.2.0.67/26
-      ipv6: 2001:db8:1:1::3/64
+      ipv4: 10.2.0.66/26
+      ipv6: 2001:db8:1:1::2/64
       linkindex: 3
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2
-        ipv4: 10.2.0.68/26
-        ipv6: 2001:db8:1:1::4/64
+        ipv4: 10.2.0.65/26
+        ipv6: 2001:db8:1:1::1/64
         node: a_eos
-      type: lan
+      pool: lan
+      type: p2p
     loopback:
       ifindex: 0
       ifname: loopback0

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -251,11 +251,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: eth1.1001
-      ipv4: 172.16.4.3/24
+      ipv4: 10.1.0.1/30
       name: s1 -> s2
       neighbors:
       - ifname: eth3.1001
-        ipv4: 172.16.4.4/24
+        ipv4: 10.1.0.2/30
         node: s2
         vrf: red_vrf
       parent_ifindex: 1
@@ -358,11 +358,11 @@ nodes:
           - bridge_group: 2
             ifindex: 3
             ifname: eth1.1001
-            ipv4: 172.16.4.3/24
+            ipv4: 10.1.0.1/30
             name: s1 -> s2
             neighbors:
             - ifname: eth3.1001
-              ipv4: 172.16.4.4/24
+              ipv4: 10.1.0.2/30
               node: s2
               vrf: red_vrf
             ospf:
@@ -483,11 +483,11 @@ nodes:
     - bridge_group: 1
       ifindex: 5
       ifname: eth3.1001
-      ipv4: 172.16.4.4/24
+      ipv4: 10.1.0.2/30
       name: s2 -> s1
       neighbors:
       - ifname: eth1.1001
-        ipv4: 172.16.4.3/24
+        ipv4: 10.1.0.1/30
         node: s1
         vrf: red_vrf
       parent_ifindex: 3
@@ -631,11 +631,11 @@ nodes:
           - bridge_group: 1
             ifindex: 5
             ifname: eth3.1001
-            ipv4: 172.16.4.4/24
+            ipv4: 10.1.0.2/30
             name: s2 -> s1
             neighbors:
             - ifname: eth1.1001
-              ipv4: 172.16.4.3/24
+              ipv4: 10.1.0.1/30
               node: s1
               vrf: red_vrf
             ospf:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -65,11 +65,11 @@ links:
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
-    ipv4: 172.16.1.2/24
+    ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.1.3/24
+    ipv4: 10.1.0.6/30
     node: r3
   libvirt:
     provider:
@@ -77,20 +77,20 @@ links:
   linkindex: 3
   node_count: 2
   prefix:
-    ipv4: 172.16.1.0/24
+    ipv4: 10.1.0.4/30
   type: lan
 - _linkname: links[4]
   bridge: input_4
   gateway:
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
     node: r3
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.2.5/24
+    ipv4: 172.16.1.5/24
     node: h2
   libvirt:
     provider:
@@ -98,25 +98,25 @@ links:
   linkindex: 4
   node_count: 2
   prefix:
-    ipv4: 172.16.2.0/24
+    ipv4: 172.16.1.0/24
   role: stub
   type: lan
 - _linkname: links[5]
   bridge: input_5
   gateway:
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
   interfaces:
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.4/24
+    ipv4: 172.16.2.4/24
     node: h1
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
     node: r3
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.5/24
+    ipv4: 172.16.2.5/24
     node: h2
   libvirt:
     provider:
@@ -124,7 +124,7 @@ links:
   linkindex: 5
   node_count: 3
   prefix:
-    ipv4: 172.16.3.0/24
+    ipv4: 172.16.2.0/24
   role: stub
   type: lan
 module:
@@ -167,16 +167,16 @@ nodes:
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.4/24
+      ipv4: 172.16.2.4/24
       linkindex: 5
       mtu: 1500
       name: h1 -> [r3,h2]
       neighbors:
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       role: stub
       type: lan
@@ -206,32 +206,32 @@ nodes:
     interfaces:
     - bridge: input_4
       gateway:
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.2.5/24
+      ipv4: 172.16.1.5/24
       linkindex: 4
       mtu: 1500
       name: h2 -> r3
       neighbors:
       - ifname: Ethernet2
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
         node: r3
       role: stub
       type: lan
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.5/24
+      ipv4: 172.16.2.5/24
       linkindex: 5
       mtu: 1500
       name: h2 -> [h1,r3]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       role: stub
       type: lan
@@ -343,12 +343,12 @@ nodes:
     - bridge: input_3
       ifindex: 3
       ifname: GigabitEthernet0/3
-      ipv4: 172.16.1.2/24
+      ipv4: 10.1.0.5/30
       linkindex: 3
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.1.3/24
+        ipv4: 10.1.0.6/30
         node: r3
       ospf:
         area: 0.0.0.0
@@ -396,12 +396,12 @@ nodes:
         name: et1
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 172.16.1.3/24
+      ipv4: 10.1.0.6/30
       linkindex: 3
       name: r3 -> r2
       neighbors:
       - ifname: GigabitEthernet0/3
-        ipv4: 172.16.1.2/24
+        ipv4: 10.1.0.5/30
         node: r2
       ospf:
         area: 0.0.0.0
@@ -413,12 +413,12 @@ nodes:
         name: et2
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 172.16.2.3/24
+      ipv4: 172.16.1.3/24
       linkindex: 4
       name: r3 -> h2
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.2.5/24
+        ipv4: 172.16.1.5/24
         node: h2
       ospf:
         area: 0.0.0.0
@@ -431,15 +431,15 @@ nodes:
         name: et3
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 172.16.3.3/24
+      ipv4: 172.16.2.3/24
       linkindex: 5
       name: r3 -> [h1,h2]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/link-tunnel.yml
+++ b/tests/topology/expected/link-tunnel.yml
@@ -27,28 +27,28 @@ links:
   interfaces:
   - ifindex: 20001
     ifname: Tunnel1
-    ipv4: 172.16.1.2/24
+    ipv4: 10.1.0.1/30
     node: r2
   - ifindex: 20001
     ifname: Tunnel1
-    ipv4: 172.16.1.3/24
+    ipv4: 10.1.0.2/30
     node: r3
   linkindex: 2
   node_count: 2
   prefix:
-    ipv4: 172.16.1.0/24
+    ipv4: 10.1.0.0/30
   type: tunnel
 - _linkname: links[3]
   bridge: input_3
   interfaces:
   - ifindex: 20002
     ifname: Tunnel2
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
     node: r3
   linkindex: 3
   node_count: 1
   prefix:
-    ipv4: 172.16.2.0/24
+    ipv4: 172.16.1.0/24
   role: stub
   type: tunnel
 - _linkname: links[4]
@@ -56,20 +56,20 @@ links:
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.3.1/24
+    ipv4: 172.16.2.1/24
     node: r1
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 172.16.3.2/24
+    ipv4: 172.16.2.2/24
     node: r2
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
     node: r3
   linkindex: 4
   node_count: 3
   prefix:
-    ipv4: 172.16.3.0/24
+    ipv4: 172.16.2.0/24
   type: lan
 name: input
 nodes:
@@ -97,15 +97,15 @@ nodes:
     - bridge: input_4
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 172.16.3.1/24
+      ipv4: 172.16.2.1/24
       linkindex: 4
       name: r1 -> [r2,r3]
       neighbors:
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.2/24
+        ipv4: 172.16.2.2/24
         node: r2
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       type: lan
     loopback:
@@ -143,27 +143,27 @@ nodes:
       virtual_interface: true
     - ifindex: 20001
       ifname: Tunnel1
-      ipv4: 172.16.1.2/24
+      ipv4: 10.1.0.1/30
       linkindex: 2
       name: r2 -> r3
       neighbors:
       - ifname: Tunnel1
-        ipv4: 172.16.1.3/24
+        ipv4: 10.1.0.2/30
         node: r3
       type: tunnel
       virtual_interface: true
     - bridge: input_4
       ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 172.16.3.2/24
+      ipv4: 172.16.2.2/24
       linkindex: 4
       name: r2 -> [r1,r3]
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.3.1/24
+        ipv4: 172.16.2.1/24
         node: r1
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       type: lan
     loopback:
@@ -201,18 +201,18 @@ nodes:
       virtual_interface: true
     - ifindex: 20001
       ifname: Tunnel1
-      ipv4: 172.16.1.3/24
+      ipv4: 10.1.0.2/30
       linkindex: 2
       name: r3 -> r2
       neighbors:
       - ifname: Tunnel1
-        ipv4: 172.16.1.2/24
+        ipv4: 10.1.0.1/30
         node: r2
       type: tunnel
       virtual_interface: true
     - ifindex: 20002
       ifname: Tunnel2
-      ipv4: 172.16.2.3/24
+      ipv4: 172.16.1.3/24
       linkindex: 3
       name: r3 -> stub
       neighbors: []
@@ -222,15 +222,15 @@ nodes:
     - bridge: input_4
       ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 172.16.3.3/24
+      ipv4: 172.16.2.3/24
       linkindex: 4
       name: r3 -> [r1,r2]
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.3.1/24
+        ipv4: 172.16.2.1/24
         node: r1
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.2/24
+        ipv4: 172.16.2.2/24
         node: r2
       type: lan
     loopback:

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -406,11 +406,11 @@ nodes:
     - bridge_group: 2
       ifindex: 12
       ifname: eth4.1001
-      ipv4: 172.16.4.4/24
+      ipv4: 10.1.0.6/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1001
-        ipv4: 172.16.4.3/24
+        ipv4: 10.1.0.5/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -424,11 +424,11 @@ nodes:
     - bridge_group: 3
       ifindex: 13
       ifname: eth4.1002
-      ipv4: 172.16.5.4/24
+      ipv4: 10.1.0.10/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1002
-        ipv4: 172.16.5.3/24
+        ipv4: 10.1.0.9/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -442,11 +442,11 @@ nodes:
     - bridge_group: 1
       ifindex: 14
       ifname: eth4.1000
-      ipv4: 172.16.6.4/24
+      ipv4: 10.1.0.14/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1000
-        ipv4: 172.16.6.3/24
+        ipv4: 10.1.0.13/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -966,11 +966,11 @@ nodes:
     - bridge_group: 2
       ifindex: 10
       ifname: eth4.1001
-      ipv4: 172.16.4.3/24
+      ipv4: 10.1.0.5/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1001
-        ipv4: 172.16.4.4/24
+        ipv4: 10.1.0.6/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4
@@ -984,11 +984,11 @@ nodes:
     - bridge_group: 3
       ifindex: 11
       ifname: eth4.1002
-      ipv4: 172.16.5.3/24
+      ipv4: 10.1.0.9/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1002
-        ipv4: 172.16.5.4/24
+        ipv4: 10.1.0.10/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4
@@ -1002,11 +1002,11 @@ nodes:
     - bridge_group: 1
       ifindex: 12
       ifname: eth4.1000
-      ipv4: 172.16.6.3/24
+      ipv4: 10.1.0.13/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1000
-        ipv4: 172.16.6.4/24
+        ipv4: 10.1.0.14/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -407,11 +407,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.6.1/24
+      ipv4: 10.1.0.5/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.6.2/24
+        ipv4: 10.1.0.6/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -427,11 +427,11 @@ nodes:
     - bridge_group: 1
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.7.1/24
+      ipv4: 10.1.0.9/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.7.2/24
+        ipv4: 10.1.0.10/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -524,11 +524,11 @@ nodes:
           - bridge_group: 2
             ifindex: 5
             ifname: Ethernet1.1
-            ipv4: 172.16.6.1/24
+            ipv4: 10.1.0.5/30
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.6.2/24
+              ipv4: 10.1.0.6/30
               node: r2
               vrf: blue
             ospf:
@@ -606,11 +606,11 @@ nodes:
           - bridge_group: 1
             ifindex: 6
             ifname: Ethernet1.2
-            ipv4: 172.16.7.1/24
+            ipv4: 10.1.0.9/30
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.7.2/24
+              ipv4: 10.1.0.10/30
               node: r2
               vrf: red
             ospf:
@@ -691,11 +691,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.6.2/24
+      ipv4: 10.1.0.6/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.6.1/24
+        ipv4: 10.1.0.5/30
         node: r1
         vrf: blue
       parent_ifindex: 1
@@ -711,11 +711,11 @@ nodes:
     - bridge_group: 1
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.7.2/24
+      ipv4: 10.1.0.10/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.7.1/24
+        ipv4: 10.1.0.9/30
         node: r1
         vrf: red
       parent_ifindex: 1
@@ -731,11 +731,11 @@ nodes:
     - bridge_group: 2
       ifindex: 7
       ifname: Ethernet2.1
-      ipv4: 172.16.8.2/24
+      ipv4: 10.1.0.13/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.8.3/24
+        ipv4: 10.1.0.14/30
         node: r3
         vrf: blue
       parent_ifindex: 2
@@ -751,11 +751,11 @@ nodes:
     - bridge_group: 1
       ifindex: 8
       ifname: Ethernet2.2
-      ipv4: 172.16.9.2/24
+      ipv4: 10.1.0.17/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.9.3/24
+        ipv4: 10.1.0.18/30
         node: r3
         vrf: red
       parent_ifindex: 2
@@ -848,11 +848,11 @@ nodes:
           - bridge_group: 2
             ifindex: 5
             ifname: Ethernet1.1
-            ipv4: 172.16.6.2/24
+            ipv4: 10.1.0.6/30
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.6.1/24
+              ipv4: 10.1.0.5/30
               node: r1
               vrf: blue
             ospf:
@@ -872,11 +872,11 @@ nodes:
           - bridge_group: 2
             ifindex: 7
             ifname: Ethernet2.1
-            ipv4: 172.16.8.2/24
+            ipv4: 10.1.0.13/30
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.8.3/24
+              ipv4: 10.1.0.14/30
               node: r3
               vrf: blue
             ospf:
@@ -936,11 +936,11 @@ nodes:
           - bridge_group: 1
             ifindex: 6
             ifname: Ethernet1.2
-            ipv4: 172.16.7.2/24
+            ipv4: 10.1.0.10/30
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.7.1/24
+              ipv4: 10.1.0.9/30
               node: r1
               vrf: red
             ospf:
@@ -960,11 +960,11 @@ nodes:
           - bridge_group: 1
             ifindex: 8
             ifname: Ethernet2.2
-            ipv4: 172.16.9.2/24
+            ipv4: 10.1.0.17/30
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.9.3/24
+              ipv4: 10.1.0.18/30
               node: r3
               vrf: red
             ospf:
@@ -1004,11 +1004,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.8.3/24
+      ipv4: 10.1.0.14/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
-        ipv4: 172.16.8.2/24
+        ipv4: 10.1.0.13/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -1024,11 +1024,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.9.3/24
+      ipv4: 10.1.0.18/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
-        ipv4: 172.16.9.2/24
+        ipv4: 10.1.0.17/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -1101,11 +1101,11 @@ nodes:
           - bridge_group: 1
             ifindex: 2
             ifname: Ethernet1.1
-            ipv4: 172.16.8.3/24
+            ipv4: 10.1.0.14/30
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.1
-              ipv4: 172.16.8.2/24
+              ipv4: 10.1.0.13/30
               node: r2
               vrf: blue
             ospf:
@@ -1145,11 +1145,11 @@ nodes:
           - bridge_group: 2
             ifindex: 3
             ifname: Ethernet1.2
-            ipv4: 172.16.9.3/24
+            ipv4: 10.1.0.18/30
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.2
-              ipv4: 172.16.9.2/24
+              ipv4: 10.1.0.17/30
               node: r2
               vrf: red
             ospf:

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -81,11 +81,11 @@ nodes:
     - bridge_group: 1
       ifindex: 3
       ifname: eth1.1000
-      ipv4: 172.16.2.1/24
+      ipv4: 10.1.0.1/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth2.1000
-        ipv4: 172.16.2.2/24
+        ipv4: 10.1.0.2/30
         node: leaf1
         vrf: customer1
       parent_ifindex: 1
@@ -101,11 +101,11 @@ nodes:
     - bridge_group: 1
       ifindex: 4
       ifname: eth2.1000
-      ipv4: 172.16.2.2/24
+      ipv4: 10.1.0.2/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth1.1000
-        ipv4: 172.16.2.1/24
+        ipv4: 10.1.0.1/30
         node: leaf1
         vrf: global
       parent_ifindex: 2
@@ -121,11 +121,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: eth1.1001
-      ipv4: 172.16.3.1/24
+      ipv4: 10.1.0.5/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth2.1001
-        ipv4: 172.16.3.2/24
+        ipv4: 10.1.0.6/30
         node: leaf1
         vrf: customer2
       parent_ifindex: 1
@@ -141,11 +141,11 @@ nodes:
     - bridge_group: 2
       ifindex: 6
       ifname: eth2.1001
-      ipv4: 172.16.3.2/24
+      ipv4: 10.1.0.6/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth1.1001
-        ipv4: 172.16.3.1/24
+        ipv4: 10.1.0.5/30
         node: leaf1
         vrf: global
       parent_ifindex: 2

--- a/tests/topology/expected/vrrp-interface-granularity.yml
+++ b/tests/topology/expected/vrrp-interface-granularity.yml
@@ -15,26 +15,26 @@ links:
       mac: 0200.cafe.00ff
       unicast: true
     id: -2
-    ipv4: 10.1.0.30/27
+    ipv4: 172.16.0.254/24
     protocol: vrrp
     vrrp:
       group: 1
   interfaces:
   - gateway:
-      ipv4: 10.1.0.30/27
+      ipv4: 172.16.0.254/24
     ifindex: 1
     ifname: Ethernet1
-    ipv4: 10.1.0.1/27
+    ipv4: 172.16.0.1/24
     node: r1
   - gateway: false
     ifindex: 1
     ifname: Ethernet1
-    ipv4: 10.1.0.2/27
+    ipv4: 172.16.0.2/24
     node: r2
   linkindex: 1
   node_count: 2
   prefix:
-    ipv4: 10.1.0.0/27
+    ipv4: 172.16.0.0/24
   type: p2p
 - _linkname: links[2]
   gateway:
@@ -42,7 +42,7 @@ links:
       mac: 0200.cafe.00ff
       unicast: true
     id: -2
-    ipv4: 10.1.0.62/27
+    ipv4: 172.16.1.254/24
     protocol: vrrp
     vrrp:
       group: 1
@@ -50,18 +50,18 @@ links:
   - gateway: false
     ifindex: 2
     ifname: Ethernet2
-    ipv4: 10.1.0.33/27
+    ipv4: 172.16.1.1/24
     node: r1
   - gateway:
-      ipv4: 10.1.0.62/27
+      ipv4: 172.16.1.254/24
     ifindex: 2
     ifname: Ethernet2
-    ipv4: 10.1.0.34/27
+    ipv4: 172.16.1.2/24
     node: r2
   linkindex: 2
   node_count: 2
   prefix:
-    ipv4: 10.1.0.32/27
+    ipv4: 172.16.1.0/24
   type: p2p
 - _linkname: links[3]
   gateway:
@@ -69,28 +69,28 @@ links:
       mac: 0200.cafe.00ff
       unicast: true
     id: -2
-    ipv4: 10.1.0.94/27
+    ipv4: 172.16.2.254/24
     protocol: vrrp
     vrrp:
       group: 1
   interfaces:
   - gateway:
-      ipv4: 10.1.0.94/27
+      ipv4: 172.16.2.254/24
       vrrp:
         priority: 100
     ifindex: 3
     ifname: Ethernet3
-    ipv4: 10.1.0.65/27
+    ipv4: 172.16.2.1/24
     node: r1
   - gateway: false
     ifindex: 3
     ifname: Ethernet3
-    ipv4: 10.1.0.66/27
+    ipv4: 172.16.2.2/24
     node: r2
   linkindex: 3
   node_count: 2
   prefix:
-    ipv4: 10.1.0.64/27
+    ipv4: 172.16.2.0/24
   type: p2p
 module:
 - gateway
@@ -108,24 +108,24 @@ nodes:
     interfaces:
     - gateway:
         id: -2
-        ipv4: 10.1.0.30/27
+        ipv4: 172.16.0.254/24
         protocol: vrrp
         vrrp:
           group: 1
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 10.1.0.1/27
+      ipv4: 172.16.0.1/24
       linkindex: 1
       name: r1 -> r2
       neighbors:
       - gateway: false
         ifname: Ethernet1
-        ipv4: 10.1.0.2/27
+        ipv4: 172.16.0.2/24
         node: r2
       type: p2p
     - ifindex: 2
       ifname: Ethernet2
-      ipv4: 10.1.0.33/27
+      ipv4: 172.16.1.1/24
       linkindex: 2
       name: r1 -> r2
       neighbors:
@@ -134,30 +134,30 @@ nodes:
             mac: 0200.cafe.00ff
             unicast: true
           id: -2
-          ipv4: 10.1.0.62/27
+          ipv4: 172.16.1.254/24
           protocol: vrrp
           vrrp:
             group: 1
         ifname: Ethernet2
-        ipv4: 10.1.0.34/27
+        ipv4: 172.16.1.2/24
         node: r2
       type: p2p
     - gateway:
         id: -2
-        ipv4: 10.1.0.94/27
+        ipv4: 172.16.2.254/24
         protocol: vrrp
         vrrp:
           group: 1
           priority: 100
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 10.1.0.65/27
+      ipv4: 172.16.2.1/24
       linkindex: 3
       name: r1 -> r2
       neighbors:
       - gateway: false
         ifname: Ethernet3
-        ipv4: 10.1.0.66/27
+        ipv4: 172.16.2.2/24
         node: r2
       type: p2p
     loopback:
@@ -186,7 +186,7 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: Ethernet1
-      ipv4: 10.1.0.2/27
+      ipv4: 172.16.0.2/24
       linkindex: 1
       name: r2 -> r1
       neighbors:
@@ -195,34 +195,34 @@ nodes:
             mac: 0200.cafe.00ff
             unicast: true
           id: -2
-          ipv4: 10.1.0.30/27
+          ipv4: 172.16.0.254/24
           protocol: vrrp
           vrrp:
             group: 1
         ifname: Ethernet1
-        ipv4: 10.1.0.1/27
+        ipv4: 172.16.0.1/24
         node: r1
       type: p2p
     - gateway:
         id: -2
-        ipv4: 10.1.0.62/27
+        ipv4: 172.16.1.254/24
         protocol: vrrp
         vrrp:
           group: 1
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 10.1.0.34/27
+      ipv4: 172.16.1.2/24
       linkindex: 2
       name: r2 -> r1
       neighbors:
       - gateway: false
         ifname: Ethernet2
-        ipv4: 10.1.0.33/27
+        ipv4: 172.16.1.1/24
         node: r1
       type: p2p
     - ifindex: 3
       ifname: Ethernet3
-      ipv4: 10.1.0.66/27
+      ipv4: 172.16.2.2/24
       linkindex: 3
       name: r2 -> r1
       neighbors:
@@ -231,13 +231,13 @@ nodes:
             mac: 0200.cafe.00ff
             unicast: true
           id: -2
-          ipv4: 10.1.0.94/27
+          ipv4: 172.16.2.254/24
           protocol: vrrp
           vrrp:
             group: 1
             priority: 100
         ifname: Ethernet3
-        ipv4: 10.1.0.65/27
+        ipv4: 172.16.2.1/24
         node: r1
       type: p2p
     loopback:

--- a/tests/topology/input/dual-stack.yml
+++ b/tests/topology/input/dual-stack.yml
@@ -6,6 +6,10 @@ addressing:
     ipv4: 10.2.0.0/16
     ipv6: 2001:db8:1::/48
     prefix: 26
+  p2p:
+    ipv4: 10.3.0.0/16
+    ipv6: 2001:db8:2::/48
+    prefix: 31
 
 nodes:
 - name: c_ios
@@ -25,9 +29,10 @@ links:
   c_nxos:
   a_eos:
   j_vsrx:
-- c_ios:
+- c_ios:    # This becomes a p2p link
   c_csr:
 - a_eos:
   c_nxos:
-  type: lan
+  # type: lan
+  pool: lan # Can no longer set the type to force use of the LAN pool
   bridge: c-to-a


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1647

* Modifies ```dual-stack``` test case to use ```pool: lan``` instead of ```type: lan```
* ```vrrp-interface-granularity``` test no longer references ```addressing.p2p.prefix``` setting