### PR TITLE
Dell OS10: Add ospf timers/priority support

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -153,6 +153,7 @@ These devices also support optional OSPF interface attributes:
 | Cisco IOS XE[^18v]       | ✅ | ✅ | ❌  | ❌  |
 | Cisco Nexus OS           | ✅ | ✅ | ❌  | ❌  |
 | Cumulus Linux            | ✅ | ✅ | ❌  | ❌  |
+| Dell OS10                | ✅ | ✅ | ❌  | ❌  |
 | FRR                      | ✅ | ✅ | ❌  | ❌  |
 
 ## Global Parameters

--- a/netsim/ansible/templates/ospf/dellos10.macro.j2
+++ b/netsim/ansible/templates/ospf/dellos10.macro.j2
@@ -14,6 +14,9 @@ interface {{ l.ifname }}
 {%   if l.ospf.passive|default(False) %}
  {{ af }} ospf passive
 {%   endif %}
+{%   if l.ospf.priority is defined %}
+ {{ af }} ospf priority {{ l.ospf.priority }}
+{%   endif %}
 {%   if l.ospf.timers.hello is defined %}
  {{ af }} ospf hello-interval {{ l.ospf.timers.hello }}
 {%   endif %}

--- a/netsim/ansible/templates/ospf/dellos10.macro.j2
+++ b/netsim/ansible/templates/ospf/dellos10.macro.j2
@@ -1,0 +1,24 @@
+{% macro configure_ospf_interface(l,ospf_pid,af="ip") %}
+interface {{ l.ifname }}
+! {{ l.name|default("") }}
+ {{ af }} ospf {{ ospf_pid }} area {{ l.ospf.area }}
+{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
+ {{ af }} ospf network {{ l.ospf.network_type }}
+{%   endif %}
+{%   if l.ospf.cost is defined %}
+ {{ af }} ospf cost {{ l.ospf.cost }}
+{%   endif %}
+{%   if l.ospf.bfd|default(False) %}
+ {{ af }} ospf bfd all-neighbors
+{%   endif %}
+{%   if l.ospf.passive|default(False) %}
+ {{ af }} ospf passive
+{%   endif %}
+{%   if l.ospf.timers.hello is defined %}
+ {{ af }} ospf hello-interval {{ l.ospf.timers.hello }}
+{%   endif %}
+{%   if l.ospf.timers.dead is defined %}
+ {{ af }} ospf dead-interval {{ l.ospf.timers.dead }}
+{%   endif %}
+!
+{% endmacro %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
@@ -1,3 +1,5 @@
+{% from "dellos10.macro.j2" import configure_ospf_interface %}
+
 router ospf {{ pid }}
 {% if ospf.router_id|ipv4 %}
  router-id {{ ospf.router_id }}
@@ -12,26 +14,5 @@ interface loopback0
  ip ospf passive
 !
 {% for l in interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
-interface {{ l.ifname }}
-! {{ l.name|default("") }}
- ip ospf {{ pid }} area {{ l.ospf.area }}
-{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
- ip ospf network {{ l.ospf.network_type }}
-{%   endif %}
-{%   if l.ospf.cost is defined %}
- ip ospf cost {{ l.ospf.cost }}
-{%   endif %}
-{%   if l.ospf.bfd|default(False) %}
- ip ospf bfd all-neighbors
-{%   endif %}
-{%   if l.ospf.passive|default(False) %}
- ip ospf passive
-{%   endif %}
-{%   if l.ospf.timers.hello is defined %}
- ip ospf hello-interval {{ l.ospf.timers.hello }}
-{%   endif %}
-{%   if l.ospf.timers.dead is defined %}
- ip ospf dead-interval {{ l.ospf.timers.dead }}
-{%   endif %}
-!
+{{   configure_ospf_interface(l,pid) }}
 {% endfor %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
@@ -27,5 +27,11 @@ interface {{ l.ifname }}
 {%   if l.ospf.passive|default(False) %}
  ip ospf passive
 {%   endif %}
+{%   if l.ospf.timers.hello is defined %}
+ ip ospf hello-interval {{ l.ospf.timers.hello }}
+{%   endif %}
+{%   if l.ospf.timers.dead is defined %}
+ ip ospf dead-interval {{ l.ospf.timers.dead }}
+{%   endif %}
 !
 {% endfor %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
@@ -1,3 +1,5 @@
+{% from "dellos10.macro.j2" import configure_ospf_interface %}
+
 router ospfv3 {{ pid }}
  router-id {{ ospf.router_id }}
 {% if ospf.reference_bandwidth is defined %}
@@ -12,26 +14,5 @@ interface loopback0
 {% endif %}
 !
 {% for l in interfaces|default([]) if 'ospf' in l and 'ipv6' in l %}
-interface {{ l.ifname }}
-! {{ l.name|default("") }}
- ipv6 ospf {{ pid }} area {{ l.ospf.area }}
-{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
- ipv6 ospf network {{ l.ospf.network_type }}
-{%   endif %}
-{%   if l.ospf.cost is defined %}
- ipv6 ospf cost {{ l.ospf.cost }}
-{%   endif %}
-{%   if l.ospf.bfd|default(False) %}
- ipv6 ospf bfd all-neighbors
-{%   endif %}
-{%   if l.ospf.passive|default(False) %}
- ipv6 ospf passive
-{%   endif %}
-{%   if l.ospf.timers.hello is defined %}
- ipv6 ospf hello-interval {{ l.ospf.timers.hello }}
-{%   endif %}
-{%   if l.ospf.timers.dead is defined %}
- ipv6 ospf dead-interval {{ l.ospf.timers.dead }}
-{%   endif %}
-!
+{{   configure_ospf_interface(l,pid,af='ipv6') }}
 {% endfor %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
@@ -8,6 +8,7 @@ router ospfv3 {{ pid }}
 {% if 'ipv6' in loopback %}
 interface loopback0
  ipv6 ospf {{ pid }} area {{ ospf.area }}
+ ipv6 ospf passive
 {% endif %}
 !
 {% for l in interfaces|default([]) if 'ospf' in l and 'ipv6' in l %}
@@ -25,6 +26,12 @@ interface {{ l.ifname }}
 {%   endif %}
 {%   if l.ospf.passive|default(False) %}
  ipv6 ospf passive
+{%   endif %}
+{%   if l.ospf.timers.hello is defined %}
+ ipv6 ospf hello-interval {{ l.ospf.timers.hello }}
+{%   endif %}
+{%   if l.ospf.timers.dead is defined %}
+ ipv6 ospf dead-interval {{ l.ospf.timers.dead }}
 {%   endif %}
 !
 {% endfor %}

--- a/netsim/ansible/templates/vrf/dellos10.j2
+++ b/netsim/ansible/templates/vrf/dellos10.j2
@@ -2,5 +2,5 @@
 {%   include 'dellos10.ospfv2-vrf.j2' %}
 {% endfor %}
 {% if bgp.as is defined %}
-{% include 'dellos10.bgp.j2' %}
+{%   include 'dellos10.bgp.j2' %}
 {% endif %}

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -1,28 +1,15 @@
+{% from "templates/ospf/dellos10.macro.j2" import configure_ospf_interface %}
+
 router ospf {{ vdata.vrfidx }} vrf {{ vname }}
   router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
   redistribute connected
 {% if bgp.as is defined %}
- redistribute bgp {{ bgp.as }}
+  redistribute bgp {{ bgp.as }}
 {% endif %}
 {% if ospf.reference_bandwidth is defined %}
- auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
+  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
 !
 {% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
-interface {{ l.ifname }}
-! {{ l.name|default("") }}
- ip ospf {{ vdata.vrfidx }} area {{ l.ospf.area }}
-{%   if l.ospf.network_type|default("") in ["broadcast","point-to-point"] %}
- ip ospf network {{ l.ospf.network_type }}
-{%   endif %}
-{%   if l.ospf.cost is defined %}
- ip ospf cost {{ l.ospf.cost }}
-{%   endif %}
-{%   if l.ospf.bfd|default(False) %}
- ip ospf bfd all-neighbors
-{%   endif %}
-{%   if l.ospf.passive|default(False) %}
- ip ospf passive
-{%   endif %}
-!
+{{   configure_ospf_interface(l,vdata.vrfidx) }}
 {% endfor %}

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -28,7 +28,8 @@ features:
         mac: 0200.01a9.0000  # Base to generate a virtual MAC
         ip: loopback.ipv4    # Use loopback.ipv4 for peer IP address
     passive: True
-  ospf: true
+  ospf:
+    timers: True
   stp:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -30,6 +30,7 @@ features:
     passive: True
   ospf:
     timers: True
+    priority: True
   stp:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True

--- a/tests/integration/ospf/ospfv2/31-priority.yml
+++ b/tests/integration/ospf/ospfv2/31-priority.yml
@@ -50,7 +50,7 @@ validate:
     show:
       frr: ip ospf neighbor {{ hostvars.dut.ospf.router_id }} json
     valid: |
-      default["{{ hostvars.dut.ospf.router_id }}"][0].nbrState == "Full/DR"
+      default["{{ hostvars.dut.ospf.router_id }}"][0].nbrPriority == 200
   v_adj:
     description: Check VRF OSPF adjacencies
     wait_msg: Waiting for OSPF adjacency in VRF customer
@@ -61,6 +61,6 @@ validate:
     description: Check the DR status
     nodes: [ x1 ]
     show:
-      frr: ip ospf neighbor {{ hostvars.dut.ospf.router_id }} json
+      frr: ip ospf neighbor {{ hostvars.dut.vrfs.customer.ospf.router_id }} json
     valid: |
-      default["{{ hostvars.dut.ospf.router_id }}"][0].nbrState == "Full/DR"
+      default["{{ hostvars.dut.vrfs.customer.ospf.router_id }}"][0].nbrPriority == 0

--- a/tests/integration/ospf/ospfv2/31-priority.yml
+++ b/tests/integration/ospf/ospfv2/31-priority.yml
@@ -45,7 +45,7 @@ validate:
     nodes: [ x1, x2 ]
     plugin: ospf_neighbor(nodes.dut.ospf.router_id)
   g_dr:
-    description: Check the DR status
+    description: Check the neighbor priority
     nodes: [ x1 ]
     show:
       frr: ip ospf neighbor {{ hostvars.dut.ospf.router_id }} json
@@ -58,7 +58,7 @@ validate:
     nodes: [ x1, x2 ]
     plugin: ospf_neighbor(nodes.dut.vrfs.customer.ospf.router_id)
   v_dr:
-    description: Check the DR status
+    description: Check the VRF neighbor priority
     nodes: [ x1 ]
     show:
       frr: ip ospf neighbor {{ hostvars.dut.vrfs.customer.ospf.router_id }} json


### PR DESCRIPTION
* Refactor templates to use a common ```configure_ospf_interface``` macro
* Keep existing redistribution configs for VRFs (though inconsistent with default VRF)
* Add ```ipv6 ospf passive``` to v6 loopback (tested - yes it makes a difference, though aesthetic more than material)
* Add ospf priority setting on interface, if defined

Passes ```integration/ospf/ospfv2/30-timers.yml``` test case
Passes (modified) ```integration/ospf/ospfv2/31-priority.yml``` test case