### PR TITLE
Dell OS10: Cleanup BGP template

### DIFF
--- a/netsim/ansible/templates/bgp/dellos10.macro.j2
+++ b/netsim/ansible/templates/bgp/dellos10.macro.j2
@@ -14,46 +14,37 @@
 {%   endif %}
     
     description "{{ n.name }}"
-
-{%     if n.local_as is defined %}
-    local-as {{ n.local_as }} no-prepend replace-as
-{%     endif %}
-
-{%     if n.type == 'ibgp' %}
-    update-source loopback0
-{%       if bgp.next_hop_self is defined and bgp.next_hop_self %}
+{%   if n.local_as is defined %}
+    local-as {{ n.local_as }}{{ ' no-prepend replace-as' if n.replace_global_as|default(True) else '' }}
+{%   endif %}
+{%   if n._source_ifname is defined %}
+    update-source {{ n._source_ifname }}
+{%   endif %}
+{%   if 'ibgp' in n.type %}
+{%     if bgp.next_hop_self is defined and bgp.next_hop_self %}
 {#
   In Dell OS10, next-hop-self is configured under AF
 #}
-{%         for af in ['ipv4','ipv6'] if bgp[af] is defined and n.activate[af] is defined and n.activate[af] %}
+{%       for af in ['ipv4','ipv6'] if bgp[af] is defined and n.activate[af] is defined and n.activate[af] %}
 !
  address-family {{ af }} unicast
    next-hop-self
  exit
-{%         endfor %}
-{%       endif %}
+{%       endfor %}
+{%     endif -%}
 
-{%       if bgp.rr|default('') and not n.rr|default('') %}
+{%     if bgp.rr|default('') and not n.rr|default('') %}
     route-reflector-client
-{%       endif %}
-{%       if bgp.community.ibgp|default([]) %}
-{%         if "standard" in bgp.community.ibgp|default([]) %}
-    send-community standard
-{%         endif %}
-{%         if "extended" in bgp.community.ibgp|default([]) %}
-    send-community extended
-{%         endif %}
-{%       endif %}
-{%   else %}
-{%       if bgp.community.ebgp|default([]) %}
-{%         if "standard" in bgp.community.ebgp|default([]) %}
-    send-community standard
-{%         endif %}
-{%         if "extended" in bgp.community.ebgp|default([]) %}
-    send-community extended
-{%         endif %}
-{%       endif %}
 {%     endif %}
+{%   endif -%}
+
+{%   if n.type in bgp.community %}
+{%     for comm in ['standard','extended'] %}
+{%       if comm in bgp.community[n.type] %}
+    send-community {{ comm }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 
 {% for af in ['ipv4','ipv6'] if bgp[af] is defined and n.activate[af] is defined and n.activate[af] %}
 !

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -7,7 +7,7 @@ lldp enable
 {% endif %}
 !
 {% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) and v.loopback.ipv4 is defined %}
-ip host {{ k|replace('_','') }} {{ v.loopback.ipv4|ipaddr('address') }}
+ip host {{ k|replace('_','') }} {{ v.loopback.ipv4.split('/')[0] }}
 {% endfor %}
 !
 {% if mtu is defined %}

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -15,6 +15,7 @@ features:
     activate_af: true
     ipv6_lla: true
     local_as: true
+    local_as_ibgp: false     # Device fails to send correct local AS (only)
     vrf_local_as: true
   evpn:
     asymmetrical_irb: true


### PR DESCRIPTION
Attempted to add ibgp_localas support, but the device just won't behave correctly

* Conditionally add 'no-prepend replace-as' flags, not always
* Use `_source_ifname` to set loopback source interface
* Handle both ibgp and localas_ibgp neighbor types
* Simplify community processing
* Fix loopback IP selection (see #1767)