### PR TITLE
EOS: Remove lag L3 quirk and configure 'no switchport' on l3 port-channels

### DIFF
--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -33,7 +33,7 @@ interface {{ mgmt.ifname|default('Management1') }}
 !
 {% for l in netlab_interfaces %}
 interface {{ l.ifname }}
-{% if l.virtual_interface is not defined %}
+{% if l.virtual_interface is not defined or (l.type=='lag' and ('ipv4' in l or 'ipv6' in l)) %}
  no switchport
 {% endif %}
 {% if l.vrf is defined %}

--- a/netsim/devices/eos.py
+++ b/netsim/devices/eos.py
@@ -67,16 +67,6 @@ def check_dhcp_clients(node: Box, topology: Box) -> None:
       category=log.IncorrectType,
       module='quirks')
 
-def check_l3_lag(node: Box, topology: Box) -> None:
-  for intf in node.interfaces:
-    if intf.type != 'lag':
-      continue
-    if intf.get('ipv4',False) is not False or intf.get('ipv6',False) is not False:
-      log.error(
-        f"Interface {intf.ifname} on Arista EOS node {node.name} cannot have IPv4/IPv6 addresses",
-        category=log.IncorrectType,
-        module='quirks')
-
 def configure_ceos_attributes(node: Box, topology: Box) -> None:
   serialnumber = node.eos.get('serialnumber',None)
   systemmacaddr = node.eos.get('systemmacaddr',None)
@@ -135,8 +125,6 @@ class EOS(_Quirks):
       check_shared_mac(node,topology)
     if 'dhcp' in mods:
       check_dhcp_clients(node,topology)
-    if 'lag' in mods:
-      check_l3_lag(node,topology)
     if 'ospf' in mods:
       passive_stub_interfaces(node,topology)
     if 'eos' in node:


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1884

Tested:
* lag/01-l3-lag
* lag/02-lag-vlan-trunk
* custom test with l2 over mlag