### PR TITLE
bgp: Fix localas_ibgp inconsistencies and issues

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -324,7 +324,7 @@ Use the **netlab show module --module bgp --feature ipv6_lla** command to displa
 (bgp-ibgp-localas)=
 **IBGP Sessions Resulting from Matching bgp.local_as on an EBGP Session**
 
-When **bgp.local_as** is configured with the same value as the neighbor AS, the result is an IBGP session (between interfaces instead of loopbacks). Most platforms treat such `localas_ibgp` sessions no different from regular `ibgp` sessions, but there could be subtle differences.
+When **bgp.local_as** is configured with the same value as the neighbor AS, the result is an IBGP session. Most platforms treat such `localas_ibgp` sessions no different from regular `ibgp` sessions, but there could be subtle differences (and even bugs)
 
 ## IPv6 Support
 

--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -163,7 +163,7 @@ Additional per-node BGP configuration parameters include:
 * **bgp.advertise_loopback** -- when set to `False`, the IP prefixes configured on loopback interfaces are not advertised in BGP. See also [*Advanced Global Configuration Parameters*](#advanced-global-configuration-parameters).
 * **bgp.community** -- override global BGP community propagation defaults for this node. See *[](bgp-community-propagation)* for more details.
 * **bgp.import** -- [import (redistribute) IPv4 and IPv6 routes](routing_import) into global BGP instance (default: **false**)
-* **bgp.local_as** -- the autonomous system used on all EBGP sessions.
+* **bgp.local_as** -- the autonomous system used on all EBGP sessions. See *[](bgp-ibgp-localas)* on how this could result in **IBGP** sessions as well.
 * **bgp.next_hop_self** -- Use *next-hop-self* on IBGP sessions. This parameter can also be specified as a global value; the system default is **true**.
 * **bgp.originate** -- a list of additional prefixes to advertise. The advertised prefixes are supported with a static route pointing to *Null0*.
 * **bgp.router_id** -- Set a static router ID. The default **router_id** is taken from the IPv4 address of the loopback interface or the **router_id** address pool if the device does not have a loopback interface or there is no usable IPv4 address on the loopback interface.
@@ -297,7 +297,7 @@ _netlab_ generates a warning for routers that have IBGP sessions without an unde
 ```
 
 (bgp-ebgp-sessions)=
-**EBGP sessions**
+**EBGP Sessions**
 
 * Whenever multiple nodes connected to the same link use different AS numbers, you'll get a full mesh of EBGP sessions between them[^EB_D].
 * Global (**bgp.as**) and local (**bgp.local_as**) autonomous systems are considered when deciding to create a session between two adjacent nodes, allowing you to create EBGP sessions between nodes belonging to the same AS or IBGP sessions between nodes belonging to different AS.
@@ -320,6 +320,11 @@ Use the **netlab show module --module bgp --feature ipv6_lla** command to displa
 *netlab* can use IPv6 EBGP sessions to transport IPv4 address family with IPv6 next hops (RFC 8950) -- the functionality commonly used to implement *interface EBGP sessions*. *netlab* will enable IPv4 AF over IPv6 LLA EBGP sessions when the **unnumbered** link- or interface attribute is set, or when **ipv4** interface address or link prefix is set to *True*.
 
 Use the **netlab show module --module bgp --feature ipv6_lla** command to display devices on which you can use the IPv4 address family on IPv6 LLA EBGP sessions and the **netlab show module --module bgp --feature rfc8950** command to display devices on which you can use the IPv4 address family on regular IPv6 EBGP sessions.
+
+(bgp-ibgp-localas)=
+**IBGP Sessions Resulting from Matching bgp.local_as on an EBGP Session**
+
+When **bgp.local_as** is configured with the same value as the neighbor AS, the result is an IBGP session (between interfaces instead of loopbacks). Most platforms treat such `localas_ibgp` sessions no different from regular `ibgp` sessions, but there could be subtle differences.
 
 ## IPv6 Support
 

--- a/netsim/extra/ebgp.multihop/plugin.py
+++ b/netsim/extra/ebgp.multihop/plugin.py
@@ -202,13 +202,6 @@ def fix_vrf_loopbacks(ndata: Box, topology: Box) -> None:
       ngb._source_ifname = ndata.loopback.ifname
 
 '''
-fix_localas_ibgp_neighbors - remove 'multihop' from any localas_ibgp neighbors
-'''
-def fix_localas_ibgp_neighbors(ndata: Box, topology: Box) -> None:
-  for ngb in _bgp.neighbors(ndata,vrf=True,select=['localas_ibgp']):    # Iterate over all localas_ibgp neighbors
-    ngb.pop('multihop',None)                                            # Remove 'multihop' config if any
-
-'''
 post_transform processing:
 
 * Remove fake interfaces and links
@@ -219,7 +212,6 @@ def post_transform(topology: Box) -> None:
   global _config_name
   for ndata in topology.nodes.values():
     fix_vrf_loopbacks(ndata,topology)
-    fix_localas_ibgp_neighbors(ndata,topology)
     cleanup_interfaces(ndata,topology)
 
   topology.links = [ link for link in topology.links if not link.get('_bgp_session',None) ]

--- a/netsim/extra/ebgp.multihop/plugin.py
+++ b/netsim/extra/ebgp.multihop/plugin.py
@@ -202,6 +202,13 @@ def fix_vrf_loopbacks(ndata: Box, topology: Box) -> None:
       ngb._source_ifname = ndata.loopback.ifname
 
 '''
+fix_localas_ibgp_neighbors - remove 'multihop' from any localas_ibgp neighbors
+'''
+def fix_localas_ibgp_neighbors(ndata: Box, topology: Box) -> None:
+  for ngb in _bgp.neighbors(ndata,vrf=True,select=['localas_ibgp']):    # Iterate over all localas_ibgp neighbors
+    ngb.pop('multihop',None)                                            # Remove 'multihop' config if any
+
+'''
 post_transform processing:
 
 * Remove fake interfaces and links
@@ -212,6 +219,7 @@ def post_transform(topology: Box) -> None:
   global _config_name
   for ndata in topology.nodes.values():
     fix_vrf_loopbacks(ndata,topology)
+    fix_localas_ibgp_neighbors(ndata,topology)
     cleanup_interfaces(ndata,topology)
 
   topology.links = [ link for link in topology.links if not link.get('_bgp_session',None) ]

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -93,7 +93,7 @@ bgp_neighbor: Create BGP neighbor data structure
 
 * n - neighbor node data
 * intf - neighbor interface data (could be addressing prefix or whatever is in the interface neighbor list)
-* ctype - session type (ibgp or ebgp)
+* ctype - session type (ibgp or ebgp or localas_ibgp)
 * extra_data - anything else we might want to pass to the neighbor data structure
 """
 def bgp_neighbor(n: Box, intf: Box, ctype: str, sessions: Box, extra_data: typing.Optional[dict] = None) -> typing.Optional[Box]:
@@ -450,6 +450,8 @@ def build_bgp_sessions(node: Box, topology: Box) -> None:
   activate = node.bgp.get('activate') or data.get_box(BGP_DEFAULT_SESSIONS)
   if not validate_bgp_sessions(node,activate,'activate'):
     return
+  if 'ibgp' in activate and 'localas_ibgp' not in activate:                     # Make 'ibgp' imply 'localas_ibgp'
+    activate.append('localas_ibgp')
 
   activate_bgp_default_af(node,activate,topology)
 

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -602,8 +602,8 @@ def bgp_transform_community_list(node: Box, topology: Box) -> None:
           module='bgp',
           more_hints=[ f"Valid values are {','.join(kw_xform.keys())}" ])
     
-  if 'ibgp_localas' not in clist:
-    clist.ibgp_localas = clist.ibgp
+  if 'localas_ibgp' not in clist:
+    clist.localas_ibgp = clist.ibgp
 
   for s_type in list(clist.keys()):
     clist[s_type] = data.kw_list_transform(kw_xform,clist[s_type])

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -29,11 +29,11 @@ attributes:
     ebgp_role: str
     as_list: dict
     sessions:
-      ipv4: [ ibgp, ebgp ]
-      ipv6: [ ibgp, ebgp ]
+      ipv4: [ ibgp, ebgp, localas_ibgp ]
+      ipv6: [ ibgp, ebgp, localas_ibgp ]
     activate:
-      ipv4: [ ibgp, ebgp ]
-      ipv6: [ ibgp, ebgp ]
+      ipv4: [ ibgp, ebgp, localas_ibgp ]
+      ipv6: [ ibgp, ebgp, localas_ibgp ]
     advertise_loopback: bool
     advertise_roles: list
     community:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -32,8 +32,8 @@ attributes:
       ipv4: [ ibgp, ebgp, localas_ibgp ]
       ipv6: [ ibgp, ebgp, localas_ibgp ]
     activate:
-      ipv4: [ ibgp, ebgp, localas_ibgp ]
-      ipv6: [ ibgp, ebgp, localas_ibgp ]
+      ipv4: [ ibgp, ebgp ]
+      ipv6: [ ibgp, ebgp ]
     advertise_loopback: bool
     advertise_roles: list
     community:

--- a/tests/integration/bgp.multihop/01-global.yml
+++ b/tests/integration/bgp.multihop/01-global.yml
@@ -29,10 +29,6 @@ bgp.multihop.sessions:
 - dut:
   pe2:
     passive: True
-- dut:
-    local_as: 65101 # localas_ibgp session
-  pe2:
-
 
 nodes:
   dut:

--- a/tests/integration/bgp.multihop/01-global.yml
+++ b/tests/integration/bgp.multihop/01-global.yml
@@ -29,6 +29,10 @@ bgp.multihop.sessions:
 - dut:
   pe2:
     passive: True
+- dut:
+    local_as: 65101 # localas_ibgp session
+  pe2:
+
 
 nodes:
   dut:

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -140,7 +140,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -202,7 +202,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -328,7 +328,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -429,7 +429,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -117,7 +117,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -243,7 +243,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -366,7 +366,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -467,7 +467,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -96,7 +96,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -193,7 +193,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -303,7 +303,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true
@@ -400,7 +400,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv6: true

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -76,7 +76,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -121,7 +121,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -177,7 +177,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -224,7 +224,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -280,7 +280,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -49,7 +49,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -116,7 +116,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -152,7 +152,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -223,7 +223,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -294,7 +294,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -365,7 +365,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -432,7 +432,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -535,7 +535,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -620,7 +620,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -66,7 +66,7 @@ nodes:
         - standard
         ibgp:
         - standard
-        ibgp_localas:
+        localas_ibgp:
         - standard
       ipv4: true
       neighbors:
@@ -146,7 +146,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -229,7 +229,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -92,7 +92,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -193,7 +193,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -288,7 +288,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -390,7 +390,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -87,7 +87,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -165,7 +165,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -145,7 +145,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -200,7 +200,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -255,7 +255,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -346,7 +346,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -437,7 +437,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -518,7 +518,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-rs-2as.yml
+++ b/tests/topology/expected/bgp-rs-2as.yml
@@ -70,7 +70,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -161,7 +161,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -253,7 +253,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -345,7 +345,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -88,7 +88,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -196,7 +196,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -282,7 +282,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -150,7 +150,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -333,7 +333,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -423,7 +423,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -489,7 +489,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -548,7 +548,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -82,7 +82,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -163,7 +163,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -263,7 +263,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -128,7 +128,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -290,7 +290,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -573,7 +573,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -204,7 +204,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -285,7 +285,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -429,7 +429,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -548,7 +548,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -667,7 +667,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -778,7 +778,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -357,7 +357,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -452,7 +452,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -547,7 +547,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -705,7 +705,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -863,7 +863,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -991,7 +991,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -1119,7 +1119,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -1277,7 +1277,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -1435,7 +1435,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -1563,7 +1563,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -51,7 +51,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -118,7 +118,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -152,7 +152,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -333,7 +333,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -473,7 +473,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -571,7 +571,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -306,7 +306,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -624,7 +624,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -61,7 +61,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -161,7 +161,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -89,7 +89,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -221,7 +221,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -61,7 +61,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -57,7 +57,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -279,7 +279,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -470,7 +470,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -608,7 +608,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -242,7 +242,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -367,7 +367,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -551,7 +551,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -647,7 +647,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -743,7 +743,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -825,7 +825,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -193,7 +193,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -67,7 +67,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -121,7 +121,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -176,7 +176,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -231,7 +231,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -286,7 +286,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -341,7 +341,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -90,7 +90,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -53,7 +53,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/module-node-only.yml
+++ b/tests/topology/expected/module-node-only.yml
@@ -58,7 +58,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -91,7 +91,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -99,7 +99,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -241,7 +241,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -335,7 +335,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -89,7 +89,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -222,7 +222,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -140,7 +140,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -215,7 +215,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -377,7 +377,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -499,7 +499,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -619,7 +619,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -57,7 +57,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -149,7 +149,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -62,7 +62,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true
@@ -151,7 +151,7 @@ nodes:
         ibgp:
         - standard
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - extended
       ipv4: true

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -82,7 +82,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -156,7 +156,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -146,7 +146,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -401,7 +401,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -668,7 +668,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -116,7 +116,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -334,7 +334,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -499,7 +499,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -204,7 +204,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -639,7 +639,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -945,7 +945,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -106,7 +106,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended
@@ -293,7 +293,7 @@ nodes:
         - standard
         - large
         - extended
-        ibgp_localas:
+        localas_ibgp:
         - standard
         - large
         - extended


### PR DESCRIPTION
This PR fixes some corner case issues around ```localas_ibgp``` sessions:
* The ebgp.multihop plugin does not handle ```localas_ibgp``` sessions that might occur
* There is a misspelled key used to populate the ```bgp.community``` dictionary
* Users by default get settings that include ```localas_ibgp```, but cannot explicitly configure settings for this type of sessions

Fixes:
* #1663 
* #1670 

Note: The fact that the ```bgp.community``` key mismatch has gone undetected for 11 months implies a lack of coverage for CI/CD test cases, happy to add a test case if it is deemed important enough

The PR adds an entry to the ```integration/bgp.multihop/01-global``` test but no actual validation; it might be better to put this in a dedicated test case instead