### PR TITLE
Libvirt: Don't depend on ifindex to identify physical interfaces

### DIFF
--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -207,8 +207,8 @@ pad_node_interfaces: Insert bogus interfaces in the node interface list to cope 
 required ifindex values.
 """
 def pad_node_interfaces(node: Box, topology: Box) -> None:
-  phy_iflist = [ intf for intf in node.interfaces if intf.ifindex < 1000 ]
-  vir_iflist = [ intf for intf in node.interfaces if intf.ifindex >= 1000 ]
+  phy_iflist = [ intf for intf in node.interfaces if 'virtual_interface' not in intf ]
+  vir_iflist = [ intf for intf in node.interfaces if 'virtual_interface' in intf ]
   phy_iflist.sort(key=lambda intf: intf.ifindex)
 
   dev_data = devices.get_consolidated_device_data(node,topology.defaults)

--- a/tests/topology/expected/node.clone-plugin-lag.yml
+++ b/tests/topology/expected/node.clone-plugin-lag.yml
@@ -811,26 +811,13 @@ nodes:
       - ifname: eth2
         node: h2-02
       type: p2p
-    - bridge_group: 1
-      ifindex: 4
-      ifname: Vlan1000
-      ipv4: 172.16.0.2/24
-      name: VLAN red (1000) -> [h2-01,r1,h2-02]
-      neighbors:
-      - ifname: vlan1000
-        ipv4: 172.16.0.5/24
-        node: h2-01
-      - ifname: Vlan1000
-        ipv4: 172.16.0.1/24
-        node: r1
-      - ifname: vlan1000
-        ipv4: 172.16.0.6/24
-        node: h2-02
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: irb
-        name: red
+    - ifindex: 4
+      ifname: Ethernet4
+      linkindex: 0
+      neighbors: []
+      remote_id: 2
+      remote_ifindex: 666
+      type: p2p
     - ifindex: 5
       ifname: Ethernet5
       linkindex: 0
@@ -848,19 +835,6 @@ nodes:
       - ifname: eth3
         node: h-01
       type: p2p
-    - ifindex: 7
-      ifname: port-channel1
-      lag:
-        ifindex: 1
-        lacp: fast
-        lacp_mode: active
-      name: r2 -> h-01
-      neighbors:
-      - ifname: bond9
-        node: h-01
-      pool: l2only
-      type: lag
-      virtual_interface: true
     - ifindex: 7
       ifname: Ethernet7
       lag:
@@ -882,6 +856,29 @@ nodes:
         node: h-02
       type: p2p
     - ifindex: 9
+      ifname: Ethernet9
+      lag:
+        _parentindex: 2
+      linkindex: 15
+      name: r2 -> h-02
+      neighbors:
+      - ifname: eth4
+        node: h-02
+      type: p2p
+    - ifindex: 7
+      ifname: port-channel1
+      lag:
+        ifindex: 1
+        lacp: fast
+        lacp_mode: active
+      name: r2 -> h-01
+      neighbors:
+      - ifname: bond9
+        node: h-01
+      pool: l2only
+      type: lag
+      virtual_interface: true
+    - ifindex: 9
       ifname: port-channel2
       lag:
         ifindex: 2
@@ -894,16 +891,6 @@ nodes:
       pool: l2only
       type: lag
       virtual_interface: true
-    - ifindex: 9
-      ifname: Ethernet9
-      lag:
-        _parentindex: 2
-      linkindex: 15
-      name: r2 -> h-02
-      neighbors:
-      - ifname: eth4
-        node: h-02
-      type: p2p
     - ifindex: 30000
       ifname: port-channel10
       lag:
@@ -944,11 +931,31 @@ nodes:
       vlan:
         access: red
         access_id: 1000
+    - bridge_group: 1
+      ifindex: 4
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h2-01,r1,h2-02]
+      neighbors:
+      - ifname: vlan1000
+        ipv4: 172.16.0.5/24
+        node: h2-01
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+      - ifname: vlan1000
+        ipv4: 172.16.0.6/24
+        node: h2-02
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red
     lag:
       lacp: fast
       lacp_mode: active
     libvirt:
-      nic_adapter_count: 12
+      nic_adapter_count: 10
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -626,23 +626,13 @@ nodes:
         vrf: red
       type: p2p
       vrf: red
-    - bridge_group: 1
-      ifindex: 8
-      ifname: vlan1000
-      ipv4: 172.16.0.1/24
-      name: VLAN red (1000) -> [h-03,h-07]
-      neighbors:
-      - ifname: vlan1000
-        ipv4: 172.16.0.2/24
-        node: h-03
-      - ifname: vlan1000
-        ipv4: 172.16.0.3/24
-        node: h-07
-      type: svi
-      virtual_interface: true
-      vlan:
-        mode: irb
-        name: red
+    - ifindex: 8
+      ifname: eth8
+      linkindex: 0
+      neighbors: []
+      remote_id: 1
+      remote_ifindex: 666
+      type: p2p
     - ifindex: 9
       ifname: eth9
       linkindex: 0
@@ -712,6 +702,23 @@ nodes:
         ipv4: 10.1.0.5/30
         node: h-07
       type: p2p
+    - bridge_group: 1
+      ifindex: 8
+      ifname: vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN red (1000) -> [h-03,h-07]
+      neighbors:
+      - ifname: vlan1000
+        ipv4: 172.16.0.2/24
+        node: h-03
+      - ifname: vlan1000
+        ipv4: 172.16.0.3/24
+        node: h-07
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red
     libvirt:
       nic_adapter_count: 18
     loopback:


### PR DESCRIPTION
As can be seen in the corrected test outputs, VLAN SVI interfaces can have an ```ifindex```<1000 which causes libvirt to count them as 'physical' interfaces. This in turn messes up the padding logic, resulting in missing interfaces

This bug can be triggered in topologies involving VLANs and custom ```ifindex``` override attributes

Partly fixes https://github.com/ipspace/netlab/issues/1738