### PR TITLE
EOS/IOS: Use 'shutdown' instead of 'no switchport' to avoid allocating internal VLAN resources

### DIFF
--- a/netsim/ansible/templates/normalize/eos.j2
+++ b/netsim/ansible/templates/normalize/eos.j2
@@ -1,6 +1,7 @@
 {% for intf in interfaces if intf.virtual_interface is not defined %}
 !
 interface {{ intf.ifname }}
- no switchport
+{# 'no switchport' allocates an internal VLAN in range 1006-, causing issues when overlapping with topology vlans #}
+ shutdown
  mac-address {{ '52dc.cafe.%02x%02x' % ( id,intf.ifindex % 100 ) }}
 {% endfor %}

--- a/netsim/ansible/templates/normalize/iosvl2.j2
+++ b/netsim/ansible/templates/normalize/iosvl2.j2
@@ -1,6 +1,7 @@
 {% for intf in interfaces if intf.virtual_interface is not defined %}
 !
 interface {{ intf.ifname }}
- no switchport
+{# 'no switchport' allocates an internal VLAN in range 1006-, causing issues when overlapping with topology vlans #}
+ shutdown
  mac-address {{ '52dc.cafe.%02x%02x' % ( id,intf.ifindex % 100 ) }}
 {% endfor %}


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1871

Summary: A user reported an issue with the 'initial' configuration step failing. The Ansible module reporting made it look like an issue with description length or invalid characters, but in reality the topology was using VLANs in the range 1006+<number of interfaces> (starting at 1011, causing issues on devices with 5 interfaces or more)

The ```normalize``` step introduced in ```1.9.4``` configures all ports as ```no switchport```, causing an internal VLAN to be allocated. This PR shuts down the port instead, avoiding the (useless) allocation of VLAN resources

![image](https://github.com/user-attachments/assets/ba797acd-78fa-49c1-b5b8-350e6ff5a887)
