### PR TITLE
EOS: Configure ipv6 anycast gateway IP when provided

### DIFF
--- a/netsim/ansible/templates/gateway/eos.j2
+++ b/netsim/ansible/templates/gateway/eos.j2
@@ -8,8 +8,13 @@ ip virtual-router mac-address {{ gateway.anycast.mac }}
 {%     endif %}
 {%   endif %}
 interface {{ intf.ifname }}
-{%   if intf.gateway.protocol == 'anycast' and 'ipv4' in intf.gateway %}
+{%   if intf.gateway.protocol == 'anycast' %}
+{%     if 'ipv4' in intf.gateway %}
   ip virtual-router address {{ intf.gateway.ipv4 }}
+{%     endif %}
+{%     if 'ipv6' in intf.gateway %}
+  ipv6 virtual-router address {{ intf.gateway.ipv6 | ipaddr('address') }}
+{%     endif %}
 {%   endif %}
 {%   if intf.gateway.protocol == 'vrrp' %}
   vrrp {{ intf.gateway.vrrp.group }} ipv4 version 3


### PR DESCRIPTION
Allows EOS to pass ```gateway/01-anycast``` tests