### PR TITLE
Fix: Deal with hosts attached to unnumbered links

### DIFF
--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -43,7 +43,6 @@ links:
   node_count: 2
   role: external
   type: p2p
-  unnumbered: true
 - _linkname: links[2]
   interfaces:
   - ifindex: 2
@@ -236,7 +235,6 @@ nodes:
         node: x1
       role: external
       type: p2p
-      unnumbered: true
     - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.1/32
       ifindex: 2
@@ -380,7 +378,6 @@ nodes:
         node: test
       role: external
       type: p2p
-      unnumbered: true
     - _parent_intf: Loopback0
       _parent_ipv4: 10.0.0.2/32
       ifindex: 2


### PR DESCRIPTION
Netlab link augmentation code uses address family from the loopback interface to figure out what to do on old-style unnumbered links.

That clearly does not work on hosts that have no loopback interface. This fix enables IPv6 LLA on hosts attached to unnumbered links, hoping someone might eventually figure out whether that makes sense.

It also removes 'unnumbered' attribute from the link, as no device configuration template checks it. We'll clean up other references to the 'unnumbered' flag in another commit.

Fixes #1692