### PR TITLE
Make IPv4/IPv6 address/prefix validation more granular

### DIFF
--- a/docs/dev/validation.md
+++ b/docs/dev/validation.md
@@ -413,9 +413,14 @@ ospf:
 
 **ipv4** and **ipv6** validators have a mandatory **use** parameter that can take the following values:
 
-* **interface** -- an IP address specified on an interface. It can take a True/False value and does not have to include a prefix length.
-* **prefix** -- an IP prefix. It can take a True/False value and must include prefix length/subnet mask.
-* **id** (IPv4 only) -- an IPv4 address or an integer. Use **id** for parameters like OSPF areas, BGP cluster IDs, or router IDs.
+* **address** -- an IP address without a subnet mask
+* **prefix** -- an IP prefix without the host bits.
+* **host_prefix** -- a host IP address with a prefix length. It must include the host bits unless the prefix length is /31 or /32 for IPv4 or /127 or /128 for IPv6.
+* **interface** -- an IP address specified on an interface. It can take an integer (offset within subnet), True (unnumbered) or False (disabled) value and does not have to include a prefix length. The missing prefix length is taken from the link IP prefix.
+* **subnet_prefix** -- an IP prefix that must include prefix length/subnet mask. It can take a True (unnumbered) or False (disabled) value.
+* **id** (IPv4 only) -- an IPv4 address or a 32-bit unsigned integer. Use **id** for parameters like OSPF areas, BGP cluster IDs, or router IDs.
+
+The **ipv4** validator recognizes an additional **named** parameter. When set to **true**, the value of the attribute can be a [named prefix](named-prefixes).
 
 (dev-valid-special-keys)=
 ## Special Attribute Dictionary Keys

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -4,6 +4,7 @@
 
 import typing,typing_extensions,types
 import functools
+import ipaddress
 import netaddr
 import re
 import textwrap
@@ -612,38 +613,71 @@ def check_named_prefix(value: str) -> typing.Optional[dict]:
       return { '_valid': True, '_transform': transform_named_prefix }
   return None
 
-#
-# Testing for IPv4 and IPv6 addresses is nasty, as netaddr module happily mixes IPv4 and IPv6
-#
-@type_test()
-def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
+"""
+Testing for IPv4 and IPv6 addresses is nasty, as netaddr module happily mixes IPv4 and IPv6
 
-  def transform_to_ipaddr(value: int) -> str:
-    return str(netaddr.IPAddress(value))
+Both tests recognize these use cases:
 
-  def prefix_to_ipv4(value: str) -> str:
-    topology = global_vars.get_topology()
-    return '' if topology is None else topology.get('prefix',{})[value].ipv4
+* 'interface' -- an IP prefix that can be used on an interface.
+  Allows int (subnet offset) and bool (unnumbered/LLA)
+* 'host_prefix' -- an IP address with a prefix length. A subset of 'interface'.
+* 'address' -- a pure IP address. Typical use case: next hops for static routes
+* 'id' -- identifier that can be an IP address or an int
+* 'subnet_prefix' -- an IP prefix that can be used on a subnet, including bool (unnum/LLA).
+  Host bits must be zero, and it cannot be in the multicast range.
+* 'prefix' -- any IP prefix, including multicast prefixes. Use case: prefix lists
 
-  if isinstance(value,bool):                                          # bool values are valid only on interfaces
-    if use not in ('interface','prefix'):
-      return { '_value' : 'an IPv4 address (boolean value is valid only on an interface)' }
+Valid types per use case:
+
+Use case      | str (w/) | str (no/) | bool | int |
+--------------+----------+-----------+------+-----+
+interface     |    OK    |    OK     |  OK  | OK  |
+host_prefix   |    OK    |           |      |     |
+address       |          |    OK     |      |     |
+id            |          |    OK     |      | OK  |
+subnet_prefix |    OK    |           |  OK  |     |
+prefix        |    OK    |           |      |     |
+--------------+----------+-----------+------+-----+
+
+Furthermore, we can use 'named' prefixes in some scenarios.
+"""
+
+def common_addr_parse(
+      value: typing.Any,
+      use: str,
+      named: bool,
+      af: str,
+      net_parse: typing.Callable,
+      addr_parse: typing.Callable,
+      xform_int: typing.Optional[typing.Callable] = None,
+      xform_pfx: typing.Optional[typing.Callable] = None) -> dict:
+
+  def check_int_value(value: int, xform_int: typing.Optional[typing.Callable]) -> dict:
+    if value < 0 or value > 2**32-1:
+      return { '_value': f'an {af} address or an integer between 0 and 2**32' }
+    else:
+      if xform_int is not None:
+        return { '_valid': True, '_transform': xform_int }
+      else:
+        return { '_valid': True }
+
+  if isinstance(value,bool):                      # bool values are valid only on interfaces and subnets
+    if use not in ('interface','subnet_prefix'):
+      return { '_value' : f'an {af} address (boolean value is valid only on an interface)' }
     else:
       return { '_valid': True }
 
-  if isinstance(value,int):                                           # integer values are valid only as IDs (OSPF area)
-    if use not in ('id','interface'):
-      return { '_value': 'an IPv4 prefix (integer value is only valid as a 32-bit ID)' }
-    if value < 0 or value > 2**32-1:
-      return { '_value': 'an IPv4 address or an integer between 0 and 2**32' }
-    if use == 'id':
-      return { '_valid': True, '_transform': transform_to_ipaddr }
-    return { '_valid': True }
+  if isinstance(value,int):                       # integer values are valid only as interface offsts or IDs (OSPF area)
+    if use == 'id' and af == 'IPv4':
+      return check_int_value(value,xform_int)
+    if use != 'interface':
+      return { '_value': f'an {af} address or prefix (integer value is only valid as interface offset or a 32-bit ID)' }
+    return check_int_value(value,None)
 
   if not isinstance(value,str):
-    return { '_type': 'IPv4 prefix' if use == 'prefix' else 'IPv4 address' }
+    return { '_type': f'{af} prefix' if 'prefix' in use else f'{af} address' }
 
-  if named:                                                           # Check whether we can use a named prefix
+  if named and xform_pfx is not None:             # Check whether we can use a named prefix
     topology = global_vars.get_topology()
     if topology is not None:
       from ..augment import addressing
@@ -651,31 +685,47 @@ def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
       if value in pfxs:
         addressing.evaluate_named_prefix(topology,value)
         if 'ipv4' in pfxs[value]:
-          return { '_valid': True, '_transform': prefix_to_ipv4 }
+          return { '_valid': True, '_transform': xform_pfx }
 
-  if '/' in value:
-    if use == 'id':                                                   # IDs should not have a prefix
-      return { '_value': 'IPv4 address (not prefix)' }
-  else:
-    if use == 'prefix':                                               # prefix must have a /
-      return { '_value': 'IPv4 prefix' }
+  if use in ['id','address'] or (use in ['interface'] and '/' not in value):
+    try:
+      addr_parse(value)
+    except Exception as Ex:
+      return { '_value': f'{af} address ({Ex})' }
+
+    return { '_valid': True }
 
   try:
-    parse = netaddr.IPNetwork(value)                                  # now let's check if we have a valid address
-  except Exception as ex:
-    return { '_value': ("IPv4 " + ("address or " if use != 'prefix' else "") + "prefix") }
-
-  try:                                                                # ... and finally we have to check it's a true IPv4 address
-    parse.ipv4()
-    if parse.is_ipv4_mapped():
-      return { '_value': "IP address in IPv4 format" }
-  except Exception as ex:
-    return { '_value': "IPv4 address/prefix" }
+    net_parse(value,strict=use not in ['interface','host_prefix'])
+  except Exception as Ex:
+    return { '_value': f'{af} prefix ({Ex})' }
 
   return { '_valid': True }
 
 @type_test()
+def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
+
+  def transform_to_ipaddr(value: int) -> str:
+    return str(ipaddress.IPv4Address(value))
+
+  def prefix_to_ipv4(value: str) -> str:
+    topology = global_vars.get_topology()
+    return '' if topology is None else topology.get('prefix',{})[value].ipv4
+
+  return common_addr_parse(
+            value=value,use=use,named=named,af='IPv4',
+            net_parse=ipaddress.IPv4Network,
+            addr_parse=ipaddress.IPv4Address,
+            xform_int=transform_to_ipaddr,
+            xform_pfx=prefix_to_ipv4)
+
+@type_test()
 def must_be_ipv6(value: typing.Any, use: str) -> dict:
+  return common_addr_parse(
+            value=value,use=use,named=False,af='IPv6',
+            net_parse=ipaddress.IPv6Network,
+            addr_parse=ipaddress.IPv6Address)
+
   if isinstance(value,bool):                                          # bool values are valid only on interfaces
     if use not in ('interface','prefix'):
       return { '_value': 'an IPv6 address (boolean value is valid only on an interface)' }

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -631,12 +631,12 @@ Valid types per use case:
 
 Use case      | str (w/) | str (no/) | bool | int |
 --------------+----------+-----------+------+-----+
-interface     |    OK    |    OK     |  OK  | OK  |
-host_prefix   |    OK    |           |      |     |
 address       |          |    OK     |      |     |
-id            |          |    OK     |      | OK  |
-subnet_prefix |    OK    |           |  OK  |     |
 prefix        |    OK    |           |      |     |
+host_prefix   |    OK    |           |      |     |
+interface     |    OK    |    OK     |  OK  | OK  |
+subnet_prefix |    OK    |           |  OK  |     |
+id            |          |    OK     |      | OK  |
 --------------+----------+-----------+------+-----+
 
 Furthermore, we can use 'named' prefixes in some scenarios.
@@ -725,40 +725,6 @@ def must_be_ipv6(value: typing.Any, use: str) -> dict:
             value=value,use=use,named=False,af='IPv6',
             net_parse=ipaddress.IPv6Network,
             addr_parse=ipaddress.IPv6Address)
-
-  if isinstance(value,bool):                                          # bool values are valid only on interfaces
-    if use not in ('interface','prefix'):
-      return { '_value': 'an IPv6 address (boolean value is valid only on an interface)' }
-    else:
-      return { '_valid': True }
-
-  if isinstance(value,int):                                           # integer values are valid only as IDs (OSPF area)
-    if use not in ('interface'):
-      return { '_value': 'NWT: an IPv6 prefix (integer value is only valid as an inteface offset)' }
-    return { '_valid': True }
-
-  if not isinstance(value,str):
-    return { '_type': 'IPv6 prefix' if use == 'prefix' else 'IPv6 address' }
-
-  if not '/' in value:
-    if use == 'prefix':                                               # prefix must have a /
-      return { '_value': 'IPv6 prefix (not an address)' }
-
-  try:
-    parse = netaddr.IPNetwork(value)                                  # now let's check if we have a valid address
-  except Exception as ex:
-    return { '_value': "IPv6 " + ("address or " if use != 'prefix' else "") + "prefix" }
-
-  if parse.is_ipv4_mapped():                                          # This is really an IPv4 address, but it looks like IPv6, so OK
-    return { '_valid': True }
-
-  try:                                                                # ... and finally we have to check it's a true IPv6 address
-    parse.ipv4()
-    return { '_value': "IPv6 (not an IPv4) address" }                 # If we could get IPv4 address out of it, it clearly is not
-  except Exception as ex:
-    pass
-
-  return { '_valid': True }
 
 @type_test()
 def must_be_prefix_str(value: typing.Any) -> dict:

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -614,9 +614,7 @@ def check_named_prefix(value: str) -> typing.Optional[dict]:
   return None
 
 """
-Testing for IPv4 and IPv6 addresses is nasty, as netaddr module happily mixes IPv4 and IPv6
-
-Both tests recognize these use cases:
+Common IP address validation functionality. Both tests recognize these use cases:
 
 * 'interface' -- an IP prefix that can be used on an interface.
   Allows int (subnet offset) and bool (unnumbered/LLA)
@@ -702,6 +700,9 @@ def common_addr_parse(
 
   return { '_valid': True }
 
+'''
+IPv4 validation -- use the common code, allowing int values and named prefixes
+'''
 @type_test()
 def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
 
@@ -719,6 +720,9 @@ def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
             xform_int=transform_to_ipaddr,
             xform_pfx=prefix_to_ipv4)
 
+'''
+IPv6 validation -- use the common code, but without int values or named prefixes
+'''
 @type_test()
 def must_be_ipv6(value: typing.Any, use: str) -> dict:
   return common_addr_parse(

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -53,8 +53,8 @@ link:                       # Global link attributes
   prefix:
     type: dict
     _keys:
-      ipv4: { type: ipv4, use: prefix }
-      ipv6: { type: ipv6, use: prefix }
+      ipv4: { type: ipv4, use: subnet_prefix }
+      ipv6: { type: ipv6, use: subnet_prefix }
       allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
       _name: str
     _alt_types: [ bool_false, prefix_str, named_pfx ]
@@ -94,14 +94,14 @@ node:
   group: list
   role: id
   mgmt:
-    ipv4: { type: ipv4, use: id }
-    ipv6: { type: ipv6, use: id }
+    ipv4: { type: ipv4, use: address }
+    ipv6: { type: ipv6, use: address }
     mac: str
     ifname: str
   mtu: { type: int, min_value: 64, max_value: 9216 }
   loopback:
-    ipv4: { type: ipv4, use: prefix }
-    ipv6: { type: ipv6, use: prefix }
+    ipv4: { type: ipv4, use: host_prefix }
+    ipv6: { type: ipv6, use: host_prefix }
     pool: addr_pool
   provider: id
   cpu:
@@ -109,8 +109,8 @@ node:
   unmanaged: bool
 
 pool:                       # Address pool definition
-  ipv4: { type: ipv4, use: prefix }
-  ipv6: { type: ipv6, use: prefix }
+  ipv4: { type: ipv4, use: subnet_prefix }
+  ipv6: { type: ipv6, use: subnet_prefix }
   start: { type: int, min_value: 1 }
   prefix: { type: int, min_value: 1, max_value: 32 }
   prefix6: { type: int, min_value: 1, max_value: 128 }
@@ -120,8 +120,8 @@ pool:                       # Address pool definition
 pool_no_copy: [ start, prefix, mac ]
 
 prefix:                     # Link prefix (called by link module directly)
-  ipv4: { type: ipv4, use: prefix }
-  ipv6: { type: ipv6, use: prefix }
+  ipv4: { type: ipv4, use: subnet_prefix }
+  ipv6: { type: ipv6, use: subnet_prefix }
   allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
 
 node_group:

--- a/netsim/extra/bgp.originate/defaults.yml
+++ b/netsim/extra/bgp.originate/defaults.yml
@@ -7,6 +7,6 @@ bgp:
       originate:
         type: list
         _subtype:
-          ipv4: { type: ipv4, use: prefix }
-          ipv6: { type: ipv6, use: prefix }
+          ipv4: { type: ipv4, use: subnet_prefix }
+          ipv6: { type: ipv6, use: subnet_prefix }
           _alt_types: [ prefix_str ]

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -52,7 +52,7 @@ attributes:
     rr_cluster_id:
     originate:
       type: list
-      _subtype: { type: ipv4, use: prefix, named: True }
+      _subtype: { type: ipv4, use: subnet_prefix, named: True }
     advertise_loopback:
     sessions:
     activate:

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -175,8 +175,8 @@ _top:                               # Modification of global defaults
         _valid_with: [ action, sequence ]
 
     static_entry:
-      ipv4: { type: ipv4, use: prefix }
-      ipv6: { type: ipv6, use: prefix }
+      ipv4: { type: ipv4, use: subnet_prefix }
+      ipv6: { type: ipv6, use: subnet_prefix }
       prefix:
         type: named_pfx
         _valid_with: [ nexthop, vrf ]

--- a/tests/errors/bgp-cluster-id.log
+++ b/tests/errors/bgp-cluster-id.log
@@ -1,4 +1,4 @@
-IncorrectValue in bgp: attribute 'nodes.r1.bgp.rr_cluster_id' must be IPv4 address or prefix
+IncorrectValue in bgp: attribute 'nodes.r1.bgp.rr_cluster_id' must be IPv4 address (Expected 4 octets in 'wrong')
 ... use 'netlab show attributes --module bgp node' to display valid attributes
-IncorrectValue in bgp: attribute 'nodes.r5.bgp.rr_cluster_id' must be IPv4 address or prefix
+IncorrectValue in bgp: attribute 'nodes.r5.bgp.rr_cluster_id' must be IPv4 address (Expected 4 octets in '10.0.0')
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/ia-ospf-links.log
+++ b/tests/errors/ia-ospf-links.log
@@ -1,9 +1,9 @@
-IncorrectValue in ospf: attribute 'links[1].ospf.area' must be IP address in IPv4 format
+IncorrectValue in ospf: attribute 'links[1].ospf.area' must be IPv4 address (Only decimal digits permitted in '::ffff:1' in '::ffff:1.2.3.4')
 ... use 'netlab show attributes --module ospf link' to display valid attributes
 IncorrectType in ospf: attribute 'links[1].ospf.bfd' must be a boolean, found str
 IncorrectValue in ospf: attribute links[1].ospf.network_type has invalid value(s): Whatever
 ... valid values are: point-to-point,point-to-multipoint,broadcast,non-broadcast
 IncorrectType in ospf: attribute 'links[1].ospf.passive' must be a boolean, found str
 IncorrectType in ospf: attribute 'links[2].ospf.cost' must be an integer, found str
-IncorrectValue in ospf: attribute 'links[3].ospf.area' must be IPv4 address (not prefix)
+IncorrectValue in ospf: attribute 'links[3].ospf.area' must be IPv4 address (Unexpected '/' in '0.0.0.0/32')
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/ia-ospf-nodes.log
+++ b/tests/errors/ia-ospf-nodes.log
@@ -6,7 +6,7 @@ IncorrectType in ospf: attribute 'nodes.r1.ospf.af.ipv4' must be a boolean, foun
 IncorrectValue in ospf: attribute 'nodes.r2.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectType in ospf: attribute 'nodes.r2.ospf.af.ipv6' must be a boolean, found int
 IncorrectType in ospf: attribute 'nodes.r2.ospf.process' must be an integer, found str
-IncorrectValue in ospf: attribute 'nodes.r2.ospf.router_id' must be IPv4 address (not prefix)
+IncorrectValue in ospf: attribute 'nodes.r2.ospf.router_id' must be IPv4 address (Unexpected '/' in '1.2.3.4/32')
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectType in ospf: attribute 'nodes.r3.ospf.process' must be an integer, found BoxList
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be an IPv4 address (boolean value is valid only on an interface)

--- a/tests/errors/link-invalid-node-addr.log
+++ b/tests/errors/link-invalid-node-addr.log
@@ -1,3 +1,3 @@
-IncorrectValue in links: attribute 'links[1].r1.ipv4' must be IPv4 address or prefix
+IncorrectValue in links: attribute 'links[1].r1.ipv4' must be IPv4 prefix (Only decimal digits permitted in 'a' in '10.a.0.1')
 ... use 'netlab show attributes interface' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/rid-pool-overflow.log
+++ b/tests/errors/rid-pool-overflow.log
@@ -1,4 +1,4 @@
-IncorrectValue in bgp: attribute 'nodes.r1.bgp.router_id' must be IPv4 address or prefix
+IncorrectValue in bgp: attribute 'nodes.r1.bgp.router_id' must be IPv4 address (Expected 4 octets in 'error')
 ... use 'netlab show attributes --module bgp node' to display valid attributes
 IncorrectAttr in nodes: Invalid node attribute 'router_id' found in nodes.r4
 ... use 'netlab show attributes node' to display valid attributes


### PR DESCRIPTION
Add more granular IPv4/IPv6 attribute uses:

* Address and prefix
* Host and subnet prefix
* Interface address and ID

Closes #1831