### PR TITLE
Cumulus NVUE: Don't trunk native VLAN unless requested

### DIFF
--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -2,8 +2,9 @@
     bridge:
       domain:
         br_default:
-          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" # The default 'auto' setting picks the same MAC for multiple instances!
-          untagged: 1
+          type: vlan-aware
+          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" # The default 'auto' setting reads the MAC from the EEPROM, which is the same for all instances
+          untagged: none
 {% if vlans is defined %}
 {%  for vname,vdata in vlans.items() %}
 {%   if loop.first %}
@@ -28,10 +29,8 @@
 {%     for v in i.vlan.trunk_id|sort %}
                '{{ v }}': {}
 {%     endfor %}
+             untagged: {{ i.vlan.access_id if 'native' in i.vlan else 'none' }}
 {%   elif i.vlan.access_id is defined %}
              access: {{ i.vlan.access_id }}
-{%   endif %}
-{%   if 'native' in i.vlan %}
-             untagged: {{ vlans[i.vlan.native].id }}
 {%   endif %}
 {% endfor %}

--- a/tests/integration/vlan/31-vlan-bridge-trunk.yml
+++ b/tests/integration/vlan/31-vlan-bridge-trunk.yml
@@ -7,6 +7,7 @@ message: |
   * h1 and h2 should be able to ping each other
   * h3 and h4 should be able to ping each other
   * h1 should not be able to reach h3
+  * h5 should not be able to reach h6 over its untagged native vlan
 
   Please note it might take a while for the lab to work due to
   STP learning phase
@@ -14,7 +15,7 @@ message: |
 groups:
   _auto_create: True
   hosts:
-    members: [ h1, h2, h3, h4 ]
+    members: [ h1, h2, h3, h4, h5, h6 ]
     device: linux
     provider: clab
   switches:
@@ -32,6 +33,12 @@ vlans:
     prefix:
       ipv4: 172.31.1.0/24
     links: [ s1-h3, s2-h4 ]
+  untagged: # Untagged links to test that device isn't passing the default VLAN on the trunk
+    id: 1
+    mode: bridge
+    prefix:
+      ipv4: 172.31.1.0/24
+    links: [ s1-h5, s2-h6 ]
 
 links:
 - s1:
@@ -55,3 +62,7 @@ validate:
     description: Ping-based reachability test between blue and red VLANs
     nodes: [ h1 ]
     plugin: ping('h3',expect='fail')
+  untagged_vlan:
+    description: Ping-based reachability test on untagged VLAN
+    nodes: [ h5 ]
+    plugin: ping('h6',expect='fail')


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1866 (Cumulus NVUE part)

Still passes VLAN tests 31 (modified), 32, 33 and 42 and initial test 01