### PR TITLE
gateway: Remove config/module if not used on a node

### DIFF
--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -85,6 +85,9 @@ def cleanup_intf_protocol_parameters(node: Box,topology: Box) -> list:
       elif k in node.get('gateway'):                                  # Do we have node-level parameters for this protocol?
         intf.gateway[k] = node.gateway[k] + intf.gateway[k]           # ... copy them to all interfaces
 
+  if not active_proto:                                                # No gateways in use anywhere?
+    node.pop('gateway',None)                                          # Remove its configuration
+    node.module = [ m for m in node.module if m != 'gateway' ]        # and the module
   return active_proto
 
 '''

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -259,6 +259,7 @@ class FHRP(_Module):
       for k in list(node.get('gateway',{})):                          # Iterate over node-level gateway parameters
         if not k in active_proto:                                     # Not a parameter for a FHRP active on this node?
           node.gateway.pop(k,None)                                    # ... zap it!
-    else:
+
+    if not active_proto:
       node.pop('gateway',None)                                        # If not: Remove its configuration entirely
       node.module = [ m for m in node.module if m != 'gateway' ]      # and the module

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -255,11 +255,17 @@ class FHRP(_Module):
 
     cleanup_unicast_ip(node)
     active_proto = cleanup_intf_protocol_parameters(node,topology)    # Cleanup interface parameters and get a list of active protocols
-    if active_proto:                                                  # Any gateway active?
-      for k in list(node.get('gateway',{})):                          # Iterate over node-level gateway parameters
+    if 'gateway' in node:                                             # Any node-level parameters?
+      for k in list(node.gateway):                                    # Iterate over node-level gateway parameters
         if not k in active_proto:                                     # Not a parameter for a FHRP active on this node?
           node.gateway.pop(k,None)                                    # ... zap it!
 
     if not active_proto:
+      if topology.defaults.get('gateway.warnings.inactive',False):
+        log.error(
+          f"Node {node.name} does not use any FHRP technology, removing 'gateway' from node modules",
+          category=Warning,
+          module='gateway')
+
       node.pop('gateway',None)                                        # If not: Remove its configuration entirely
       node.module = [ m for m in node.module if m != 'gateway' ]      # and the module

--- a/netsim/modules/gateway.py
+++ b/netsim/modules/gateway.py
@@ -67,7 +67,7 @@ def cleanup_unicast_ip(node: Box) -> None:
 # parameters from interfaces and returns a list of active protocols so we know what to clean on the
 # node level.
 
-def cleanup_intf_protocol_parameters(node: Box,topology: Box) -> list:
+def cleanup_intf_protocol_parameters(node: Box, topology: Box) -> list:
   active_proto: list = []
 
   proto_list = topology.defaults.gateway.attributes.protocols         # List of known FHRP protocols

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -18,6 +18,7 @@ groups:
     members:
     - r1
     - r2
+    - r3
     module:
     - gateway
     - vlan
@@ -52,11 +53,11 @@ links:
     node: r2
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.1.4/24
+    ipv4: 172.16.1.5/24
     node: h1
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.1.5/24
+    ipv4: 172.16.1.6/24
     node: h2
   linkindex: 1
   node_count: 4
@@ -86,7 +87,7 @@ links:
       access: red
   - ifindex: 1
     ifname: eth1
-    ipv4: 172.16.0.6/24
+    ipv4: 172.16.0.7/24
     node: h3
   linkindex: 2
   node_count: 2
@@ -218,6 +219,36 @@ links:
     ipv6: 2001:db8:cafe:1::/64
   role: stub
   type: lan
+- _linkname: links[7]
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 1
+    ifname: Ethernet1
+    ipv4: 10.1.0.2/30
+    node: r3
+  linkindex: 7
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+- _linkname: links[8]
+  interfaces:
+  - ifindex: 6
+    ifname: Ethernet6
+    ipv4: 10.1.0.5/30
+    node: r2
+  - ifindex: 2
+    ifname: Ethernet2
+    ipv4: 10.1.0.6/30
+    node: r3
+  linkindex: 8
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.4/30
+  type: p2p
 module:
 - vlan
 - ospf
@@ -229,7 +260,7 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 4
+    id: 5
     interfaces:
     - bridge: input_1
       gateway:
@@ -243,7 +274,7 @@ nodes:
           group: 1
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.1.4/24
+      ipv4: 172.16.1.5/24
       linkindex: 1
       name: h1 -> [r1,r2,h2]
       neighbors:
@@ -272,13 +303,13 @@ nodes:
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
-        ipv4: 172.16.1.5/24
+        ipv4: 172.16.1.6/24
         node: h2
       type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.104
-      mac: 08:4f:a9:00:00:04
+      ipv4: 192.168.121.105
+      mac: 08:4f:a9:00:00:05
     name: h1
     role: host
     routing:
@@ -304,7 +335,7 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 5
+    id: 6
     interfaces:
     - bridge: input_1
       gateway:
@@ -318,7 +349,7 @@ nodes:
           group: 1
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.1.5/24
+      ipv4: 172.16.1.6/24
       linkindex: 1
       name: h2 -> [r1,r2,h1]
       neighbors:
@@ -347,13 +378,13 @@ nodes:
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
-        ipv4: 172.16.1.4/24
+        ipv4: 172.16.1.5/24
         node: h1
       type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.105
-      mac: 08:4f:a9:00:00:05
+      ipv4: 192.168.121.106
+      mac: 08:4f:a9:00:00:06
     name: h2
     role: host
     routing:
@@ -379,7 +410,7 @@ nodes:
       ipv4: true
     box: generic/ubuntu2004
     device: linux
-    id: 6
+    id: 7
     interfaces:
     - bridge: input_2
       gateway:
@@ -393,7 +424,7 @@ nodes:
           group: 1
       ifindex: 1
       ifname: eth1
-      ipv4: 172.16.0.6/24
+      ipv4: 172.16.0.7/24
       linkindex: 2
       name: h3 -> [r1,h4,r2]
       neighbors:
@@ -409,8 +440,8 @@ nodes:
       type: lan
     mgmt:
       ifname: eth0
-      ipv4: 192.168.121.106
-      mac: 08:4f:a9:00:00:06
+      ipv4: 192.168.121.107
+      mac: 08:4f:a9:00:00:07
     name: h3
     role: host
     routing:
@@ -456,7 +487,7 @@ nodes:
       name: h4 -> [h3,r1,r2]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.6/24
+        ipv4: 172.16.0.7/24
         node: h3
       - ifname: Vlan1000
         ipv4: 172.16.0.2/24
@@ -624,10 +655,10 @@ nodes:
         ipv4: 172.16.1.3/24
         node: r2
       - ifname: eth1
-        ipv4: 172.16.1.4/24
+        ipv4: 172.16.1.5/24
         node: h1
       - ifname: eth1
-        ipv4: 172.16.1.5/24
+        ipv4: 172.16.1.6/24
         node: h2
       ospf:
         area: 0.0.0.0
@@ -640,12 +671,26 @@ nodes:
       name: '[Access VLAN red] r1 -> h3'
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.6/24
+        ipv4: 172.16.0.7/24
         node: h3
       type: lan
       vlan:
         access: red
         access_id: 1000
+    - ifindex: 3
+      ifname: Ethernet3
+      ipv4: 10.1.0.1/30
+      linkindex: 7
+      name: r1 -> r3
+      neighbors:
+      - ifname: Ethernet1
+        ipv4: 10.1.0.2/30
+        node: r3
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
     - bridge_group: 1
       gateway:
         anycast:
@@ -654,13 +699,13 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 3
+      ifindex: 4
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h3,h4,r2]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.6/24
+        ipv4: 172.16.0.7/24
         node: h3
       - ifname: eth1
         ipv4: 172.16.0.13/24
@@ -748,10 +793,10 @@ nodes:
         ipv4: 172.16.1.2/24
         node: r1
       - ifname: eth1
-        ipv4: 172.16.1.4/24
+        ipv4: 172.16.1.5/24
         node: h1
       - ifname: eth1
-        ipv4: 172.16.1.5/24
+        ipv4: 172.16.1.6/24
         node: h2
       ospf:
         area: 0.0.0.0
@@ -842,6 +887,20 @@ nodes:
         passive: true
       role: stub
       type: lan
+    - ifindex: 6
+      ifname: Ethernet6
+      ipv4: 10.1.0.5/30
+      linkindex: 8
+      name: r2 -> r3
+      neighbors:
+      - ifname: Ethernet2
+        ipv4: 10.1.0.6/30
+        node: r3
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
     - bridge_group: 1
       gateway:
         anycast:
@@ -850,13 +909,13 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 6
+      ifindex: 7
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h3,r1,h4]
       neighbors:
       - ifname: eth1
-        ipv4: 172.16.0.6/24
+        ipv4: 172.16.0.7/24
         node: h3
       - ifname: Vlan1000
         ipv4: 172.16.0.2/24
@@ -907,6 +966,63 @@ nodes:
         prefix:
           allocation: id_based
           ipv4: 172.16.0.0/24
+  r3:
+    af:
+      ipv4: true
+    box: arista/veos
+    device: eos
+    id: 4
+    interfaces:
+    - ifindex: 1
+      ifname: Ethernet1
+      ipv4: 10.1.0.2/30
+      linkindex: 7
+      name: r3 -> r1
+      neighbors:
+      - ifname: Ethernet3
+        ipv4: 10.1.0.1/30
+        node: r1
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
+    - ifindex: 2
+      ifname: Ethernet2
+      ipv4: 10.1.0.6/30
+      linkindex: 8
+      name: r3 -> r2
+      neighbors:
+      - ifname: Ethernet6
+        ipv4: 10.1.0.5/30
+        node: r2
+      ospf:
+        area: 0.0.0.0
+        network_type: point-to-point
+        passive: false
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.4/32
+      neighbors: []
+      ospf:
+        area: 0.0.0.0
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: Management1
+      ipv4: 192.168.121.104
+      mac: 08:4f:a9:00:00:04
+    module:
+    - vlan
+    - ospf
+    name: r3
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.0
+      router_id: 10.0.0.4
 ospf:
   area: 0.0.0.0
 provider: libvirt
@@ -917,7 +1033,7 @@ vlans:
     id: 1000
     neighbors:
     - ifname: eth1
-      ipv4: 172.16.0.6/24
+      ipv4: 172.16.0.7/24
       node: h3
     - ifname: Vlan1000
       ipv4: 172.16.0.2/24

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -5,20 +5,16 @@
 gateway.id: 1
 
 groups:
+  _auto_create: True
   switches:
     module: [gateway, vlan, ospf]
-    members: [r1, r2]
+    members: [r1, r2, r3]
     device: eos
   hosts:
     members: [h1, h2, h3, h4]
     device: linux
 
 nodes:
-  r1:
-  r2:
-  h1:
-  h2:
-  h3:
   h4:
     id: 13
 
@@ -61,6 +57,10 @@ links:
     ipv4: 172.31.31.0/24
     ipv6: 2001:db8:cafe:1::/64
   gateway: true
+
+# Add a 3rd router with no gateway configured - verify the module is removed
+- r1-r3
+- r2-r3
 
 #
 # Use these formats to display a summary of transformed topology when debugging the test case


### PR DESCRIPTION
Similar to IGP routing protocols, the module should be removed when not used

(Note: Same could be done for the ```vlan``` module on ```r3``` in this test case)