### PR TITLE
Cumulus NVUE: Configure global stp.priority also for each VLAN (in case of PVRST)

### DIFF
--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -9,7 +9,7 @@
 {% if 'priority' in stp %}
             priority: {{ stp.priority }}
 {% endif %}
-{% if vlans is defined %}
+{% if vlans is defined and stp.protocol=='pvrst' %}
 {%  for vname,vdata in vlans.items() if vdata.stp.priority is defined or stp.priority is defined %}
 {%   if loop.first %}
             vlan:

--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -10,12 +10,12 @@
             priority: {{ stp.priority }}
 {% endif %}
 {% if vlans is defined %}
-{%  for vname,vdata in vlans.items() if vdata.stp.priority is defined %}
+{%  for vname,vdata in vlans.items() if vdata.stp.priority is defined or stp.priority is defined %}
 {%   if loop.first %}
             vlan:
 {%   endif %}
              '{{ vdata.id }}':
-               bridge-priority: {{ vdata.stp.priority }}
+               bridge-priority: {{ vdata.stp.priority|default(stp.priority) }}
 {%  endfor %}
 {% endif %}
 


### PR DESCRIPTION
It is not sufficient to configure the priority globally, the default priority per VLAN must also be configured

Fixes https://github.com/ipspace/netlab/issues/1746