### PR TITLE
Add 'lag' support to the 'none' device

### DIFF
--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -43,6 +43,9 @@ features:
       ipv4: True
       ipv6: True
       network: True
+  lag:
+    mlag: True
+    passive: True
   mpls:
     ldp: True
     bgp: True


### PR DESCRIPTION
The ```none``` device should declare to support lag features, such that devices can be emulated without being instantiated