### PR TITLE
Fix: restrict interface description length

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -195,7 +195,13 @@ Each link could have a **name** attribute. That attribute is copied into interfa
 
 * Interfaces connected to P2P links: `R1 -> R2`
 * Interfaces connected to LAN links: `R1 -> [R2,R3,R4]`
-* There is no default name for stub interfaces/links.
+* `R1 -> stub` for stub interfaces/links.
+
+```{tip}
+* VLAN interfaces get interface names in the format `X -> [list]` where X is either the link or VLAN **‌name**, or VLAN description.
+* The maximum interface description length is 255 characters (limited by SNMP MIB-2) and can be changed with the `defaults.const.ifname.maxlength` [system parameter](defaults).
+* The interface description contains up to five neighbors. That limit can be changed with the `defaults.const.ifname.neighbors` [system parameter](defaults).
+```
 
 ### Example
 

--- a/netsim/defaults/const.yml
+++ b/netsim/defaults/const.yml
@@ -4,3 +4,6 @@
 routing_protocols: [ bgp, connected, eigrp, isis, ospf, ripv2 ]
 vrf_igp_protocols: [ connected, ospf, isis, ripv2 ]
 multi_provider: [ libvirt, clab ]
+ifname:
+  neighbors: 5
+  maxlength: 255

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -906,7 +906,7 @@ def set_svi_neighbor_list(node: Box, topology: Box) -> None:
       if ifdata.neighbors:
         if ' -> ' in ifdata.name:
           ifdata.name = ifdata.name.split(' -> ')[0]
-        ifdata.name = ifdata.name + " -> [" + ",".join([ n.node for n in ifdata.neighbors]) + "]"
+        ifdata.name = links.create_ifname(ifdata.name,[ n.node for n in ifdata.neighbors],p2p_OK=False)
 
 """
 map_trunk_vlans: build a list of VLAN IDs on trunk interfaces

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -95,7 +95,7 @@ nodes:
       ipv4: 172.19.0.2/24
       ipv6: 2001:db8:1::2/64
       linkindex: 1
-      name: a_eos -> [c_nxos,j_vsrx,n_cumulus]
+      name: a_eos -> [c_nxos,j_vsrx,n_c...
       neighbors:
       - ifname: Ethernet1/1
         ipv4: 172.19.0.1/24
@@ -167,7 +167,7 @@ nodes:
       ipv4: 172.19.0.1/24
       ipv6: 2001:db8:1::1/64
       linkindex: 1
-      name: c_nxos -> [a_eos,j_vsrx,n_cumulus]
+      name: c_nxos -> [a_eos,j_vsrx,n_c...
       neighbors:
       - ifname: Ethernet1
         ipv4: 172.19.0.2/24
@@ -241,7 +241,7 @@ nodes:
       junos_interface: ge-0/0/0
       junos_unit: '0'
       linkindex: 1
-      name: j_vsrx -> [c_nxos,a_eos,n_cumulus]
+      name: j_vsrx -> [c_nxos,a_eos,n_c...
       neighbors:
       - ifname: Ethernet1/1
         ipv4: 172.19.0.1/24
@@ -301,7 +301,7 @@ nodes:
       ipv6: 2001:db8:1::4/64
       linkindex: 1
       mtu: 1500
-      name: n_cumulus -> [c_nxos,a_eos,j_vsrx]
+      name: n_cumulus -> [c_nxos,a_eos,...
       neighbors:
       - ifname: Ethernet1/1
         ipv4: 172.19.0.1/24

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -108,7 +108,7 @@ nodes:
       ipv4: 172.16.0.1/24
       linkindex: 1
       mtu: 1500
-      name: h1 -> [s1,s2,h2]
+      name: h1 -> [s1,s2...]
       neighbors:
       - ifname: Vlan1000
         ipv4: 172.16.0.2/24
@@ -172,7 +172,7 @@ nodes:
       ipv4: 172.16.0.17/24
       linkindex: 3
       mtu: 1500
-      name: h2 -> [h1,s1,s2]
+      name: h2 -> [h1,s1...]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
@@ -260,7 +260,7 @@ nodes:
       ifindex: 3
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
-      name: VLAN red (1000) -> [h1,s2,h2]
+      name: VLAN red (1000) -> [h1,s2...]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24
@@ -361,7 +361,7 @@ nodes:
       ifindex: 3
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
-      name: VLAN red (1000) -> [h1,s1,h2]
+      name: VLAN red (1000) -> [h1,s1...]
       neighbors:
       - ifname: eth1
         ipv4: 172.16.0.1/24

--- a/tests/topology/input/unnumbered.yml
+++ b/tests/topology/input/unnumbered.yml
@@ -8,6 +8,8 @@ addressing:
   core:
     unnumbered: true
 
+defaults.const.ifname.maxlength: 30     # Regression test for 1709
+
 nodes:
 - name: c_nxos
   device: nxos

--- a/tests/topology/input/vlan-access-links.yml
+++ b/tests/topology/input/vlan-access-links.yml
@@ -1,5 +1,7 @@
 provider: clab
 
+defaults.const.ifname.neighbors: 2      # Regression test for 1709
+
 vlans:
   red:
     ospf.cost: 25


### PR DESCRIPTION
The interface description is limited to 255 characters due to SNMP MIB-2 limitations. This fix introduces two system const parameters (maxlength and max neighbors) that limit the length of the interface description.

Fixes #1709