### PR TITLE
Libvirt/Vagrant: Fix vm name constant to be lowercase

### DIFF
--- a/netsim/templates/provider/libvirt/define-domain.j2
+++ b/netsim/templates/provider/libvirt/define-domain.j2
@@ -7,7 +7,8 @@
 #}
 {% set vm_name = name %}
   vm_name = "{{ name }}"
-{% set name = name|replace('-','') %}
+{# Ruby requires the first character to be lowercase #}
+{% set name = name|replace('-','')|lower() %}
   config.vm.define vm_name do |{{ name }}|
 {% if n.mgmt is defined and n.mgmt.mac is defined %}
     {{ name }}.vm.provider :libvirt do |domain|


### PR DESCRIPTION
Ruby requires at least the first character to be lower case, easier to just make the entire string ```lower()```

Fixes https://github.com/ipspace/netlab/issues/1675