### PR TITLE
OSPFv2: Add VLAN trunk MTU test, highlights MTU issue in FRR

### DIFF
--- a/tests/integration/ospf/ospfv2/07-vlan-trunk-mtu.yml
+++ b/tests/integration/ospf/ospfv2/07-vlan-trunk-mtu.yml
@@ -1,0 +1,51 @@
+---
+message: |
+  This lab tests OSPF adjacencies on VLAN interfaces with non-default MTU
+  settings. The adjacency establishment could fail due to MTU mismatch.
+
+  Failure to establish X2-DUT adjacency means that the VLAN interface does not
+  get the correct MTU. Failure to establish X1-DUT adjacency indicates a
+  potential problem with system MTU.
+
+module: [ ospf, vlan ]
+
+vlans:
+  ospf_1:
+    # links: [ dut-x1 ]
+    ospf.network_type: point-to-point
+  ospf_2:
+    mtu: 1280
+    # links: [ dut-x2 ]
+    ospf.network_type: point-to-point
+
+groups:
+  probe:
+    device: frr
+    provider: clab
+    members: [ x1, x2 ]
+
+nodes:
+  dut:
+    mtu: 1400
+  x1:
+    mtu: 1400
+  x2:
+
+links:
+- x1:
+  dut:
+  vlan.trunk: [ ospf_1 ]
+- dut:
+  x2:
+  vlan.trunk: [ ospf_2 ]
+
+
+defaults.devices.vjunos-router.netlab_validate.adj.wait: 120
+
+validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: 60
+    nodes: [ x1, x2 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)


### PR DESCRIPTION
Fails for Cumulus_NVUE with FRR:
https://github.com/ipspace/netlab/issues/1896 tests system MTU and access VLAN MTU, but not MTU on VLAN trunks

```netlab up integration/ospf/ospfv2/07-vlan-trunk-mtu.yml -p libvirt -d cumulus_nvue -v``` fails:

* MTU on FRR X2 vlan1001 interface is default 1500 instead of 1280; ```ip link set dev vlan1001 mtu 1280``` fixes it