### PR TITLE
Cumulus NVUE: Postpone bringing lag member interfaces up until the bond is in place

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -11,7 +11,7 @@ LAG is currently supported on these platforms:
 | Arista EOS [❗](caveats-eos) | ✅ | ✅ | ✅ | ✅ |
 | Aruba AOS-CX          | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x     | ✅ | ✅ | ❌  | ❌ |
-| Cumulus 5.x (NVUE)    | ✅ | ✅ | ❌  | ❌ |
+| Cumulus 5.x (NVUE)    | ✅ | ✅ | ❌  | ✅ |
 | Dell OS10             | ✅ | ✅ | ✅  | ✅ |
 | FRR                   | ✅ | ✅ | ❌  | ❌ |
 | Generic Linux hosts   | ✅ | ✅ | ❌  | ❌ |

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -6,7 +6,7 @@
           mtu: {{ i.mtu }}
 {%  endif %}
           state:
-            up: {}
+            {{ 'down' if i.lag._parentindex is defined else 'up' }} : {}
 {%  if i.name is defined %}
         description: "{{ i.name }}{{ " ["+i.role+"]" if i.role is defined else "" }}"
 {%  elif i.type|default("") == "stub" %}

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -28,6 +28,12 @@
 - set:
     interface:
 {%  endif %}
+{%  for c in interfaces if c.lag._parentindex|default(False) == i.lag.ifindex %}
+      {{ c.ifname }}:
+        link:
+          state:
+            up: {}
+{%  endfor %}
       {{ i.ifname }}:
 {%  if i.mtu is defined %}
         link:


### PR DESCRIPTION
Depending on RACE conditions, the bond could fail to come up if a lag member is brought up too early, and a duplicate IP is detected

Initially keep lag member interfaces down, and only bring them up once the peerlink is configured

Fixes https://github.com/ipspace/netlab/issues/1759