### PR TITLE
EOS: Set 'no switchport' on parent interface of routed lag subinterface

### DIFF
--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -78,4 +78,11 @@ interface {{ l.ifname }}
  no shutdown
 {% endif %}
 !
+
+{# Routed subinterfaces require 'no switchport' on parent #}
+{%   if l.parent_ifname is defined and l.vlan.mode|default("")=="route" %}
+interface {{ l.parent_ifname }}
+ no switchport
+!
+{%   endif %}
 {% endfor %}


### PR DESCRIPTION
It is possible to have an L2 port-channel or an L3 parent with routed subinterfaces; in both cases, there is no IP address on the parent

Fixes test case https://github.com/ipspace/netlab/pull/1888