### PR TITLE
lag: Correct comparison with missing _parentindex using 'None', not 'False' (==0)

### DIFF
--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -124,7 +124,7 @@ network:
   ethernets:
 {%   if l.type in ['lag','bond'] %}
 {%     if l.type=='lag' %}
-{%       for i in interfaces if i.lag._parentindex|default(0)==l.lag.ifindex %}
+{%       for i in interfaces if i.lag._parentindex|default(None)==l.lag.ifindex %}
     {{ i.ifname }}:
       dhcp4: no
 {%       endfor %}
@@ -138,7 +138,7 @@ network:
     {{ l.ifname }}:
       interfaces:
 {%     if l.type=='lag' %}
-{%       for i in interfaces if i.lag._parentindex|default(0)==l.lag.ifindex %}
+{%       for i in interfaces if i.lag._parentindex|default(None)==l.lag.ifindex %}
         - {{ i.ifname }}
 {%       endfor %}
 {%     elif l.bonding.members is defined %}

--- a/netsim/ansible/templates/lag/arubacx.j2
+++ b/netsim/ansible/templates/lag/arubacx.j2
@@ -54,7 +54,7 @@ interface {{ intf.ifname }}{{ mclag_intf }}{{ mclag_intf_static }}
     no shutdown
 
 !
-{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.lag.ifindex %}
+{%   for ch in interfaces if ch.lag._parentindex|default(None) == intf.lag.ifindex %}
 !
 interface {{ ch.ifname }}
     description {{ ch.name }} in lag {{ intf.lag.ifindex }}

--- a/netsim/ansible/templates/lag/cumulus.j2
+++ b/netsim/ansible/templates/lag/cumulus.j2
@@ -12,7 +12,7 @@ iface {{ data.ifname }}
   pre-up ip link add {{ data.ifname }} type bond
   bond-slaves {%-
     for i in interfaces
-      if i.lag._parentindex|default(False) == data.lag.ifindex %} {{ i.ifname }}{%- endfor +%}
+      if i.lag._parentindex|default(None) == data.lag.ifindex %} {{ i.ifname }}{%- endfor +%}
 {%    set _lacp = data.lag.lacp|default(lag.lacp) %}
 {%    if _lacp=='slow' %}
   bond-lacp-rate slow

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -29,7 +29,7 @@
 - set:
     interface:
 {%  endif %}
-{%  for c in interfaces if c.lag._parentindex|default(False) == i.lag.ifindex %}
+{%  for c in interfaces if c.lag._parentindex|default(None) == i.lag.ifindex %}
       {{ c.ifname }}:
         link:
           state:
@@ -53,7 +53,7 @@
           mode: static
 {%  endif %}
           member:
-{%  for c in interfaces if c.lag._parentindex|default(False) == i.lag.ifindex %}
+{%  for c in interfaces if c.lag._parentindex|default(None) == i.lag.ifindex %}
             {{ c.ifname }}: {}
 {%  endfor %}
 {% endfor %}

--- a/netsim/ansible/templates/lag/dellos10.j2
+++ b/netsim/ansible/templates/lag/dellos10.j2
@@ -25,7 +25,7 @@ interface {{ intf.ifname }}
  description "{{ intf.name }}"
 {%  endif %}
 !
-{%  for ch in interfaces if ch.lag._parentindex|default(False) == intf.lag.ifindex %}
+{%  for ch in interfaces if ch.lag._parentindex|default(None) == intf.lag.ifindex %}
 {%   set _lag_mode = 
       'on' if intf.lag.lacp|default('') == 'off' else
       'active' if intf.lag.lacp_mode|default('') == 'active' else 

--- a/netsim/ansible/templates/lag/eos.j2
+++ b/netsim/ansible/templates/lag/eos.j2
@@ -47,7 +47,7 @@ interface {{ intf.ifname }}
  description {{ intf.name }}
 {%  endif %}
 !
-{%   for ch in interfaces if ch.lag._parentindex|default(False) == intf.lag.ifindex %}
+{%   for ch in interfaces if ch.lag._parentindex|default(None) == intf.lag.ifindex %}
 !
 {%     set _lag_mode = 
          'on' if intf.lag.lacp|default('') == 'off' else


### PR DESCRIPTION
Allows the use of lag.ifindex==0