### PR TITLE
AOS-CX: support for static routing

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -47,6 +47,7 @@ nodes:
 * Ansible automation of Aruba AOS-CX requires the installation of the [ArubaNetworks Ansible Collection](https://galaxy.ansible.com/arubanetworks/aoscx) with `ansible-galaxy collection install arubanetworks.aoscx`.
 * The limitations of the Aruba AOS-CX Simulator can be found [here](https://feature-navigator.arubanetworks.com/), selecting *CX Simulator* as platform.
 * It seems that the Aruba AOS-CX Simulator cannot generate ICMP Fragmentation-Needed messages.
+* Inter-VRF static routes are supported only for IPv4.
 
 ### VRF and L3VPN Caveats
 

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -493,6 +493,7 @@ _netlab_ supports static routes on these platforms:
 | Operating system    | Global<br>static routes | VRF static<br>routes | Inter-VRF<br>static routes |
 |---------------------|:--:|:--:|:--:|
 | Arista EOS          | ✅ | ✅ | ✅ |
+| Aruba AOS-CX        | ✅ | ✅ | [❗](caveats-aruba) |
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x   | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ |

--- a/netsim/ansible/templates/routing/arubacx.j2
+++ b/netsim/ansible/templates/routing/arubacx.j2
@@ -26,3 +26,19 @@ ip community-list {{ c_value.type }} {{ c_name }} {{ c_line.action }} {{ c_line.
 {{     routemap.common_route_map_entry(p_entry,af_list) }}
 {%-  endcall %} 
 {% endif %}
+!
+! Static routes
+!
+{% for sr_data in routing.static|default([]) %}
+{%   set cmd_vrf = 'vrf ' + sr_data.vrf + ' ' if 'vrf' in sr_data else '' %}
+{%   set cmd_intf = sr_data.nexthop.intf + ' ' if 'intf' in sr_data.nexthop else '' %}
+{%   if 'ipv4' in sr_data %}
+ip route {{ 
+    sr_data.ipv4|ipaddr('network') }} {{
+    sr_data.ipv4|ipaddr('netmask') }} {{ cmd_intf }}{{ sr_data.nexthop.ipv4 }} {{ cmd_vrf }}
+{%   endif %}
+{%   if 'ipv6' in sr_data %}
+{%   set cmd_nh_v6 = sr_data.nexthop.intf if 'vrf' in sr_data.nexthop else sr_data.nexthop.ipv6 %}
+ipv6 route {{ sr_data.ipv6 }} {{ cmd_nh_v6 }} {{ cmd_vrf }}
+{%   endif %}
+{% endfor %}

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -13,7 +13,7 @@ libvirt:
       --ram=4096 --network=network:vagrant-libvirt,model=virtio --graphics none --import
       --disk path=vm.qcow2,format=qcow2,bus=ide
 clab:
-  image: vrnetlab/vr-aoscx:20240129204649
+  image: vrnetlab/aruba_arubaos-cx:20240731173624
   build: https://containerlab.dev/manual/kinds/vr-aoscx/
   mtu: 1500
   node:

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -65,6 +65,9 @@ features:
     aspath: True
     community:
       expanded: True
+    static:
+      vrf: True
+      inter_vrf: True
   vlan:
     # model: l3-switch
     model: switch


### PR DESCRIPTION
(merge after #1687)

**AOS-CX: support for static routing**

Tests:

* 20-static: OK
* 21-static-vrf: OK
* 22-static-inter-vrf: caveat for IPv6