### PR TITLE
Cumulus NVUE: Remove policer increase

### DIFF
--- a/netsim/ansible/templates/stp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/stp/cumulus_nvue.j2
@@ -19,15 +19,6 @@
 {%  endfor %}
 {% endif %}
 
-# When using PVRST, NVidia recommends to increase from default 2000 pps
-{% if stp.protocol=='pvrst' %}
-    system:
-      control-plane:
-        policer:
-          rpvst:
-            burst: 7200
-            rate: 7200
-{% endif %}
 {% for ifdata in interfaces if 'stp' in ifdata or ifdata.vlan.trunk|default({})|dict2items|map(attribute='value')|selectattr('stp','defined') %}
 {%  if loop.first %}
     interface:


### PR DESCRIPTION
Labs are unlikely to hit the 300 VLANs times 24 ports limit to require 7200 pps, the default 2000 pps should suffice