### PR TITLE
Use # of nodes on a link (not link type) to select default pool

### DIFF
--- a/docs/addressing.md
+++ b/docs/addressing.md
@@ -11,13 +11,13 @@ You can assign a static prefix to a link with a **prefix** link attribute and a 
 
 * **mgmt** pool: Management IPv4 and MAC addresses. IPv6 addresses are assigned if specified, but not used at the moment.
 * **loopback** pool: Loopback IPv4 and IPv6 addresses.
-* **lan** pool: IPv4 and IPv6 addresses used all links apart from P2P links (links with more or less than two nodes attached to them), or links with **type** set to *lan*.
-* **p2p** pool: IPv4 and IPv6 addresses used on point-to-point links
+* **lan** pool: IPv4 and IPv6 addresses used for all links apart from P2P or stub links ([more details](links-default-pools)).
+* **p2p** pool: IPv4 and IPv6 addresses used on point-to-point links between two routers.
 * **router_id** pool is used to allocate BGP router IDs in IPv6-only networks.
 * **l2only** pool has no IPv4 or IPv6 addresses. You can use it to create L2-only links. See [layer-2-only pools](#layer-2-only-pools) and *[Using l2only Address Pool](example/addressing-tutorial.md#layer-2-only-links-using-l2only-address-pool)* for details.
 * **vrf_loopback** pool: IPv4 and IPv6 prefixes used on optional VRF loopback interfaces.
 
-You can specify additional address pools, and [use them with the **pool** link attribute](links.md#selecting-custom-address-pools).
+You can specify additional address pools, and [use them with the **pool** link attribute](links-custom-pools).
 
 Default IPv4 address pools are defined in system settings:
 

--- a/docs/dev/transform.md
+++ b/docs/dev/transform.md
@@ -80,10 +80,10 @@ The data transformation has three major steps:
 * Execute **pre_link_transform** plugin hooks (`netsim.augment.plugin.execute`)
 * Execute **pre_link_transform** module hooks (`netsim.modules.pre_link_transform`)
 * Check [link attributes](../links.md#link-attributes) (`netsim.augment.links.check_link_attributes`)
-* Set [link type](../links.md#link-types) based on the number of devices connected to the link (`netsim.augment.links.get_link_type`)
+* Set [link type](links-types) based on the number of devices connected to the link (`netsim.augment.links.get_link_type`)
 * [Augment link](../links.md#augmenting-link-data) and [node interface data](../links.md#augmenting-node-data) (`netsim.augment.links.augment_p2p_link` and `netsim.augment.links.augment_lan_link`):
 
-  * If the link does not have a **prefix** attribute, get link prefix from the [corresponding address pool](../links.md#selecting-custom-address-pools)
+  * If the link does not have a **prefix** attribute, get link prefix from the [corresponding address pool](links-custom-pools)
   * Set node interface IP addresses to first and second subnet IP address for numbered P2P links.
   * Calculate node interface IP addresses from node ID and link prefix for all other links unless the on-link node data contains [static IP addresses](../links.md#static-interface-addressing).
   * Copy link-level configuration module data into node interface data (example: OSPF area)

--- a/docs/example/addr-builtin.txt
+++ b/docs/example/addr-builtin.txt
@@ -26,19 +26,16 @@ vrf_loopback:
   prefix: 32
 ```
 
-* **loopback** pool generates IP address for loopback interfaces
-* **lan** pool is used to assign prefixes to stub links[^STUB] and multi-access links[^LAN].
-* **p2p** pool is used to assign prefixes to point-to-point links[^P2P]
-* **mgmt** pool contains management network addresses. It's the only pool that uses **mac** addresses at the moment. Changing its definition is probably a bad idea.
+* **loopback** pool generates IP addresses for loopback interfaces
+* **stub** pool (when defined) is used to assign prefixes to stub links[^STUB]
+* **p2p** pool is used to assign prefixes to point-to-point links between routers.
+* **lan** pool is used to assign prefixes to all other links, including links with hosts and multi-access links ([more details](links-default-pools)).
+* **mgmt** pool contains management network addresses. It's the only pool that uses **mac** addresses. Changing its definition is probably a bad idea.
 * **l2only** pool contains no addresses. You can use it on layer-2-only links -- add **pool: l2only** attribute to the link.
 * **router_id** address pool is used to allocate BGP and OSPFv3 router IDs in IPv6-only networks.
 * **vrf_loopback** address pool is used for optional VRF loopback interfaces.
 
-[^STUB]: Links with a single non-host node attached to them or links that have **type: stub** attribute.
-
-[^LAN]: Links with more than two non-host nodes attached to them or links that have **type: lan** attribute.
-
-[^P2P]: Links with exactly two non-host nodes and no hosts attached to them
+[^STUB]: Links with a single router and no hosts attached to them.
 
 (addressing-loopback)=
 ### Loopback Addresses
@@ -54,7 +51,7 @@ links:
 - r1-r3-r4
 - r3:
   r4:
-  type: lan
+  pool: lan
 ```
 
 One of the first things *netlab* topology transformation code does is assign node identifiers to lab devices:
@@ -142,9 +139,9 @@ nodes:
 
 ### Stub Links
 
-Stub links[^STUB] get their IP prefixes from the **lan** address pool[^POOL]. To get an IP address for a node on a stub link, *netlab* combines link prefix with node ID (see also: [lan links](addressing-tutorial-lan-links)).
+As the topology does not define the **stub** pool, stub links[^STUB] get their IP prefixes from the **lan** address pool[^POOL]. To get an IP address for a node on a stub link, *netlab* combines the link prefix with the node ID (see also: [lan links](addressing-tutorial-lan-links)).
 
-[^POOL]: You can also specify the pool to use with **pool** link attribute; we'll cover that a bit later.
+[^POOL]: You can also specify the pool to use with the **pool** link attribute; we'll cover that later.
 
 Imagine the simplest possible lab topology: one device and one link:
 
@@ -216,7 +213,7 @@ You could argue that a network device should always have a .1 IP address on a st
 
 ### Loopback Links
 
-[Loopback links](links-loopback) are a special case of stub links, and use the same address allocation mechanisms. They are configured as loopback interfaces not as physical interfaces and thus don't consume VM/container resources.
+[Loopback links](links-loopback) are a special case of stub links and use the same address allocation mechanisms. They are configured as loopback interfaces, not as physical interfaces, and thus don't consume VM/container resources.
 
 The only difference between loopback- and stub links is the support for host prefixes -- you can configure a /32 IPv4 or a /128 IPv6 prefix on a loopback link, for example:
 

--- a/docs/prefix.md
+++ b/docs/prefix.md
@@ -1,7 +1,7 @@
 (named-prefixes)=
 # Named IP Prefixes
 
-In most lab topologies, you probably don't care about the exact IP addresses and subnets. Defining IPv4 and IPv6 prefixes in [addressing pools](address pools) is good enough.
+In most lab topologies, you probably don't care about the exact IP addresses and subnets. Defining IPv4 and IPv6 prefixes in [addressing pools](address-pools) is good enough.
 
 However, to tighten control over IP address allocation, you can use the **prefix** attribute on links or VLANS or the **ipv4**/**ipv6** attributes on node interfaces.
 

--- a/docs/release/1.9.md
+++ b/docs/release/1.9.md
@@ -14,6 +14,7 @@
 * Multi-chassis Link Aggregation (MLAG) support in the [](module-lag)
 * Generic object (node, VRF, VLAN) groups
 * Global/node setting of default OSPF passive interface state
+* Consistent selection of prefix pools based on the number of nodes attached to a link ([breaking change](release-1.9.3-breaking))
 
 **Minor improvements**
 
@@ -391,6 +392,18 @@ VyOS:
 * Integration tests for 'routing' module and new OSPF functionality
 
 ## Breaking changes
+
+(release-1.9.3-breaking)=
+### Release 1.9.3
+
+Release 1.9.3 selects the pool used to assign a prefix to a link based on the number of nodes attached to the link, whereas the previous releases used the **type** parameter that could be set to **lan** even for some point-to-point links. This change will make the prefix assignment more consistent but might change lab IP prefixes in these scenarios:
+
+* Lab topology sets **type: lan** on a link to force link prefix assignment from the **lan** pool. Use **pool: lan** instead.
+* **lan** pool was used to assign prefixes to tunnels and point-to-point routed VLANs in VLAN trunks[^ARV]. In release 1.9.3, they get prefixes from the **p2p** pool.
+* Links with a single node will get prefixes from the **stub** pool if the lab topology (or user defaults) defines it. Previously, these links would get their prefix from the **lan** pool unless the link definition included **pool: stub**.
+* Point-to-point links between a *libvirt* device and a *containerlab* device are marked as **lan** links and got a prefix from the **lan** pool. These links will now get their prefix from the **p2p** pool.
+
+[^ARV]: Access links of routed VLANs with two routers attached to them already used the **p2p** pool.
 
 (release-1.9.2-breaking)=
 ### Release 1.9.2

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -153,11 +153,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.3.1/24
+      ipv4: 10.1.0.5/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.3.2/24
+        ipv4: 10.1.0.6/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -174,11 +174,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.4.1/24
+      ipv4: 10.1.0.9/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.4.2/24
+        ipv4: 10.1.0.10/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -240,7 +240,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 2
-            ipv4: 172.16.3.2
+            ipv4: 10.1.0.6
             name: r2
             type: ebgp
         export:
@@ -260,7 +260,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 3
-            ipv4: 172.16.4.2
+            ipv4: 10.1.0.10
             name: r2
             type: ebgp
         export:
@@ -363,11 +363,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.3.2/24
+      ipv4: 10.1.0.6/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.3.1/24
+        ipv4: 10.1.0.5/30
         node: r1
         vrf: blue
       parent_ifindex: 1
@@ -384,11 +384,11 @@ nodes:
     - bridge_group: 3
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.4.2/24
+      ipv4: 10.1.0.10/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.4.1/24
+        ipv4: 10.1.0.9/30
         node: r1
         vrf: red
       parent_ifindex: 1
@@ -405,11 +405,11 @@ nodes:
     - bridge_group: 2
       ifindex: 7
       ifname: Ethernet2.1
-      ipv4: 172.16.5.2/24
+      ipv4: 10.1.0.13/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.5.3/24
+        ipv4: 10.1.0.14/30
         node: r3
         vrf: blue
       parent_ifindex: 2
@@ -426,11 +426,11 @@ nodes:
     - bridge_group: 3
       ifindex: 8
       ifname: Ethernet2.2
-      ipv4: 172.16.6.2/24
+      ipv4: 10.1.0.17/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.6.3/24
+        ipv4: 10.1.0.18/30
         node: r3
         vrf: red
       parent_ifindex: 2
@@ -505,12 +505,12 @@ nodes:
             type: ebgp
           - as: 65100
             ifindex: 5
-            ipv4: 172.16.3.1
+            ipv4: 10.1.0.5
             name: r1
             type: ebgp
           - as: 65101
             ifindex: 7
-            ipv4: 172.16.5.3
+            ipv4: 10.1.0.14
             name: r3
             type: ebgp
           router_id: 172.32.0.2
@@ -537,12 +537,12 @@ nodes:
             type: ebgp
           - as: 65100
             ifindex: 6
-            ipv4: 172.16.4.1
+            ipv4: 10.1.0.9
             name: r1
             type: ebgp
           - as: 65101
             ifindex: 8
-            ipv4: 172.16.6.3
+            ipv4: 10.1.0.18
             name: r3
             type: ebgp
           router_id: 172.31.0.1
@@ -598,11 +598,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.5.3/24
+      ipv4: 10.1.0.14/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
-        ipv4: 172.16.5.2/24
+        ipv4: 10.1.0.13/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -619,11 +619,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.6.3/24
+      ipv4: 10.1.0.18/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
-        ipv4: 172.16.6.2/24
+        ipv4: 10.1.0.17/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -685,7 +685,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 2
-            ipv4: 172.16.5.2
+            ipv4: 10.1.0.13
             name: r2
             type: ebgp
         export:
@@ -705,7 +705,7 @@ nodes:
           neighbors:
           - as: 65000
             ifindex: 3
-            ipv4: 172.16.6.2
+            ipv4: 10.1.0.17
             name: r2
             type: ebgp
         export:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -161,12 +161,12 @@ links:
   interfaces:
   - ifindex: 10001
     ifname: Loopback1
-    ipv4: 172.16.0.6/24
+    ipv6: 2001:db8:2:2::6/64
     node: e2
   linkindex: 9
   node_count: 1
   prefix:
-    ipv4: 172.16.0.0/24
+    ipv6: 2001:db8:2:2::/64
   type: loopback
 - _linkname: links[10]
   interfaces:
@@ -333,7 +333,7 @@ nodes:
         advertise: true
       ifindex: 10001
       ifname: Loopback1
-      ipv4: 172.16.0.6/24
+      ipv6: 2001:db8:2:2::6/64
       linkindex: 9
       name: e2 -> stub
       neighbors: []

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -66,6 +66,7 @@ links:
     node: c_nxos
   linkindex: 3
   node_count: 2
+  pool: lan
   prefix:
     ipv4: 10.2.0.64/26
     ipv6: 2001:db8:1:1::/64
@@ -117,6 +118,7 @@ nodes:
         ipv4: 10.2.0.67/26
         ipv6: 2001:db8:1:1::3/64
         node: c_nxos
+      pool: lan
       type: lan
     loopback:
       ifindex: 0
@@ -289,6 +291,7 @@ nodes:
         ipv4: 10.2.0.68/26
         ipv6: 2001:db8:1:1::4/64
         node: a_eos
+      pool: lan
       type: lan
     loopback:
       ifindex: 0

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -251,11 +251,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: eth1.1001
-      ipv4: 172.16.4.3/24
+      ipv4: 10.1.0.1/30
       name: s1 -> s2
       neighbors:
       - ifname: eth3.1001
-        ipv4: 172.16.4.4/24
+        ipv4: 10.1.0.2/30
         node: s2
         vrf: red_vrf
       parent_ifindex: 1
@@ -358,11 +358,11 @@ nodes:
           - bridge_group: 2
             ifindex: 3
             ifname: eth1.1001
-            ipv4: 172.16.4.3/24
+            ipv4: 10.1.0.1/30
             name: s1 -> s2
             neighbors:
             - ifname: eth3.1001
-              ipv4: 172.16.4.4/24
+              ipv4: 10.1.0.2/30
               node: s2
               vrf: red_vrf
             ospf:
@@ -483,11 +483,11 @@ nodes:
     - bridge_group: 1
       ifindex: 5
       ifname: eth3.1001
-      ipv4: 172.16.4.4/24
+      ipv4: 10.1.0.2/30
       name: s2 -> s1
       neighbors:
       - ifname: eth1.1001
-        ipv4: 172.16.4.3/24
+        ipv4: 10.1.0.1/30
         node: s1
         vrf: red_vrf
       parent_ifindex: 3
@@ -631,11 +631,11 @@ nodes:
           - bridge_group: 1
             ifindex: 5
             ifname: eth3.1001
-            ipv4: 172.16.4.4/24
+            ipv4: 10.1.0.2/30
             name: s2 -> s1
             neighbors:
             - ifname: eth1.1001
-              ipv4: 172.16.4.3/24
+              ipv4: 10.1.0.1/30
               node: s1
               vrf: red_vrf
             ospf:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -65,11 +65,11 @@ links:
   interfaces:
   - ifindex: 3
     ifname: GigabitEthernet0/3
-    ipv4: 172.16.1.2/24
+    ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.1.3/24
+    ipv4: 10.1.0.6/30
     node: r3
   libvirt:
     provider:
@@ -77,20 +77,20 @@ links:
   linkindex: 3
   node_count: 2
   prefix:
-    ipv4: 172.16.1.0/24
+    ipv4: 10.1.0.4/30
   type: lan
 - _linkname: links[4]
   bridge: input_4
   gateway:
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
     ifname: Ethernet2
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
     node: r3
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.2.5/24
+    ipv4: 172.16.1.5/24
     node: h2
   libvirt:
     provider:
@@ -98,25 +98,25 @@ links:
   linkindex: 4
   node_count: 2
   prefix:
-    ipv4: 172.16.2.0/24
+    ipv4: 172.16.1.0/24
   role: stub
   type: lan
 - _linkname: links[5]
   bridge: input_5
   gateway:
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
   interfaces:
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.4/24
+    ipv4: 172.16.2.4/24
     node: h1
   - ifindex: 3
     ifname: Ethernet3
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
     node: r3
   - ifindex: 2
     ifname: eth2
-    ipv4: 172.16.3.5/24
+    ipv4: 172.16.2.5/24
     node: h2
   libvirt:
     provider:
@@ -124,7 +124,7 @@ links:
   linkindex: 5
   node_count: 3
   prefix:
-    ipv4: 172.16.3.0/24
+    ipv4: 172.16.2.0/24
   role: stub
   type: lan
 module:
@@ -167,16 +167,16 @@ nodes:
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.4/24
+      ipv4: 172.16.2.4/24
       linkindex: 5
       mtu: 1500
       name: h1 -> [r3,h2]
       neighbors:
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       role: stub
       type: lan
@@ -206,32 +206,32 @@ nodes:
     interfaces:
     - bridge: input_4
       gateway:
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.2.5/24
+      ipv4: 172.16.1.5/24
       linkindex: 4
       mtu: 1500
       name: h2 -> r3
       neighbors:
       - ifname: Ethernet2
-        ipv4: 172.16.2.3/24
+        ipv4: 172.16.1.3/24
         node: r3
       role: stub
       type: lan
     - bridge: input_5
       ifindex: 2
       ifname: eth2
-      ipv4: 172.16.3.5/24
+      ipv4: 172.16.2.5/24
       linkindex: 5
       mtu: 1500
       name: h2 -> [h1,r3]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: Ethernet3
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       role: stub
       type: lan
@@ -343,12 +343,12 @@ nodes:
     - bridge: input_3
       ifindex: 3
       ifname: GigabitEthernet0/3
-      ipv4: 172.16.1.2/24
+      ipv4: 10.1.0.5/30
       linkindex: 3
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.1.3/24
+        ipv4: 10.1.0.6/30
         node: r3
       ospf:
         area: 0.0.0.0
@@ -396,12 +396,12 @@ nodes:
         name: et1
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 172.16.1.3/24
+      ipv4: 10.1.0.6/30
       linkindex: 3
       name: r3 -> r2
       neighbors:
       - ifname: GigabitEthernet0/3
-        ipv4: 172.16.1.2/24
+        ipv4: 10.1.0.5/30
         node: r2
       ospf:
         area: 0.0.0.0
@@ -413,12 +413,12 @@ nodes:
         name: et2
       ifindex: 2
       ifname: Ethernet2
-      ipv4: 172.16.2.3/24
+      ipv4: 172.16.1.3/24
       linkindex: 4
       name: r3 -> h2
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.2.5/24
+        ipv4: 172.16.1.5/24
         node: h2
       ospf:
         area: 0.0.0.0
@@ -431,15 +431,15 @@ nodes:
         name: et3
       ifindex: 3
       ifname: Ethernet3
-      ipv4: 172.16.3.3/24
+      ipv4: 172.16.2.3/24
       linkindex: 5
       name: r3 -> [h1,h2]
       neighbors:
       - ifname: eth2
-        ipv4: 172.16.3.4/24
+        ipv4: 172.16.2.4/24
         node: h1
       - ifname: eth2
-        ipv4: 172.16.3.5/24
+        ipv4: 172.16.2.5/24
         node: h2
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/link-tunnel.yml
+++ b/tests/topology/expected/link-tunnel.yml
@@ -27,28 +27,28 @@ links:
   interfaces:
   - ifindex: 20001
     ifname: Tunnel1
-    ipv4: 172.16.1.2/24
+    ipv4: 10.1.0.1/30
     node: r2
   - ifindex: 20001
     ifname: Tunnel1
-    ipv4: 172.16.1.3/24
+    ipv4: 10.1.0.2/30
     node: r3
   linkindex: 2
   node_count: 2
   prefix:
-    ipv4: 172.16.1.0/24
+    ipv4: 10.1.0.0/30
   type: tunnel
 - _linkname: links[3]
   bridge: input_3
   interfaces:
   - ifindex: 20002
     ifname: Tunnel2
-    ipv4: 172.16.2.3/24
+    ipv4: 172.16.1.3/24
     node: r3
   linkindex: 3
   node_count: 1
   prefix:
-    ipv4: 172.16.2.0/24
+    ipv4: 172.16.1.0/24
   role: stub
   type: tunnel
 - _linkname: links[4]
@@ -56,20 +56,20 @@ links:
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
-    ipv4: 172.16.3.1/24
+    ipv4: 172.16.2.1/24
     node: r1
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 172.16.3.2/24
+    ipv4: 172.16.2.2/24
     node: r2
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 172.16.3.3/24
+    ipv4: 172.16.2.3/24
     node: r3
   linkindex: 4
   node_count: 3
   prefix:
-    ipv4: 172.16.3.0/24
+    ipv4: 172.16.2.0/24
   type: lan
 name: input
 nodes:
@@ -97,15 +97,15 @@ nodes:
     - bridge: input_4
       ifindex: 1
       ifname: Ethernet1
-      ipv4: 172.16.3.1/24
+      ipv4: 172.16.2.1/24
       linkindex: 4
       name: r1 -> [r2,r3]
       neighbors:
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.2/24
+        ipv4: 172.16.2.2/24
         node: r2
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       type: lan
     loopback:
@@ -143,27 +143,27 @@ nodes:
       virtual_interface: true
     - ifindex: 20001
       ifname: Tunnel1
-      ipv4: 172.16.1.2/24
+      ipv4: 10.1.0.1/30
       linkindex: 2
       name: r2 -> r3
       neighbors:
       - ifname: Tunnel1
-        ipv4: 172.16.1.3/24
+        ipv4: 10.1.0.2/30
         node: r3
       type: tunnel
       virtual_interface: true
     - bridge: input_4
       ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 172.16.3.2/24
+      ipv4: 172.16.2.2/24
       linkindex: 4
       name: r2 -> [r1,r3]
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.3.1/24
+        ipv4: 172.16.2.1/24
         node: r1
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.3/24
+        ipv4: 172.16.2.3/24
         node: r3
       type: lan
     loopback:
@@ -201,18 +201,18 @@ nodes:
       virtual_interface: true
     - ifindex: 20001
       ifname: Tunnel1
-      ipv4: 172.16.1.3/24
+      ipv4: 10.1.0.2/30
       linkindex: 2
       name: r3 -> r2
       neighbors:
       - ifname: Tunnel1
-        ipv4: 172.16.1.2/24
+        ipv4: 10.1.0.1/30
         node: r2
       type: tunnel
       virtual_interface: true
     - ifindex: 20002
       ifname: Tunnel2
-      ipv4: 172.16.2.3/24
+      ipv4: 172.16.1.3/24
       linkindex: 3
       name: r3 -> stub
       neighbors: []
@@ -222,15 +222,15 @@ nodes:
     - bridge: input_4
       ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 172.16.3.3/24
+      ipv4: 172.16.2.3/24
       linkindex: 4
       name: r3 -> [r1,r2]
       neighbors:
       - ifname: Ethernet1
-        ipv4: 172.16.3.1/24
+        ipv4: 172.16.2.1/24
         node: r1
       - ifname: GigabitEthernet0/1
-        ipv4: 172.16.3.2/24
+        ipv4: 172.16.2.2/24
         node: r2
       type: lan
     loopback:

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -406,11 +406,11 @@ nodes:
     - bridge_group: 2
       ifindex: 12
       ifname: eth4.1001
-      ipv4: 172.16.4.4/24
+      ipv4: 10.1.0.6/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1001
-        ipv4: 172.16.4.3/24
+        ipv4: 10.1.0.5/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -424,11 +424,11 @@ nodes:
     - bridge_group: 3
       ifindex: 13
       ifname: eth4.1002
-      ipv4: 172.16.5.4/24
+      ipv4: 10.1.0.10/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1002
-        ipv4: 172.16.5.3/24
+        ipv4: 10.1.0.9/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -442,11 +442,11 @@ nodes:
     - bridge_group: 1
       ifindex: 14
       ifname: eth4.1000
-      ipv4: 172.16.6.4/24
+      ipv4: 10.1.0.14/30
       name: br -> sw
       neighbors:
       - ifname: eth4.1000
-        ipv4: 172.16.6.3/24
+        ipv4: 10.1.0.13/30
         node: sw
       parent_ifindex: 4
       parent_ifname: eth4
@@ -966,11 +966,11 @@ nodes:
     - bridge_group: 2
       ifindex: 10
       ifname: eth4.1001
-      ipv4: 172.16.4.3/24
+      ipv4: 10.1.0.5/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1001
-        ipv4: 172.16.4.4/24
+        ipv4: 10.1.0.6/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4
@@ -984,11 +984,11 @@ nodes:
     - bridge_group: 3
       ifindex: 11
       ifname: eth4.1002
-      ipv4: 172.16.5.3/24
+      ipv4: 10.1.0.9/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1002
-        ipv4: 172.16.5.4/24
+        ipv4: 10.1.0.10/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4
@@ -1002,11 +1002,11 @@ nodes:
     - bridge_group: 1
       ifindex: 12
       ifname: eth4.1000
-      ipv4: 172.16.6.3/24
+      ipv4: 10.1.0.13/30
       name: sw -> br
       neighbors:
       - ifname: eth4.1000
-        ipv4: 172.16.6.4/24
+        ipv4: 10.1.0.14/30
         node: br
       parent_ifindex: 4
       parent_ifname: eth4

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -407,11 +407,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.6.1/24
+      ipv4: 10.1.0.5/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.6.2/24
+        ipv4: 10.1.0.6/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -427,11 +427,11 @@ nodes:
     - bridge_group: 1
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.7.1/24
+      ipv4: 10.1.0.9/30
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.7.2/24
+        ipv4: 10.1.0.10/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -524,11 +524,11 @@ nodes:
           - bridge_group: 2
             ifindex: 5
             ifname: Ethernet1.1
-            ipv4: 172.16.6.1/24
+            ipv4: 10.1.0.5/30
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.6.2/24
+              ipv4: 10.1.0.6/30
               node: r2
               vrf: blue
             ospf:
@@ -606,11 +606,11 @@ nodes:
           - bridge_group: 1
             ifindex: 6
             ifname: Ethernet1.2
-            ipv4: 172.16.7.1/24
+            ipv4: 10.1.0.9/30
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.7.2/24
+              ipv4: 10.1.0.10/30
               node: r2
               vrf: red
             ospf:
@@ -691,11 +691,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: Ethernet1.1
-      ipv4: 172.16.6.2/24
+      ipv4: 10.1.0.6/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.6.1/24
+        ipv4: 10.1.0.5/30
         node: r1
         vrf: blue
       parent_ifindex: 1
@@ -711,11 +711,11 @@ nodes:
     - bridge_group: 1
       ifindex: 6
       ifname: Ethernet1.2
-      ipv4: 172.16.7.2/24
+      ipv4: 10.1.0.10/30
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.7.1/24
+        ipv4: 10.1.0.9/30
         node: r1
         vrf: red
       parent_ifindex: 1
@@ -731,11 +731,11 @@ nodes:
     - bridge_group: 2
       ifindex: 7
       ifname: Ethernet2.1
-      ipv4: 172.16.8.2/24
+      ipv4: 10.1.0.13/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
-        ipv4: 172.16.8.3/24
+        ipv4: 10.1.0.14/30
         node: r3
         vrf: blue
       parent_ifindex: 2
@@ -751,11 +751,11 @@ nodes:
     - bridge_group: 1
       ifindex: 8
       ifname: Ethernet2.2
-      ipv4: 172.16.9.2/24
+      ipv4: 10.1.0.17/30
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
-        ipv4: 172.16.9.3/24
+        ipv4: 10.1.0.18/30
         node: r3
         vrf: red
       parent_ifindex: 2
@@ -848,11 +848,11 @@ nodes:
           - bridge_group: 2
             ifindex: 5
             ifname: Ethernet1.1
-            ipv4: 172.16.6.2/24
+            ipv4: 10.1.0.6/30
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.6.1/24
+              ipv4: 10.1.0.5/30
               node: r1
               vrf: blue
             ospf:
@@ -872,11 +872,11 @@ nodes:
           - bridge_group: 2
             ifindex: 7
             ifname: Ethernet2.1
-            ipv4: 172.16.8.2/24
+            ipv4: 10.1.0.13/30
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.1
-              ipv4: 172.16.8.3/24
+              ipv4: 10.1.0.14/30
               node: r3
               vrf: blue
             ospf:
@@ -936,11 +936,11 @@ nodes:
           - bridge_group: 1
             ifindex: 6
             ifname: Ethernet1.2
-            ipv4: 172.16.7.2/24
+            ipv4: 10.1.0.10/30
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.7.1/24
+              ipv4: 10.1.0.9/30
               node: r1
               vrf: red
             ospf:
@@ -960,11 +960,11 @@ nodes:
           - bridge_group: 1
             ifindex: 8
             ifname: Ethernet2.2
-            ipv4: 172.16.9.2/24
+            ipv4: 10.1.0.17/30
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.2
-              ipv4: 172.16.9.3/24
+              ipv4: 10.1.0.18/30
               node: r3
               vrf: red
             ospf:
@@ -1004,11 +1004,11 @@ nodes:
     - bridge_group: 1
       ifindex: 2
       ifname: Ethernet1.1
-      ipv4: 172.16.8.3/24
+      ipv4: 10.1.0.14/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
-        ipv4: 172.16.8.2/24
+        ipv4: 10.1.0.13/30
         node: r2
         vrf: blue
       parent_ifindex: 1
@@ -1024,11 +1024,11 @@ nodes:
     - bridge_group: 2
       ifindex: 3
       ifname: Ethernet1.2
-      ipv4: 172.16.9.3/24
+      ipv4: 10.1.0.18/30
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
-        ipv4: 172.16.9.2/24
+        ipv4: 10.1.0.17/30
         node: r2
         vrf: red
       parent_ifindex: 1
@@ -1101,11 +1101,11 @@ nodes:
           - bridge_group: 1
             ifindex: 2
             ifname: Ethernet1.1
-            ipv4: 172.16.8.3/24
+            ipv4: 10.1.0.14/30
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.1
-              ipv4: 172.16.8.2/24
+              ipv4: 10.1.0.13/30
               node: r2
               vrf: blue
             ospf:
@@ -1145,11 +1145,11 @@ nodes:
           - bridge_group: 2
             ifindex: 3
             ifname: Ethernet1.2
-            ipv4: 172.16.9.3/24
+            ipv4: 10.1.0.18/30
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.2
-              ipv4: 172.16.9.2/24
+              ipv4: 10.1.0.17/30
               node: r2
               vrf: red
             ospf:

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -81,11 +81,11 @@ nodes:
     - bridge_group: 1
       ifindex: 3
       ifname: eth1.1000
-      ipv4: 172.16.2.1/24
+      ipv4: 10.1.0.1/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth2.1000
-        ipv4: 172.16.2.2/24
+        ipv4: 10.1.0.2/30
         node: leaf1
         vrf: customer1
       parent_ifindex: 1
@@ -101,11 +101,11 @@ nodes:
     - bridge_group: 1
       ifindex: 4
       ifname: eth2.1000
-      ipv4: 172.16.2.2/24
+      ipv4: 10.1.0.2/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth1.1000
-        ipv4: 172.16.2.1/24
+        ipv4: 10.1.0.1/30
         node: leaf1
         vrf: global
       parent_ifindex: 2
@@ -121,11 +121,11 @@ nodes:
     - bridge_group: 2
       ifindex: 5
       ifname: eth1.1001
-      ipv4: 172.16.3.1/24
+      ipv4: 10.1.0.5/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth2.1001
-        ipv4: 172.16.3.2/24
+        ipv4: 10.1.0.6/30
         node: leaf1
         vrf: customer2
       parent_ifindex: 1
@@ -141,11 +141,11 @@ nodes:
     - bridge_group: 2
       ifindex: 6
       ifname: eth2.1001
-      ipv4: 172.16.3.2/24
+      ipv4: 10.1.0.6/30
       name: leaf1 -> leaf1
       neighbors:
       - ifname: eth1.1001
-        ipv4: 172.16.3.1/24
+        ipv4: 10.1.0.5/30
         node: leaf1
         vrf: global
       parent_ifindex: 2

--- a/tests/topology/input/dual-stack.yml
+++ b/tests/topology/input/dual-stack.yml
@@ -30,4 +30,5 @@ links:
 - a_eos:
   c_nxos:
   type: lan
+  pool: lan
   bridge: c-to-a


### PR DESCRIPTION
netlab used the link.type attribute to select the default prefix allocation pool, resulting in LAN prefixes assigned to some P2P links.

This commit removes the dependency on link.type and consistently assigns prefixes from p2p pool to inter-router P2P links.

Closes #1647, replaces #1648