### PR TITLE
AOS-CX: support for LAG and MCLAG

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -9,6 +9,7 @@ LAG is currently supported on these platforms:
 | Operating system      | LACP | Static | Passive<br>LACP | MLAG
 | --------------------- |:--:|:--:|:--:|:---:|
 | Arista EOS [❗](caveats-eos) | ✅ | ✅ | ✅ | ✅ |
+| Aruba AOS-CX          | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x     | ✅ | ✅ | ❌  | ❌ |
 | Cumulus 5.x (NVUE)    | ✅ | ✅ | ❌  | ❌ |
 | Dell OS10             | ✅ | ✅ | ✅ | ✅ |

--- a/netsim/ansible/templates/initial/arubacx.j2
+++ b/netsim/ansible/templates/initial/arubacx.j2
@@ -26,7 +26,14 @@ interface {{ mgmt.ifname|default('mgmt') }}
 
 {% for l in interfaces|default([]) %}
 
-interface {{ l.ifname }}
+{#
+# Unfortunately we have to mix domains here.
+# If a LAG interface is defined as a simple LAG here on the initial module, it cannot be set as multi-chassis later on.
+#}
+{%   set mclag_intf = ' multi-chassis' if (l.type|default('') == 'lag' and '_mlag' in l.lag) else '' %}
+{%   set mclag_intf_static = ' static' if (l.type|default('') == 'lag' and '_mlag' in l.lag and l.lag.lacp|default('') == 'off') else '' %}
+
+interface {{ l.ifname }}{{ mclag_intf }}{{ mclag_intf_static }}
 {% if l.virtual_interface is not defined %}
     shutdown
 {# Set the maximun allowed L2 MTU here. Fine tuning of L3 MTU will be done with ip mtu on L3 interfaces only #}

--- a/netsim/ansible/templates/lag/arubacx.j2
+++ b/netsim/ansible/templates/lag/arubacx.j2
@@ -23,7 +23,7 @@ interface {{ ch.ifname }}
 !
 vsx
     system-mac {{ intf.lag.mlag.mac | hwaddr('linux') }}
-    inter-switch-link lag 255
+    inter-switch-link lag {{ intf.lag.mlag.ifindex }}
     role {{ intf.lag.mlag._vsx_role }}
 !
 {% endfor %}

--- a/netsim/ansible/templates/lag/arubacx.j2
+++ b/netsim/ansible/templates/lag/arubacx.j2
@@ -1,0 +1,65 @@
+{# Provision VSX peerlink #}
+{% for intf in interfaces if intf.lag.mlag.peergroup is defined %}
+
+interface lag {{ intf.lag.mlag.ifindex }}
+    no shutdown
+    no routing
+    vlan trunk native 1
+    vlan trunk allowed all
+    lacp mode active
+    description VSX ISL
+
+!
+{%   for ch in ([intf]+interfaces) if ch==intf or ch.lag._parentindex|default(False) == intf.linkindex %}
+interface {{ ch.ifname }}
+    no shutdown
+    description {{ ch.name }} (ISL in lag {{intf.lag.mlag.ifindex }})
+    lag {{ intf.lag.mlag.ifindex }}
+!
+{%   endfor %}
+
+!
+! VSX Config
+!
+vsx
+    system-mac {{ intf.lag.mlag.mac | hwaddr('linux') }}
+    inter-switch-link lag 255
+    role {{ intf.lag.mlag._vsx_role }}
+!
+{% endfor %}
+
+{# LAG interfaces #}
+{% for intf in interfaces if intf.type == 'lag' %}
+{%   set _lacp = intf.lag.lacp|default(lag.lacp) %}
+{%   set mclag_intf = ' multi-chassis' if '_mlag' in intf.lag else '' %}
+{%   set mclag_intf_static = ' static' if ('_mlag' in intf.lag and _lacp == 'off') else '' %}
+interface {{ intf.ifname }}{{ mclag_intf }}{{ mclag_intf_static }}
+{%   if '_mlag' in intf.lag %}
+    description {{ intf.name }} (VSX LAG {{ intf.lag.ifindex }})
+{%   else %}
+    description {{ intf.name }}
+{%   endif %}
+{%  if _lacp=='off' %}
+    no lacp mode
+{%  endif %}
+{%   if intf.lag.lacp_mode|default('') == 'active' %}
+    lacp mode active
+{%   endif %}
+{%   if intf.lag.lacp_mode|default('') == 'passive' %}
+    lacp mode passive
+{%   endif %}
+{%     if _lacp in [ 'fast', 'slow' ] %}
+    lacp rate {{ _lacp }}
+{%     endif %}
+    no shutdown
+
+!
+{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
+!
+interface {{ ch.ifname }}
+    description {{ ch.name }} in lag {{ intf.lag.ifindex }}
+    lag {{ intf.lag.ifindex }}
+!
+{%   endfor %}
+!
+{% endfor %}

--- a/netsim/devices/arubacx.py
+++ b/netsim/devices/arubacx.py
@@ -47,6 +47,37 @@ class ARUBACX(_Quirks):
           f'ArubaCX MPLS data plane works only on physical devices (using the external provider)',
           log.IncorrectType,
           'quirks')
+    
+    # LAG + VSX quirks
+    ## on VSX, you **must** configure the switch role as primary or secondary.
+    ### The roles do not indicate which device is forwarding traffic at a given time as VSX is an active-active forwarding solution.
+    ### The roles are used to determine which device stays active when there is a VSX split.
+    ### -- HERE we will assume the first device found for a specific peer-link is the primary, and the second one is the secondary.
+    if 'lag' in mods:
+      # find my MC-LAG
+      for intf in node.get('interfaces', []):
+        pgroup = intf.get('lag', {}).get('mlag', {}).get('peergroup', False)
+        if not pgroup:
+          continue
+        log.info(f'ArubaCX VSX: Found MLAG ID {pgroup} on node {node.name}')
+        # search for another ArubaCX peer with same MLAG ID and _vsx_role set to 'primary'
+        for n,nattrs in topology.nodes.items():
+          if n == node.name:
+            continue
+          if nattrs.device != 'arubacx':
+            continue
+          for n_intf in nattrs.get('interfaces', []):
+            n_pgroup = n_intf.get('lag', {}).get('mlag', {}).get('peergroup', False)
+            if not n_pgroup:
+              continue
+            if n_pgroup == pgroup:
+              # I have found my peer. Verify if it's the primary.
+              _vsx_role = n_intf.get('lag', {}).get('mlag', {}).get('_vsx_role', '')
+              my_role = 'primary'
+              if _vsx_role == 'primary':
+                my_role = 'secondary'
+              log.info(f'  - MLAG Peer is node {n} (ID {pgroup}) - which has role: "{_vsx_role}" - setting my role to "{my_role}"')
+              intf.lag.mlag._vsx_role = my_role
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'arubanetworks.aoscx')

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -4,6 +4,7 @@ interface_name: 1/1/{ifindex}
 mgmt_if: mgmt
 loopback_interface_name: "loopback {ifindex}"
 tunnel_interface_name: "tunnel {ifindex}"
+lag_interface_name: "lag {lag.ifindex}"
 ifindex_offset: 1
 libvirt:
   image: aruba/cx
@@ -43,6 +44,12 @@ features:
     irb: true
   gateway:
     protocol: [ anycast, vrrp ]
+  lag:
+    mlag:
+      peer:
+        ifindex: 255         # Use this port-channel
+        mac: 0600.0000.0000  # Base to generate a virtual MAC
+    passive: True
   mpls:
     ldp: true
     vpn: true


### PR DESCRIPTION
Tested with all 'lag' integration tests except for *11-host-lag-active-standby.yml* (which complains about unsupported lag module on linux).

Will re-run the tests after #1698 - but there should be no problems.

