### PR TITLE
Dell OS10: interface description fixes & mlag switchport fix

### DIFF
--- a/netsim/ansible/templates/lag/dellos10.j2
+++ b/netsim/ansible/templates/lag/dellos10.j2
@@ -14,6 +14,9 @@ vlt-domain {{ intf.lag.mlag.peergroup }}
 interface {{ intf.ifname }}
 {%  if '_mlag' in intf.lag %}
  description "{{ intf.name }} in vlt-port-channel {{ intf.lag.ifindex }}"
+{%    if 'vlan' not in intf %}
+ switchport mode access
+{%    endif %}
  vlt-port-channel {{ intf.lag.ifindex }}
 {% else %}
  description "{{ intf.name }}"

--- a/netsim/ansible/templates/lag/dellos10.j2
+++ b/netsim/ansible/templates/lag/dellos10.j2
@@ -5,7 +5,7 @@ vlt-domain {{ intf.lag.mlag.peergroup }}
  backup destination {{ intf.lag.mlag.peer }}
  vlt-mac {{ intf.lag.mlag.mac | hwaddr('linux') }}
  discovery-interface {{ intf.ifname }}
-{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
+{%   for ch in interfaces if ch.lag._peerlink|default(0) == intf.linkindex %}
  discovery-interface {{ ch.ifname }}
 {%   endfor %}
 {% endfor %}
@@ -13,22 +13,24 @@ vlt-domain {{ intf.lag.mlag.peergroup }}
 {% for intf in interfaces if intf.type == 'lag' %}
 interface {{ intf.ifname }}
 {%  if '_mlag' in intf.lag %}
- description "{{ intf.name }} in vlt-port-channel {{ intf.lag.ifindex }}"
-{%    if 'vlan' not in intf %}
+{%   set desc = intf.name.replace(",", "\\\\,") + " in vlt-port-channel " + intf.lag.ifindex|string %}
+ description "{{ desc[:255] }}"
+{%  if 'vlan' not in intf %}
  switchport mode access
-{%    endif %}
+{%  endif %}
  vlt-port-channel {{ intf.lag.ifindex }}
 {% else %}
  description "{{ intf.name }}"
 {%  endif %}
 !
-{%  for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
+{%  for ch in interfaces if ch.lag._parentindex|default(False) == intf.lag.ifindex %}
 {%   set _lag_mode = 
       'on' if intf.lag.lacp|default('') == 'off' else
       'active' if intf.lag.lacp_mode|default('') == 'active' else 
       'passive' %}
 interface {{ ch.ifname }}
- description "{{ ch.name }} in channel-group {{ intf.lag.ifindex }}"
+{%   set desc = ch.name.replace(",", "\\\\,") + " in channel-group " + intf.lag.ifindex|string %}
+ description "{{ desc[:255] }}"
  channel-group {{ intf.lag.ifindex }} mode {{ _lag_mode }}
  lacp rate {{ 'fast' if intf.lag.lacp|default('fast') == 'fast' else 'normal' }}
 !

--- a/netsim/ansible/templates/lag/dellos10.j2
+++ b/netsim/ansible/templates/lag/dellos10.j2
@@ -5,7 +5,7 @@ vlt-domain {{ intf.lag.mlag.peergroup }}
  backup destination {{ intf.lag.mlag.peer }}
  vlt-mac {{ intf.lag.mlag.mac | hwaddr('linux') }}
  discovery-interface {{ intf.ifname }}
-{%   for ch in interfaces if ch.lag._peerlink|default(0) == intf.linkindex %}
+{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
  discovery-interface {{ ch.ifname }}
 {%   endfor %}
 {% endfor %}
@@ -23,7 +23,7 @@ interface {{ intf.ifname }}
  description "{{ intf.name }}"
 {%  endif %}
 !
-{%  for ch in interfaces if ch.lag._parentindex|default(False) == intf.lag.ifindex %}
+{%  for ch in interfaces if ch.lag._parentindex|default(False) == intf.linkindex %}
 {%   set _lag_mode = 
       'on' if intf.lag.lacp|default('') == 'off' else
       'active' if intf.lag.lacp_mode|default('') == 'active' else 

--- a/netsim/devices/dellos10.py
+++ b/netsim/devices/dellos10.py
@@ -44,21 +44,6 @@ def check_anycast_gateways(node: Box) -> None:
       more_data=err_data,
       node=node)
 
-def check_l3_mlag(node: Box, topology: Box) -> None:
-  err_data = []
-  for intf in node.interfaces:
-    if intf.type != 'lag' or 'vlan' in intf or '_mlag' not in intf.lag:
-      continue
-    if intf.get('ipv4',False) is not False or intf.get('ipv6',False) is not False:
-      err_data.append(f'Interface {intf.ifname}')
-
-  if err_data:
-    report_quirk(
-      f"Dell OS10 node {node.name} cannot have an IPv4/IPv6 address on a MLAG interface without a VLAN",
-      quirk='l3_mlag_without_vlan',
-      more_data=err_data,
-      node=node)
-
 class OS10(_Quirks):
 
   @classmethod
@@ -71,9 +56,6 @@ class OS10(_Quirks):
     
     if 'gateway' in mods and 'anycast' in node.get('gateway',{}):
       check_anycast_gateways(node)
-
-    if 'lag' in mods:
-      check_l3_mlag(node,topology)
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'dellemc.os10')


### PR DESCRIPTION
Updated after feedback:
* (still) limit interface descriptions to 255 characters when adding local string
* Enable switchport on mlag interfaces in case there is no VLAN (-trunk)
* Replace comma's in descriptions, if any