### PR TITLE
Fix: Start SVI ifindex values at 40000 (Fixes #1738)

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -16,7 +16,7 @@ from ..data.global_vars import get_const
 from . import devices,addressing
 
 VIRTUAL_INTERFACE_TYPES: typing.Final[typing.List[str]] = [
-  'loopback', 'tunnel', 'lag' ]
+  'loopback', 'tunnel', 'lag', 'svi' ]
 
 def adjust_interface_list(iflist: list, link: Box, nodes: Box) -> list:
   link_intf = []

--- a/tests/topology/expected/addressing-prefix.yml
+++ b/tests/topology/expected/addressing-prefix.yml
@@ -173,7 +173,7 @@ nodes:
         access: v1
         access_id: 1000
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1000
       ipv6: 2001:db8:cafe:1::2a/64
       name: VLAN v1 (1000)

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -715,7 +715,7 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h3,h4,r2]
@@ -925,7 +925,7 @@ nodes:
         id: 1
         ipv4: 172.16.0.1/24
         protocol: anycast
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h3,r1,h4]

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -502,7 +502,7 @@ nodes:
         id: 1
         ipv6: 2001:db8:cafe:1::1/64
         protocol: anycast
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1001
       ipv6: 2001:db8:cafe:1::2/64
       name: VLAN blue (1001) -> [h3]
@@ -527,7 +527,7 @@ nodes:
           - 192.168.42.6
         server:
         - dhs
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,h2]

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -463,7 +463,7 @@ nodes:
         passive: false
       type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,s2]
@@ -483,7 +483,7 @@ nodes:
     - bgp:
         advertise: true
       bridge_group: 2
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [h3]
@@ -499,7 +499,7 @@ nodes:
         name: green
       vrf: tenant
     - bridge_group: 3
-      ifindex: 7
+      ifindex: 40002
       ifname: Vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [h2,s2]
@@ -618,7 +618,7 @@ nodes:
               auto: true
           interfaces:
           - bridge_group: 1
-            ifindex: 5
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.1/24
             name: VLAN red (1000) -> [h1,s2]
@@ -641,7 +641,7 @@ nodes:
           - bgp:
               advertise: true
             bridge_group: 2
-            ifindex: 6
+            ifindex: 40001
             ifname: Vlan1002
             ipv4: 172.16.2.1/24
             name: VLAN green (1002) -> [h3]
@@ -661,7 +661,7 @@ nodes:
               name: green
             vrf: tenant
           - bridge_group: 3
-            ifindex: 7
+            ifindex: 40002
             ifname: Vlan1001
             ipv4: 172.16.1.1/24
             name: VLAN blue (1001) -> [h2,s2]
@@ -781,7 +781,7 @@ nodes:
         passive: false
       type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s1,h2]
@@ -801,7 +801,7 @@ nodes:
     - bgp:
         advertise: true
       bridge_group: 2
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1003
       ipv4: 172.16.3.2/24
       name: VLAN purple (1003) -> [h4]
@@ -817,7 +817,7 @@ nodes:
         name: purple
       vrf: tenant
     - bridge_group: 3
-      ifindex: 7
+      ifindex: 40002
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s1]
@@ -936,7 +936,7 @@ nodes:
               auto: true
           interfaces:
           - bridge_group: 1
-            ifindex: 5
+            ifindex: 40000
             ifname: Vlan1001
             ipv4: 172.16.1.2/24
             name: VLAN blue (1001) -> [s1,h2]
@@ -959,7 +959,7 @@ nodes:
           - bgp:
               advertise: true
             bridge_group: 2
-            ifindex: 6
+            ifindex: 40001
             ifname: Vlan1003
             ipv4: 172.16.3.2/24
             name: VLAN purple (1003) -> [h4]
@@ -979,7 +979,7 @@ nodes:
               name: purple
             vrf: tenant
           - bridge_group: 3
-            ifindex: 7
+            ifindex: 40002
             ifname: Vlan1000
             ipv4: 172.16.0.2/24
             name: VLAN red (1000) -> [h1,s1]

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -92,7 +92,7 @@ nodes:
     - bgp:
         advertise: true
       bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000)

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -86,7 +86,7 @@ nodes:
     - bgp:
         advertise: true
       bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000)

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -428,7 +428,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,h3,s2]
@@ -451,7 +451,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 4
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [h2,h4,s3]
@@ -605,7 +605,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 2
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s1,h3]
@@ -743,7 +743,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 2
+      ifindex: 40000
       ifname: Vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [h2,s1,h4]

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -111,7 +111,7 @@ nodes:
         - 1001
         - 1000
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.1.1/24
       name: VLAN blue (1000) -> [r2,r3]
@@ -132,7 +132,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 9
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.0.1/24
       name: VLAN red (1001) -> [r2,r3]
@@ -153,7 +153,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 3
-      ifindex: 10
+      ifindex: 40002
       ifname: Vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [r2]
@@ -247,7 +247,7 @@ nodes:
         - 1001
         - 1000
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.1.2/24
       name: VLAN blue (1000) -> [r1,r3]
@@ -268,7 +268,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.0.2/24
       name: VLAN red (1001) -> [r1,r3]
@@ -289,7 +289,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 3
-      ifindex: 7
+      ifindex: 40002
       ifname: Vlan1002
       ipv4: 172.16.2.2/24
       name: VLAN green (1002) -> [r1]
@@ -383,7 +383,7 @@ nodes:
         - 1001
         - 1000
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.1.3/24
       name: VLAN blue (1000) -> [r2,r1]
@@ -403,7 +403,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.0.3/24
       name: VLAN red (1001) -> [r2,r1]

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -313,7 +313,7 @@ nodes:
         routed_link: true
       vrf: red_vrf
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red_vlan (1000) -> [s2]
@@ -425,7 +425,7 @@ nodes:
               routed_link: true
             vrf: red_vrf
           - bridge_group: 1
-            ifindex: 5
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.3/24
             name: VLAN red_vlan (1000) -> [s2]
@@ -545,7 +545,7 @@ nodes:
         routed_link: true
       vrf: red_vrf
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.4/24
       name: VLAN red_vlan (1000) -> [s1]
@@ -698,7 +698,7 @@ nodes:
               routed_link: true
             vrf: red_vrf
           - bridge_group: 2
-            ifindex: 7
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.4/24
             name: VLAN red_vlan (1000) -> [s1]

--- a/tests/topology/expected/lag-l3-access-vlan.yml
+++ b/tests/topology/expected/lag-l3-access-vlan.yml
@@ -118,7 +118,7 @@ nodes:
         node: r2
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN v1 (1000) -> [r2]
@@ -226,7 +226,7 @@ nodes:
         node: r1
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN v1 (1000) -> [r1]

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -196,7 +196,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,b1,b2,a2,h2]
@@ -300,7 +300,7 @@ nodes:
         node: b2
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,a1,b1,b2,h2]
@@ -404,7 +404,7 @@ nodes:
         trunk_id:
         - 1000
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h1,a1,b2,a2,h2]
@@ -521,7 +521,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.4/24
       name: VLAN red (1000) -> [h1,a1,b1,a2,h2]

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -333,7 +333,7 @@ nodes:
         node: s1
       type: p2p
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [s2,s1,h2]
@@ -502,7 +502,7 @@ nodes:
         node: s2
       type: p2p
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.4/24
       name: VLAN red (1000) -> [h1,s2,s1]
@@ -754,7 +754,7 @@ nodes:
         node: h2
       type: p2p
     - bridge_group: 1
-      ifindex: 10
+      ifindex: 40000
       ifname: virtual-network1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,s2,h2]
@@ -967,7 +967,7 @@ nodes:
         node: h2
       type: p2p
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: virtual-network1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s1,h2]

--- a/tests/topology/expected/lag-vlan-trunk.yml
+++ b/tests/topology/expected/lag-vlan-trunk.yml
@@ -142,7 +142,7 @@ nodes:
         access: v2-bridge
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN v1-irb (1000) -> [r2]
@@ -156,7 +156,7 @@ nodes:
         mode: irb
         name: v1-irb
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: vlan1001
       name: VLAN v2-bridge (1001) -> [r2]
       neighbors:
@@ -293,7 +293,7 @@ nodes:
         access: v2-bridge
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN v1-irb (1000) -> [r1]
@@ -307,7 +307,7 @@ nodes:
         mode: irb
         name: v1-irb
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: vlan1001
       name: VLAN v2-bridge (1001) -> [r1]
       neighbors:

--- a/tests/topology/expected/node.clone-plugin-lag.yml
+++ b/tests/topology/expected/node.clone-plugin-lag.yml
@@ -431,7 +431,7 @@ nodes:
         node: r2
       type: p2p
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.5/24
       name: VLAN red (1000) -> [r2,r1,h2-02]
@@ -525,7 +525,7 @@ nodes:
         node: r2
       type: p2p
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.6/24
       name: VLAN red (1000) -> [h2-01,r2,r1]
@@ -721,7 +721,7 @@ nodes:
         node: h2-02
       type: p2p
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h2-01,r2,h2-02]
@@ -932,7 +932,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h2-01,r1,h2-02]

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -231,7 +231,7 @@ nodes:
       type: p2p
       vrf: red
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [r,h-07]
@@ -330,7 +330,7 @@ nodes:
       type: p2p
       vrf: red
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h-03,r]
@@ -703,7 +703,7 @@ nodes:
         node: h-07
       type: p2p
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h-03,h-07]

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -195,7 +195,7 @@ nodes:
         trunk_id:
         - 1000
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN blue (1000) -> [h,s2]
@@ -276,7 +276,7 @@ nodes:
         id: -2
         ipv4: 172.16.0.254/24
         protocol: anycast
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN blue (1000) -> [h,s1]

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -539,7 +539,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 21
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [rt,h,sw]
       neighbors:
@@ -557,7 +557,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 22
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [rt,sw]
       neighbors:
@@ -571,7 +571,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 3
-      ifindex: 23
+      ifindex: 40002
       ifname: Vlan1002
       name: VLAN green (1002) -> [rt,sw]
       neighbors:
@@ -805,7 +805,7 @@ nodes:
         mode: route
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1001
       name: VLAN blue (1001) -> [br,sw]
       neighbors:
@@ -819,7 +819,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 3
-      ifindex: 8
+      ifindex: 40001
       ifname: Vlan1002
       ipv4: 172.16.2.2/24
       name: VLAN green (1002) -> [br,sw]
@@ -1079,7 +1079,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 16
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [rt,h,br]
       neighbors:
@@ -1097,7 +1097,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 17
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [br,rt]
       neighbors:
@@ -1111,7 +1111,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 3
-      ifindex: 18
+      ifindex: 40002
       ifname: Vlan1002
       ipv4: 172.16.2.3/24
       name: VLAN green (1002) -> [br,rt]

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -156,7 +156,7 @@ nodes:
         - 1000
         - 1001
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [ros]
@@ -170,7 +170,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 4
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [ros]

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -144,7 +144,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,h2]
       neighbors:

--- a/tests/topology/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/topology/expected/rt-vlan-role-unnumbered.yml
@@ -74,7 +74,7 @@ nodes:
         access: vxlan
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: vlan1000
       ipv4: true
       ipv6: true
@@ -160,7 +160,7 @@ nodes:
         access: vxlan
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: vlan1000
       ipv4: true
       ipv6: true

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -65,7 +65,7 @@ nodes:
         - 1000
         - 1002
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [s3]
@@ -79,7 +79,7 @@ nodes:
         mode: irb
         name: green
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [s2]
@@ -149,7 +149,7 @@ nodes:
         - 1000
         - 1001
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s3]
@@ -163,7 +163,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [s1]
@@ -233,7 +233,7 @@ nodes:
         - 1001
         - 1002
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [s2]
@@ -247,7 +247,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1002
       ipv4: 172.16.2.3/24
       name: VLAN green (1002) -> [s1]

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -462,7 +462,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 9
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s2,h2]
       neighbors:
@@ -480,7 +480,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 10
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s2]
       neighbors:
@@ -598,7 +598,7 @@ nodes:
         access: green
         access_id: 1002
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1002
       name: VLAN green (1002) -> [s3,h4]
       neighbors:
@@ -613,7 +613,7 @@ nodes:
         mode: bridge
         name: green
     - bridge_group: 2
-      ifindex: 8
+      ifindex: 40001
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h2]
       neighbors:
@@ -631,7 +631,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 3
-      ifindex: 9
+      ifindex: 40002
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1]
       neighbors:
@@ -741,7 +741,7 @@ nodes:
         port_type: auto
       type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1002
       name: VLAN green (1002) -> [s2,h4]
       neighbors:

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -454,7 +454,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s2,h2,s3]
       neighbors:
@@ -474,7 +474,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s3,s2,h4]
       neighbors:
@@ -598,7 +598,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h2,s3]
       neighbors:
@@ -618,7 +618,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 9
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s3,h4]
       neighbors:
@@ -734,7 +734,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h3,s1,s2,h4]
       neighbors:
@@ -754,7 +754,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 2
-      ifindex: 8
+      ifindex: 40001
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,s2,h2]
       neighbors:

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -257,7 +257,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s2...]
@@ -358,7 +358,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h1,s1...]

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -255,7 +255,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [r1,r2]

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -218,7 +218,7 @@ nodes:
         node: h2
       type: lan
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: BVI1
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1]
@@ -291,7 +291,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: BVI1
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s1,h2]

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -298,7 +298,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s2,s3,h2]
@@ -402,7 +402,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 3
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h1,s1,s3,h2]
@@ -491,7 +491,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 2
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.42/24
       name: VLAN red (1000) -> [h1,s1,s2,h2]

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -325,7 +325,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s2,r1]
       neighbors:
@@ -343,7 +343,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h2,s2,r1]
       neighbors:
@@ -440,7 +440,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,r1]
       neighbors:
@@ -458,7 +458,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h2,s1,r1]
       neighbors:

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -272,7 +272,7 @@ nodes:
         node: s2
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: BVI1
       ipv4: 172.16.0.2/24
       name: VLAN red (1001) -> [h1,s2,h2]
@@ -372,7 +372,7 @@ nodes:
         node: s1
       type: p2p
     - bridge_group: 1
-      ifindex: 5
+      ifindex: 40000
       ifname: BVI1
       ipv4: 172.16.0.3/24
       name: VLAN red (1001) -> [h1,s1,h2]
@@ -392,7 +392,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 6
+      ifindex: 40001
       ifname: BVI2
       name: VLAN blue (1000) -> [h2]
       neighbors:

--- a/tests/topology/expected/vlan-mode-priority.yml
+++ b/tests/topology/expected/vlan-mode-priority.yml
@@ -175,7 +175,7 @@ nodes:
         access: orange
         access_id: 1003
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [s2]
@@ -189,7 +189,7 @@ nodes:
         mode: vl_irb
         name: red
     - bridge_group: 2
-      ifindex: 9
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [s2]
@@ -203,7 +203,7 @@ nodes:
         mode: g_irb
         name: blue
     - bridge_group: 3
-      ifindex: 10
+      ifindex: 40002
       ifname: Vlan1002
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [s2]
@@ -216,7 +216,7 @@ nodes:
         mode: vl_irb
         name: green
     - bridge_group: 4
-      ifindex: 11
+      ifindex: 40003
       ifname: Vlan1003
       ipv4: 172.16.3.1/24
       name: VLAN orange (1003) -> [s2]
@@ -372,7 +372,7 @@ nodes:
         mode: route
         name: orange
     - bridge_group: 1
-      ifindex: 8
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [s1]
@@ -386,7 +386,7 @@ nodes:
         mode: n_irb
         name: red
     - bridge_group: 2
-      ifindex: 9
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [s1]
@@ -400,7 +400,7 @@ nodes:
         mode: n_irb
         name: blue
     - bridge_group: 3
-      ifindex: 10
+      ifindex: 40002
       ifname: Vlan1002
       name: VLAN green (1002) -> [s1]
       neighbors:

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -158,7 +158,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 2
-      ifindex: 4
+      ifindex: 40000
       ifname: BVI2
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [r2]
@@ -172,7 +172,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 3
-      ifindex: 5
+      ifindex: 40001
       ifname: BVI3
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [r2]
@@ -278,7 +278,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 2
-      ifindex: 4
+      ifindex: 40000
       ifname: BVI2
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [r1]
@@ -292,7 +292,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 3
-      ifindex: 5
+      ifindex: 40001
       ifname: BVI3
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [r1]

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -241,7 +241,7 @@ nodes:
       role: stub
       type: stub
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [r1,r2]
       neighbors:

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -176,7 +176,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [r]
@@ -190,7 +190,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [r]

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -778,7 +778,7 @@ nodes:
         - 1002
         - 1001
     - bridge_group: 1
-      ifindex: 10
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [r1,r2,h1,s2]
@@ -802,7 +802,7 @@ nodes:
         name: red
       vrf: red
     - bridge_group: 2
-      ifindex: 11
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [r1,r2,s2,h2]
@@ -826,7 +826,7 @@ nodes:
         name: blue
       vrf: blue
     - bridge_group: 3
-      ifindex: 12
+      ifindex: 40002
       ifname: Vlan1002
       name: VLAN green (1002) -> [r1,r2,s2,h3]
       neighbors:
@@ -1083,7 +1083,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 11
+      ifindex: 40000
       ifname: vlan1001
       name: VLAN blue (1001) -> [r1,r2,s1,h2]
       neighbors:
@@ -1106,7 +1106,7 @@ nodes:
         name: blue
       vrf: blue
     - bridge_group: 2
-      ifindex: 12
+      ifindex: 40001
       ifname: vlan1002
       name: VLAN green (1002) -> [r1,r2,s1,h3]
       neighbors:
@@ -1132,7 +1132,7 @@ nodes:
         name: green
       vrf: green
     - bridge_group: 3
-      ifindex: 13
+      ifindex: 40002
       ifname: vlan1000
       name: VLAN red (1000) -> [r1,r2,h1,s1]
       neighbors:

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -368,7 +368,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [r1,s2,ros]
       neighbors:
@@ -387,7 +387,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [r2,s2,ros]
       neighbors:
@@ -475,7 +475,7 @@ nodes:
         - 1000
         - 1001
     - bridge_group: 1
-      ifindex: 7
+      ifindex: 40000
       ifname: Vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [r2,s1,ros]
@@ -494,7 +494,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 2
-      ifindex: 8
+      ifindex: 40001
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [r1,s1,ros]

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -614,7 +614,7 @@ nodes:
         access: red
         access_id: 1000
     - bridge_group: 1
-      ifindex: 9
+      ifindex: 40000
       ifname: BVI1
       ipv4: 172.16.0.1/24
       name: VLAN red (1000) -> [h1,s2,h3]
@@ -638,7 +638,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 10
+      ifindex: 40001
       ifname: BVI2
       ipv4: 172.16.1.1/24
       name: VLAN blue (1001) -> [h2,s2,h4]
@@ -661,7 +661,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 3
-      ifindex: 11
+      ifindex: 40002
       ifname: BVI3
       ipv4: 172.16.2.1/24
       name: VLAN green (1002) -> [s2,h5,h1]
@@ -822,7 +822,7 @@ nodes:
         - 1001
         - 1002
     - bridge_group: 1
-      ifindex: 10
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s1,h3]
@@ -846,7 +846,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 11
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.2/24
       name: VLAN blue (1001) -> [h2,s1,h4]
@@ -869,7 +869,7 @@ nodes:
         mode: irb
         name: blue
     - bridge_group: 3
-      ifindex: 12
+      ifindex: 40002
       ifname: Vlan1002
       ipv4: 172.16.2.2/24
       name: VLAN green (1002) -> [s1,h5,h1]

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -313,7 +313,7 @@ nodes:
         vrrp:
           group: 1
           priority: 100
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.2/24
       name: VLAN red (1000) -> [h1,s2,h2]
@@ -349,7 +349,7 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.24/24
       name: VLAN blue (1001) -> [s2]
@@ -459,7 +459,7 @@ nodes:
         vrrp:
           group: 1
           priority: 200
-      ifindex: 5
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [h1,s1,h2]
@@ -486,7 +486,7 @@ nodes:
         vrrp:
           group: 1
           priority: 180
-      ifindex: 6
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [s1]

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -99,7 +99,7 @@ nodes:
         node: s2
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.3/24
       name: VLAN red (1000) -> [s2,s1,r2]
@@ -117,7 +117,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.3/24
       name: VLAN blue (1001) -> [s2,s1,r2]
@@ -214,7 +214,7 @@ nodes:
       parentindex: {}
       type: p2p
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.4/24
       name: VLAN red (1000) -> [s2,s1,r1]
@@ -233,7 +233,7 @@ nodes:
         mode: irb
         name: red
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: vlan1001
       ipv4: 172.16.1.4/24
       name: VLAN blue (1001) -> [s2,s1,r1]
@@ -334,7 +334,7 @@ nodes:
         - 1000
         - 1001
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1001
       name: VLAN blue (1001) -> [s2,r1,r2]
       neighbors:
@@ -352,7 +352,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1000
       name: VLAN red (1000) -> [s2,r1,r2]
       neighbors:
@@ -458,7 +458,7 @@ nodes:
         node: r2
       type: p2p
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1001
       name: VLAN blue (1001) -> [s1,r1,r2]
       neighbors:
@@ -476,7 +476,7 @@ nodes:
         mode: bridge
         name: blue
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1000
       name: VLAN red (1000) -> [s1,r1,r2]
       neighbors:

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -299,7 +299,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,h3,s2]
       neighbors:
@@ -317,7 +317,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h2,h4,s2]
       neighbors:
@@ -441,7 +441,7 @@ nodes:
         access: blue
         access_id: 1001
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       name: VLAN red (1000) -> [h1,s1,h3]
       neighbors:
@@ -459,7 +459,7 @@ nodes:
         mode: bridge
         name: red
     - bridge_group: 2
-      ifindex: 5
+      ifindex: 40001
       ifname: Vlan1001
       name: VLAN blue (1001) -> [h2,s1,h4]
       neighbors:

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -572,7 +572,7 @@ nodes:
       type: lan
       vrf: blue
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.6/24
       name: VLAN red_transport (1000) -> [s2,s3]
@@ -590,7 +590,7 @@ nodes:
         name: red_transport
       vrf: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.6/24
       name: VLAN blue_transport (1001) -> [s2]
@@ -692,7 +692,7 @@ nodes:
             type: lan
             vrf: blue
           - bridge_group: 2
-            ifindex: 7
+            ifindex: 40001
             ifname: Vlan1001
             ipv4: 172.16.1.6/24
             name: VLAN blue_transport (1001) -> [s2]
@@ -748,7 +748,7 @@ nodes:
             type: lan
             vrf: red
           - bridge_group: 1
-            ifindex: 6
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.6/24
             name: VLAN red_transport (1000) -> [s2,s3]
@@ -831,7 +831,7 @@ nodes:
       type: lan
       vrf: blue
     - bridge_group: 1
-      ifindex: 6
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.7/24
       name: VLAN red_transport (1000) -> [s1,s3]
@@ -849,7 +849,7 @@ nodes:
         name: red_transport
       vrf: red
     - bridge_group: 2
-      ifindex: 7
+      ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.7/24
       name: VLAN blue_transport (1001) -> [s1]
@@ -951,7 +951,7 @@ nodes:
             type: lan
             vrf: blue
           - bridge_group: 2
-            ifindex: 7
+            ifindex: 40001
             ifname: Vlan1001
             ipv4: 172.16.1.7/24
             name: VLAN blue_transport (1001) -> [s1]
@@ -1007,7 +1007,7 @@ nodes:
             type: lan
             vrf: red
           - bridge_group: 1
-            ifindex: 6
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.7/24
             name: VLAN red_transport (1000) -> [s1,s3]
@@ -1077,7 +1077,7 @@ nodes:
       type: lan
       vrf: red
     - bridge_group: 1
-      ifindex: 4
+      ifindex: 40000
       ifname: Vlan1000
       ipv4: 172.16.0.8/24
       name: VLAN red_transport (1000) -> [s1,s2]
@@ -1171,7 +1171,7 @@ nodes:
             type: lan
             vrf: red
           - bridge_group: 1
-            ifindex: 4
+            ifindex: 40000
             ifname: Vlan1000
             ipv4: 172.16.0.8/24
             name: VLAN red_transport (1000) -> [s1,s2]


### PR DESCRIPTION
There is no reason to start SVI ifindex values immediately after the last already-created interface ifindex. This change makes SVI ifindex processing align with loopback and tunnel interfaces.