### PR TITLE
NXOS: Move netlab_check_* variables to group_vars (where they get read)

### DIFF
--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -14,13 +14,13 @@ clab:
     kind: cisco_n9kv
   interface.name: eth{ifindex}
   build: https://containerlab.dev/manual/kinds/vr-n9kv/
-  netlab_check_retries: 50
-  netlaby_check_delay: 10
 group_vars:
   ansible_user: vagrant
   ansible_ssh_pass: vagrant
   ansible_network_os: nxos
   ansible_connection: network_cli
+  netlab_check_retries: 50
+  netlab_check_delay: 10
 bfd:           # NXOS requires lower default timer values
   min_rx: 500
 evpn._start_transit_vlan: 3800

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -21,6 +21,8 @@ group_vars:
   ansible_connection: network_cli
   netlab_check_retries: 50
   netlab_check_delay: 10
+  # yamllint disable-line rule:line-length
+  netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group14-sha1 -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
 bfd:           # NXOS requires lower default timer values
   min_rx: 500
 evpn._start_transit_vlan: 3800


### PR DESCRIPTION
Correct typo in name ```netlaby_check_delay```