### PR TITLE
Migrate from netaddr to ipaddress

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -641,7 +641,7 @@ def IPAM_id_based(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -
 
 def IPAM_loopback(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -> bool:
   for intf in link.interfaces:
-    prefixlen = 128 if ':' in str(pfx) else 32
+    prefixlen = 128 if af == 'ipv6' else 32
     intf[af] = f'{str(pfx.network_address)}/{prefixlen}'
 
   return True

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -4,7 +4,7 @@
 #
 import typing
 
-import netaddr
+import ipaddress
 from box import Box
 
 # Related modules
@@ -373,7 +373,7 @@ def set_fhrp_gateway(link: Box, pfx_list: Box, nodes: Box, link_path: str) -> No
       continue
 
     try:                                                              # Now try to get N-th IP address on that link
-      link.gateway[af] = get_nth_ip_from_prefix(netaddr.IPNetwork(link.prefix[af]),link.gateway.id)
+      link.gateway[af] = addressing.get_nth_ip_from_prefix(link.prefix[af],link.gateway.id)
       fhrp_assigned = True
     except Exception as ex:
       log.error(
@@ -468,15 +468,15 @@ Get IPAM policy for link/prefix
 
 Return 'error' if the prefix size is too small
 """
-def get_prefix_IPAM_policy(link: Box, pfx: typing.Union[netaddr.IPNetwork,bool], ndict: Box) -> str:
+def get_prefix_IPAM_policy(link: Box, pfx: typing.Union[ipaddress._BaseNetwork,bool], ndict: Box) -> str:
   if isinstance(pfx,bool):
     return 'unnumbered'
 
   gwid = get_gateway_id(link) or 0                                    # Get link gateway ID (if set) --- must be int for min to work
   if link.type == 'p2p' and not gwid:                                 # P2P allocation policy cannot be used with default gateway
-    return 'p2p' if pfx.first != pfx.last else 'error'
+    return 'p2p' if pfx.num_addresses > 1 else 'error'
 
-  pfx_size = pfx.last - pfx.first + 1
+  pfx_size = pfx.num_addresses
   add_extra_ip = 0
   subtract_reserved_ip = -2
 
@@ -502,19 +502,6 @@ def get_prefix_IPAM_policy(link: Box, pfx: typing.Union[netaddr.IPNetwork,bool],
   return 'error'
 
 """
-Get Nth IP address in a prefix returned as a nice string with a subnet mask
-
-*** WARNING *** WARNING *** WARNING ***
-
-Parent must catch the exception as we don't know what error text to display
-"""
-
-def get_nth_ip_from_prefix(pfx: netaddr.IPNetwork, n_id: int) -> str:
-  node_addr = netaddr.IPNetwork(pfx[n_id])
-  node_addr.prefixlen = pfx.prefixlen
-  return str(node_addr)
-
-"""
 check_interface_host_bits: Check whether the IP addresses on an interface have host bits. The check is disabled
 for special prefixes (IPv4: /31, /32, IPv6: /127, /128)
 """
@@ -533,8 +520,8 @@ def check_interface_host_bits(intf: Box, node: Box, link: typing.Optional[Box] =
       continue
     if not isinstance(intf[af],str):            # Skip unnumbered interfaces
       continue
-    pfx = netaddr.IPNetwork(intf[af])
-    if pfx[0].is_multicast():
+    pfx = ipaddress.ip_interface(intf[af])
+    if pfx.ip.is_multicast:
       log.error(
         f'Interfaces cannot have multicast {af} addresses ({intf[af]} on {node.name}/{intf_name})',
         log.IncorrectValue,
@@ -542,10 +529,10 @@ def check_interface_host_bits(intf: Box, node: Box, link: typing.Optional[Box] =
       OK = False
       continue
 
-    if pfx.last <= pfx.first + 1:               # Are we dealing with special prefix (loopback or /31)
+    if pfx.network.num_addresses <= 2:          # Are we dealing with special prefix (loopback or /31)
       continue                                  # ... then it's OK not to have host bits
 
-    if str(pfx) == str(pfx.cidr):               # Does the IP address have host bits -- is it different from its CIDR subnet?
+    if pfx.ip == pfx.network.network_address:   # Does the IP address have host bits -- is it different from its CIDR subnet?
       log.error(
         f'Address {intf[af]} on node {node.name}/{intf_name} does not contain host bits',
         log.IncorrectValue,
@@ -553,7 +540,7 @@ def check_interface_host_bits(intf: Box, node: Box, link: typing.Optional[Box] =
       OK = False
       continue
 
-    if str(pfx[-1]) == str(pfx.ip) and af == 'ipv4':
+    if pfx.ip == pfx.network.broadcast_address:
       log.error(
         f'Address {intf[af]} on node {node.name}/{intf_name} is a subnet broadcast address',
         log.IncorrectValue,
@@ -566,7 +553,7 @@ def check_interface_host_bits(intf: Box, node: Box, link: typing.Optional[Box] =
 """
 Set an interface address based on the link prefix and interface sequential number (could be node.id or counter)
 """
-def set_interface_address(intf: Box, af: str, pfx: netaddr.IPNetwork, node_id: int) -> bool:
+def set_interface_address(intf: Box, af: str, pfx: ipaddress._BaseNetwork, node_id: int) -> bool:
   if af in intf:                                # Check static interface addresses
     if isinstance(intf[af],bool):               # unnumbered or unaddressed node, leave it alone
       return True
@@ -575,22 +562,23 @@ def set_interface_address(intf: Box, af: str, pfx: netaddr.IPNetwork, node_id: i
       node_id = intf[af]
     elif isinstance(intf[af],str):              # static address specified on the interface
       try:
-        intf_pfx = netaddr.IPNetwork(intf[af])  # Try to parse the interface IP address
-        if not '/' in intf[af]:
-          intf_pfx.prefixlen = pfx.prefixlen    # If it lacks a prefix, add link prefix
+        if '/' not in intf[af]:                 # Add link prefix if needed
+          intf[af] += f'/{pfx.prefixlen}'
+        intf_pfx = ipaddress.ip_interface(intf[af])
         intf[af] = str(intf_pfx)                # ... and save modified/validated interface IP address
       except Exception as ex:
         log.error(
-          f'Cannot parse {af} address {intf.af} for node {intf.node}\n'+strings.extra_data_printout(str(ex)),
-          log.IncorrectValue,
-          'links')
+          f'Cannot parse {af} address {intf.af} for node {intf.node}',
+          more_data=str(ex),
+          category=log.IncorrectValue,
+          module='links')
         return False
 
       return True                               # Further checks done in check_interface_host_bits
 
   # No static interface address, or static address specified as relative node_id
   try:
-    intf[af] = get_nth_ip_from_prefix(pfx,node_id)
+    intf[af] = addressing.get_nth_ip_from_prefix(pfx,node_id)
     return True
   except Exception as ex:
     log.error(
@@ -625,8 +613,8 @@ def IPAM_unnumbered(link: Box, af: str, pfx: typing.Optional[bool], ndict: Box) 
 
   return OK
 
-def IPAM_sequential(link: Box, af: str, pfx: netaddr.IPNetwork, ndict: Box) -> bool:
-  start = 1 if pfx.last != pfx.first + 1 else 0
+def IPAM_sequential(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -> bool:
+  start = 1 if pfx.num_addresses > 2 else 0
   gwid = get_gateway_id(link)
   OK = True
   for count,intf in enumerate(link.interfaces):
@@ -636,25 +624,25 @@ def IPAM_sequential(link: Box, af: str, pfx: netaddr.IPNetwork, ndict: Box) -> b
 
   return OK
 
-def IPAM_p2p(link: Box, af: str, pfx: netaddr.IPNetwork, ndict: Box) -> bool:
-  start = 1 if pfx.last != pfx.first + 1 else 0
+def IPAM_p2p(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -> bool:
+  start = 1 if pfx.num_addresses > 2 else 0
   OK = True
   for count,intf in enumerate(sorted(link.interfaces, key=lambda intf: intf.node)):
     OK = set_interface_address(intf,af,pfx,count+start) and OK
 
   return OK
 
-def IPAM_id_based(link: Box, af: str, pfx: netaddr.IPNetwork, ndict: Box) -> bool:
+def IPAM_id_based(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -> bool:
   OK = True
   for intf in link.interfaces:
     OK = set_interface_address(intf,af,pfx,ndict[intf.node].id) and OK
 
   return OK
 
-def IPAM_loopback(link: Box, af: str, pfx: netaddr.IPNetwork, ndict: Box) -> bool:
+def IPAM_loopback(link: Box, af: str, pfx: ipaddress._BaseNetwork, ndict: Box) -> bool:
   for intf in link.interfaces:
-    pfx.prefixlen = 128 if ':' in str(pfx) else 32
-    intf[af] = str(pfx)
+    prefixlen = 128 if ':' in str(pfx) else 32
+    intf[af] = f'{str(pfx.network_address)}/{prefixlen}'
 
   return True
 
@@ -699,14 +687,13 @@ def assign_interface_addresses(link: Box, addr_pools: Box, ndict: Box, defaults:
       pfx_net = pfx_list[af]
     else:
       try:                                            # Parse the AF prefix
-        pfx_net = netaddr.IPNetwork(pfx_list[af])
+        pfx_net = ipaddress.ip_network(pfx_list[af])
       except Exception as ex:                         # Report an error and move on if it cannot be parsed
         log.error(
-          f'Cannot parse {af} prefix {pfx_list[af]} on {link._linkname}\n' + \
-            strings.extra_data_printout(f'{ex}') + '\n' + \
-            strings.extra_data_printout(f'{link}'),
-          log.IncorrectValue,
-          'links')
+          f'Cannot parse {af} prefix {pfx_list[af]} on {link._linkname}',
+          more_data=[ str(ex), str(link) ],
+          category=log.IncorrectValue,
+          module='links')
         error = True
         continue
 

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -360,7 +360,7 @@ def loopback_interface(n: Box, pools: Box, topology: Box) -> None:
         if prefix_list[af].prefixlen == 128:
           n.loopback[af] = str(prefix_list[af])
         else:
-          n.loopback[af] = addressing.get_addr_mask(prefix_list[af],1)
+          n.loopback[af] = addressing.get_nth_ip_from_prefix(prefix_list[af],1)
       else:
         n.loopback[af] = str(prefix_list[af])
       n.af[af] = True

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -2,7 +2,7 @@
 # Data validation routines
 #
 
-import typing,typing_extensions,types
+import typing,typing_extensions
 import functools
 import ipaddress
 import netaddr
@@ -743,21 +743,14 @@ def must_be_prefix_str(value: typing.Any) -> dict:
     return { '_type': 'IPv4 or IPv6 prefix' }
 
   try:
-    parse = netaddr.IPNetwork(value)                                  # now let's check if we have a valid address
+    parse = ipaddress.ip_network(value)                              # now let's check if we have a valid prefix
   except Exception as ex:
-    return check_named_prefix(value) or { '_value': "IPv4, IPv6, or named prefix" }
+    return check_named_prefix(value) or { '_value': f"IPv4, IPv6, or named prefix" }
 
-  if parse.network != parse.ip:
-    return { '_value': "IPv4 or IPv6 prefix without the host bits" }
-
-  try:                                                                # ... and finally we have to check it's a true IPv4 address
-    parse.ipv4()
-    if not parse.is_ipv4_mapped():
-      return { '_valid': True, '_transform': transform_to_ipv4 }
-  except Exception as ex:
-    pass
-
-  return { '_valid': True, '_transform': transform_to_ipv6 }
+  if isinstance(parse,ipaddress.IPv4Network):
+    return { '_valid': True, '_transform': transform_to_ipv4 }
+  else:
+    return { '_valid': True, '_transform': transform_to_ipv6 }
 
 @type_test()
 def must_be_named_pfx(value: typing.Any) -> dict:
@@ -832,9 +825,7 @@ def must_be_rd(value: typing.Any) -> dict:
     rdt_parsed = int(rdt)
   except Exception as ex:
     try:
-      if '/' in rdt:
-        return { '_value': "route distinguisher in asn:id or ip:id format" }
-      netaddr.IPNetwork(rdt)
+      ipaddress.IPv4Address(rdt)
     except Exception as ex:
       return { '_value': "an RD in asn:id or ip:id format where asn is an integer or ip is an IPv4 address" }
 

--- a/netsim/extra/ebgp.multihop/plugin.py
+++ b/netsim/extra/ebgp.multihop/plugin.py
@@ -1,5 +1,5 @@
 from box import Box
-import netaddr
+import ipaddress
 
 from netsim.utils import log,routing as _bgp
 from netsim.modules import vrf
@@ -177,7 +177,7 @@ def fix_vrf_loopbacks(ndata: Box, topology: Box) -> None:
       for af in ('ipv4','ipv6'):                                # Now copy remote VRF loopback IPv4/IPv6 address
         ngb.pop(af)                                             # ... into neighbor data
         if af in lb:                                            # ... removing whatever might have come from the
-          ngb[af] = str(netaddr.IPNetwork(lb[af]).ip)           # ... global loopback
+          ngb[af] = str(ipaddress.ip_interface(lb[af]).ip)      # ... global loopback
 
     if '_src_vrf' in ngb:                                       # Is out endpoint in a VRF?
       if not isinstance(features.bgp.multihop,Box) or features.bgp.multihop.vrf is not True:

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -37,7 +37,7 @@ def pre_link_transform(topology: Box) -> None:
       if 'vxlan' in node.module:
           vtep_loopback = data.get_empty_box()
           vtep_loopback.type = 'loopback'           # Assign same static IP to both nodes
-          vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network)+"/32" } ]
+          vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network_address)+"/32" } ]
           vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
           vtep_loopback.vxlan.vtep = True
           topology.links.append(vtep_loopback)

--- a/netsim/extra/multilab/__init__.py
+++ b/netsim/extra/multilab/__init__.py
@@ -1,4 +1,4 @@
-import typing, netaddr
+import typing
 from box import Box
 from netsim import utils,data
 

--- a/netsim/extra/proxy-arp/plugin.py
+++ b/netsim/extra/proxy-arp/plugin.py
@@ -1,4 +1,4 @@
-import typing, netaddr
+import typing
 from box import Box
 
 from netsim import api

--- a/netsim/modules/_routing.py
+++ b/netsim/modules/_routing.py
@@ -202,20 +202,22 @@ def router_id(node: Box, proto: str, pools: Box) -> None:
       node[proto].router_id = _rp_utils.get_address(node[proto].router_id)
     except Exception as ex:
       log.error(
-        f'{proto} router_id "{node[proto].router_id}" specified on node {node.name} is not an IPv4 address',
-        log.IncorrectValue,
-        proto)
+        f'{proto} router_id "{node[proto].router_id}" specified for {proto} on node {node.name} is not an IPv4 address',
+        more_data=str(ex),
+        category=log.IncorrectValue,
+        module=proto)
     return
 
   if 'router_id' in node:                     # Node has a configured router ID, copy it and get out
     try:
-      node.router_id = _rp_utils.get_address(node[proto].router_id)
+      node.router_id = _rp_utils.get_address(node.router_id)
       node[proto].router_id = node.router_id
     except Exception as ex:
       log.error(
         f'router_id "{node.router_id}" specified on node {node.name} is not an IPv4 address',
-        log.IncorrectValue,
-        proto)
+        more_data=str(ex),
+        category=log.IncorrectValue,
+        module=proto)
     return
 
   if 'ipv4' in node.get('loopback',{}):       # Do we have IPv4 address on the loopback? If so, use it as router ID

--- a/netsim/modules/srv6.py
+++ b/netsim/modules/srv6.py
@@ -5,23 +5,25 @@ from box import Box
 
 from . import _Module
 from ..utils import log
-import netaddr
+import ipaddress
 
 class SRV6(_Module):
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
 
       # Could model this as another addressing pool too
-      locator = netaddr.IPNetwork( f'{topology.defaults.srv6.locator}:{node.id:x}::/64' )
+      locator = f'{topology.defaults.srv6.locator}:{node.id:x}::/64'
+      locator_net = ipaddress.IPv6Network(locator)
 
       if 'ipv6' not in node.loopback:
-        log.error( f"SRv6 requires an ipv6 loopback address on node {node.name}",
-                      log.MissingValue, 'srv6' )
-      elif netaddr.IPNetwork(node.loopback.ipv6) in locator:
-        log.error( f"Node {node.name} ipv6 loopback address {node.loopback.ipv6} overlaps with locator {locator}",
-                      log.IncorrectValue, 'srv6' )
+        log.error(
+          f"SRv6 requires an ipv6 loopback address on node {node.name}",
+          category=log.MissingValue,
+          module='srv6')
+      elif ipaddress.IPv6Interface(node.loopback.ipv6).network.subnet_of(locator_net):
+        log.error(
+          f"Node {node.name} ipv6 loopback address {node.loopback.ipv6} overlaps with locator {locator}",
+          category=log.IncorrectValue,
+          module='srv6')
 
-      node.srv6.locator = str( locator )
-
-      # TODO process per-interface srv6 parameters?
-      # for l in node.get('interfaces',[]):
+      node.srv6.locator = locator

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -2,7 +2,7 @@
 # VRF module
 #
 import typing, re
-import netaddr
+import ipaddress
 from box import Box
 
 from . import _Module,_routing,_dataplane,get_effective_module_attribute,remove_module
@@ -75,7 +75,7 @@ def parse_rdrt_value(value: str) -> typing.Optional[typing.List[typing.Union[int
     return [int(asn),int(vid)]
   except Exception as ex:
     try:
-      netaddr.IPNetwork(asn)
+      ipaddress.IPv4Address(asn)
       return [asn,int(vid)]
     except Exception as ex:
       return None
@@ -349,7 +349,7 @@ def vrf_loopbacks(node : Box, topology: Box) -> None:
 
     for af in vrfaddr:
       if af == 'ipv6':
-        ifdata[af] = addressing.get_addr_mask(vrfaddr[af],1)
+        ifdata[af] = addressing.get_nth_ip_from_prefix(vrfaddr[af],1)
       else:
         ifdata[af] = str(vrfaddr[af])
       vrfaddr[af] = str(ifdata[af])                                         # Save string copy in vrfaddr, we need it later

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -114,20 +114,16 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
         f'Device {node.device} (node {node.name}) does not support VXLAN over IPv6',
         log.IncorrectValue,
         'vxlan')
-    if 'ipv6' not in vtep_interface:
-      log.error(
-        f'You want to use IPv6 VTEP -- VXLAN module needs an IPv6 address on loopback interface of {node.name}',
-        log.IncorrectValue,
-        'vxlan')
       return False
   else:
     vtep_af = 'ipv4'
-    if not 'ipv4' in vtep_interface:
-      log.error(
-        f'VXLAN module needs an IPv4 address on loopback interface of {node.name}',
-        log.IncorrectValue,
-        'vxlan')
-      return False
+
+  if not vtep_af in vtep_interface:
+    log.error(
+      f'VXLAN module needs an {vtep_af.upper()} address on interface {loopback_name} of {node.name}',
+      category=log.IncorrectValue,
+      module='vxlan')
+    return False
 
   # Save VTEP IP address (from the selected VTEP interface) and VTEP interface name
   #

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -10,7 +10,7 @@ import typing
 from box import Box
 import pathlib
 import tempfile
-import netaddr
+import ipaddress,netaddr
 import argparse
 
 from ..data import types,get_empty_box,get_box
@@ -38,8 +38,8 @@ Replacements have to match single quotes (in XML) to ensure we don't replace par
 """
 
 def replace_xml_mgmt_subnet(xml: str, mgmt: Box, m_subnet: str) -> str:
-  o_net = netaddr.IPNetwork(m_subnet)
-  d_net = netaddr.IPNetwork(mgmt.ipv4)
+  o_net = ipaddress.IPv4Network(m_subnet)
+  d_net = ipaddress.IPv4Network(mgmt.ipv4)
 
   xml = xml.replace(f"'{o_net.netmask}'",f"'{d_net.netmask}'")
   for offset in [1,2]:
@@ -62,7 +62,7 @@ def replace_xml_mgmt_subnet(xml: str, mgmt: Box, m_subnet: str) -> str:
     xml = xml.replace(f"'{o_addr}'",f"'{d_net[d_start]}'")
 
   eui = netaddr.EUI(mgmt.mac)
-  while d_start < min(d_net.size,256) - 2:
+  while d_start < min(d_net.num_addresses,256) - 2:
     eui[5] = mac_cnt
     xstring = f"<host mac='{str(eui).replace('-',':')}' ip='{d_net[d_start]}'/>\n<!--more-->"
     xml = xml.replace("<!--more-->",xstring)

--- a/netsim/utils/routing.py
+++ b/netsim/utils/routing.py
@@ -2,10 +2,35 @@
 # BGP neighbor traversal utilities
 #
 
+import typing
+import ipaddress
+
 from box import Box
 from . import log
 from ..augment import devices
-import typing
+
+# Return IP address from int, address, or prefix
+#
+def get_ipv4_address(addr: typing.Union[str,int]) -> str:
+  return str(ipaddress.IPv4Interface(addr).ip)
+
+def get_intf_address(addr: typing.Union[str,int]) -> str:
+  return str(ipaddress.ip_interface(addr).ip)
+
+def get_address(addr: str) -> str:
+  return str(ipaddress.ip_address(addr))
+
+def get_prefix(addr: str) -> str:
+  return str(ipaddress.ip_interface(addr).network)
+
+# try_intf_address is used when validation functions need an IP address from an
+# interface address. The target address could be hostname, so we only try our best
+#
+def try_intf_address(addr: str) -> str:
+  try:
+    return get_intf_address(addr)
+  except:
+    return addr
 
 # Return all global and optionaly VRF neighbors
 #

--- a/netsim/validate/_common.py
+++ b/netsim/validate/_common.py
@@ -4,8 +4,7 @@ Common BGP validation code -- utility functions and such
 
 from box import Box,BoxList
 import typing
-import netaddr
-from ..utils import log
+from ..utils import log,routing as _rp_utils
 
 # Find neighbor IP address from neighbor name
 def get_bgp_neighbor_id(ngb: list, n_id: str, af: str) -> typing.Union[bool, str]:
@@ -17,14 +16,6 @@ def get_bgp_neighbor_id(ngb: list, n_id: str, af: str) -> typing.Union[bool, str
     return n[af]
   
   raise Exception(f'Cannot find the {af} address of the neighbor {n_id}')
-
-def get_pure_prefix(pfx: str) -> str:
-  pfx_net = netaddr.IPNetwork(pfx)
-  pfx = f'{pfx_net.network}/{pfx_net.prefixlen}'
-  return pfx
-
-def get_address(pfx: str) -> str:
-  return pfx.split('/')[0]
 
 def report_state(exit_msg: str, OK: bool) -> typing.NoReturn:
   if OK:
@@ -61,7 +52,7 @@ def run_prefix_checks(
       names: dict,
       **rest: typing.Any) -> str:
   
-  pfx = get_pure_prefix(pfx)
+  pfx = _rp_utils.get_prefix(pfx)
   data = check_for_prefix(pfx=pfx,lookup=lookup,data=data,table=table,state=state)
 
   keys = list(checks.keys())

--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -5,7 +5,7 @@ Arista EOS BGP validation routines
 from box import Box,BoxList
 import typing
 from netsim.data import global_vars
-from netsim.utils import log
+from netsim.utils import log, routing as _rp_utils
 from .. import _common
 from . import BGP_PREFIX_NAMES,check_community_kw
 
@@ -208,7 +208,7 @@ BGP prefix validation function:
 * Use the run_prefix_checks framework for validation
 """
 def show_bgp_prefix(pfx: str, af: str = 'ipv4', **kwargs: typing.Any) -> str:
-  pfx = _common.get_pure_prefix(pfx)
+  pfx = _rp_utils.get_prefix(pfx)
   return f"bgp {af} unicast {pfx} | json"
 
 def valid_bgp_prefix(

--- a/netsim/validate/eos.py
+++ b/netsim/validate/eos.py
@@ -7,7 +7,7 @@ Import BGP checks
 from box import Box
 from netsim.validate.bgp.eos import *
 from netsim.validate.ospf.eos import *
-from netsim.validate._common import get_address
+from netsim.utils import routing as _rp_utils
 
 def exec_ping(
       host: str,
@@ -17,10 +17,10 @@ def exec_ping(
       pkt_len: typing.Optional[int] = None,
       **kwargs: typing.Any) -> str:
 
-  host = get_address(host)
+  host = _rp_utils.try_intf_address(host)
   cmd = 'enable\nping ' + ('ip' if af is None or af == 'ipv4' else af) + ' ' + host
   if src:
-    cmd += f' source {get_address(src)}'
+    cmd += f' source {_rp_utils.try_intf_address(src)}'
 
   if pkt_len:
     cmd += f' size {pkt_len}'
@@ -39,9 +39,9 @@ def valid_ping(
       expect: typing.Optional[str] = None) -> str:
   _result = global_vars.get_result_dict('_result')
 
-  msg = f'Ping to {af + " " if af else ""}{get_address(host)}'
+  msg = f'Ping to {af + " " if af else ""}{_rp_utils.try_intf_address(host)}'
   if src:
-    msg += f' from {get_address(src)}'
+    msg += f' from {_rp_utils.try_intf_address(host)}'
   if pkt_len:
     msg += f' size {pkt_len}'
 

--- a/netsim/validate/isis/frr.py
+++ b/netsim/validate/isis/frr.py
@@ -4,9 +4,8 @@ FRR IS-IS validation routines
 
 import typing
 from box import Box
-import netaddr
-
 from netsim.data import global_vars
+from netsim.utils import routing as _rp_utils
 
 def show_isis_neighbor(id: str, **kwargs: typing.Any) -> str:
   return f'isis neighbor {id} json'
@@ -76,8 +75,7 @@ def valid_isis_prefix(
 
   _result = global_vars.get_result_dict('_result')
 
-  pfx_net = netaddr.IPNetwork(pfx)
-  pfx = f'{pfx_net.network}/{pfx_net.prefixlen}'
+  pfx = _rp_utils.get_prefix(pfx)
 
   for isa in _result:
     l_id = f'level-{level}'

--- a/netsim/validate/ospf/eos.py
+++ b/netsim/validate/ospf/eos.py
@@ -4,9 +4,9 @@ FRR OSPFv2 validation routines
 
 from box import Box
 import typing
+import ipaddress
 from netsim.data import global_vars
 from netsim.utils import log
-import netaddr
 from .. import _common
 from . import OSPF_PREFIX_NAMES
 
@@ -27,7 +27,7 @@ def get_ospf_neighbor_data(data: Box, *, id: str, proto: str, vrf: str = 'defaul
 
 def show_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> str:
   try:
-    netaddr.IPAddress(id)
+    ipaddress.IPv4Address(id)
   except:
     raise Exception(f'OSPF router ID {id} is not a valid IP address')
   return f'ip ospf neighbor {id} vrf {vrf} | json'
@@ -56,7 +56,7 @@ def valid_ospf_neighbor(
 
 def show_ospf6_neighbor(id: str, present: bool = True, vrf: str = 'default', **kwargs: typing.Any) -> str:
   try:
-    netaddr.IPAddress(id)
+    ipaddress.IPv4Address(id)
   except:
     raise Exception(f'OSPFv3 router ID {id} is not a valid IP address')
   return f'ipv6 ospf neighbor {id} vrf {vrf} | json'

--- a/netsim/validate/ospf/frr.py
+++ b/netsim/validate/ospf/frr.py
@@ -4,7 +4,7 @@ FRR OSPFv2 validation routines
 
 from box import Box
 import typing
-import netaddr
+import ipaddress
 from netsim.data import global_vars
 from netsim.utils import log
 from .. import _common
@@ -12,9 +12,9 @@ from . import OSPF_PREFIX_NAMES
 
 def show_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> str:
   try:
-    netaddr.IPAddress(id)
+    ipaddress.IPv4Address(id)
   except:
-    raise Exception(f'OSPF router ID {id} is not a valid IP address')
+    raise Exception(f'OSPF router ID {id} is not a valid IPv4 address')
   return f'ip ospf ' + (f'vrf {vrf} ' if vrf != 'default' else '') + f'neighbor {id} json'
 
 def valid_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> bool:
@@ -39,6 +39,10 @@ def valid_ospf_neighbor(id: str, present: bool = True, vrf: str = 'default') -> 
     raise log.Result(exit_msg)
 
 def show_ospf6_neighbor(id: str, **kwargs: typing.Any) -> str:
+  try:
+    ipaddress.IPv4Address(id)
+  except:
+    raise Exception(f'OSPF router ID {id} is not a valid IPv4 address')
   return f'ipv6 ospf6 neighbor {id} json'
 
 def valid_ospf6_neighbor(id: str, present: bool = True) -> bool:

--- a/netsim/validate/route/frr.py
+++ b/netsim/validate/route/frr.py
@@ -5,7 +5,7 @@ FRR routing table validation routines
 from box import Box
 import typing
 from netsim.data import global_vars
-from .._common import get_pure_prefix
+from netsim.utils import routing as _rp_utils
 
 def show_rt_prefix(pfx: str, af: str = 'ipv4', proto: str = '', **kwargs: typing.Any) -> str:
   if af == 'ipv4':
@@ -28,7 +28,7 @@ def valid_rt_prefix(
   if not isinstance(pfx,str):
     raise Exception(f'Prefix {pfx} is not a string')
 
-  pfx = get_pure_prefix(pfx)
+  pfx = _rp_utils.get_prefix(pfx)
 
   if not pfx in _result:
     result_text = f'The prefix {pfx} is not in {af} routing table'

--- a/tests/errors/addr-pool-errors.log
+++ b/tests/errors/addr-pool-errors.log
@@ -1,5 +1,5 @@
-IncorrectValue in addressing: Cannot parse address prefix: invalid IPNetwork 10.a.0.0/24
-IncorrectValue in addressing: Cannot parse address prefix: invalid IPNetwork 2001:none:2::/48
+IncorrectValue in addressing: Cannot parse address prefix: '10.a.0.0/24' does not appear to be an IPv4 or IPv6 network
+IncorrectValue in addressing: Cannot parse address prefix: '2001:none:2::/48' does not appear to be an IPv4 or IPv6 network
 IncorrectType in addressing: attribute 'addressing.pfx_string.prefix' must be an integer, found str
 ... use 'netlab show attributes pool' to display valid attributes
 IncorrectValue in addressing: attribute 'addressing.pfx_long.prefix' must be an integer between 1 and 32


### PR DESCRIPTION
* Most netaddr calls have been replaced with ipaddress calls, the major exception is MAC address handling which is not available in ipaddress
* The 'get ip from interface' and 'get prefix from interface' functions have been moved to 'utils.routing' and most other modules use those functions
* Direct calls to ipaddress functions are use only for more advanced use cases.
* Error messages in augment.addressing and augment.links have been simplified and include parsing error information from ipaddress
* 'get_addr_mask' and 'get_nth_ip_from_prefix' functions did almost the same thing and have been merged into a single function
* Extra properties available in ipaddress make it easier to check if an address is a network address, multicast address, or a broadcast address

Note:
* Sometimes we still cheat and merge IP address string with a prefix length string to get a full prefix. There's no good way to get that done with ipaddress functions (you cannot change the prefix length in IPv4Network/IPv6Network)
* Some error checking code has been removed from old modules; that functionality is now available as generic data validation

Closes #1921