### PR TITLE
Cumulus NVUE: Allow only those VLANs requested on the trunk, not all vlans on the bridge

### DIFF
--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -23,17 +23,15 @@
        bridge:
          domain:
            br_default:
-{%-     if i.vlan.access_id is defined +%}
-{%       if 'native' in i.vlan %}
-             untagged: {{ vlans[i.vlan.native].id }}
-{%       else %}
-             access: {{ i.vlan.access_id }}
-{%       endif %}
-{%     elif i.vlan.trunk_id is defined +%}
+{%   if i.vlan.trunk_id is defined +%}
              vlan:
-{%       for v in i.vlan.trunk_id|sort %}
+{%     for v in i.vlan.trunk_id|sort %}
                '{{ v }}': {}
-{%       endfor %}
-{%     else %} {}
-{%     endif %}
+{%     endfor %}
+{%   elif i.vlan.access_id is defined %}
+             access: {{ i.vlan.access_id }}
+{%   endif %}
+{%   if 'native' in i.vlan %}
+             untagged: {{ vlans[i.vlan.native].id }}
+{%   endif %}
 {% endfor %}

--- a/tests/integration/vlan/41-vlan-bridge-native.yml
+++ b/tests/integration/vlan/41-vlan-bridge-native.yml
@@ -7,6 +7,7 @@ message: |
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
+  * h5 should not be able to reach h6
 
   Please note it might take a while for the lab to work due to
   STP learning phase
@@ -14,7 +15,7 @@ message: |
 groups:
   _auto_create: True
   hosts:
-    members: [ h1, h2, h3, h4 ]
+    members: [ h1, h2, h3, h4, h5, h6 ]
     device: linux
     provider: clab
   switches:
@@ -32,6 +33,11 @@ vlans:
     prefix:
       ipv4: 172.31.1.0/24
     links: [ s1-h3, s2-h4 ]
+  green: # VLAN not in trunk, to test for devices opening the trunk to more vlans than requested
+    mode: bridge
+    prefix:
+      ipv4: 172.31.1.0/24
+    links: [ s1-h5, s2-h6 ]
 
 links:
 - s1:
@@ -56,3 +62,7 @@ validate:
     description: Ping-based reachability test between blue and red VLANs
     nodes: [ h1 ]
     plugin: ping('h3',expect='fail')
+  vlan_no_trunk:
+    description: Ping-based reachability test on disconnected green VLAN
+    nodes: [ h5 ]
+    plugin: ping('h6',expect='fail')


### PR DESCRIPTION
This PR fixes an issue that arises in case of a trunk with a native vlan. Somewhat counter-intuitively, the ```access_id``` attribute gets set, and hence the template failed to create the trunk. As a consequence, all vlans on the bridge would be allowed on the trunk

Fixes logic order of testing, start with trunk

Expand test 41-vlan-bridge-native to include a vlan that is not on the trunk, and hence should be blocked.

Note: All vlan tests are testing DUT against itself, which might fail to detect certain misconfigurations. For example, a device configuring a vlan as tagged while it should be untagged, or vice versa, would still succeed in talking to itself