### PR TITLE
Dell OS10: Already configures system wide mtu, enable unreachables

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -54,7 +54,7 @@ interface {{ l.ifname }}
 {% if 'ipv4' in l %}
 {%   if l.ipv4|ipv4 %}
  ip address {{ l.ipv4 }}
-{%     if l.type|default('') != 'loopback' %}
+{%     if l.virtual_interface is not defined %}
  ip unreachables
 {%     endif %}
 {%   else %}
@@ -76,12 +76,13 @@ interface {{ l.ifname }}
 {%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable
- ipv6 unreachables
 {%   elif l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
- ipv6 unreachables
 {%   else %}
 ! Invalid IPv6 address {{ l.ipv6 }}
+{%   endif %}
+{%   if l.virtual_interface is not defined %}
+  ipv6 unreachables
 {%   endif %}
 {% elif 'ipv4' in l %}
  no ipv6 enable

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -74,6 +74,7 @@ interface {{ l.ifname }}
 {%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable
+ ipv6 unreachables
 {%   elif l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
  ipv6 unreachables

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -54,6 +54,7 @@ interface {{ l.ifname }}
 {% if 'ipv4' in l %}
 {%   if l.ipv4|ipv4 %}
  ip address {{ l.ipv4 }}
+ ip unreachables
 {%   else %}
 ! Invalid IPv4 address {{ l.ipv4 }}
 {%   endif %}
@@ -67,11 +68,15 @@ interface {{ l.ifname }}
  ipv6 nd max-ra-interval 4
  ipv6 nd min-ra-interval 3
  ipv6 nd send-ra
+{%     if l.mtu is defined %}
+ ipv6 nd mtu {{ l.mtu }}
+{%     endif %}
 {%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable
 {%   elif l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6 }}
+ ipv6 unreachables
 {%   else %}
 ! Invalid IPv6 address {{ l.ipv6 }}
 {%   endif %}

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -54,7 +54,9 @@ interface {{ l.ifname }}
 {% if 'ipv4' in l %}
 {%   if l.ipv4|ipv4 %}
  ip address {{ l.ipv4 }}
+{%     if l.type|default('') != 'loopback' %}
  ip unreachables
+{%     endif %}
 {%   else %}
 ! Invalid IPv4 address {{ l.ipv4 }}
 {%   endif %}

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -6,6 +6,7 @@ loopback_interface_name: loopback{ifindex}
 lag_interface_name: "port-channel{lag.ifindex}"
 features:
   initial:
+    system_mtu: true
     ipv4:
       unnumbered: true
     ipv6:

--- a/tests/topology/expected/lag-l2.yml
+++ b/tests/topology/expected/lag-l2.yml
@@ -128,7 +128,6 @@ nodes:
         ifindex: 2
         lacp: slow
         lacp_mode: active
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel2
@@ -141,7 +140,6 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel3
@@ -181,7 +179,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 6
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/3
@@ -194,7 +191,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 7
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/4
@@ -207,7 +203,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 8
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/5
@@ -220,7 +215,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 9
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/6
@@ -280,7 +274,6 @@ nodes:
         ifindex: 2
         lacp: slow
         lacp_mode: active
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel2
@@ -293,7 +286,6 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel3
@@ -333,7 +325,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 6
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/3
@@ -346,7 +337,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 7
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/4
@@ -359,7 +349,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 8
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/5
@@ -372,7 +361,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 9
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/6

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -92,7 +92,6 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: port-channel1
@@ -113,7 +112,6 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - gateway: false
@@ -129,7 +127,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 3
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/1
@@ -142,7 +139,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 4
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/2
@@ -155,7 +151,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 5
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/3
@@ -168,7 +163,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 6
-      mtu: 1500
       name: r1 -> r2
       neighbors:
       - ifname: ethernet1/1/4
@@ -210,7 +204,6 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: port-channel1
@@ -225,7 +218,6 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - gateway:
@@ -249,7 +241,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 3
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/1
@@ -262,7 +253,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 4
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/2
@@ -275,7 +265,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 5
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/3
@@ -288,7 +277,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 6
-      mtu: 1500
       name: r2 -> r1
       neighbors:
       - ifname: ethernet1/1/4

--- a/tests/topology/expected/lag-mlag.yml
+++ b/tests/topology/expected/lag-mlag.yml
@@ -574,7 +574,6 @@ nodes:
           peer: 10.0.0.2
           peergroup: 1
       linkindex: 1
-      mtu: 1500
       name: s1 -> s2
       neighbors:
       - ifname: ethernet1/1/1
@@ -587,7 +586,6 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s1 -> [h1,s2]'
       neighbors:
       - ifname: bond1
@@ -607,7 +605,6 @@ nodes:
         ifindex: 2
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: bond2
@@ -622,7 +619,6 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
       - ifname: bond1
@@ -643,7 +639,6 @@ nodes:
         ifindex: 4
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s1 -> [h2,s2]'
       neighbors:
       - ifname: bond2
@@ -664,7 +659,6 @@ nodes:
       lag:
         _peerlink: 1
       linkindex: 6
-      mtu: 1500
       name: s1 -> s2
       neighbors:
       - ifname: ethernet1/1/2
@@ -677,7 +671,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 7
-      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: eth1
@@ -690,7 +683,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 8
-      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: eth2
@@ -703,7 +695,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 11
-      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: eth5
@@ -716,7 +707,6 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 12
-      mtu: 1500
       name: s1 -> h1
       neighbors:
       - ifname: eth6
@@ -729,7 +719,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 13
-      mtu: 1500
       name: s1 -> h2
       neighbors:
       - ifname: eth1
@@ -742,7 +731,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 14
-      mtu: 1500
       name: s1 -> h2
       neighbors:
       - ifname: eth2
@@ -755,7 +743,6 @@ nodes:
       lag:
         _parentindex: 4
       linkindex: 17
-      mtu: 1500
       name: s1 -> h2
       neighbors:
       - ifname: eth5
@@ -830,7 +817,6 @@ nodes:
           peer: 10.0.0.1
           peergroup: 1
       linkindex: 1
-      mtu: 1500
       name: s2 -> s1
       neighbors:
       - ifname: ethernet1/1/1
@@ -843,7 +829,6 @@ nodes:
         ifindex: 1
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s2 -> [h1,s1]'
       neighbors:
       - ifname: bond1
@@ -864,7 +849,6 @@ nodes:
         ifindex: 3
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
       - ifname: bond1
@@ -885,7 +869,6 @@ nodes:
         ifindex: 4
         lacp: fast
         lacp_mode: active
-      mtu: 1500
       name: '[Access VLAN red] s2 -> [h2,s1]'
       neighbors:
       - ifname: bond2
@@ -906,7 +889,6 @@ nodes:
       lag:
         _peerlink: 1
       linkindex: 6
-      mtu: 1500
       name: s2 -> s1
       neighbors:
       - ifname: ethernet1/1/2
@@ -919,7 +901,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 9
-      mtu: 1500
       name: s2 -> h1
       neighbors:
       - ifname: eth3
@@ -932,7 +913,6 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 10
-      mtu: 1500
       name: s2 -> h1
       neighbors:
       - ifname: eth4
@@ -945,7 +925,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 15
-      mtu: 1500
       name: s2 -> h2
       neighbors:
       - ifname: eth3
@@ -958,7 +937,6 @@ nodes:
       lag:
         _parentindex: 3
       linkindex: 16
-      mtu: 1500
       name: s2 -> h2
       neighbors:
       - ifname: eth4
@@ -971,7 +949,6 @@ nodes:
       lag:
         _parentindex: 4
       linkindex: 18
-      mtu: 1500
       name: s2 -> h2
       neighbors:
       - ifname: eth6


### PR DESCRIPTION
Passes ```initial/04-mtu``` test

The Dell templates already configure a system wide MTU - this PR simplifies the configuration by removing per-interface MTU settings and declaring system MTU as supported

Some tweaks to the initial template to enable unreachables and MTU discovery on ipv6