### PR TITLE
Cumulus NVUE: Fix case of custom loopbacks with OSPF

### DIFF
--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -58,7 +58,7 @@
 {% endmacro %}
 
 {% if ospf is defined %}
-{% set _lo = (loopback | combine( { 'ospf': { 'area': ospf.area|default('0.0.0.0') } } )) if 'ipv4' in loopback else {} %}
-{% set _ospf_intfs = [_lo] + interfaces|default([])|selectattr('ospf','defined')|list %}
+{% set _lo = [loopback] if 'ipv4' in loopback else [] %}
+{% set _ospf_intfs = _lo + interfaces|default([])|selectattr('ospf','defined')|selectattr('type','ne','loopback')|list %}
 {{ vrf_ospf("default", { 'ospf': ospf | combine( { 'interfaces': _ospf_intfs } ) } ) }}
 {% endif %}


### PR DESCRIPTION
Extra loopbacks are a problem with NVUE, due to its over-simplified model of having a single loopback interface "lo"

This fix is not great, could add a quirk to detect unsupported combinations, e.g. multiple loopbacks with different OSPF areas, or declare custom loopbacks unsupported in combination with OSPF. Not to be merged as-is, only a starting point for discussion

Not sure if VRF loopbacks could get advertised in OSPF at all

The OSPF module adds the area to the loopback interface, so I removed the custom area inclusion from the template.

Fixes https://github.com/ipspace/netlab/issues/1836