### PR TITLE
Libvirt Linux lag: Fix conditional logic to set link speed on lag members

### DIFF
--- a/netsim/ansible/templates/lag/linux.j2
+++ b/netsim/ansible/templates/lag/linux.j2
@@ -1,4 +1,3 @@
-{% if node_provider=='clab' or netlab_linux_distro|default("") != "ubuntu" %}
 #!/bin/bash
 #
 set -e # Exit immediately when any command fails
@@ -10,15 +9,16 @@ set -e # Exit immediately when any command fails
 {%     if node_provider!='clab' %}
 ethtool -s {{ l.ifname }} autoneg off speed 1000 duplex full
 {%     endif %}
+{%     if node_provider=='clab' or netlab_linux_distro|default("") != "ubuntu" %}
 ip link set dev {{ l.ifname }} down
 ip link set dev {{ l.ifname }} master {%
        for i in interfaces if i.type=='lag' and i.lag.ifindex==l.lag._parentindex %}{{ i.ifname }}
 {%     endfor %}
-{%   endif %}
 ip link set dev {{ l.ifname }} up
+{%     endif %}
+{%   endif %}
 {% endfor %}
 {% for l in interfaces if 'lag' in l and l.type in ['lag','bond'] %}
 ip link set dev {{ l.ifname }} up
 {% endfor %}
 exit 0
-{% endif %}


### PR DESCRIPTION
```ethtool``` line needs to be executed also on libvirt