### PR TITLE
lag: Add integration test for routed trunk over lag

### DIFF
--- a/tests/integration/lag/04-lag-vlan-routed-trunk.yml
+++ b/tests/integration/lag/04-lag-vlan-routed-trunk.yml
@@ -1,0 +1,35 @@
+message: |
+  The device under test is a router connected with a routed VLAN trunk on a LAG to
+  another router. Hosts should be able to ping each other.
+
+  On routers, this case tests routed subinterfaces on a port-channel interface
+groups:
+  _auto_create: true
+  hosts:
+    members: [h1, h2]
+    device: linux
+    provider: clab
+  routers:
+    members: [dut, xr]
+    module: [lag, vlan, ospf]
+    vlan.mode: route
+  probe:
+    members: [xr]
+    device: frr
+
+vlans:
+  v1:
+    links: [dut-h1, xr-h2]
+
+links:
+- vlan.trunk: [v1]
+  lag:
+    members: [dut-xr, dut-xr]
+
+validate:
+  ping_v1:
+    description: Pinging H2 from H1 on VLAN v1
+    nodes: [h1]
+    wait_msg: Waiting for STP to enable the ports
+    wait: 45
+    plugin: ping('h2')

--- a/tests/integration/lag/04-lag-vlan-routed-trunk.yml
+++ b/tests/integration/lag/04-lag-vlan-routed-trunk.yml
@@ -6,30 +6,37 @@ message: |
 groups:
   _auto_create: true
   hosts:
-    members: [h1, h2]
+    members: [ h1, h2 ]
     device: linux
     provider: clab
   routers:
-    members: [dut, xr]
-    module: [lag, vlan, ospf]
+    members: [ dut, xr ]
+    module: [ lag, vlan, ospf ]
     vlan.mode: route
   probe:
-    members: [xr]
+    members: [ xr ]
     device: frr
 
 vlans:
   v1:
-    links: [dut-h1, xr-h2]
+    links: [ dut-h1, xr-h2 ]
+    ospf.network_type: point-to-point
 
 links:
-- vlan.trunk: [v1]
+- vlan.trunk: [ v1 ]
   lag:
-    members: [dut-xr, dut-xr]
+    members: [ dut-xr, dut-xr ]
 
 validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: 60
+    nodes: [ xr ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
   ping_v1:
     description: Pinging H2 from H1 on VLAN v1
-    nodes: [h1]
-    wait_msg: Waiting for STP to enable the ports
-    wait: 45
+    nodes: [ h1 ]
+    wait_msg: Waiting for STP and OSPF to do their job
+    wait: 15
     plugin: ping('h2')


### PR DESCRIPTION
EOS currently fails this test (separate PR):

```
dut#show run int port-channel 1
interface Port-Channel1
   description dut -> xr
dut#show run int port-channel 1.1
interface Port-Channel1.1
   description dut -> xr
   encapsulation dot1q vlan 1000
   ip address 10.1.0.1/30
   ip ospf network point-to-point
   ip ospf area 0.0.0.0
dut#show int Port-Channel 1.1
Port-Channel1.1 is down, line protocol is dormant (notconnect)
  Hardware is Subinterface, address is 001c.73f0.28da
  Description: dut -> xr
  Internet address is 10.1.0.1/30
  Broadcast address is 255.255.255.255
  IP MTU 9194 bytes (default), BW 2000000 kbit
  Down 1 minute, 4 seconds
```