### PR TITLE
lag: Set Linux feature flag, create lag devices on FRR

### DIFF
--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -1,3 +1,4 @@
+{% from "initial/linux/create-bond.j2" import create_bond_dev %}
 #!/bin/bash
 #
 set -e
@@ -71,12 +72,16 @@ fi
 {% endif %}
 
 #
-# Create loopbacks and stub devices
+# Create loopbacks, stub and lag/bond devices
 #
-{% for i in netlab_interfaces if i.type in ['loopback','stub'] %}
+{% for i in netlab_interfaces if i.type in ['loopback','stub','lag','bond'] %}
 if [ ! -e /sys/class/net/{{ i.ifname }} ]; then
   if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
+{%   if i.type in ['lag','bond'] %}
+{{     create_bond_dev(i,node_provider) }}
+{%   else %}
     ip link add {{ i.ifname }} type dummy
+{%   endif %}
     ip link set dev {{ i.ifname }} up
   fi
 fi

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -10,6 +10,8 @@ features:
       ipv6: true
     server: true
     relay: true
+  lag:
+    passive: False
   routing:
     static: true
 libvirt:


### PR DESCRIPTION
Combining the bonding plugin branch with the Linux lag support changes wasn't the best idea in hindsight - some obvious integration test cases got skipped in the process

* Set 'lag' feature flag for Linux devices
* Create lag devices on FRR

Tested:
```netlab up integration/lag/01-l3-lag.yml -p clab -d frr -s lag.mode=balance-xor```
```netlab up integration/lag/04-host-mlag.yml -d eos -p clab```