### PR TITLE
Dell OS10: Apply global stp.priority per VLAN too

### DIFF
--- a/netsim/ansible/templates/stp/dellos10.j2
+++ b/netsim/ansible/templates/stp/dellos10.j2
@@ -16,11 +16,12 @@ spanning-tree rstp priority {{ stp.priority }}
 
 {# Check for per-VLAN enable and priority; implies Rapid-PVST #}
 {%  if vlans is defined %}
-{%   for vname,vdata in vlans.items() if 'stp' in vdata %}
+{%   set apply_stp_prio_per_vlan = stp.priority is defined and stp.protocol=='pvrst' %}
+{%   for vname,vdata in vlans.items() if 'stp' in vdata or apply_stp_prio_per_vlan %}
 {%    if not vdata.stp.enable|default(True) %}
 spanning-tree vlan {{ vdata.id }} disable
-{%    elif 'priority' in vdata.stp %}
-spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
+{%    elif 'priority' in vdata.stp|default({}) or apply_stp_prio_per_vlan %}
+spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority|default(stp.priority) }}
 {%    endif %}
 {%   endfor +%}
 {%  endif %}


### PR DESCRIPTION
Partially fixes https://github.com/ipspace/netlab/issues/1747

STP path cost on Dell OS10 is lower (800) than EOS (20000) because Dell OS10 emulates 25G NICs versus EOS' 1G NICs