### PR TITLE
STP: Prevent propagation of attributes to neighbor data

### DIFF
--- a/netsim/modules/stp.yml
+++ b/netsim/modules/stp.yml
@@ -24,6 +24,7 @@ attributes:
     enable:
       copy: global
 
+  intf_to_neighbor: False # By default, do not include STP attributes in neighbors
   interface:
     enable: bool
     port_priority: { type: int, min_value: 0, max_value: 15 }  # 4-bit value, default '8' if not set

--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -89,8 +89,6 @@ nodes:
       neighbors:
       - ifname: port-channel1
         node: r2
-        stp:
-          enable: false
       stp:
         enable: false
       type: lag
@@ -170,8 +168,6 @@ nodes:
       neighbors:
       - ifname: port-channel1
         node: r1
-        stp:
-          enable: false
       stp:
         enable: false
       type: lag

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -17,7 +17,7 @@ groups:
     - vlan
     - stp
 input:
-- topology/input/stp-pvrst.yml
+- topology/input/stp.yml
 - package:topology-defaults.yml
 libvirt:
   providers:
@@ -47,12 +47,40 @@ links:
     trunk:
       blue: {}
       red: {}
+- _linkname: links[2]
+  interfaces:
+  - ifindex: 1
+    ifname: Ethernet1
+    node: s1
+  - ifindex: 2
+    ifname: Ethernet2
+    node: s2
+  linkindex: 2
+  name: P2P L2 link with STP disabled on link
+  node_count: 2
+  stp:
+    enable: false
+  type: p2p
+- _linkname: links[3]
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    node: s2
+  - ifindex: 2
+    ifname: Ethernet2
+    node: s3
+    stp:
+      enable: false
+  linkindex: 3
+  name: P2P L2 link with STP disabled on s3 interface
+  node_count: 2
+  type: p2p
 - _linkname: vlans.red.links[1]
-  bridge: input_2
+  bridge: input_4
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 1
-    ifname: Ethernet1
+    ifindex: 2
+    ifname: Ethernet2
     node: s1
     vlan:
       access: red
@@ -63,7 +91,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 2
+  linkindex: 4
   node_count: 2
   prefix:
     allocation: id_based
@@ -72,11 +100,11 @@ links:
   vlan:
     access: red
 - _linkname: vlans.red.links[2]
-  bridge: input_3
+  bridge: input_5
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 2
-    ifname: Ethernet2
+    ifindex: 4
+    ifname: Ethernet4
     node: s2
     vlan:
       access: red
@@ -87,7 +115,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 3
+  linkindex: 5
   node_count: 2
   prefix:
     allocation: id_based
@@ -96,21 +124,21 @@ links:
   vlan:
     access: red
 - _linkname: vlans.red.links[3]
-  bridge: input_4
+  bridge: input_6
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 2
-    ifname: Ethernet2
+    ifindex: 3
+    ifname: Ethernet3
     node: s1
     vlan:
       access: red
   - _vlan_mode: bridge
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 5
+    ifname: Ethernet5
     node: s2
     vlan:
       access: red
-  linkindex: 4
+  linkindex: 6
   node_count: 2
   prefix:
     allocation: id_based
@@ -119,11 +147,11 @@ links:
   vlan:
     access: red
 - _linkname: vlans.blue.links[1]
-  bridge: input_5
+  bridge: input_7
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 4
+    ifname: Ethernet4
     node: s1
     vlan:
       access: blue
@@ -134,7 +162,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 5
+  linkindex: 7
   node_count: 2
   prefix:
     allocation: id_based
@@ -143,11 +171,11 @@ links:
   vlan:
     access: blue
 - _linkname: vlans.blue.links[2]
-  bridge: input_6
+  bridge: input_8
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 2
-    ifname: Ethernet2
+    ifindex: 3
+    ifname: Ethernet3
     node: s3
     vlan:
       access: blue
@@ -158,7 +186,7 @@ links:
   libvirt:
     provider:
       clab: true
-  linkindex: 6
+  linkindex: 8
   node_count: 2
   prefix:
     allocation: id_based
@@ -167,21 +195,21 @@ links:
   vlan:
     access: blue
 - _linkname: vlans.blue.links[3]
-  bridge: input_7
+  bridge: input_9
   interfaces:
   - _vlan_mode: bridge
-    ifindex: 4
-    ifname: Ethernet4
+    ifindex: 5
+    ifname: Ethernet5
     node: s1
     vlan:
       access: blue
   - _vlan_mode: bridge
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 4
+    ifname: Ethernet4
     node: s3
     vlan:
       access: blue
-  linkindex: 7
+  linkindex: 9
   node_count: 2
   prefix:
     allocation: id_based
@@ -208,11 +236,11 @@ nodes:
     hostname: clab-input-h1
     id: 3
     interfaces:
-    - bridge: input_2
+    - bridge: input_4
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.3/24
-      linkindex: 2
+      linkindex: 4
       mtu: 1500
       name: h1 -> [s1,s2,h2,s3]
       neighbors:
@@ -248,11 +276,11 @@ nodes:
     hostname: clab-input-h2
     id: 4
     interfaces:
-    - bridge: input_3
+    - bridge: input_5
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
-      linkindex: 3
+      linkindex: 5
       mtu: 1500
       name: h2 -> [h1,s1,s2,s3]
       neighbors:
@@ -288,11 +316,11 @@ nodes:
     hostname: clab-input-h3
     id: 5
     interfaces:
-    - bridge: input_5
+    - bridge: input_7
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.5/24
-      linkindex: 5
+      linkindex: 7
       mtu: 1500
       name: h3 -> [s1,s3,s2,h4]
       neighbors:
@@ -328,11 +356,11 @@ nodes:
     hostname: clab-input-h4
     id: 6
     interfaces:
-    - bridge: input_6
+    - bridge: input_8
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.6/24
-      linkindex: 6
+      linkindex: 8
       mtu: 1500
       name: h4 -> [h3,s1,s3,s2]
       neighbors:
@@ -361,10 +389,20 @@ nodes:
     device: eos
     id: 1
     interfaces:
-    - bridge: input_2
-      ifindex: 1
+    - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      name: P2P L2 link with STP disabled on link
+      neighbors:
+      - ifname: Ethernet2
+        node: s2
+      stp:
+        enable: false
+      type: p2p
+    - bridge: input_4
+      ifindex: 2
+      ifname: Ethernet2
+      linkindex: 4
       name: '[Access VLAN red] s1 -> h1'
       neighbors:
       - ifname: eth1
@@ -374,22 +412,22 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_4
-      ifindex: 2
-      ifname: Ethernet2
-      linkindex: 4
+    - bridge: input_6
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 6
       name: '[Access VLAN red] s1 -> s2'
       neighbors:
-      - ifname: Ethernet3
+      - ifname: Ethernet5
         node: s2
       type: lan
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_5
-      ifindex: 3
-      ifname: Ethernet3
-      linkindex: 5
+    - bridge: input_7
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 7
       name: '[Access VLAN blue] s1 -> h3'
       neighbors:
       - ifname: eth1
@@ -399,20 +437,20 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - bridge: input_7
-      ifindex: 4
-      ifname: Ethernet4
-      linkindex: 7
+    - bridge: input_9
+      ifindex: 5
+      ifname: Ethernet5
+      linkindex: 9
       name: '[Access VLAN blue] s1 -> s3'
       neighbors:
-      - ifname: Ethernet3
+      - ifname: Ethernet4
         node: s3
       type: lan
       vlan:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 6
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s2,h2,s3]
       neighbors:
@@ -432,7 +470,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 7
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s3,s2,h4]
       neighbors:
@@ -510,10 +548,28 @@ nodes:
         trunk_id:
         - 1000
         - 1001
-    - bridge: input_3
-      ifindex: 2
+    - ifindex: 2
       ifname: Ethernet2
+      linkindex: 2
+      name: P2P L2 link with STP disabled on link
+      neighbors:
+      - ifname: Ethernet1
+        node: s1
+      stp:
+        enable: false
+      type: p2p
+    - ifindex: 3
+      ifname: Ethernet3
       linkindex: 3
+      name: P2P L2 link with STP disabled on s3 interface
+      neighbors:
+      - ifname: Ethernet2
+        node: s3
+      type: p2p
+    - bridge: input_5
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 5
       name: '[Access VLAN red] s2 -> h2'
       neighbors:
       - ifname: eth1
@@ -523,20 +579,20 @@ nodes:
       vlan:
         access: red
         access_id: 1000
-    - bridge: input_4
-      ifindex: 3
-      ifname: Ethernet3
-      linkindex: 4
+    - bridge: input_6
+      ifindex: 5
+      ifname: Ethernet5
+      linkindex: 6
       name: '[Access VLAN red] s2 -> s1'
       neighbors:
-      - ifname: Ethernet2
+      - ifname: Ethernet3
         node: s1
       type: lan
       vlan:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 8
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h2,s3]
       neighbors:
@@ -556,7 +612,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 9
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s3,h4]
       neighbors:
@@ -634,10 +690,20 @@ nodes:
         trunk_id:
         - 1000
         - 1001
-    - bridge: input_6
-      ifindex: 2
+    - ifindex: 2
       ifname: Ethernet2
-      linkindex: 6
+      linkindex: 3
+      name: P2P L2 link with STP disabled on s3 interface
+      neighbors:
+      - ifname: Ethernet3
+        node: s2
+      stp:
+        enable: false
+      type: p2p
+    - bridge: input_8
+      ifindex: 3
+      ifname: Ethernet3
+      linkindex: 8
       name: '[Access VLAN blue] s3 -> h4'
       neighbors:
       - ifname: eth1
@@ -647,20 +713,20 @@ nodes:
       vlan:
         access: blue
         access_id: 1001
-    - bridge: input_7
-      ifindex: 3
-      ifname: Ethernet3
-      linkindex: 7
+    - bridge: input_9
+      ifindex: 4
+      ifname: Ethernet4
+      linkindex: 9
       name: '[Access VLAN blue] s3 -> s1'
       neighbors:
-      - ifname: Ethernet4
+      - ifname: Ethernet5
         node: s1
       type: lan
       vlan:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 7
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s2,h4]
       neighbors:
@@ -680,7 +746,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 8
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,s2,h2]
       neighbors:

--- a/tests/topology/input/stp.yml
+++ b/tests/topology/input/stp.yml
@@ -1,5 +1,10 @@
+---
 defaults.device: eos
 stp.protocol: pvrst  # Topology requires running STP per VLAN
+
+addressing:
+  p2p:
+    ipv4: False      # STP only applies to L2 interfaces
 
 groups:
   _auto_create: true
@@ -23,6 +28,16 @@ links:
 - s2:
   s3:
   vlan.trunk: [red, blue]
+
+- name: P2P L2 link with STP disabled on link
+  s1:
+  s2:
+  stp.enable: False
+
+- name: P2P L2 link with STP disabled on s3 interface
+  s2:
+  s3:
+    stp.enable: False
 
 nodes:
   s1:


### PR DESCRIPTION
* Set ```intf_to_neighbor``` to False to prevent propagation to neighbor data
* Generalize STP test case to include various ```stp.enable: False``` cases