### PR TITLE
Generic host static routing framework

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -1048,8 +1048,7 @@ def set_default_gateway(link: Box, nodes: Box) -> None:
     if nodes[ifdata.node].get('role','') == 'host':       # Set gateway only for hosts
       for interface in nodes[ifdata.node].interfaces:     # Find the corresponding host interface
         if link.linkindex == interface.linkindex:
-          if interface.ifindex == 1:                      # Set the default gateway only on the first host interface
-            interface.gateway = link.gateway
+          interface.gateway = link.gateway                # Copy link gateway to host interface
 
 """
 Set node.af flags to indicate that the node has IPv4 and/or IPv6 address family configured

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -87,6 +87,7 @@ def transform_data(topology: Box) -> None:
 
 def post_transform(topology: Box) -> None:
   augment.validate.process_validation(topology)
+  augment.nodes.post_transform(topology)
   modules.post_transform(topology)
   augment.plugin.execute('post_transform',topology)
   augment.groups.node_config_templates(topology)

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -281,6 +281,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
   h2:
     af:
       ipv4: true
@@ -338,6 +356,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.254
   h3:
     af:
       ipv4: true
@@ -377,6 +413,24 @@ nodes:
       mac: 08:4f:a9:00:00:06
     name: h3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h4:
     af:
       ipv4: true
@@ -413,7 +467,14 @@ nodes:
       type: lan
     - bridge: input_4
       gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -3
         ipv4: 10.42.42.13/28
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 2
       ifname: eth2
       ipv4: 10.42.42.2/28
@@ -435,6 +496,15 @@ nodes:
       role: stub
       type: lan
     - bridge: input_5
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 10.42.42.1/29
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 3
       ifname: eth3
       ipv4: 10.42.42.3/29
@@ -456,6 +526,16 @@ nodes:
       role: stub
       type: lan
     - bridge: input_6
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.31.31.1/24
+        ipv6: 2001:db8:cafe:1::1/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 4
       ifname: eth4
       ipv4: 172.31.31.13/24
@@ -485,6 +565,28 @@ nodes:
       mac: 08:4f:a9:00:00:0d
     name: h4
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth4
+          ipv4: 172.31.31.1
+          ipv6: 2001:db8:cafe:1::1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth4
+          ipv4: 172.31.31.1
+          ipv6: 2001:db8:cafe:1::1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth4
+          ipv4: 172.31.31.1
+          ipv6: 2001:db8:cafe:1::1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth4
+          ipv4: 172.31.31.1
+          ipv6: 2001:db8:cafe:1::1
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -691,6 +691,24 @@ nodes:
     mtu: 1500
     name: srv
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
   pod_1_l2_leaf:
     af:
       ipv4: true
@@ -849,6 +867,24 @@ nodes:
     mtu: 1500
     name: srv
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.6
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.6
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.6
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.6
   pod_1_s1:
     af:
       ipv4: true
@@ -1263,6 +1299,24 @@ nodes:
     mtu: 1500
     name: srv
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.10
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.10
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.10
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.10
   pod_2_l2_leaf:
     af:
       ipv4: true
@@ -1421,6 +1475,24 @@ nodes:
     mtu: 1500
     name: srv
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.12
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.12
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.12
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.12
   pod_2_s1:
     af:
       ipv4: true

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -80,6 +80,24 @@ nodes:
     mtu: 1500
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -116,6 +134,24 @@ nodes:
     mtu: 1500
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   rtr:
     af:
       ipv4: true

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -240,6 +240,24 @@ nodes:
     name: dhs
     provider: clab
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 192.168.42.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 192.168.42.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 192.168.42.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 192.168.42.2
   h1:
     af:
       ipv4: true
@@ -277,6 +295,24 @@ nodes:
     - dhcp
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h2:
     af:
       ipv4: true
@@ -314,6 +350,24 @@ nodes:
     - dhcp
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h3:
     af:
       ipv6: true

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -200,6 +200,24 @@ nodes:
     module: []
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -230,6 +248,24 @@ nodes:
     module: []
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
   h3:
     af:
       ipv4: true
@@ -258,6 +294,24 @@ nodes:
     module: []
     name: h3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
   h4:
     af:
       ipv4: true
@@ -286,6 +340,24 @@ nodes:
     module: []
     name: h4
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -164,6 +164,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -196,6 +214,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   h3:
     af:
       ipv4: true
@@ -228,6 +264,24 @@ nodes:
       mac: 08:4f:a9:00:00:06
     name: h3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h4:
     af:
       ipv4: true
@@ -260,6 +314,24 @@ nodes:
       mac: 08:4f:a9:00:00:07
     name: h4
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.3
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -504,6 +504,24 @@ nodes:
       mac: 08:4f:a9:00:00:07
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -531,6 +549,24 @@ nodes:
       mac: 08:4f:a9:00:00:08
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
   l1:
     _fabric_count: 1
     af:

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -187,6 +187,24 @@ nodes:
       mac: 08:4f:a9:00:00:01
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.4
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.4
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.4
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.4
   h2:
     af:
       ipv4: true
@@ -215,6 +233,24 @@ nodes:
       mac: 08:4f:a9:00:00:02
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.4
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.4
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.4
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.4
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -693,6 +693,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -731,6 +749,24 @@ nodes:
       mac: 08:4f:a9:00:00:06
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.4
 provider: libvirt
 vlans:
   red:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -165,6 +165,8 @@ nodes:
         node: r2
       type: lan
     - bridge: input_5
+      gateway:
+        ipv4: 172.16.2.3/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.2.4/24
@@ -188,6 +190,24 @@ nodes:
     name: h1
     provider: clab
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
   h2:
     af:
       ipv4: true
@@ -220,6 +240,8 @@ nodes:
       role: stub
       type: lan
     - bridge: input_5
+      gateway:
+        ipv4: 172.16.2.3/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.2.5/24
@@ -243,6 +265,24 @@ nodes:
     name: h2
     provider: clab
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.3
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -411,6 +411,24 @@ nodes:
       mac: 08:4f:a9:00:00:0a
     name: host_w_long_n-01
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   host_w_long_n-02:
     af:
       ipv4: true
@@ -438,6 +456,24 @@ nodes:
       mac: 08:4f:a9:00:00:0b
     name: host_w_long_n-02
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
   host_w_long_n-03:
     af:
       ipv4: true
@@ -465,6 +501,24 @@ nodes:
       mac: 08:4f:a9:00:00:0c
     name: host_w_long_n-03
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
   r:
     _set_ifindex: true
     af:

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -127,6 +127,24 @@ nodes:
       mac: 08:4f:a9:00:00:01
     name: h
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.0.254
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.0.254
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.0.254
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.0.254
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -686,6 +686,24 @@ nodes:
       mac: 08:4f:a9:00:00:01
     name: h
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth3
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth3
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth3
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth3
+          ipv4: 172.16.0.2
   rt:
     af:
       ipv4: true

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -66,6 +66,24 @@ nodes:
       mac: 08:4f:a9:00:00:02
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -128,6 +128,24 @@ nodes:
     name: h1
     netlab_lldp_enable: false
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h2:
     af:
       ipv4: true
@@ -169,6 +187,24 @@ nodes:
     mtu: 1500
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -110,6 +110,24 @@ nodes:
       mac: 08:4f:a9:00:00:03
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -139,6 +157,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -151,6 +151,24 @@ nodes:
     mtu: 1500
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h2:
     af:
       ipv4: true
@@ -195,6 +213,24 @@ nodes:
     mtu: 1500
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -153,6 +153,24 @@ nodes:
       mac: 08:4f:a9:00:00:02
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -183,6 +201,24 @@ nodes:
       mac: 08:4f:a9:00:00:03
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -141,6 +141,24 @@ nodes:
       mac: 08:4f:a9:00:00:01
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h2:
     af:
       ipv4: true
@@ -184,6 +202,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.3
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -81,6 +81,24 @@ nodes:
     module: []
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -83,6 +83,24 @@ nodes:
       mac: 08:4f:a9:00:00:02
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   h2:
     af:
       ipv4: true
@@ -110,6 +128,24 @@ nodes:
       mac: 08:4f:a9:00:00:03
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -247,6 +247,24 @@ nodes:
       mac: 08:4f:a9:00:00:03
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth2
+          ipv4: 172.16.2.2
   h2:
     af:
       ipv4: true
@@ -279,6 +297,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.1
   h3:
     af:
       ipv4: true
@@ -311,6 +347,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.2
   h4:
     af:
       ipv4: true
@@ -343,6 +397,24 @@ nodes:
       mac: 08:4f:a9:00:00:06
     name: h4
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.1.2
   h5:
     af:
       ipv4: true
@@ -375,6 +447,24 @@ nodes:
       mac: 08:4f:a9:00:00:07
     name: h5
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -227,6 +227,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.1
   h2:
     af:
       ipv4: true
@@ -255,6 +273,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.2
   h3:
     af:
       ipv4: true
@@ -283,6 +319,24 @@ nodes:
       mac: 08:4f:a9:00:00:06
     name: h3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.1
   h4:
     af:
       ipv4: true
@@ -311,6 +365,24 @@ nodes:
       mac: 08:4f:a9:00:00:07
     name: h4
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.2
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.2
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.2
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.2
   h5:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -174,6 +174,24 @@ nodes:
       mac: 08:4f:a9:00:00:04
     name: h1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -223,6 +241,24 @@ nodes:
       mac: 08:4f:a9:00:00:05
     name: h2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.0.1
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -227,6 +227,24 @@ nodes:
     module: []
     name: bh1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.6
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.6
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.6
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.5.6
   bh2:
     af:
       ipv4: true
@@ -256,6 +274,24 @@ nodes:
     module: []
     name: bh2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.6.7
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.6.7
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.6.7
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.6.7
   c:
     af:
       ipv4: true
@@ -355,6 +391,24 @@ nodes:
     module: []
     name: rh1
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.6
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.6
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.6
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.2.6
   rh2:
     af:
       ipv4: true
@@ -384,6 +438,24 @@ nodes:
     module: []
     name: rh2
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.7
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.7
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.7
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.3.7
   rh3:
     af:
       ipv4: true
@@ -413,6 +485,24 @@ nodes:
     module: []
     name: rh3
     role: host
+    routing:
+      static:
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.8
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.8
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.8
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          intf: eth1
+          ipv4: 172.16.4.8
   s1:
     af:
       ipv4: true


### PR DESCRIPTION
This commit prepares the static routes that have to be configured on lab devices not running a routing protocol (hosts). It mirrors the functionality currently implemented in the Linux configuration template but makes it generic and ensures the static routes always have a next hop if at least one interface has a default gateway.

The data structures for all hosts in a lab topology are significantly modified:

* The 'gateway' data structure is always copied from the link to the hosts to ensure the next step has all the relevant information available
* The host data contains 'routing.static' list of static routes pointing to the first usable gateway.ipv4 address.

The change prepares the data structures needed to fix #1641 but provides a more generic framework that will be used to implement 'network devices as hosts'