### PR TITLE
Junos IS-IS fixes: enable wide metrics, set IS type

### DIFF
--- a/netsim/ansible/templates/isis/junos.j2
+++ b/netsim/ansible/templates/isis/junos.j2
@@ -8,6 +8,11 @@ protocols {
       ipv6-unicast;
     }
 {% endif %}
+{% for level in ['1','2'] if level not in isis.type|default('1-2') %}
+    level {{ level }} disable;
+{% endfor %}
+    level 1 wide-metrics-only;
+    level 2 wide-metrics-only;
     interface lo0.0;
 {% for l in interfaces|default([]) if 'isis' in l %}
     interface {{ l.ifname }} {


### PR DESCRIPTION
Junos IS-IS configuration template did not set the default IS type and used the 'transition' metrics, resulting in two integration test failures. This commit fixes both problems.