### PR TITLE
lag: Restore mtu attribute on lag interfaces

### DIFF
--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -108,8 +108,8 @@ ip link set {{ l.ifname }} up
 echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 #
 # Set Ethernet interface MTU
-{% for l in interfaces if l.mtu is defined and l.type!='lag' %}
-ip link set {{ l.ifname }} mtu {{ l.mtu }}
+{% for l in interfaces if l.mtu is defined %}
+ip link set dev {{ l.ifname }} mtu {{ l.mtu }}
 {% endfor %}
 
 #

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -46,8 +46,8 @@ ip -6 addr del {{ l.ipv6 }} dev {{ l.ifname }} 2>/dev/null
 set -e
 ip -6 addr add {{ l.ipv6 }} dev {{ l.ifname }}
 {% endif %}
-{% if l.mtu is defined and l.type != 'lag' %}
-ip link set {{ l.ifname }} mtu {{ l.mtu }}
+{% if l.mtu is defined %}
+ip link set dev {{ l.ifname }} mtu {{ l.mtu }}
 {% endif %}
 {% endfor %}
 #

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -29,6 +29,10 @@
     interface:
 {%  endif %}
       {{ i.ifname }}:
+{%  if i.mtu is defined %}
+        link:
+          mtu: {{ i.mtu }}
+{%  endif %}
         bond:
 {%  if '_mlag' in i.lag %}
           mlag:

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -443,7 +443,6 @@ class LAG(_Module):
       elif i.type=='lag':
         node_atts = { k:v for k,v in node.get('lag',{}).items() if k!='mlag'}
         i.lag = node_atts + i.lag              # Merge node level settings with interface overrides
-        i.pop('mtu',None)                      # Remove any MTU settings - inherited from members
 
         if 'mode' in i.lag:
           log.error(f'lag.mode {i.lag.mode} used by node {node.name} is deprecated, use only 802.3ad',

--- a/netsim/modules/lag.yml
+++ b/netsim/modules/lag.yml
@@ -56,4 +56,3 @@ attributes:
     interfaces:
     _linkname:
     name:
-    mtu:

--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -113,6 +113,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1600
       name: r1 -> r2
       neighbors:
       - ifname: port-channel1
@@ -127,6 +128,7 @@ nodes:
         ifindex: 2
         lacp: slow
         lacp_mode: active
+      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel2
@@ -139,6 +141,7 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel3
@@ -262,6 +265,7 @@ nodes:
         ifindex: 1
         lacp: slow
         lacp_mode: active
+      mtu: 1600
       name: r2 -> r1
       neighbors:
       - ifname: port-channel1
@@ -276,6 +280,7 @@ nodes:
         ifindex: 2
         lacp: slow
         lacp_mode: active
+      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel2
@@ -288,6 +293,7 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel3

--- a/tests/topology/expected/lag-l3-access-vlan.yml
+++ b/tests/topology/expected/lag-l3-access-vlan.yml
@@ -74,6 +74,7 @@ nodes:
         ifindex: 1
         lacp: 'off'
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN v1] r1 -> r2'
       neighbors:
       - ifname: bond1
@@ -182,6 +183,7 @@ nodes:
         ifindex: 1
         lacp: 'off'
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN v1] r2 -> r1'
       neighbors:
       - ifname: bond1

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -92,6 +92,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel1
@@ -112,6 +113,7 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r1 -> r2
       neighbors:
       - gateway: false
@@ -208,6 +210,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel1
@@ -222,6 +225,7 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r2 -> r1
       neighbors:
       - gateway:

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -240,6 +240,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] h1 -> [s1,s2]'
       neighbors:
       - ifname: port-channel1
@@ -259,6 +260,7 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: h1 -> s1
       neighbors:
       - ifname: port-channel2
@@ -403,6 +405,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] h2 -> [s1,s2]'
       neighbors:
       - ifname: port-channel3
@@ -422,6 +425,7 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] h2 -> [s1,s2]'
       neighbors:
       - ifname: port-channel4
@@ -583,6 +587,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s1 -> [h1,s2]'
       neighbors:
       - ifname: bond1
@@ -602,6 +607,7 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: bond2
@@ -616,6 +622,7 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
       - ifname: bond1
@@ -636,6 +643,7 @@ nodes:
         ifindex: 4
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
       - ifname: bond2
@@ -835,6 +843,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s2 -> [h1,s1]'
       neighbors:
       - ifname: bond1
@@ -855,6 +864,7 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
       - ifname: bond1
@@ -875,6 +885,7 @@ nodes:
         ifindex: 4
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
       - ifname: bond2

--- a/tests/topology/expected/lag-vlan-trunk.yml
+++ b/tests/topology/expected/lag-vlan-trunk.yml
@@ -74,6 +74,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: bond1
@@ -225,6 +226,7 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
+      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: bond1


### PR DESCRIPTION
It used to be that setting MTU on a Linux bond device resulted in an error - or so I thought. In any case, now it works so we can use that to fix MTU related issues with lags

Setting the MTU changes the MTUs of all members

Fixes https://github.com/ipspace/netlab/issues/1750 and #1751 