### PR TITLE
EOS: Fix variable name typo in bfd template

### DIFF
--- a/netsim/ansible/templates/bfd/eos.j2
+++ b/netsim/ansible/templates/bfd/eos.j2
@@ -8,7 +8,7 @@ interface {{ l.ifname }}
    link_bfd.min_rx|default(bfd.min_rx)|default(500) }} multiplier {{
    link_bfd.multiplier|default(bfd.multiplier)|default(3)
    }}
-{%     if bfd.min_echo_rx|default(0) or link_bfx.min_echo_rx|default(0) %}
+{%     if bfd.min_echo_rx|default(0) or link_bfd.min_echo_rx|default(0) %}
  bfd echo
 {%     endif %}
 {%   else %}


### PR DESCRIPTION
bfd echo wasn't being configured when requested on a link