### PR TITLE
(v)Junos VLAN Major Fixes and refactoring

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -325,7 +325,6 @@ See also [](caveats-junos).
 
 * You can run Juniper vJunos-switch as a container packaged by Roman Dodin's fork of [vrnetlab](https://github.com/hellt/vrnetlab/). See [_containerlab_ documentation](https://containerlab.dev/manual/kinds/vr-vjunosswitch/) for further details.
 * Use a recent *vrnetlab* release that places the management interface into the **mgmt_junos** routing instance to avoid the conflict between [management IP subnet](clab-vrnetlab) `10.0.0.0/24` and **netlab** loopback addressing.
-* _netlab_ does not support VLANs on vJunos-router yet.
 
 See also [](caveats-junos).
 

--- a/docs/module/vlan.md
+++ b/docs/module/vlan.md
@@ -42,7 +42,8 @@ VLANs are supported on these platforms:
 | Juniper vMX           | ✅  | ✅  | ✅  | ✅ | ✅ |
 | Juniper vPTX          | ✅  | ✅  | ✅  | ✅ | ✅ |
 | Juniper vSRX 3.0      | ❌   | ❌   | ✅  |  ❌ |  ❌ |
-| vJunos-switch         | ✅  | ❌   | ❌   | ✅ | ❌  |
+| vJunos-switch         | ✅  | ✅   | ✅   | ✅ | ✅  |
+| vJunos-router         | ✅  | ✅   | ✅   | ✅ | ✅  |
 | Mikrotik RouterOS 6   | ✅  | ✅  | ✅  | ✅ | ✅ |
 | Mikrotik RouterOS 7   | ✅  | ✅  | ✅  | ✅ | ✅ |
 | Nokia SR Linux        | ✅  | ✅  | ✅   | ✅ | ✅ |

--- a/netsim/ansible/tasks/readiness-check/vptx-clab.yml
+++ b/netsim/ansible/tasks/readiness-check/vptx-clab.yml
@@ -2,5 +2,5 @@
 - name: Wait for SSH server
   include_tasks: vm-clab-ssh-check.yml
 
-- name: Wait for et-0/0/1 interface
+- name: Wait for et-0/0/0 interface
   include_tasks: vptx.yml

--- a/netsim/ansible/tasks/readiness-check/vptx.yml
+++ b/netsim/ansible/tasks/readiness-check/vptx.yml
@@ -1,9 +1,9 @@
 ---
-- name: Wait for et-0/0/1 to appear
+- name: Wait for et-0/0/0 to appear
   junos_command:
     commands:
     - show interfaces terse
     wait_for:
-    - result[0] contains et-0/0/1
+    - result[0] contains et-0/0/0
     interval: 5
     retries: 60

--- a/netsim/ansible/templates/initial/junos.j2
+++ b/netsim/ansible/templates/initial/junos.j2
@@ -21,7 +21,12 @@ system {
 interfaces {
 {# Handle MTU outside the main interface loop, since it needs to be applied only to the master interface #}
 {% for l in interfaces|default([]) %}
-{%   if l.mtu is defined %}
+{%   if l.mtu is defined and l._vlan_master|default(false) and l._vlan_mtu_override is defined %}
+{#   - i.e., can be 22 bytes more (depending on mode) #}
+  {{ l.junos_interface }} {
+    mtu {{ l.mtu + l._vlan_mtu_override }};
+  }
+{%   elif l.mtu is defined %}
   {{ l.junos_interface }} {
     mtu {{ l.mtu + 14 }};
   }

--- a/netsim/ansible/templates/initial/junos.j2
+++ b/netsim/ansible/templates/initial/junos.j2
@@ -19,16 +19,14 @@ system {
 {% endif %}
 
 interfaces {
-{# Handle MTU outside the main interface loop, since it needs to be applied only to the master interface #}
+{#
+# Handle MTU outside the main interface loop, since it needs to be applied only to the master interface
+# JunOS MTU with headers is calculated on device quirks python code, depending on interface and model type.
+#}
 {% for l in interfaces|default([]) %}
-{%   if l.mtu is defined and l._vlan_master|default(false) and l._vlan_mtu_override is defined %}
-{#   - i.e., can be 22 bytes more (depending on mode) #}
+{%   if l._junos_mtu_with_headers is defined %}
   {{ l.junos_interface }} {
-    mtu {{ l.mtu + l._vlan_mtu_override }};
-  }
-{%   elif l.mtu is defined %}
-  {{ l.junos_interface }} {
-    mtu {{ l.mtu + 14 }};
+    mtu {{ l._junos_mtu_with_headers }};
   }
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/initial/junos.vlan.j2
+++ b/netsim/ansible/templates/initial/junos.vlan.j2
@@ -43,7 +43,7 @@ interfaces {
 
 {%     endif %}
 
-{%   elif l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and not(l.vlan is defined) %}
+{%   elif l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and 'vlan' not in l %}
 {#
 # in this case unit 0 is still present, but not handling any real vlan traffic (no vlan definition apart from _vlan_master)
 # --> we need to force a vlan id in any case on the sub unit 0, so let's put 1
@@ -57,7 +57,7 @@ interfaces {
 {%   endif %}
 
 {# handling for devices with vlan model router #}
-{%   if netlab_device_type == 'vmx' or netlab_device_type == 'vsrx' or netlab_device_type == 'vjunos-router' %}
+{%   if netlab_device_type in [ 'vmx', 'vsrx', 'vjunos-router' ] %}
 
 {%     if l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and l.vlan.access_id is defined %}
 {# this is a irb port in access mode on unit 0 #}

--- a/netsim/ansible/templates/initial/junos.vlan.j2
+++ b/netsim/ansible/templates/initial/junos.vlan.j2
@@ -42,9 +42,22 @@ interfaces {
   }
 
 {%     endif %}
+
+{%   elif l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and not(l.vlan is defined) %}
+{#
+# in this case unit 0 is still present, but not handling any real vlan traffic (no vlan definition apart from _vlan_master)
+# --> we need to force a vlan id in any case on the sub unit 0, so let's put 1
+#   'flexible-vlan-tagging' - VLAN-ID must be specified on tagged ethernet interfaces
+#}
+
+  {{ l.junos_interface }}.0 {
+    vlan-id 1;
+  }
+
 {%   endif %}
 
-{%   if netlab_device_type != 'vptx' %}
+{# handling for devices with vlan model router #}
+{%   if netlab_device_type == 'vmx' or netlab_device_type == 'vsrx' or netlab_device_type == 'vjunos-router' %}
 
 {%     if l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and l.vlan.access_id is defined %}
 {# this is a irb port in access mode on unit 0 #}

--- a/netsim/ansible/templates/vlan/vjunos-switch.j2
+++ b/netsim/ansible/templates/vlan/vjunos-switch.j2
@@ -16,7 +16,7 @@ vlans {
 {# for any interface in switched mode, set family eth switching & appropriate params #}
 interfaces {
 
-{% for ifdata in interfaces if ifdata.vlan is defined and ifdata._vlan_master is defined %}
+{% for ifdata in interfaces if ifdata.vlan is defined and ifdata._vlan_master is defined and ifdata.vlan.mode|default('') != 'route' %}
 
   {{ ifdata.ifname }} {
     family ethernet-switching {

--- a/netsim/ansible/templates/vlan/vmx.j2
+++ b/netsim/ansible/templates/vlan/vmx.j2
@@ -1,6 +1,4 @@
 
-
-
 interfaces {
 {% for ifdata in interfaces|default([]) if ifdata.vlan.access_id is defined and ifdata.vlan.mode|default('') != 'route' and (ifdata.type == 'vlan_member' or ifdata._vlan_master is defined) %}
 

--- a/netsim/ansible/templates/vlan/vptx.j2
+++ b/netsim/ansible/templates/vlan/vptx.j2
@@ -16,7 +16,7 @@ vlans {
 {# for any interface in switched mode, set family eth switching & appropriate params #}
 interfaces {
 
-{% for ifdata in interfaces if ifdata.vlan is defined and ifdata._vlan_master is defined %}
+{% for ifdata in interfaces if ifdata.vlan is defined and ifdata._vlan_master is defined and ifdata.vlan.mode|default('') != 'route' %}
 
   {{ ifdata.ifname }} {
     family ethernet-switching {

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -11,6 +11,9 @@ from . import _Quirks
 from ..utils import log
 from ..augment import devices
 
+JUNOS_MTU_DEFAULT_HEADER_LENGTH = 14
+JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH = 22
+
 def unit_0_trick(intf: Box, round: str ='global') -> None:
   oldname = intf.ifname
   newname = oldname + ".0"
@@ -20,6 +23,11 @@ def unit_0_trick(intf: Box, round: str ='global') -> None:
   intf.junos_interface = oldname
   intf.junos_unit = '0'
 
+def set_junos_mtu(intf: Box, delta: int) -> None:
+  if 'mtu' in intf:
+    mtu = int(intf.mtu)
+    intf._junos_mtu_with_headers = mtu + delta
+
 def fix_unit_0(node: Box, topology: Box) -> None:
   mods = node.get('module',[])
   # Need to understand if I need to configure unit 0 or not.
@@ -28,6 +36,7 @@ def fix_unit_0(node: Box, topology: Box) -> None:
   for intf in node.get('interfaces', []):
     if not '.' in intf.ifname:
         unit_0_trick(intf)
+        set_junos_mtu(intf, JUNOS_MTU_DEFAULT_HEADER_LENGTH)
         if 'vlan' in mods:
           # check VLAN params, and add if needed
           if '_vlan_native' in intf:
@@ -52,11 +61,11 @@ def fix_unit_0(node: Box, topology: Box) -> None:
         # in case of "flexible vlan tagging", 22 bytes more, depending on link type
         if junos_vlan_kind == 'router':
           # for a router, always add it
-          intf._vlan_mtu_override = 22
+          set_junos_mtu(intf, JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH)
         elif junos_vlan_kind == 'l3-switch':
           # for a l3-switch, add it on vlan mode route or if no vlan structure is defined (flex vlan tagging with native only)
-          if not intf.get('vlan') or intf.get('vlan', {}).get('mode', '') == 'route':
-            intf._vlan_mtu_override = 22
+          if 'vlan' not in intf or intf.get('vlan', {}).get('mode', '') == 'route':
+            set_junos_mtu(intf, JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH)
   
   # need to append .0 unit trick to the interface list copied into vrf->ospf
   if 'vrf' in mods and 'ospf' in mods:

--- a/netsim/devices/vjunos-router.py
+++ b/netsim/devices/vjunos-router.py
@@ -1,12 +1,1 @@
-#
-# Juniper JunOS quirks
-#
-
-from . import junos
-from box import Box
-
-class vjunos_router(junos.JUNOS):
-
-  @classmethod
-  def device_quirks(self, node: Box, topology: Box) -> None:
-    super().device_quirks(node,topology)
+junos.py

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -1,16 +1,17 @@
 ---
-description: vJunos Router
-parent: vjunos-switch
+description: vJunos Router (similar to vMX)
+parent: vmx
+interface_name: ge-0/0/{ifindex}
 group_vars:
   netlab_device_type: vjunos-router
 
 features:
   vlan:
-#    model: router
-#    svi_interface_name: irb.{vlan}
-#    subif_name: "{ifname}.{vlan.access_id}"
-#    mixed_trunk: true
-#    native_routed: true
+    model: router
+    svi_interface_name: irb.{vlan}
+    subif_name: "{ifname}.{vlan.access_id}"
+    mixed_trunk: true
+    native_routed: true
 
 clab:
   image: vrnetlab/juniper_vjunos-router:23.4R2-S2.1
@@ -18,5 +19,12 @@ clab:
   mtu: 1500
   node:
     kind: juniper_vjunosrouter
+  interface:
+    name: eth{ifindex+1}
+  group_vars:
+    ansible_user: admin
+    ansible_ssh_pass: admin@123
+    netlab_check_retries: 40
+    netlab_check_delay: 10
 
 graphite.icon: router

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -10,11 +10,10 @@ features:
     model: l3-switch
     svi_interface_name: irb.{vlan}
     subif_name: "{ifname}.{vlan.access_id}"
-    mixed_trunk: true
     native_routed: true
 
 clab:
-  image: vrnetlab/juniper_vjunos-switch:23.2R1.14
+  image: vrnetlab/juniper_vjunos-switch:23.4R2-S2.1
   build: https://containerlab.dev/manual/kinds/vr-vjunosswitch/
   mtu: 1500
   node:

--- a/netsim/devices/vptx.yml
+++ b/netsim/devices/vptx.yml
@@ -11,7 +11,6 @@ features:
     model: l3-switch
     svi_interface_name: irb.{vlan}
     subif_name: "{ifname}.{vlan.access_id}"
-    mixed_trunk: true
     native_routed: true
 
 libvirt:
@@ -21,7 +20,7 @@ libvirt:
   create_template: vptx.xml.j2
 
 clab:
-  image: vrnetlab/vr-vjunosevolved:23.2R1-S1.8-EVO
+  image: vrnetlab/juniper_vjunosevolved:23.4R2-S2.1
   build: https://containerlab.dev/manual/kinds/vr-vjunosevolved/
   mtu: 1500
   node:

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -659,7 +659,8 @@ nodes:
     device: vsrx
     id: 4
     interfaces:
-    - bridge: input_1
+    - _junos_mtu_with_headers: 1514
+      bridge: input_1
       ifindex: 0
       ifname: ge-0/0/0.0
       ipv4: 172.19.0.4/24
@@ -687,7 +688,8 @@ nodes:
         cost: 10
         passive: false
       type: lan
-    - _parent_intf: lo0.0
+    - _junos_mtu_with_headers: 1414
+      _parent_intf: lo0.0
       _parent_ipv4: 172.18.1.4/32
       ifindex: 1
       ifname: ge-0/0/1.0
@@ -708,7 +710,8 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - _parent_intf: lo0.0
+    - _junos_mtu_with_headers: 1414
+      _parent_intf: lo0.0
       _parent_ipv4: 172.18.1.4/32
       ifindex: 2
       ifname: ge-0/0/2.0
@@ -729,7 +732,8 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - _parent_intf: lo0.0
+    - _junos_mtu_with_headers: 1414
+      _parent_intf: lo0.0
       _parent_ipv4: 172.18.1.4/32
       ifindex: 3
       ifname: ge-0/0/3.0
@@ -750,7 +754,8 @@ nodes:
         passive: false
       pool: core
       type: p2p
-    - bridge: input_10
+    - _junos_mtu_with_headers: 1414
+      bridge: input_10
       ifindex: 4
       ifname: ge-0/0/4.0
       ipv4: 172.19.3.4/24


### PR DESCRIPTION
**(v)Junos VLAN Major Fixes and refactoring**

(unfortunately for multiple stuff it was hard to split in different PR, so I preferred to keep all the things together)

Re-tested vJunos-switch, vJunos-router, vJunos-EVO (vPTX) and an old version of vSRX (unable to access newer ones)(only for specific supported features) with: 

* 01-vlan-bridge-single.yml
* 02-vlan-bridge-multiple.yml
* 21-vlan-irb-single.yml
* 22-vlan-irb-multiple.yml
* 23-vlan-mixed-multiple.yml
* 31-vlan-bridge-trunk.yml
* 32-vlan-bridge-trunk-router.yml
* 33-vlan-irb-trunk.yml
* 41-vlan-bridge-native.yml
* 42-vlan-irb-native.yml
* 51-vlan-routed-trunk.yml
* 52-vlan-vrf-lite.yml
* 61-vlan-routed-native.yml
* 62-vlan-mixed-trunk.yml (mixed trunk not supported on switch devices)
* 63-vlan-mixed-native.yml (mixed trunk not supported on switch devices)
