### PR TITLE
AOS-CX: optimize configuration task

### DIFF
--- a/netsim/ansible/tasks/deploy-config/arubacx.yml
+++ b/netsim/ansible/tasks/deploy-config/arubacx.yml
@@ -10,14 +10,10 @@
     src: "{{ config_template }}"
     dest: "{{ tempfile_1.path }}"
 
-# This is required when running "netlab initial" multiple times...
-- name: "aoscx_config: set session auto-confirm for {{ netsim_action }}"
-  arubanetworks.aoscx.aoscx_config:
-    lines:
-    - "auto-confirm"
-
 - name: "aoscx_config: deploying {{ netsim_action }} from {{ config_template }}"
   arubanetworks.aoscx.aoscx_config:
+    # auto-confirm is required for multiple config execution (i.e., running "netlab initial" multiple times)
+    before: "auto-confirm"
     match: "none"
     src: "{{ tempfile_1.path }}"
   tags: [ print_action, always ]


### PR DESCRIPTION
Instead of invoking two times `aoscx_config`, we can add the `auto-confirm` as *before* param of the "real" module call.