### PR TITLE
Cumulus NVUE: Disable ipv6 on l2-only interfaces

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -14,27 +14,27 @@
 {%  endif %}
         ip:
 {%  if i.ipv4 is defined or (i.ipv6 is string and i.ipv6|ipv6) %}
-        address:
+          address:
 {%    if i.ipv4 is defined %}
-          {{ (loopback if i.ipv4 == True else i).ipv4 }}: {}
+            {{ (loopback if i.ipv4 == True else i).ipv4 }}: {}
 {%    endif %}
 {%    if i.ipv6 is string and i.ipv6|ipv6 %}
-          {{ i.ipv6 }}: {}
+            {{ i.ipv6 }}: {}
 {%    endif %}
 {%  endif %}
-        ipv6:
+          ipv6:
 {%  if i.ipv6 is defined %}
-          forward: on
+            forward: on
 {%    if 'ipv6' not in i.dhcp.client|default({}) %}
-        neighbor-discovery:
-          enable: on
-          router-advertisement:
+          neighbor-discovery:
             enable: on
-            interval: 5000
+            router-advertisement:
+              enable: on
+              interval: 5000
 {%    endif %}
 {%  else %}
-          enable: off
-{%  endif %}            
+            enable: off
+{%  endif %}
 {%  if i.type=='lag' %}
       bridge:
         domain:

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -12,40 +12,34 @@
 {%  elif i.type|default("") == "stub" %}
         description: Stub interface
 {%  endif %}
-{%  if i.ipv4 is defined or i.ipv6 is defined %}
         ip:
 {%    if i.ipv4 is defined or (i.ipv6 is string and i.ipv6|ipv6) %}
           address:
-{%    endif %}
-{%    if i.ipv4 is defined %}
-{%      if i.ipv4 == True %}
-            {{ loopback.ipv4 }}: {}
-{%      else %}
-            {{ i.ipv4 }}: {}
+{%      if i.ipv4 is defined %}
+            {{ (loopback if i.ipv4 == True else i).ipv4 }}: {}
 {%      endif %}
-{%    endif %}
-{%    if i.ipv6 is defined %}
 {%      if i.ipv6 is string and i.ipv6|ipv6 %}
             {{ i.ipv6 }}: {}
 {%      endif %}
+{%    endif %}
           ipv6:
+{%    if i.ipv6 is defined %}
             forward: on
-{%        if 'ipv6' not in i.dhcp.client|default({}) %}
+{%      if 'ipv6' not in i.dhcp.client|default({}) %}
           neighbor-discovery:
             enable: on
             router-advertisement:
               enable: on
               interval: 5000
-{%        endif %}
+{%      endif %}
 {%    else %}
-          ipv6:
             enable: off
 {%    endif %}            
-{%  elif i.type=='lag' %}
+{%    if i.type=='lag' %}
         bridge:
           domain:
             br_default: {}
-{%  endif %}
+{%    endif %}
 {% endmacro %}
 
 - set:

--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -13,33 +13,33 @@
         description: Stub interface
 {%  endif %}
         ip:
-{%    if i.ipv4 is defined or (i.ipv6 is string and i.ipv6|ipv6) %}
-          address:
-{%      if i.ipv4 is defined %}
-            {{ (loopback if i.ipv4 == True else i).ipv4 }}: {}
-{%      endif %}
-{%      if i.ipv6 is string and i.ipv6|ipv6 %}
-            {{ i.ipv6 }}: {}
-{%      endif %}
+{%  if i.ipv4 is defined or (i.ipv6 is string and i.ipv6|ipv6) %}
+        address:
+{%    if i.ipv4 is defined %}
+          {{ (loopback if i.ipv4 == True else i).ipv4 }}: {}
 {%    endif %}
-          ipv6:
-{%    if i.ipv6 is defined %}
-            forward: on
-{%      if 'ipv6' not in i.dhcp.client|default({}) %}
-          neighbor-discovery:
+{%    if i.ipv6 is string and i.ipv6|ipv6 %}
+          {{ i.ipv6 }}: {}
+{%    endif %}
+{%  endif %}
+        ipv6:
+{%  if i.ipv6 is defined %}
+          forward: on
+{%    if 'ipv6' not in i.dhcp.client|default({}) %}
+        neighbor-discovery:
+          enable: on
+          router-advertisement:
             enable: on
-            router-advertisement:
-              enable: on
-              interval: 5000
-{%      endif %}
-{%    else %}
-            enable: off
-{%    endif %}            
-{%    if i.type=='lag' %}
-        bridge:
-          domain:
-            br_default: {}
+            interval: 5000
 {%    endif %}
+{%  else %}
+          enable: off
+{%  endif %}            
+{%  if i.type=='lag' %}
+      bridge:
+        domain:
+          br_default: {}
+{%  endif %}
 {% endmacro %}
 
 - set:


### PR DESCRIPTION
Fixes #1864

> It might be better to go for a loop over 'ipv4' and 'ipv6' checking if intf[ax] is defined

I considered that, but the conditions are different for each so I think writing them out separately works better in this case