### PR TITLE
Dell OS10: Enable tagged VLAN 1 on trunks

### DIFF
--- a/netsim/ansible/templates/vlan/dellos10.j2
+++ b/netsim/ansible/templates/vlan/dellos10.j2
@@ -12,17 +12,31 @@ interface vlan {{ vlan.id }}
 {%   endfor %}
 {% endif %}
 !
+
+{# Check if the platform default vlan 1 is used as tagged on a trunk - if so, change the default #}
+{% for ifdata in interfaces if 1 in ifdata.vlan.trunk_id|default([]) %}
+{%   if loop.first %}
+{%     set used_vlans = vlans.values()|map(attribute='id')|list|sort %}
+{%     set new_default = 4093 if 4093 not in used_vlans else used_vlans|last + 1 %}
+interface vlan {{ new_default }}
+ description "New default internal untagged vlan, instead of platform default 1"
+!
+default vlan-id {{ new_default }}
+{%   endif %}
+{% endfor %}
+
 {% for ifdata in interfaces if ifdata.vlan is defined %}
 !
 interface {{ ifdata.ifname }}
 {%   if ifdata.vlan.trunk_id is defined %}
+{%     set native_vlan = ifdata.vlan.access_id if ifdata.vlan.native is defined else None %}
  switchport mode trunk
-{%     if ifdata.vlan.native is defined or 1 in ifdata.vlan.trunk_id %}
- switchport access vlan {{ ifdata.vlan.access_id|default(1) }}
+{%     if native_vlan %}
+ switchport access vlan {{ native_vlan }}
 {%     else %}
  no switchport access vlan
 {%     endif %}
- switchport trunk allowed vlan {{ ifdata.vlan.trunk_id|difference([ifdata.vlan.access_id|default(1)])|join(",") }}
+ switchport trunk allowed vlan {{ ifdata.vlan.trunk_id|difference([native_vlan])|sort|join(",") }}
 {%   elif ifdata.vlan.access_id is defined %}
  switchport mode access
  switchport access vlan {{ ifdata.vlan.access_id }}

--- a/netsim/ansible/templates/vlan/dellos10.j2
+++ b/netsim/ansible/templates/vlan/dellos10.j2
@@ -16,10 +16,10 @@ interface vlan {{ vlan.id }}
 {# Check if the platform default vlan 1 is used as tagged on a trunk - if so, change the default #}
 {% for ifdata in interfaces if 1 in ifdata.vlan.trunk_id|default([]) %}
 {%   if loop.first %}
-{%     set used_vlans = vlans.values()|map(attribute='id')|list|sort %}
-{%     set new_default = 4093 if 4093 not in used_vlans else used_vlans|last + 1 %}
+{%     set used_vlans = vlans.values()|map(attribute='id')|list %}
+{%     set new_default = range(2,4094)|difference(used_vlans)|last %}
 interface vlan {{ new_default }}
- description "New default internal untagged vlan, instead of platform default 1"
+ description "New default internal untagged vlan instead of platform default 1"
 !
 default vlan-id {{ new_default }}
 {%   endif %}


### PR DESCRIPTION
This PR modifies the VLAN templates to configure a new internal untagged VLAN different than 1, in case 1 is used as a tagged VLAN on any trunk

With this, Dell OS10 passes the new ```70-vlan-1-trunk``` test