### PR TITLE
Cumulus NVUE: Move initialization of bridge MAC to 'initial' step

### DIFF
--- a/netsim/ansible/templates/initial/cumulus_nvue.j2
+++ b/netsim/ansible/templates/initial/cumulus_nvue.j2
@@ -54,6 +54,14 @@
             content: |
               { "address": { "defaults": { "mtu": "{{ mtu }}" } } }
 {% endif %}
+    bridge:
+      domain:
+        br_default:
+          type: vlan-aware
+          # The default 'auto' setting reads the EEPROM to pick the same MAC for all instances!
+          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" 
+          untagged: 1
+
     interface:
       eth0:
         ip:

--- a/netsim/ansible/templates/normalize/cumulus_nvue.j2
+++ b/netsim/ansible/templates/normalize/cumulus_nvue.j2
@@ -1,0 +1,7 @@
+- set:
+    bridge:
+      domain:
+        br_default:
+          # The default 'auto' setting uses the EEPROM to pick the same MAC for all instances!
+          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" 
+          untagged: 1

--- a/netsim/ansible/templates/normalize/cumulus_nvue.j2
+++ b/netsim/ansible/templates/normalize/cumulus_nvue.j2
@@ -1,8 +1,0 @@
-- set:
-    bridge:
-      domain:
-        br_default:
-          type: vlan-aware
-          # The default 'auto' setting reads the EEPROM to pick the same MAC for all instances!
-          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" 
-          untagged: 1

--- a/netsim/ansible/templates/normalize/cumulus_nvue.j2
+++ b/netsim/ansible/templates/normalize/cumulus_nvue.j2
@@ -2,6 +2,7 @@
     bridge:
       domain:
         br_default:
-          # The default 'auto' setting uses the EEPROM to pick the same MAC for all instances!
+          type: vlan-aware
+          # The default 'auto' setting reads the EEPROM to pick the same MAC for all instances!
           mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" 
           untagged: 1

--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -1,13 +1,10 @@
+{% if vlans is defined %}
+{%  for vname,vdata in vlans.items() %}
+{%   if loop.first %}
 - set:
     bridge:
       domain:
         br_default:
-          type: vlan-aware
-          mac-address: "{{ '08:4f:c2:a9:00:%02x' | format(id) }}" # The default 'auto' setting reads the MAC from the EEPROM, which is the same for all instances
-          untagged: none
-{% if vlans is defined %}
-{%  for vname,vdata in vlans.items() %}
-{%   if loop.first %}
           vlan:
 {%   endif %}
             '{{ vdata.id }}': {}


### PR DESCRIPTION
…such that it also works in (mlag) topologies without VLANs

The MAC is read from the EEPROM, and if it's not set to a unique value each instance gets the same (duplicate) value which breaks mlag and STP to name a few