### PR TITLE
Cumulus NVUE: Fail in case of errors in "nv config apply"

### DIFF
--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -25,7 +25,7 @@
 
 - name: "execute on cumulus: 'nv config patch' for {{ netsim_action }} config"
   command: nv config patch {{ nvue_config_file }}
-  
+
 - name: "execute on cumulus: 'nv config apply -y' for {{ netsim_action }} config"
   command: nv config apply -y
   tags: [ print_action, always ]

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -25,7 +25,9 @@
 
 - name: "execute on cumulus: 'nv config patch' for {{ netsim_action }} config"
   command: nv config patch {{ nvue_config_file }}
-
+  
 - name: "execute on cumulus: 'nv config apply -y' for {{ netsim_action }} config"
   command: nv config apply -y
   tags: [ print_action, always ]
+  register: nv_config_apply
+  failed_when: "'failed' in nv_config_apply.stdout"  # Catch errors also when 'nv' returns success


### PR DESCRIPTION
There are cases where the output of ```nv config apply``` shows errors, while the command returns "success".
In my case, due to a bug somewhere else the script was trying to provision a non-existent device

Catch such errors and report failure