### PR TITLE
Migrate to FRR release 10.2

### DIFF
--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -23,7 +23,7 @@ clab:
     ansible_user: root
     netlab_show_command: [ vtysh, -c, 'show $@' ]
     netlab_mgmt_vrf: True
-  image: quay.io/frrouting/frr:10.0.1
+  image: quay.io/frrouting/frr:10.2.1
   kmods:
   node:
     kind: linux

--- a/netsim/validate/isis/frr.py
+++ b/netsim/validate/isis/frr.py
@@ -64,8 +64,8 @@ def show_isis_prefix(pfx: str, level: str = '2', **kwargs: typing.Any) -> str:
   return f'isis route level-{level} json'
 
 def check_prefix_cost(pfx: str, cost: int, p_info: Box) -> None:
-  if p_info.Metric != cost:
-    raise Exception(f'Invalid cost for prefix {pfx}: expected {cost} found {p_info.Metric}')
+  if p_info.metric != cost:
+    raise Exception(f'Invalid cost for prefix {pfx}: expected {cost} found {p_info.metric}')
 
 def valid_isis_prefix(
       pfx: str,
@@ -89,7 +89,7 @@ def valid_isis_prefix(
     pfx_list = info[af]
 
     for p_info in pfx_list:
-      if p_info.Prefix == pfx:
+      if p_info.prefix == pfx:
         if not present:
           raise Exception(f'{af} prefix {pfx} should not be in level-{level} IS-IS database')
         if cost is not None:

--- a/tests/integration/isis/01-ipv4.yml
+++ b/tests/integration/isis/01-ipv4.yml
@@ -10,7 +10,6 @@ defaults.interfaces.mtu: 1500
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/02-ipv6.yml
+++ b/tests/integration/isis/02-ipv6.yml
@@ -10,7 +10,6 @@ defaults.sources.extra: [ defaults-ipv6.yml ]
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/03-dual-stack.yml
+++ b/tests/integration/isis/03-dual-stack.yml
@@ -11,7 +11,6 @@ defaults.sources.extra: [ defaults-ds.yml ]
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/10-network.yml
+++ b/tests/integration/isis/10-network.yml
@@ -9,7 +9,6 @@ defaults.interfaces.mtu: 1500
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/11-cost.yml
+++ b/tests/integration/isis/11-cost.yml
@@ -8,7 +8,6 @@ defaults.interfaces.mtu: 1500
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/12-passive.yml
+++ b/tests/integration/isis/12-passive.yml
@@ -8,7 +8,6 @@ defaults.interfaces.mtu: 1500
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, x2 ]
 

--- a/tests/integration/isis/21-import-ds.yml
+++ b/tests/integration/isis/21-import-ds.yml
@@ -14,7 +14,6 @@ addressing:
 
 groups:
   probes:
-    device: frr
     provider: clab
     members: [ x1, r2, r3 ]
 

--- a/tests/integration/isis/30-vrf.yml
+++ b/tests/integration/isis/30-vrf.yml
@@ -18,13 +18,13 @@ groups:
   ce_isis:
     members: [ r1, r3 ]
     module: [ isis ]
-    device: frr
     provider: clab
   ce_bgp:
     members: [ r2, r4 ]
     module: [ bgp ]
-    device: frr
     provider: clab
+  probes:
+    members: [ r1, r2, r3, r4 ]
   pe:
     members: [ dut ]
     module: [ vrf, isis, bgp ]

--- a/tests/integration/isis/topology-defaults.yml
+++ b/tests/integration/isis/topology-defaults.yml
@@ -1,4 +1,11 @@
 #
+# Fix the FRR version used in probes
+groups:
+  probes:
+    device: frr
+    box: quay.io/frrouting/frr:10.2.1
+
+#
 # IS-IS on Junos starts slower than expected, so we're changing
 # the initial delay for Junos devices, but just for IS-IS tests.
 #


### PR DESCRIPTION
The only major change found between FRR release 10.0 and 10.2 is the change in the **show isis route** JSON field names.

However, 10.2.1 has a showstopper: BGP daemon crashes in EVPN deployments. The **frr:master** container works, which means they already found the problem and fixed it. We just have to wait for the new image.
