### PR TITLE
Cumulus and Cumulus NVUE: Limit vlans on bonds to those actually part of the trunk

### DIFF
--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -30,4 +30,4 @@
   command: nv config apply -y
   tags: [ print_action, always ]
   register: nv_config_apply
-  failed_when: "'failed' in nv_config_apply.stdout"  # Catch errors also when 'nv' returns success
+  failed_when: "'failed' in nv_config_apply.stdout or 'Invalid config' in nv_config_apply.stderr"  # Catch errors also when 'nv' returns success

--- a/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
+++ b/netsim/ansible/tasks/deploy-config/cumulus_nvue.yml
@@ -30,4 +30,4 @@
   command: nv config apply -y
   tags: [ print_action, always ]
   register: nv_config_apply
-  failed_when: "'failed' in nv_config_apply.stdout or 'Invalid config' in nv_config_apply.stderr"  # Catch errors also when 'nv' returns success
+  failed_when: "'failed' in nv_config_apply.stdout or 'Invalid config' in nv_config_apply.stderr"

--- a/netsim/ansible/templates/vlan/cumulus.j2
+++ b/netsim/ansible/templates/vlan/cumulus.j2
@@ -34,7 +34,7 @@ cat >/etc/network/interfaces.d/51-bridge-interfaces.intf <<CONFIG
 auto {{ ifdata.ifname }}
 {%   endif %}
 iface {{ ifdata.ifname }}
-{%   if ifdata.vlan.trunk_id is defined and ifdata.type != "lag" %}
+{%   if ifdata.vlan.trunk_id is defined %}
     bridge-vids {{ ifdata.vlan.trunk_id|sort|join(",") }}
 {%     if ifdata.vlan.native is defined %}
     bridge-pvid {{ ifdata.vlan.access_id }}

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -23,7 +23,7 @@
        bridge:
          domain:
            br_default:
-{%     if i.vlan.access_id is defined %}
+{%-     if i.vlan.access_id is defined +%}
 {%       if 'native' in i.vlan %}
              untagged: {{ vlans[i.vlan.native].id }}
 {%       else %}
@@ -34,6 +34,6 @@
 {%       for v in i.vlan.trunk_id|sort %}
                '{{ v }}': {}
 {%       endfor %}
-{%     else -%} {}
+{%     else %} {}
 {%     endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -13,14 +13,13 @@
 {%  endfor %}
 {% endif %}
 
+{# Note: interface.xyz.vlan is only used for SVI interfaces in case of multiple bridges #}
+
 {% for i in interfaces if i.vlan is defined and (i.virtual_interface is not defined or i.type=="lag") %}
 {%   if loop.first %}
     interface:
 {%   endif %}
      {{ i.ifname }}:
-{%   if i.type=="lag" and i.vlan.access_id is defined +%}
-       vlan: {{ i.vlan.access_id }}
-{%   endif %}
        bridge:
          domain:
            br_default:

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -18,15 +18,13 @@
     interface:
 {%   endif %}
      {{ i.ifname }}:
+{%   if i.type=="lag" and i.vlan.access_id is defined +%}
+       vlan: {{ i.vlan.access_id }}
+{%   endif %}
        bridge:
          domain:
            br_default:
-{%-  if i.type=="lag" %} {}
-{%     if i.vlan.access_id is defined +%}
-       vlan: {{ i.vlan.access_id }}
-{%     endif %}
-{%   else %}
-{%     if i.vlan.access_id is defined +%}
+{%     if i.vlan.access_id is defined %}
 {%       if 'native' in i.vlan %}
              untagged: {{ vlans[i.vlan.native].id }}
 {%       else %}
@@ -37,7 +35,6 @@
 {%       for v in i.vlan.trunk_id|sort %}
                '{{ v }}': {}
 {%       endfor %}
-{%     else %} {}
+{%     else -%} {}
 {%     endif %}
-{%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -18,19 +18,26 @@
     interface:
 {%   endif %}
      {{ i.ifname }}:
-        bridge:
-          domain:
-            br_default:{% if i.vlan.access_id is defined +%}
-{%            if 'native' in i.vlan %}
-              untagged: {{ vlans[i.vlan.native].id }}
-{%            else %}
-              access: {{ i.vlan.access_id }}
-{%            endif %}
-{%          elif i.vlan.trunk_id is defined and i.type != "lag" +%}
-              vlan:
-{%            for v in i.vlan.trunk_id|sort %}
-                '{{ v }}': {}
-{%            endfor %}
-{%          else %} {}
-{%          endif %}
+       bridge:
+         domain:
+           br_default:
+{%-  if i.type=="lag" %} {}
+{%     if i.vlan.access_id is defined +%}
+       vlan: {{ i.vlan.access_id }}
+{%     endif %}
+{%   else %}
+{%     if i.vlan.access_id is defined +%}
+{%       if 'native' in i.vlan %}
+             untagged: {{ vlans[i.vlan.native].id }}
+{%       else %}
+             access: {{ i.vlan.access_id }}
+{%       endif %}
+{%     elif i.vlan.trunk_id is defined +%}
+             vlan:
+{%       for v in i.vlan.trunk_id|sort %}
+               '{{ v }}': {}
+{%       endfor %}
+{%     else %} {}
+{%     endif %}
+{%   endif %}
 {% endfor %}


### PR DESCRIPTION
```bridge-vids``` turns out to be a filter for the vlans allowed on a bond device; if not set, it defaults to *all* vlans on the ```br_default``` bridge, which is obviously incorrect in many cases

The integration tests don't check for this, and it is somewhat tricky to adapt them because FRR on the other side of the bond is doing the right thing and only allowing the correct set of vlans.

While fixing this, I found another case of the ```nv config apply``` command not reporting an error when it should (though not normally triggered by the script)

Tested:
* ```netlab up integration/lag/01-l3-lag.yml -p libvirt -d cumulus_nvue```
* ```netlab up integration/lag/02-lag-vlan-trunk.yml -p libvirt -d cumulus_nvue```
* ```netlab up integration/lag/10-mlag.yml -p libvirt -d cumulus_nvue```

