### PR TITLE
Implement static routing on Linux and use it to configure host static routes

### DIFF
--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -22,22 +22,22 @@ This configuration module implements generic routing features:
 The following table describes high-level per-platform support of generic routing features:
 
 | Operating system      | Routing<br>policies | Prefix<br>filters| AS-path<br>filters | BGP<br>communities | Static<br>routes|
-| ------------------ | :-: | :-: | :-: |:-: | :-: |
-| Arista EOS          |  ✅  |  ✅  |  ✅  |  ✅  |
-| Aruba AOS-CX        |  ✅  |  ✅  |  ✅  |  ✅  |
-| Cisco IOSv/IOSvL2   |  ✅  |  ✅  |  ✅  |  ✅  |
-| Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |
-| Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |
-| FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |
-| Nokia SR Linux      |  ✅  |  ✅ [❗](caveats-srlinux) |
-| Nokia SR OS         |  ✅  |
-| VyOS                |  ✅  |  ✅  |  ✅  |  ✅  |
+| ------------------ |:--:|:--:|:--:|:--:|:--:|
+| Arista EOS         | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Aruba AOS-CX       | ✅ | ✅ | ✅ | ✅ |
+| Cisco IOS/XE[^18v] | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Cumulus Linux      | ✅ | ✅ | ✅ | ✅ | ✅ |
+| FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |
+| Nokia SR Linux     |  ✅ |  ✅ [❗](caveats-srlinux) |
+| Nokia SR OS        |  ✅ |
+| VyOS               |  ✅ |  ✅ | ✅ |  ✅  |
 
 ```{tip}
 See [Routing Integration Tests Results](https://release.netlab.tools/_html/coverage.routing) for more details.
 ```
 
-[^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
+[^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
 
 (generic-routing-policies)=
 ## Routing Policies
@@ -101,8 +101,7 @@ You can use these routing policy **match** parameters on devices supported by th
 |---------------------|:--:|:--:|:--:|:--:|
 | Arista EOS          | ✅ | ❌  | ✅ | ✅ |
 | Aruba AOS-CX        | ✅ | ❌  | ✅ | ✅ |
-| Cisco IOSv/IOSvL2   | ✅ | ❌  | ✅ | ✅ |
-| Cisco IOS-XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
+| Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ |
 | FRR                 | ✅ | ❌  | ✅ | ✅ |
 | Nokia SR Linux      | ✅ |
@@ -114,8 +113,7 @@ You can use these routing policy **set** parameters on devices supported by the 
 |---------------------|:--:|:--:|:--:|:--:| :--:|
 | Arista EOS          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Aruba AOS-CX        | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOSv/IOSvL2   | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS-XE[^18v]  | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux      | ❌  | ✅ | ✅ | ❌  | ❌  |
@@ -128,8 +126,7 @@ The **set.community** attribute can be used to set these BGP communities on supp
 |---------------------|:--:|:--:|:--:|:--:|:--:|
 | Arista EOS          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Aruba AOS-CX        | ✅ | ❌  | ❌  | ✅ | ✅ |
-| Cisco IOSv/IOSvL2   | ✅ | ❌  | ❌  | ✅ | ❌  |
-| Cisco IOS-XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
+| Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
 | VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
@@ -497,8 +494,7 @@ _netlab_ supports static routes on these platforms:
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x   | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ |
-
-[^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
+| Linux               | ✅ |  ❌ |  ❌ |
 
 ### Global Static Routes
 

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -150,11 +150,11 @@ network:
 {%   for intf in routing.static|map(attribute='nexthop.intf',default='')|unique if intf %}
     {{ intf }}:
       routes:
-{%     for sr_entry in routing.static|default([])
-         if 'ipv4' in sr_entry and
-            sr_entry.nexthop.intf|default('') == intf %}
-        - to: {{ sr_entry.ipv4 }}
-          via: {{ sr_entry.nexthop.ipv4 }}
+{%     for sr_entry in routing.static|default([]) if sr_entry.nexthop.intf|default('') == intf %}
+{%       for sr_af in ['ipv4','ipv6'] if sr_af in sr_entry %}
+      - to: {{ sr_entry[sr_af] }}
+        via: {{ sr_entry.nexthop[sr_af] }}
+{%       endfor %}
 {%     endfor %}
 {%   endfor %}
 SCRIPT

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -140,23 +140,25 @@ network:
 SCRIPT
 {% endfor %}
 
-# Add routes to IPv4 address pools pointing to the first neighbor on the first link
-{% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
-cat <<SCRIPT > /etc/netplan/04-routes-{{ ifdata.ifname }}.yaml
+{% if routing.static|default([]) %}
+# Add IPv4 static routes
+cat <<SCRIPT > /etc/netplan/04-routes.yaml
 network:
   version: 2
   renderer: networkd
   ethernets:
-    {{ ifdata.ifname }}:
+{%   for intf in routing.static|map(attribute='nexthop.intf',default='')|unique if intf %}
+    {{ intf }}:
       routes:
-{%   for name,pool in pools.items()|default({}) %}
-{%     for af,pfx in pool.items() if af == 'ipv4' and name != 'mgmt' and name != 'router_id' %}
-        - to: {{ pfx }}
-          via: {{ ifdata.gateway.ipv4|ipaddr('address') }}
+{%     for sr_entry in routing.static|default([])
+         if 'ipv4' in sr_entry and
+            sr_entry.nexthop.intf|default('') == intf %}
+        - to: {{ sr_entry.ipv4 }}
+          via: {{ sr_entry.nexthop.ipv4 }}
 {%     endfor %}
 {%   endfor %}
 SCRIPT
-{% endfor  %}
+{% endif %}
 
 echo -n 'Starting netplan generate ' && date
 netplan generate

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -51,13 +51,10 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% set sr_list = routing.static|default([]) %}
 {% for pfx in sr_list|map(attribute='ipv4',default='')|unique if pfx %}
 {%   if loop.first %}
-set +e
 echo Removing existing IPv4 routes
 {%   endif %}
-ip route del {{ pfx }} 2>/dev/null
-{%   if loop.last %}
-set -e
-{%   endif %}
+while ip route del {{ pfx }} 2>/dev/null; do
+  : ; done
 {% endfor %}
 #
 {% for pfx in sr_list|map(attribute='ipv6',default='')|unique if pfx %}
@@ -65,10 +62,8 @@ set -e
 set +e
 echo Removing existing IPv6 routes
 {%   endif %}
-ip route del {{ pfx }} 2>/dev/null
-{%   if loop.last %}
-set -e
-{%   endif %}
+while ip route del {{ pfx }} 2>/dev/null; do
+  : ; done
 {% endfor %}
 #
 {% macro sr_add(sr_entry) %}

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -46,24 +46,18 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% endif %}
 {% endfor %}
 #
-# Add routes to IPv4 address pools pointing to the first neighbor on the first link
+# Add routes to IPv4 address pools pointing to the first usable default gateway
 #
 # If you need anything better, use FRR instead of Linux and start routing (or use IPv6)
 #
-{% for ifdata in interfaces|default([]) if ifdata.gateway is defined %}
-{%   for name,pool in pools.items()|default({}) %}
-{%     for af,pfx in pool.items() if af == 'ipv4' %}
-# {{ name }} prefix: {{ pfx }} local subnet: {{ ifdata.gateway.ipv4|ipaddr('subnet') }}
-{%       if name not in ['mgmt','router_id'] and pfx is string and
-            pfx != ifdata.gateway.ipv4|ipaddr('subnet') %}
+{% for sr_entry in routing.static|default([]) if 'ipv4' in sr_entry %}
+echo "sr_entry: {{ sr_entry }}"
 set +e
-ip route del {{ pfx }} 2>/dev/null
+ip route del {{ sr_entry.ipv4 }} via {{ sr_entry.nexthop.ipv4 }} 2>/dev/null
 set -e
-ip route add {{ pfx }} via {{ ifdata.gateway.ipv4|ipaddr('address') }}
-{%       endif %}
-{%     endfor %}
-{%   endfor %}
-{% endfor  %}
+ip route add {{ sr_entry.ipv4 }} via {{ sr_entry.nexthop.ipv4 }}{{
+  ' dev '+sr_entry.nexthop.intf if 'intf' in sr_entry.nexthop else '' }}
+{% endfor %}
 #
 # Print the final routing table
 ip route

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -46,17 +46,49 @@ ip link set {{ l.ifname }} mtu {{ l.mtu }}
 {% endif %}
 {% endfor %}
 #
-# Add routes to IPv4 address pools pointing to the first usable default gateway
+# Add static routes (usually IPv4 routes pointing to the first usable gateway)
 #
-# If you need anything better, use FRR instead of Linux and start routing (or use IPv6)
-#
-{% for sr_entry in routing.static|default([]) if 'ipv4' in sr_entry %}
-echo "sr_entry: {{ sr_entry }}"
+{% set sr_list = routing.static|default([]) %}
+{% for pfx in sr_list|map(attribute='ipv4',default='')|unique if pfx %}
+{%   if loop.first %}
 set +e
-ip route del {{ sr_entry.ipv4 }} via {{ sr_entry.nexthop.ipv4 }} 2>/dev/null
+echo Removing existing IPv4 routes
+{%   endif %}
+ip route del {{ pfx }} 2>/dev/null
+{%   if loop.last %}
 set -e
-ip route add {{ sr_entry.ipv4 }} via {{ sr_entry.nexthop.ipv4 }}{{
-  ' dev '+sr_entry.nexthop.intf if 'intf' in sr_entry.nexthop else '' }}
+{%   endif %}
+{% endfor %}
+#
+{% for pfx in sr_list|map(attribute='ipv6',default='')|unique if pfx %}
+{%   if loop.first %}
+set +e
+echo Removing existing IPv6 routes
+{%   endif %}
+ip route del {{ pfx }} 2>/dev/null
+{%   if loop.last %}
+set -e
+{%   endif %}
+{% endfor %}
+#
+{% macro sr_add(sr_entry) %}
+{%   for sr_af in ['ipv4','ipv6'] if sr_af in sr_entry %}
+ip route {{ 'append' if sr_entry.nexthop.idx else 'add' }} {{ sr_entry[sr_af] }} via {{ 
+  sr_entry.nexthop[sr_af] }}{{ ' dev '+sr_entry.nexthop.intf if 'intf' in sr_entry.nexthop else '' }} protocol static
+{%   endfor %}
+{% endmacro %}
+{% for sr_entry in sr_list if 'intf' in sr_entry.nexthop %}
+{%   if loop.first %}
+echo Adding direct static routes
+{%   endif %}
+{{ sr_add(sr_entry) -}}
+{% endfor %}
+{% for sr_entry in sr_list if 'intf' not in sr_entry.nexthop %}
+{%   if loop.first %}
+echo Adding indirect static routes
+set -x
+{%   endif %}
+{{ sr_add(sr_entry) -}}
 {% endfor %}
 #
 # Print the final routing table

--- a/netsim/ansible/templates/routing/linux.j2
+++ b/netsim/ansible/templates/routing/linux.j2
@@ -1,0 +1,8 @@
+#!/bin/bash
+{% if routing.static|default([]) %}
+#
+echo "Static routes are configured as part of the initial configuration template"
+echo
+#
+ip route
+{% endif %}

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -421,9 +421,10 @@ def default_static_route_list(topology: Box) -> list:
     if ap_name in ['mgmt','router_id']:
       continue
 
-    sr_entry = { af:ap_data[af] for af in log.AF_LIST if af in ap_data and isinstance(ap_data[af],str) }
-    if sr_entry:
-      sr_list.append(data.get_box(sr_entry))
+    if not isinstance(ap_data.get('ipv4',False),str):
+      continue
+
+    sr_list.append(data.get_box({ 'ipv4': ap_data.ipv4 }))
 
   return sr_list
 

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -437,6 +437,7 @@ def create_host_static_routes(sr_list: BoxList, intf: Box) -> list:
   # Extract next hops from the gateway data structure
   next_hop = { kw:value.split('/')[0] for (kw,value) in intf.gateway.items() if kw in log.AF_LIST }
   next_hop['intf'] = intf.ifname
+  next_hop['idx'] = 0
 
   for sr_entry in sr_list:
     host_list.append(sr_entry + { 'nexthop': next_hop })

--- a/netsim/devices/linux.py
+++ b/netsim/devices/linux.py
@@ -7,6 +7,15 @@ from . import _Quirks
 from ..utils import log
 from ..augment import devices
 
+def check_indirect_static_routes(node: Box) -> None:
+  for sr_entry in node.get('routing.static',[]):
+    if 'intf' not in sr_entry.nexthop:
+      log.error(
+        f'Linux (node {node.name}) does not support static routes to non-connected next hops',
+        more_data=f'Static route data: {sr_entry}',
+        category=log.IncorrectType,
+        module='quirks')
+
 class Linux(_Quirks):
 
   @classmethod
@@ -20,3 +29,6 @@ class Linux(_Quirks):
         more_hints=[ "Use 'cumulus' for DHCP client or 'dnsmasq' for DHCP server" ],
         category=log.IncorrectType,
         module='quirks')
+
+    if node.get('routing.static',[]):
+      check_indirect_static_routes(node)

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -9,6 +9,9 @@ features:
       ipv6: true
     server: true
     relay: true
+  routing:
+    static:
+      max_nexthop: 1
 libvirt:
   image: generic/ubuntu2004
   group_vars:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -10,8 +10,7 @@ features:
     server: true
     relay: true
   routing:
-    static:
-      max_nexthop: 1
+    static: true
 libvirt:
   image: generic/ubuntu2004
   group_vars:

--- a/netsim/modules/routing.py
+++ b/netsim/modules/routing.py
@@ -867,12 +867,15 @@ def check_static_routes(idx: int,o_name: str,node: Box,topology: Box) -> None:
     for af in log.AF_LIST:
       if af not in sr_data:
         continue
-      for nh_entry in sr_data.nexthop.nhlist[:sr_features.get('max_nexthop',256)]:
-        sr_entry = { af: sr_data[af], 'nexthop': nh_entry }
+      for (nh_idx,nh_entry) in enumerate(sr_data.nexthop.nhlist[:sr_features.get('max_nexthop',256)]):
+        sr_entry = data.get_box({ af: sr_data[af], 'nexthop': nh_entry })
+        sr_entry.nexthop.idx = nh_idx
         if 'vrf' in sr_data:
           sr_entry['vrf'] = sr_data.vrf
 
         node.routing[o_name].append(sr_entry)
+  else:
+    sr_data.nexthop.idx = 0
 
   node.routing[o_name][idx] = sr_data
 

--- a/netsim/modules/routing.py
+++ b/netsim/modules/routing.py
@@ -777,12 +777,7 @@ def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
 """
 Check whether a VRF static route is valid and supported by the device on which it's used
 """
-def check_VRF_static_route(sr_data: Box, node: Box, topology: Box) -> bool:
-  d_features = devices.get_device_features(node,topology.defaults)
-  sr_features = d_features.get('routing.static')
-  if not isinstance(sr_features,dict):
-    sr_features = data.get_empty_box()
-
+def check_VRF_static_route(sr_data: Box, node: Box, sr_features: Box) -> bool:
   if 'vrf' in sr_data:
     if sr_data.vrf not in node.get('vrfs',{}):
       log.error(
@@ -819,6 +814,10 @@ def check_VRF_static_route(sr_data: Box, node: Box, topology: Box) -> bool:
 
 def check_static_routes(idx: int,o_name: str,node: Box,topology: Box) -> None:
   sr_data = node.routing[o_name][idx]
+  d_features = devices.get_device_features(node,topology.defaults)
+  sr_features = d_features.get('routing.static')
+  if not isinstance(sr_features,dict):
+    sr_features = data.get_empty_box()
 
   if 'pool' in sr_data:
     sr_data = sr_data + extract_af_info(topology.addressing[sr_data.pool])
@@ -845,7 +844,7 @@ def check_static_routes(idx: int,o_name: str,node: Box,topology: Box) -> None:
     return
 
   if 'vrf' in sr_data or 'vrf' in sr_data.nexthop:
-    if not check_VRF_static_route(sr_data,node,topology):
+    if not check_VRF_static_route(sr_data,node,sr_features):
       return
 
   if sr_data.nexthop.get('node',None):
@@ -868,7 +867,7 @@ def check_static_routes(idx: int,o_name: str,node: Box,topology: Box) -> None:
     for af in log.AF_LIST:
       if af not in sr_data:
         continue
-      for nh_entry in sr_data.nexthop.nhlist:
+      for nh_entry in sr_data.nexthop.nhlist[:sr_features.get('max_nexthop',256)]:
         sr_entry = { af: sr_data[af], 'nexthop': nh_entry }
         if 'vrf' in sr_data:
           sr_entry['vrf'] = sr_data.vrf

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -285,18 +285,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
   h2:
@@ -360,18 +364,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.254
   h3:
@@ -417,18 +425,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h4:
@@ -569,21 +581,25 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -695,18 +695,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
   pod_1_l2_leaf:
@@ -871,18 +875,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.6
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.6
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.6
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.6
   pod_1_s1:
@@ -1303,18 +1311,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.10
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.10
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.10
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.10
   pod_2_l2_leaf:
@@ -1479,18 +1491,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.12
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.12
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.12
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.12
   pod_2_s1:

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -84,18 +84,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -138,18 +142,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   rtr:

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -244,18 +244,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 192.168.42.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 192.168.42.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 192.168.42.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 192.168.42.2
   h1:
@@ -299,18 +303,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h2:
@@ -354,18 +362,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h3:

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -204,18 +204,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -252,18 +256,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
   h3:
@@ -298,18 +306,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
   h4:
@@ -344,18 +356,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.2
   s1:

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -168,18 +168,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -218,18 +222,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   h3:
@@ -268,18 +276,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h4:
@@ -318,18 +330,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.3
   s1:

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -508,18 +508,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -553,18 +557,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
   l1:

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -191,18 +191,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.4
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.4
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.4
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.4
   h2:
@@ -237,18 +241,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.4
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.4
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.4
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.4
   s1:

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -697,18 +697,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -753,18 +757,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.4
 provider: libvirt

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -194,18 +194,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
   h2:
@@ -269,18 +273,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.3
   r1:

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -415,18 +415,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   host_w_long_n-02:
@@ -460,18 +464,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
   host_w_long_n-03:
@@ -505,18 +513,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
   r:

--- a/tests/topology/expected/rp-static.yml
+++ b/tests/topology/expected/rp-static.yml
@@ -150,64 +150,76 @@ nodes:
       - ipv4: 10.0.0.0/24
         ipv6: 2001:db8::/48
         nexthop:
+          idx: 0
           ipv4: 10.0.0.3
           ipv6: 2001:db8:0:3::1
           node: x
         pool: loopback
       - ipv4: 10.42.0.0/16
         nexthop:
+          idx: 0
           ipv4: 10.0.0.1
         prefix: p1
       - ipv6: 2001:db8:cafe:1::/64
         nexthop:
+          idx: 0
           ipv4: 10.0.0.3
           ipv6: 2001:db8:0:3::1
           node: x
         prefix: p2
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           ipv4: 10.0.0.42
           ipv6: 2001:db8:0:3::1
           node: x
         pool: lan
       - ipv4: 0.0.0.0/0
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 10.1.0.2
           ipv6: 2001:db8:1::2
       - ipv4: 0.0.0.0/0
         nexthop:
+          idx: 1
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
       - ipv4: 10.0.0.3/32
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 10.1.0.2
           ipv6: 2001:db8:1::2
       - ipv4: 10.0.0.3/32
         nexthop:
+          idx: 1
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
       - ipv6: 2001:db8:0:3::/64
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 10.1.0.2
           ipv6: 2001:db8:1::2
       - ipv6: 2001:db8:0:3::/64
         nexthop:
+          idx: 1
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 10.1.0.14
           ipv6: 2001:db8:1:3::2
         vrf: red
       - ipv4: 172.17.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 10.1.0.2
           ipv6: 2001:db8:1::2
@@ -215,6 +227,7 @@ nodes:
         vrf: red
       - ipv4: 172.17.0.0/16
         nexthop:
+          idx: 1
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
@@ -222,6 +235,7 @@ nodes:
         vrf: red
       - ipv4: 172.18.0.0/16
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 10.1.0.14
           ipv6: 2001:db8:1:3::2

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -131,18 +131,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.0.254
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.0.254
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.0.254
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.0.254
   s1:

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -690,18 +690,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth3
           ipv4: 172.16.0.2
   rt:

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -70,18 +70,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   r1:

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -132,18 +132,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h2:
@@ -191,18 +195,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
   s1:

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -114,18 +114,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -161,18 +165,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
   s1:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -155,18 +155,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h2:
@@ -217,18 +221,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
   s1:

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -157,18 +157,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -205,18 +209,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   r1:

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -145,18 +145,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h2:
@@ -206,18 +210,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.3
   s1:

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -85,18 +85,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
   r1:

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -87,18 +87,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   h2:
@@ -132,18 +136,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
   r1:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -251,18 +251,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth2
           ipv4: 172.16.2.2
   h2:
@@ -301,18 +305,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.1
   h3:
@@ -351,18 +359,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.2
   h4:
@@ -401,18 +413,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.1.2
   h5:
@@ -451,18 +467,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.2
   s1:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -231,18 +231,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.1
   h2:
@@ -277,18 +281,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.2
   h3:
@@ -323,18 +331,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.1
   h4:
@@ -369,18 +381,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.2
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.2
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.2
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.2
   h5:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -178,18 +178,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   h2:
@@ -245,18 +249,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.0.1
   s1:

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -231,18 +231,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.6
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.6
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.6
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.5.6
   bh2:
@@ -278,18 +282,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.6.7
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.6.7
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.6.7
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.6.7
   c:
@@ -395,18 +403,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.6
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.6
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.6
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.2.6
   rh2:
@@ -442,18 +454,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.7
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.7
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.7
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.3.7
   rh3:
@@ -489,18 +505,22 @@ nodes:
       static:
       - ipv4: 172.16.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.8
       - ipv4: 10.0.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.8
       - ipv4: 10.1.0.0/16
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.8
       - ipv4: 10.2.0.0/24
         nexthop:
+          idx: 0
           intf: eth1
           ipv4: 172.16.4.8
   s1:


### PR DESCRIPTION
This PR:

* Replaces the hardcoded static routes in Linux initial configuration template with configuration generated from 'routing.static' (see #1681)
* Enables static routing part of generic routing module for Linux
* Implements "limit maximum next hops for a static route" functionality because **ip route** command cannot handle more than one route to a prefix.

It's a spin-off from #1681 and will be rebased once that one is merged.