### PR TITLE
vJunos: VLAN 1 trunk tweak/fix

### DIFF
--- a/netsim/ansible/templates/initial/junos.vlan.j2
+++ b/netsim/ansible/templates/initial/junos.vlan.j2
@@ -46,12 +46,14 @@ interfaces {
 {%   elif l.junos_interface != 'irb' and l.junos_unit == '0' and l._vlan_master is defined and 'vlan' not in l %}
 {#
 # in this case unit 0 is still present, but not handling any real vlan traffic (no vlan definition apart from _vlan_master)
-# --> we need to force a vlan id in any case on the sub unit 0, so let's put 1
+# --> we need to force a vlan id in any case on the sub unit 0, so let's put **an unused VLAN ID**
 #   'flexible-vlan-tagging' - VLAN-ID must be specified on tagged ethernet interfaces
 #}
+{% set used_vlans = vlans.values()|map(attribute='id')|list %}
+{% set internal_vlan = range(1,4094)|difference(used_vlans)|last %}
 
   {{ l.junos_interface }}.0 {
-    vlan-id 1;
+    vlan-id {{ internal_vlan }};
   }
 
 {%   endif %}

--- a/tests/integration/vlan/70-vlan-1-trunk.yml
+++ b/tests/integration/vlan/70-vlan-1-trunk.yml
@@ -56,6 +56,8 @@ links:
   vlan.trunk: [ red, vlan_1 ]
   vlan.native: red                        # VLAN 1 is tagged, VLAN red is untagged
 
+defaults.devices.vjunos-router.netlab_validate.ping_irb_1.wait: 90
+
 validate:
   ping_red:
     description: Ping-based reachability test in VLAN red


### PR DESCRIPTION
Closes #1910

Tested with vjunos-router (and compat testing with vjunos-switch)

(side note, as reported: requires adding wait timer to test `70-vlan-1-trunk//ping_irb_1`)