### PR TITLE
Cumulus NVUE: Add VXLAN support

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -205,6 +205,7 @@ ansible-galaxy collection install git+https://github.com/jmussmann/ansible_colle
 
 * The Cumulus VX 4.4.0 Vagrant box for VirtualBox is broken. *netlab* is using Cumulus VX 4.3.0 with *virtualbox* virtualization provider.
 * The Cumulus VX 4.x uses Python version 3.7, which recent versions of Ansible refuse to work with. The permanent fix is coming in release 1.9.3. Until then, use the **frrouting** device or [Cumulus VX 5.x image](caveats-cumulus-5x).
+* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed, is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
 
 _netlab_ uses the VLAN-aware bridge paradigm to configure VLANs on Cumulus Linux. That decision results in the following restrictions:
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -205,7 +205,7 @@ ansible-galaxy collection install git+https://github.com/jmussmann/ansible_colle
 
 * The Cumulus VX 4.4.0 Vagrant box for VirtualBox is broken. *netlab* is using Cumulus VX 4.3.0 with *virtualbox* virtualization provider.
 * The Cumulus VX 4.x uses Python version 3.7, which recent versions of Ansible refuse to work with. The permanent fix is coming in release 1.9.3. Until then, use the **frrouting** device or [Cumulus VX 5.x image](caveats-cumulus-5x).
-* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed, is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
+* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
 
 _netlab_ uses the VLAN-aware bridge paradigm to configure VLANs on Cumulus Linux. That decision results in the following restrictions:
 
@@ -227,8 +227,6 @@ See also [other FRRouting caveats](caveats-frr).
 
 You could configure Cumulus Linux 5.x with configuration templates developed for Cumulus Linux 4.4 (use device type **cumulus** and specify desired device image), or with NVUE.
 
-NVUE has several shortcomings that prevent *netlab* from configuring basic designs like IBGP on top of IGP. Don't be surprised if the labs that work with **cumulus** device don't work with **cumulus_nvue** device, and please create a GitHub issue whenever you find a glitch. We'd love to know (at least) what doesn't work as expected.
-
 (caveats-cumulus-5x)=
 To run Cumulus Linux 5.x with **cumulus** device type, set the following default values in [lab topology](defaults-topology) or one of the [defaults files](defaults-user-file):
 
@@ -240,6 +238,7 @@ defaults.devices.cumulus.libvirt.memory: 2048
 Other caveats:
 
 * The default MTU value is 1500 to match the implementation defaults from other vendors and enable things like seamless OSPF peering.
+* Older Cumulus Linux releases (up to at least 5.9.2) do not support asymmetrical IRB over VXLAN.
 * *netlab* uses Cumulus VX 5.3 containers created by Michael Kashin and downloaded from his Docker Hub account. These containers are severely out-of-date, are not tested in our integration tests, and might not work as expected.
 
 (caveats-os10)=

--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -29,7 +29,8 @@ The following table describes per-platform support of individual VXLAN features:
 | Aruba AOS-CX       | ✅  | ✅  |  ❌  |
 | Cisco CSR 1000v    | ✅  | ✅  |  ❌  |
 | Cisco Nexus OS     | ✅  | ✅  |  ❌  |
-| Cumulus Linux      | ✅  | ✅  |  ❌  |
+| Cumulus Linux 4.x  | ✅  | ✅  |  ❌  |
+| Cumulus 5.x (NVUE) | ✅  | ✅  |  ❌  |
 | Dell OS10          | ✅  | ✅  |  ❌  |
 | FRR                | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅ [❗](caveats-srlinux)  |  ❌  |  ❌  |

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -9,15 +9,17 @@
 {%  endif %}
             '{{ vlan.id }}':
               vni:
+{%  if vlan.vtep_list|default([]) %}
                 '{{ vlan.vni }}':
                   flooding:
                     enable: on
-{%   if vlan.vtep_list|default([]) %}
                     head-end-replication:
-{%     for remote_vtep in vlan.vtep_list %}
+{%    for remote_vtep in vlan.vtep_list %}
                       {{ remote_vtep }}: {}
-{%     endfor %}
-{%   endif %}
+{%    endfor %}
+{%  else %}
+                '{{ vlan.vni }}': {}
+{%  endif %}
 {% endfor %}
 {% if vxlan.vlans is defined %}
 - set:

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -27,6 +27,10 @@
       vxlan:
         enable: on
         mac-learning: {{ 'on' if vxlan.flooding|default("") != "evpn" else 'off' }}
+{%   if vxlan._shared_vtep is defined %}
+        mlag:
+          shared-address: {{ vxlan.vtep }}
+{%   endif %}
         source:
           address: {{ vxlan.vtep }}
 {% endif %}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -1,0 +1,30 @@
+{% for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%   set vlan = vlans[vname] %}
+{%   if loop.first %}
+- set:
+    bridge:
+      domain:
+        br_default:
+          vlan:
+{%  endif %}
+            '{{ vlan.id }}':
+              vni:
+                '{{ vlan.vni }}':
+                  flooding:
+                    enable: on
+{%   if vlan.vtep_list|default([]) %}
+                    head-end-replication:
+{%     for remote_vtep in vlan.vtep_list %}
+                      {{ remote_vtep }}: {}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+{% if vxlan.vlans is defined %}
+- set:
+    nve:
+      vxlan:
+        enable: on
+        mac-learning: {{ 'on' if vxlan.flooding|default("") != "evpn" else 'off' }}
+        source:
+          address: {{ vxlan.vtep }}
+{% endif %}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -6,20 +6,20 @@
       domain:
         br_default:
           vlan:
-{%  endif %}
+{%   endif %}
             '{{ vlan.id }}':
               vni:
-{%  if vlan.vtep_list|default([]) %}
+{%   if vlan.vtep_list|default([]) %}
                 '{{ vlan.vni }}':
                   flooding:
                     enable: on
                     head-end-replication:
-{%    for remote_vtep in vlan.vtep_list %}
+{%     for remote_vtep in vlan.vtep_list %}
                       {{ remote_vtep }}: {}
-{%    endfor %}
-{%  else %}
+{%     endfor %}
+{%   else %}
                 '{{ vlan.vni }}': {}
-{%  endif %}
+{%   endif %}
 {% endfor %}
 {% if vxlan.vlans is defined %}
 - set:

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -68,13 +68,15 @@ def nvue_check_ospf_passive_in_vrf(node: Box) -> None:
   err_data = []
   for vrf,vdata in node.get('vrfs',{}).items():
     for i in vdata.get('ospf.interfaces',[]):
-      if 'passive' in i.ospf:
-        err_data.append(f'Interface {i.ifname} inside VRF {i.vrf} using OSPF passive')
+      if 'passive' in i.ospf and i.ospf.passive is True:
+        err_data.append(f'Interface {i.ifname} inside VRF {i.vrf} using ospf.passive=True')
+        i.ospf.passive = False
 
   if err_data:
     report_quirk(
-      f'Node {node.name} uses passive OSPF interfaces inside a VRF, which NVUE does not support',
+      f'Node {node.name} uses passive OSPF interfaces inside a VRF, which NVUE does not support; auto-converted to False',
       quirk='vrf_ospf_passive',
+      category=Warning,
       more_data=err_data,
       node=node)
 

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -80,6 +80,32 @@ def nvue_check_ospf_passive_in_vrf(node: Box) -> None:
       more_data=err_data,
       node=node)
 
+"""
+In case of multiple loopbacks, merges OSPF settings into 1 if compatible; else throws an error
+"""
+def nvue_merge_ospf_loopbacks(node: Box) -> None:
+  err_data = []
+  for i in node.get('interfaces',[]):
+    if i.type!='loopback' or 'ospf' not in i:
+      continue
+    if 'ospf' in node.loopback and 'vrf' not in i:
+      if i.ospf == node.loopback.ospf or (i.ospf == node.loopback.ospf+{'passive': False}):
+        i.pop('ospf',None)
+        report_quirk(
+          f'Node {node.name} uses a secondary loopback with OSPF { i.ifname }, merged with primary loopback',
+          quirk='loopback_merge_ospf',
+          category=Warning,
+          node=node)
+        continue
+    err_data.append(f'Secondary loopback {i.ifname}')
+
+  if err_data:
+    report_quirk(
+      f'Node {node.name} uses secondary loopback(s) with OSPF configuration that differs from the primary loopback, or is in a VRF',
+      quirk='secondary_loopback_ospf',
+      more_data=err_data,
+      node=node)
+
 class Cumulus_Nvue(_Quirks):
 
   @classmethod
@@ -91,6 +117,7 @@ class Cumulus_Nvue(_Quirks):
         check_ospf_vrf_default(node)
         nvue_check_ospf_passive_in_vrf(node)
       nvue_check_ospfv3(node)
+      nvue_merge_ospf_loopbacks(node)
 
     # NVUE specific quirks
     if 'stp' in mods:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -59,6 +59,7 @@ features:
   vrf:
     ospfv2: True
   vxlan: True
+  # vtep6: true                                # Waiting for https://github.com/CumulusNetworks/ifupdown2/pull/315
 clab:
   kmods:
     initial: [ ebtables ]

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -58,6 +58,7 @@ features:
     subif_name: "{ifname}.{vlan.access_id}"
   vrf:
     ospfv2: True
+  vxlan: True
 clab:
   kmods:
     initial: [ ebtables ]


### PR DESCRIPTION
Passes all integration tests except 07 (IPv6 VTEP not supported, blocked on lack of support in ifupdown2)

* Test ```04-vxlan-irb-ospf.yml```: Added a quirk to remove ospf.passive configuration from VRF interfaces, with warning
* Test ```08-vxlan-alt-vtep.yml```: Added a quirk to merge loopback OSPF settings if they are identical, else throw error