### PR TITLE
Improve 'unmanaged' node support

### DIFF
--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -130,7 +130,7 @@ def load_topology(args: typing.Union[argparse.Namespace,Box]) -> Box:
 
 # Snapshot loading code -- loads the specified snapshot file and checks its modification date
 #
-def load_snapshot(args: typing.Union[argparse.Namespace,Box]) -> Box:
+def load_snapshot(args: typing.Union[argparse.Namespace,Box],ghosts: bool = True) -> Box:
   if not os.path.isfile(args.snapshot):
     print(f"The topology snapshot file {args.snapshot} does not exist.\n"+
           "Looks like no lab was started from this directory")
@@ -140,6 +140,9 @@ def load_snapshot(args: typing.Union[argparse.Namespace,Box]) -> Box:
   if topology is None:
     print(f"Cannot read the topology snapshot file {args.snapshot}")
     sys.exit(1)
+
+  if not ghosts:
+    topology = augment.nodes.ghost_buster(topology)
 
   global_vars.init(topology)
   check_modified_source(args.snapshot,topology)

--- a/netsim/cli/capture.py
+++ b/netsim/cli/capture.py
@@ -53,6 +53,8 @@ def run(cli_args: typing.List[str]) -> None:
       more_hints=[ 'Use "netlab status" to display the node names in the current lab topology' ])
   
   ndata = topology.nodes[args.node]
+  if ndata.get('unmanaged',False):
+    error_and_exit(f'Node {args.node} is an unmanaged node and cannot be used in the capture command')
   intf_hint = [ f'Use "netlab report --node {args.node} addressing" to display valid interface names and their descriptions' ]
   if not args.intf:
     error_and_exit('Missing interface name',more_hints=intf_hint)

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -19,7 +19,7 @@ class LogLevel(IntEnum):
 
 from box import Box
 
-from . import external_commands, set_dry_run
+from . import external_commands, set_dry_run, error_and_exit
 
 from . import load_snapshot, parser_add_verbose
 from ..outputs import common as outputs_common
@@ -243,6 +243,8 @@ def run(cli_args: typing.List[str]) -> None:
 
   try:
     if host in topology.nodes:
+      if topology.nodes[host].get('unmanaged',False):
+        error_and_exit(f'"netlab connect" command cannot be used to connect to unmanaged node {args.host}')
       connect_to_node(node=host,args=args,rest=rest,topology=topology,log_level=log_level)
     elif host in topology.tools:
       connect_to_tool(host,rest,topology,log_level)

--- a/netsim/cli/down.py
+++ b/netsim/cli/down.py
@@ -201,7 +201,7 @@ def run(cli_args: typing.List[str]) -> None:
   if args.instance:
     change_lab_instance(args.instance)
 
-  topology = load_snapshot(args)
+  topology = load_snapshot(args,ghosts=False)
   log.status_success()
   print(f"Read transformed lab topology from snapshot file {args.snapshot}")
 

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -119,12 +119,16 @@ def show_lab_nodes(topology: Box) -> None:
     p_module   = providers.get_provider_module(topology,n_provider)
     load_provider_status(p_status,n_provider,topology)
 
-    row = [ n_data.name, n_data.device, n_data.box, n_data.mgmt.ipv4, n_ext.ansible_connection, n_provider ]
-    wk_name = p_module.call('get_node_name',n_name,topology)
-    row.append(wk_name)
+    if n_data.get('unmanaged',False):
+      row = [ n_data.name, n_data.device, 'unmanaged', n_data.mgmt.ipv4 ]
+    else:
+      row = [ n_data.name, n_data.device, n_data.box, n_data.mgmt.ipv4, n_ext.ansible_connection, n_provider ]
+      wk_name = p_module.call('get_node_name',n_name,topology)
+      row.append(wk_name)
 
-    wk_state = p_status[n_provider].get(wk_name,None) or p_status[n_provider].get(n_name,None)
-    row.append(wk_state.status if wk_state else 'Unknown')
+      wk_state = p_status[n_provider].get(wk_name,None) or p_status[n_provider].get(n_name,None)
+      row.append(wk_state.status if wk_state else 'Unknown')
+
     rows.append(row)
 
   for t_name,t_data in topology.tools.items():

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -341,6 +341,9 @@ class Libvirt(_Provider):
         if not 'libvirt' in link.provider:                          # Not a libvirt link? skip it
           continue
 
+        if 'bridge' in link:                                        # Copy link bridge name into interface for P2P links
+          intf.bridge = link.bridge                                 # that became stubs due to unmanaged node removal
+
         if 'libvirt' in link:                                       # Do we have libvirt-specific data on the link?
           intf.libvirt = link.libvirt + intf.libvirt                # ... then add it to the interface data
           continue                                                  # ... and move on -- links with libvirt attributes

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -3,21 +3,18 @@ input:
 - package:topology-defaults.yml
 links:
 - _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: Ethernet1
     ipv4: 10.1.0.2/30
     node: r1
-  - ifindex: 1
-    ifname: Ethernet1
-    ipv4: 10.1.0.1/30
-    node: external
   linkindex: 1
-  node_count: 2
+  node_count: 1
   prefix:
     ipv4: 10.1.0.0/30
   role: external
-  type: p2p
+  type: stub
 - _linkname: links[2]
   bridge: input_2
   gateway:


### PR DESCRIPTION
The unmanaged nodes were designed to be used in rare cases where a netlab lab connects to external devices. The initial scenarios assumed libvirt- or clab uplinks on the connecting links, but that approach broke when creative engineers started using 'unmanaged' nodes to reduce workload of exceedingly large topologies.

This commit fixes a number of problems that creativity introduced:

* When the 'unmanaged' nodes are used within the lab (as opposed to on uplinks), a number of provider configuration mechanisms break. The unmanaged nodes thus have to be removed from link interfaces, and some 'p2p' links have to be converted to stub links (nodes.py)
* The 'p2p' links converted to stub links lack 'bridge' attribute on node interfaces. That attribute is copied (again) to interfaces during 'what type of link are we dealing with' libvirt processing (libvirt.py)

Furthermore, a number of netlab commands (up, down) broke when dealing with topology snapshot that includes ghost (unmanaged) nodes. These commands have to redo the ghostbusting process to get to a topology that is safe to handle.

Similarly, executing 'netlab connect' or 'netlab capture' on an unmanaged node makes no sense.

Finally, 'netlab status' command produced bogus information for unmanaged nodes that (by definition) do not have a corresponding VM or container.