### PR TITLE
Links: update hint to remove obsolete 'type' method of controlling addressing

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -665,7 +665,7 @@ def assign_interface_addresses(link: Box, addr_pools: Box, ndict: Box, defaults:
         rq = rq + f' plus first-hop gateway'
       hints = []
       if link.type == 'p2p':
-        hints = ['Use "type: lan" or a custom pool on links with default gateways']
+        hints = ['Use a custom pool with prefix /29 or shorter on links with default gateways']
 
       log.error(
         f'Cannot use {af} prefix {pfx_list[af]} to address {rq} on {link._linkname}',

--- a/tests/errors/anycast-prefix.log
+++ b/tests/errors/anycast-prefix.log
@@ -1,5 +1,5 @@
 IncorrectValue in links: Cannot use ipv4 prefix 10.1.0.0/30 to address 2 nodes plus first-hop gateway on links[1]
-... Use "type: lan" or a custom pool on links with default gateways
+... Use a custom pool with prefix /29 or shorter on links with default gateways
 ... link data: {'_linkname': 'links[1]', 'gateway': {'id': 1, 'protocol': 'anycast',
 ... 'anycast': {'mac': '0200.cafe.00ff', 'unicast': True}, 'vrrp': {'group': 1},
 ... 'ipv4': '10.1.0.1/30'}, 'interfaces': [{'node': 'r1', 'gateway': {'ipv4':


### PR DESCRIPTION
#1673 deprecated the use of ```link.type``` to select addressing pools