### PR TITLE
Dell OS10: Don't enable IPv6 for L2-only interfaces or VLANs

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -82,9 +82,10 @@ interface {{ l.ifname }}
 ! Invalid IPv6 address {{ l.ipv6 }}
 {%   endif %}
 {%   if l.virtual_interface is not defined %}
-  ipv6 unreachables
+ ipv6 unreachables
 {%   endif %}
-{% elif 'ipv4' in l %}
+{% elif 'lag' not in l %}
+{# Don't configure IP related settings for discovery interfaces, L2-only port-channels or lag member links #}
  no ipv6 enable
 {% endif %}
 !

--- a/netsim/ansible/templates/vlan/dellos10.j2
+++ b/netsim/ansible/templates/vlan/dellos10.j2
@@ -2,11 +2,11 @@
 {% if vlans is defined %}
 {%   for vlan_name, vlan in vlans.items() %}
 virtual-network {{ vlan.id }}
-  exit
+ exit
 interface vlan {{ vlan.id }}
-  description "VLAN {{ vlan_name }}"
-  virtual-network {{ vlan.id }}
-  exit
+ description "VLAN {{ vlan_name }}"
+ virtual-network {{ vlan.id }}
+ exit
 {%   endfor %}
 {% endif %}
 !
@@ -24,5 +24,12 @@ interface {{ ifdata.ifname }}
 {%   elif ifdata.vlan.access_id is defined %}
  switchport mode access
  switchport access vlan {{ ifdata.vlan.access_id }}
+{%   endif %}
+
+{%   if ifdata.type=='svi' and 'ipv6' not in ifdata %}
+interface vlan {{ vlans[ifdata.vlan.name].id }}
+ no ipv6 enable
+ exit
+!
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/dellos10.j2
+++ b/netsim/ansible/templates/vlan/dellos10.j2
@@ -3,6 +3,8 @@
 {%   for vlan_name, vlan in vlans.items() %}
 virtual-network {{ vlan.id }}
  exit
+clear virtual-network {{ vlan.id }} counters
+!
 interface vlan {{ vlan.id }}
  description "VLAN {{ vlan_name }}"
  virtual-network {{ vlan.id }}
@@ -24,12 +26,5 @@ interface {{ ifdata.ifname }}
 {%   elif ifdata.vlan.access_id is defined %}
  switchport mode access
  switchport access vlan {{ ifdata.vlan.access_id }}
-{%   endif %}
-
-{%   if ifdata.type=='svi' and 'ipv6' not in ifdata %}
-interface vlan {{ vlans[ifdata.vlan.name].id }}
- no ipv6 enable
- exit
-!
 {%   endif %}
 {% endfor %}

--- a/tests/integration/vlan/22-vlan-irb-multiple.yml
+++ b/tests/integration/vlan/22-vlan-irb-multiple.yml
@@ -5,10 +5,6 @@ message: |
 
   All hosts should be able to ping each other
 
-addressing:
-  lan:
-    ipv6: 2001:db8:1::/48
-
 groups:
   _auto_create: True
   hosts:
@@ -34,7 +30,3 @@ validate:
     wait_msg: Waiting for STP to enable the ports
     nodes: [ h1, h2, h3 ]
     plugin: ping('h4')
-  ping_v6:
-    description: IPv6 inter-VLAN reachability
-    nodes: [ h1, h2, h3 ]
-    plugin: ping('h4',af='ipv6')

--- a/tests/integration/vlan/22-vlan-irb-multiple.yml
+++ b/tests/integration/vlan/22-vlan-irb-multiple.yml
@@ -5,6 +5,10 @@ message: |
 
   All hosts should be able to ping each other
 
+addressing:
+  lan:
+    ipv6: 2001:db8:1::/48
+
 groups:
   _auto_create: True
   hosts:
@@ -30,3 +34,7 @@ validate:
     wait_msg: Waiting for STP to enable the ports
     nodes: [ h1, h2, h3 ]
     plugin: ping('h4')
+  ping_v6:
+    description: IPv6 inter-VLAN reachability
+    nodes: [ h1, h2, h3 ]
+    plugin: ping('h4',af='ipv6')


### PR DESCRIPTION
Expand the types of interfaces for which to disable ipv6: Everything except LAG related interfaces such as peerlinks, port-channels and lag member interfaces.

NB L2-only interfaces include bridged VLANs

Fixes https://github.com/ipspace/netlab/issues/1868

Clear counters on virtual network interfaces (they remain 0)

Tested using OS Version 10.5.6.5 on clab:
* ```lag/11-mlag-anycast.yml```
* ```vlan/21-vlan-irb-single.yml```
* ```vlan/22-vlan-irb-multiple.yml``` (modified to add ipv6 tests in separate PR)
* ```vlan/41-vlan-bridge-native.yml```

Note: Only one of the VLAN integration tests includes ipv6 testing (21), and not between hosts - I figured it would be good to add one more