### PR TITLE
AOS-CX: Add OSPFv2 timers, priority, plain text auth

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -149,6 +149,7 @@ These devices also support optional OSPF interface attributes:
 | Operating system         | Interface<br>timers | Router<br />priority | Cleartext<br>password | MD5<br>digest |
 | ------------------------ |:--:|:--:|:--:|:--:|
 | Arista EOS               | ✅ | ✅ | ✅ | ❌  |
+| Aruba AOS-CX             | ✅ | ✅ | ✅ | ❌  |
 | Cisco IOSv/IOSvL2        | ✅ | ✅ | ✅ | ❌  |
 | Cisco IOS XE[^18v]       | ✅ | ✅ | ✅ | ❌  |
 | Cisco Nexus OS           | ✅ | ✅ | ✅ | ❌  |

--- a/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
@@ -43,5 +43,18 @@ interface {{ l.ifname }}
 {%   if l.ospf.passive|default(False) and not l.ifname.startswith('loopback') %}
     ip ospf passive
 {%   endif %}
+{%   if l.ospf.timers.hello is defined %}
+    ip ospf hello-interval {{ l.ospf.timers.hello }}
+{%   endif %}
+{%   if l.ospf.timers.dead is defined %}
+    ip ospf dead-interval {{ l.ospf.timers.dead }}
+{%   endif %}
+{%   if l.ospf.priority is defined %}
+    ip ospf priority {{ l.ospf.priority }}
+{%   endif %}
+{%   if l.ospf.password is defined %}
+    ip ospf authentication simple-text
+    ip ospf authentication-key plaintext {{ l.ospf.password }}
+{%   endif %}
 !
 {% endfor %}

--- a/netsim/ansible/templates/vrf/arubacx.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/arubacx.ospfv2-vrf.j2
@@ -37,5 +37,18 @@ interface {{ l.ifname }}
 {%   if l.ospf.passive|default(False) and not l.ifname.startswith('loopback') %}
     ip ospf passive
 {%   endif %}
+{%   if l.ospf.timers.hello is defined %}
+    ip ospf hello-interval {{ l.ospf.timers.hello }}
+{%   endif %}
+{%   if l.ospf.timers.dead is defined %}
+    ip ospf dead-interval {{ l.ospf.timers.dead }}
+{%   endif %}
+{%   if l.ospf.priority is defined %}
+    ip ospf priority {{ l.ospf.priority }}
+{%   endif %}
+{%   if l.ospf.password is defined %}
+    ip ospf authentication simple-text
+    ip ospf authentication-key plaintext {{ l.ospf.password }}
+{%   endif %}
 !
 {% endfor %}

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -56,6 +56,9 @@ features:
   ospf:
     import: [ bgp, connected, vrf ]
     default: true
+    password: true
+    priority: true
+    timers: true
   routing:
     policy:
       set:


### PR DESCRIPTION
Tested with:

* 30-timers.yml
* 31-priority.yml
* 32-password.yml
