### PR TITLE
Dell OS10: Fix default VLAN case of 1

### DIFF
--- a/netsim/ansible/templates/vlan/dellos10.j2
+++ b/netsim/ansible/templates/vlan/dellos10.j2
@@ -21,7 +21,7 @@ interface {{ ifdata.ifname }}
  switchport mode trunk
 
 {%     set vid_list = [] %}
-{%     for vid in ifdata.vlan.trunk_id if vid != ifdata.vlan.access_id|default(0) %}
+{%     for vid in ifdata.vlan.trunk_id if vid != ifdata.vlan.access_id|default(1) %}
 {{       vid_list.append(vid) }}
 {%     endfor %}
 


### PR DESCRIPTION
When creating a vlan trunk on Dell OS10 containing the native vlan 1, OS10 complains when VLAN 1 is included in the trunk since it is also (implicitly) defined as an access VLAN

If the access_id is not set, it defaults to 1 - not 0

Current template raises an error about VLAN 1 being both an access vlan and a trunk vlan

Minimal topology:
```YAML
---
groups:
  _auto_create: True
  dell:
    members: [s1, s2]
    device: dellos10
    module: [vlan]

vlans:
  native:
    id: 1
  normal:
    id: 2

links:
- s1:
  s2:
  vlan.trunk: [ native, normal ]
```

Result:
```
fatal: [s2]: FAILED! => changed=false 
  command: switchport trunk allowed vlan 1,2
  msg: |-
    switchport trunk allowed vlan 1,2
    % Error: Interface cannot be an access and trunk member of the same VLAN. One of the vlan in the range provided is already an access vlan.
    s2(conf-if-eth1/1/1)#
  rc: -32603
fatal: [s1]: FAILED! => changed=false 
  command: switchport trunk allowed vlan 1,2
  msg: |-
    switchport trunk allowed vlan 1,2
    % Error: Interface cannot be an access and trunk member of the same VLAN. One of the vlan in the range provided is already an access vlan.
    s1(conf-if-eth1/1/1)#
  rc: -32603
```