### PR TITLE
Node.clone: Allow override of properties by including cloned node name in topology

### DIFF
--- a/docs/plugins/node.clone.md
+++ b/docs/plugins/node.clone.md
@@ -17,6 +17,8 @@ The *node.clone* plugin avoids tedious repetitive work by allowing users to mark
 
 The plugin is invoked early in the _netlab_ topology transformation process and updates groups and adds nodes and links to the lab topology.
 
+It is possible to override properties of cloned nodes by including a node with the clone name in the topology. See the example below
+
 ### Supported attributes
 
 The naming of cloned nodes can be controlled through global **clone.node_name_pattern**, default "{name[:13]}-{id:02d}".
@@ -56,15 +58,16 @@ nodes:
     device: frr
     module: [ vlan ]
   H:
-    device: none
+    device: linux
     clone.count: 10
+    provider: external  # Mark as 'external' such that no containers get created for these nodes
 
   H-01:
-    device: linux    # Instantiate only the first node as a container, leave the rest virtual
+    provider: clab      # Instantiate only the first node as a container, leave the rest virtual
     
 links:
 - ToR:
-    ifindex: 4       # Start from port 4
+    ifindex: 4          # Start from port 4
     vlan.access: v1
   H:
 ```

--- a/docs/plugins/node.clone.md
+++ b/docs/plugins/node.clone.md
@@ -17,7 +17,7 @@ The *node.clone* plugin avoids tedious repetitive work by allowing users to mark
 
 The plugin is invoked early in the _netlab_ topology transformation process and updates groups and adds nodes and links to the lab topology.
 
-It is possible to override properties of cloned nodes by including a node with the clone name in the topology. See the example below
+It is possible to override properties of cloned nodes by including a node with the resulting clone name in the topology. See the example below
 
 ### Supported attributes
 
@@ -60,10 +60,10 @@ nodes:
   H:
     device: linux
     clone.count: 10
-    provider: external  # Mark as 'external' such that no containers get created for these nodes
+    unmanaged: True     # Mark as 'unmanaged' such that no containers get created for these nodes
 
   H-01:
-    provider: clab      # Instantiate only the first node as a container, leave the rest virtual
+    unmanaged: False    # Instantiate only the first node as a container, leave the rest virtual
     
 links:
 - ToR:

--- a/docs/plugins/node.clone.md
+++ b/docs/plugins/node.clone.md
@@ -60,10 +60,10 @@ nodes:
   H:
     device: linux
     clone.count: 10
-    unmanaged: True     # Mark as 'unmanaged' such that no containers get created for these nodes
+    unmanaged: True     # Mark as 'unmanaged' such that no containers or VMs get created for these nodes
 
   H-01:
-    unmanaged: False    # Instantiate only the first node as a container, leave the rest virtual
+    unmanaged: False    # Instantiate only the first node as a container or VM, leave the rest virtual
     
 links:
 - ToR:

--- a/docs/plugins/node.clone.md
+++ b/docs/plugins/node.clone.md
@@ -43,7 +43,7 @@ Avoid the use of static IPv4/v6 attributes for clones, they are not checked nor 
 ### Connect Multiple Hosts to a ToR
 
 The following lab topology has a cluster of 10 hosts all connected to a Top-of-Rack switch in the same way.
-The clones will be called H_01, H_02, ...
+The clones will be called H-01, H-02, ...
 
 ```yaml
 plugin: [ node.clone ]
@@ -56,8 +56,11 @@ nodes:
     device: frr
     module: [ vlan ]
   H:
-    device: linux
+    device: none
     clone.count: 10
+
+  H-01:
+    device: linux    # Instantiate only the first node as a container, leave the rest virtual
     
 links:
 - ToR:

--- a/netsim/extra/node.clone/plugin.py
+++ b/netsim/extra/node.clone/plugin.py
@@ -118,14 +118,11 @@ def clone_node(node: Box, topology: Box) -> None:
     clone = data.get_box(node)
     clone.name = strings.eval_format(name_format, node + { 'id': c } )
 
-    if clone.name in topology.nodes:                                         # Check for overlapping names
-      log.error("Generated clone name '{clone.name}' conflicts with an existing node",
-                category=AttributeError, module='node.clone')
-      return
-
     clone.interfaces = []                                                    # Start clean, remove reference to original node
     if 'id' in node:
       clone.id = node.id + c - 1                                             # Update any explicit node ID sequentially
+    if clone.name in topology.nodes:                                         # Check for existing nodes that may override
+      clone = clone + topology.nodes[ clone.name ]                           # ...and merge its settings
     topology.nodes[ clone.name ] = clone
     clones.append( clone.name )
 


### PR DESCRIPTION
Use case: Declare a large number of hosts as 'unmanaged', instantiate one or two for validation testing

Rather than reject clones matching existing node names, this PR merges their properties