### PR TITLE
Make '--instance' and '--snapshot' CLI parameters consistent

### DIFF
--- a/docs/netlab/capture.md
+++ b/docs/netlab/capture.md
@@ -12,8 +12,7 @@ You cannot capture traffic on point-to-point links between *‌libvirt* virtual 
 The **netlab capture** command takes two parameters: the node you want to perform packet capture on and the interface name within that node.
 
 ```text
-$ netlab capture -h
-usage: netlab capture [-h] [--snapshot [SNAPSHOT]] node [intf]
+usage: netlab capture [-h] [-i INSTANCE] node [intf]
 
 Start a packet capture on the specified node/interface
 
@@ -23,8 +22,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to capture traffic in
 
 All other arguments are passed directly to the packet-capturing utility
 ```

--- a/docs/netlab/collect.md
+++ b/docs/netlab/collect.md
@@ -3,22 +3,23 @@
 
 **netlab collect** command uses Ansible *device facts* modules (or an equivalent list of Ansible tasks) to collect device configurations and store them in specified output directory.
 
-A single configuration file in the output directory is created for most network devices; multiple files stored in host-specific subdirectory are collected from Cumulus VX.
+A single configuration file in the output directory is created for most network devices; multiple files are collected from FRR and Cumulus VX.
 
 After collecting the device configurations, you can save them in a tar archive with the `--tar` option and clean up the working directory with `--cleanup` option.
 
 ```{tip}
-**netlab collect** command does not need a topology file (so you don't have to specify one even if you're using a non-default topology name). It's just a thin wrapper around an Ansible playbook which uses Ansible inventory created by **netlab create** or **netlab up** command.
+* **netlab collect** command is just a thin wrapper around an Ansible playbook which uses Ansible inventory created by **netlab create** or **netlab up** command.
+* When executed with the `-i` option, **‌netlab collect** switches to the lab directory to execute the Ansible playbook, but stores the results within the directory from which it was executed.
 ```
 
 ## Usage
 
 ```text
-usage: netlab collect [-h] [-v] [-q] [-o [OUTPUT]] [--tar TAR] [--cleanup]
+usage: netlab collect [-h] [-v] [-q] [-o [OUTPUT]] [--tar TAR] [--cleanup] [-i INSTANCE]
 
 Collect device configurations
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         Verbose logging
   -q, --quiet           Run Ansible playbook and tar with minimum output
@@ -27,6 +28,8 @@ optional arguments:
   --tar TAR             Create configuration tarball
   --cleanup             Clean up config directory and modified configuration file after
                         creating tarball
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to collect configuration from
 
 All other arguments are passed directly to ansible-playbook
 ```

--- a/docs/netlab/config.md
+++ b/docs/netlab/config.md
@@ -5,23 +5,23 @@
 
 You have to use **netlab config** on a running lab. If you want to try out the configuration templates without starting the lab,  add the [**config** attribute](custom-config) to node data and run **netlab create** (to create the Ansible inventory) followed by **[netlab initial -c -o](netlab-initial)** to create the configuration files.
 
-```
-
 ## Usage
 
 ```text
-usage: netlab config [-h] [-r] [-v] [-q] template
+usage: netlab config [-h] [-r] [-v] [-q] [-i INSTANCE] template
 
 Deploy custom configuration template
 
 positional arguments:
-  template       Configuration template or a directory with templates
+  template              Configuration template or a directory with templates
 
 options:
-  -h, --help     show this help message and exit
-  -r, --reload   Reload saved device configurations
-  -v, --verbose  Verbose logging (add multiple flags for increased verbosity)
-  -q, --quiet    Report only major errors
+  -h, --help            show this help message and exit
+  -r, --reload          Reload saved device configurations
+  -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
+  -q, --quiet           Report only major errors
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to configure
 
 All other arguments are passed directly to ansible-playbook
 ```
@@ -33,6 +33,10 @@ The configuration template specified in the **netlab config** command can be a J
 When you specify a directory name, the **netlab config** command tries to find the configuration template for individual lab devices using node name, `netlab_device_type`, and `ansible_network_os` Ansible variables, allowing you to create a set of templates to deploy the same functionality to lab devices running different network operating systems.
 
 See [](custom-config), [](netlab-initial-custom) and [](dev-find-custom) for more details.
+
+```{tip}
+When executed with the `-i` option, **‌netlab config** expects the configuration template file or directory to be within the lab directory.
+```
 
 ## Limiting the Scope of Configuration Deployments
 
@@ -51,4 +55,4 @@ After that, it treats the saved device configurations as custom templates and us
 
 To display device configurations within the Ansible playbook without deploying them, use `-v --tags test` parameters after the template name. 
 
-The `-v` flag will trigger a debugging printout, and the bogus `test` flag will skip the actual configuration deployment.
+The `-v` flag triggers a debugging printout, and the bogus `test` flag skips the configuration deployment.

--- a/docs/netlab/connect.md
+++ b/docs/netlab/connect.md
@@ -6,9 +6,8 @@
 ## Usage
 
 ```text
-usage: netlab connect [-h] [-v] [-q] [--dry-run] [--snapshot [SNAPSHOT]]
-                      [-s SHOW [SHOW ...]]
-                      host
+$ netlab connect -h
+usage: netlab connect [-h] [-v] [-q] [--dry-run] [-s SHOW [SHOW ...]] [-i INSTANCE] host
 
 Connect to a network device or an external tool
 
@@ -17,13 +16,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -v, --verbose         Verbose logging
-  -q, --quiet           No logging
-  --dry-run             Print the commands that would be executed, but do not execute them
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
+  -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
+  -q, --quiet           Report only major errors
+  --dry-run             Print the commands that would be executed, but do not execute
+                        them
   -s SHOW [SHOW ...], --show SHOW [SHOW ...]
                         Show command to execute on the device
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to connect to
 
 The rest of the arguments are passed to SSH or docker exec command
 ```

--- a/docs/netlab/down.md
+++ b/docs/netlab/down.md
@@ -8,7 +8,8 @@ This command uses the lab topology or the snapshot file created by **netlab up**
 ## Usage
 
 ```
-usage: netlab down [-h] [-v] [--cleanup] [--dry-run] [-i INSTANCE] [--force] [--snapshot [SNAPSHOT]]
+$ netlab down -h
+usage: netlab down [-h] [-v] [--cleanup] [--dry-run] [--force] [-i INSTANCE]
 
 Destroy the virtual lab
 
@@ -16,16 +17,17 @@ options:
   -h, --help            show this help message and exit
   -v, --verbose         Verbose logging (where applicable)
   --cleanup             Remove all configuration files created by netlab create
-  --dry-run             Print the commands that would be executed, but do not execute them
+  --dry-run             Print the commands that would be executed, but do not execute
+                        them
+  --force               Force shutdown or cleanup (use at your own risk)
   -i INSTANCE, --instance INSTANCE
                         Specify lab instance to shut down
-  --force               Force shutdown or cleanup (use at your own risk)
 ```
 
 Notes:
 
 * **netlab down** needs transformed topology data to find the virtualization provider and link (bridge) names.
-* **netlab down** reads the transformed topology from `netlab.snapshot.yml` file created by **netlab up** or **netlab create**. You can specify a different snapshot file name, but you really should not.
+* **netlab down** reads the transformed topology from `netlab.snapshot.yml` file created by **netlab up** or **netlab create**.
 * With the `--instance` flag, you can shut down a lab instance running in a different directory. Use the `netlab status --all` command to display all running instances.
 * Use the `--cleanup` flag to delete all Ansible-, Vagrant- or containerlab-related configuration files.
 * Use the `--force` flag with the `--cleanup` flag if you want to clean up the directory even when the virtualization provider fails during the shutdown process.

--- a/docs/netlab/exec.md
+++ b/docs/netlab/exec.md
@@ -6,21 +6,22 @@
 ## Usage
 
 ```text
-usage: netlab exec [-h] [-v] [-q] [--dry-run] [--snapshot [SNAPSHOT]]                      
-                      node
+$ netlab exec -h
+usage: netlab exec [-h] [-v] [-q] [--dry-run] [-i INSTANCE] node
 
-Executes a command on one or more network devices
+Run a command on one or more network devices
 
 positional arguments:
-  node                  Device(s) to execute the command on
+  node                  Node(s) to run command on
 
 options:
   -h, --help            show this help message and exit
-  -v, --verbose         Verbose logging
-  -q, --quiet           No logging
-  --dry-run             Print the commands that would be executed, but do not execute them
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
+  -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
+  -q, --quiet           Report only major errors
+  --dry-run             Print the hosts and the commands that would be executed on them,
+                        but do not execute them
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to execute commands in
 
 The rest of the arguments are passed to SSH or docker exec command
 ```

--- a/docs/netlab/graph.md
+++ b/docs/netlab/graph.md
@@ -10,7 +10,9 @@ You will have to install [Graphviz](https://graphviz.org/download/) or [D2](http
 ## Usage
 
 ```text
-usage: netlab graph [-h] [--snapshot [SNAPSHOT]] [-t {topology,bgp}] [-e {graphviz,d2}] [output]
+usage: netlab graph [-h] [-t {topology,bgp}] [-e {graphviz,d2}] [-i INSTANCE]
+                    [--snapshot [SNAPSHOT]]
+                    [output]
 
 Create a graph description in Graphviz or D2 format
 
@@ -19,12 +21,18 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
   -t {topology,bgp}, --type {topology,bgp}
                         Graph type
   -e {graphviz,d2}, --engine {graphviz,d2}
                         Graphing engine
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to create a graph from
+  --snapshot [SNAPSHOT]
+                        Transformed topology snapshot file
+```
+
+```{tip}
+When executed with the `--instance` option, **‌netlab graph** creates the graph description file in the lab directory.
 ```
 
 ## Examples

--- a/docs/netlab/initial.md
+++ b/docs/netlab/initial.md
@@ -33,29 +33,37 @@ Jinja2 templates are used together with **_device_\_config** Ansible modules to 
 ## Usage
 
 ```text
-usage: netlab initial [--log] [-q] [-v] [-i] [-m [MODULE]] [-c]  [--ready] [--fast] [-o [OUTPUT]]
+$ netlab initial -h
+usage: netlab initial [-h] [--log] [-v] [-q] [-i] [-m [MODULE]] [-c] [--ready] [--fast]
+                      [-o [OUTPUT]] [--instance INSTANCE]
 
 Initial device configurations
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --log                 Enable basic logging
+  -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
   -q, --quiet           Report only major errors
-  -v, --verbose         Verbose logging
   -i, --initial         Deploy just the initial configuration
   -m [MODULE], --module [MODULE]
-                        Deploy module-specific configuration (optionally including a 
+                        Deploy module-specific configuration (optionally including a
                         list of modules separated by commas)
-  -c, --custom          Deploy custom configuration templates (specified in "config" 
+  -c, --custom          Deploy custom configuration templates (specified in "config"
                         group or node attribute)
   --ready               Wait for devices to become ready
-  --fast                Use "free" strategy in Ansible playbook for faster
-                        configuration deployment
+  --fast                Use "free" strategy in Ansible playbook for faster configuration
+                        deployment
   -o [OUTPUT], --output [OUTPUT]
                         Create a directory with initial configurations instead of
-                        deploying them
+                        deploying them (default output directory: config)
+  --instance INSTANCE   Specify lab instance to configure
 
 All other arguments are passed directly to ansible-playbook
+```
+
+```{tip}
+* While most **‌netlab** commands accept the `-i` option to specify the lab instance, you have to use the `--instance` option with **‌netlab initial**.
+* When executed with the `--instance` option, **‌netlab initial -o** switches to the lab directory to execute the Ansible playbook, but stores the results within the directory from which it was executed.
 ```
 
 ## Wait for Devices to Become Ready

--- a/docs/netlab/inspect.md
+++ b/docs/netlab/inspect.md
@@ -12,8 +12,10 @@ When selecting data from an individual node, _netlab_ adds group variables to no
 ## Usage
 
 ```text
-usage: netlab inspect [-h] [--snapshot [SNAPSHOT]] [--node NODE] 
-                      [--all] [--format {yaml,json}] [expr]
+$ netlab inspect -h
+usage: netlab inspect [-h] [--node NODE] [--all] [--format {yaml,json}] [-q]
+                      [-i INSTANCE] [--snapshot [SNAPSHOT]]
+                      [expr]
 
 Inspect data structures in transformed lab topology
 
@@ -22,11 +24,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
   --node NODE           Display data for selected node(s)
   --all                 Add global Ansible variables to node data
   --format {yaml,json}  Select data presentation format
+  -q, --quiet           Report only major errors
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to inspect
+  --snapshot [SNAPSHOT]
+                        Transformed topology snapshot file
 ```
 
 ## Topology Inspection Examples

--- a/docs/netlab/report.md
+++ b/docs/netlab/report.md
@@ -6,7 +6,9 @@ The **netlab report** command creates a report from the transformed lab topology
 ## Usage
 
 ```text
-usage: netlab report [-h] [--snapshot [SNAPSHOT]] [--node NODE] report [output]
+$ netlab report -h
+usage: netlab report [-h] [--node NODE] [-i INSTANCE] [--snapshot [SNAPSHOT]]
+                     report [output]
 
 Create a report from the transformed lab topology data
 
@@ -16,9 +18,11 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  --node NODE           Limit the report to selected node(s)
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to report on
   --snapshot [SNAPSHOT]
                         Transformed topology snapshot file
-  --node NODE           Limit the report to selected node(s)
 ```
 
 ```{tip}

--- a/docs/netlab/restart.md
+++ b/docs/netlab/restart.md
@@ -2,16 +2,18 @@
 
 **netlab restart** executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the transformed lab topology stored in `netlab.snapshot.yml` snapshot file.
 
-You can use **netlab restart** to restart the existing lab (use `--snapshot` keyword), or to recreate the lab configuration files in case you changed the lab topology.
+You can use **netlab restart** to restart the existing lab (use `--snapshot` keyword) or recreate the lab configuration files if you changed the lab topology.
 
 ```{warning}
-**netlab restart** does not support `-d`, `-p` or `-s` flags used by **netlab create** or **netlab up**. If you want to change lab topology settings with CLI parameters use **netlab down** and **netlab up** commands.
+* **netlab restart** does not support `-d`, `-p` or `-s` flags used by **netlab create** or **netlab up**. If you want to change lab topology settings with CLI parameters, use **netlab down** and **netlab up** commands.
+* You must execute the **‌netlab restart** command within the lab directory.
 ```
 
 ## Usage
 
 ```text
-usage: netlab [-h] [--log] [-q] [-v] [--no-config] [--fast-config]
+$ netlab restart -h
+usage: netlab [-h] [--log] [-v] [-q] [--no-config] [--fast-config]
               [--snapshot [SNAPSHOT]]
               [topology]
 
@@ -20,14 +22,13 @@ Reconfigure and restart the virtual lab
 positional arguments:
   topology              Topology file (default: topology.yml)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --log                 Enable basic logging
-  -q, --quiet           Report only major errors
   -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
+  -q, --quiet           Report only major errors
   --no-config           Do not configure lab devices
   --fast-config         Use fast device configuration (Ansible strategy = free)
   --snapshot [SNAPSHOT]
-                        Use netlab snapshot file created by a previous lab run 
-                        to start the lab
+                        Transformed topology snapshot file
 ```

--- a/docs/netlab/status.md
+++ b/docs/netlab/status.md
@@ -9,20 +9,20 @@ This command uses the *netlab* status file (default: `~/.netlab/status.yml`) to 
 
 ```
 $ netlab status -h
-usage: netlab status [-h] [-i INSTANCE] [-l] [--cleanup] [--reset] [--all] [-v] [-q]
+usage: netlab status [-h] [-l] [--cleanup] [--reset] [--all] [-v] [-q] [-i INSTANCE]
 
 Display lab status
 
 options:
   -h, --help            show this help message and exit
-  -i INSTANCE, --instance INSTANCE
-                        Display or cleanup specific lab instance(s)
   -l, --log             Display the lab instance event log
   --cleanup             Cleanup the current or specified lab instance
   --reset               Reset the lab instance tracking system
   --all                 Display an overview of all lab instance(s)
   -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
   -q, --quiet           Report only major errors
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to inspect
 ```
 
 * **netlab status** displays the status and workload (VMs or containers) of the current or selected lab instance.

--- a/docs/netlab/validate.md
+++ b/docs/netlab/validate.md
@@ -7,7 +7,9 @@
 
 ```text
 $ netlab validate -h
-usage: netlab inspect [-h] [-v] [--snapshot [SNAPSHOT]] [--list] [--node NODES] [tests ...]
+usage: netlab inspect [-h] [-v] [-q] [--list] [--node NODES] [--skip-wait] [-e]
+                      [--dump {result} [{result} ...]] [-i INSTANCE]
+                      [tests ...]
 
 Inspect data structures in transformed lab topology
 
@@ -17,12 +19,15 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
-  --snapshot [SNAPSHOT]
-                        Transformed topology snapshot file
+  -q, --quiet           Report only major errors
   --list                List validation tests
   --node NODES          Execute validation tests only on selected node(s)
   --skip-wait           Skip the waiting period
   -e, --error-only      Display only validation errors (on stderr)
+  --dump {result} [{result} ...]
+                        Dump additional information during validation process
+  -i INSTANCE, --instance INSTANCE
+                        Specify lab instance to validate
 ```
 
 The **netlab validate** command returns the overall test results in its exit code:

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -36,11 +36,13 @@ def parser_add_debug(parser: argparse.ArgumentParser) -> None:
 
 # Some CLI utilities might use the 'verbose' flag without other common arguments
 #
-def parser_add_verbose(parser: argparse.ArgumentParser) -> None:
-  parser.add_argument('-v','--verbose', dest='verbose', action='count', default = 0,
-                  help='Verbose logging (add multiple flags for increased verbosity)')
-  parser.add_argument('-q','--quiet', dest='quiet', action='store_true',
-                  help='Report only major errors')
+def parser_add_verbose(parser: argparse.ArgumentParser, verbose: bool = True, quiet: bool = True) -> None:
+  if verbose:
+    parser.add_argument('-v','--verbose', dest='verbose', action='count', default = 0,
+                    help='Verbose logging (add multiple flags for increased verbosity)')
+  if quiet:
+    parser.add_argument('-q','--quiet', dest='quiet', action='store_true',
+                    help='Report only major errors')
 
 def common_parse_args(debugging: bool = False) -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(description='Common argument parsing',add_help=False)
@@ -54,15 +56,34 @@ def common_parse_args(debugging: bool = False) -> argparse.ArgumentParser:
 
   return parser
 
-def parser_add_snapshot(parser: argparse.ArgumentParser, hide: bool = False) -> None:
-  parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help=argparse.SUPPRESS if hide else 'Transformed topology snapshot file')
+'''
+Add --snapshot or --instance parameter, optionally hiding 'snapshot' from the help message
+'''
+def parser_lab_location(
+      parser: argparse.ArgumentParser,
+      snapshot: bool = False,
+      instance: bool = False,
+      i_used: bool = False,
+      hide: bool = False,
+      action: str = 'work on') -> None:
+  i_flags = ['--instance']
+  if not i_used:
+    i_flags = ['-i'] + i_flags
+  if instance:
+    parser.add_argument(
+      *i_flags,
+      dest='instance',
+      action='store',
+      help=argparse.SUPPRESS if hide else f'Specify lab instance to {action}')
+  if snapshot:
+    parser.add_argument(
+      '--snapshot',
+      dest='snapshot',
+      action='store',
+      nargs='?',
+      default='netlab.snapshot.yml',
+      const='netlab.snapshot.yml',
+      help=argparse.SUPPRESS if hide else 'Transformed topology snapshot file')
 
 def topology_parse_args() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(description='Common topology arguments',add_help=False)
@@ -128,15 +149,54 @@ def load_topology(args: typing.Union[argparse.Namespace,Box]) -> Box:
   log.exit_on_error()
   return topology
 
+"""
+Find a lab instance and change directory so the rest of the shutdown
+process works from that directory
+"""
+def change_lab_instance(instance: typing.Union[int,str], quiet: bool = False) -> None:
+  topology = _read.system_defaults()
+  lab_states = _status.read_status(topology)
+  try:                                                      # Maybe the instance is an integer?
+    instance = int(instance)
+  except:
+    pass
+
+  if not instance in lab_states:
+    error_and_exit(
+      f'Unknown instance {instance}',
+      more_hints=[ "Use 'netlab status --all' to display running instances" ])
+
+  target_dir = lab_states[instance].dir
+  try:
+    os.chdir(target_dir)
+  except Exception as ex:
+    log.fatal(f'Cannot change directory to {target_dir}: {str(ex)}')
+  
+  if not quiet:
+    log.status_green('CHANGED','')
+    print(f'Selected instance {instance}, current directory changed to {target_dir}')
+
 # Snapshot loading code -- loads the specified snapshot file and checks its modification date
 #
 def load_snapshot(args: typing.Union[argparse.Namespace,Box],ghosts: bool = True) -> Box:
-  if not os.path.isfile(args.snapshot):
-    print(f"The topology snapshot file {args.snapshot} does not exist.\n"+
-          "Looks like no lab was started from this directory")
+  if 'instance' in args and args.instance:
+    change_lab_instance(args.instance,args.quiet if 'quiet' in args else False)
+  
+  snapshot = 'netlab.snapshot.yml'
+  if 'snapshot' in args and args.snapshot and args.snapshot != snapshot:
+    snapshot = args.snapshot
+    if 'quiet' not in args or not args.quiet:
+      log.info(f'Using lab snapshot file {args.snapshot}')
+
+  if not os.path.isfile(snapshot):
+    error_and_exit(
+      f"The topology snapshot file {snapshot} does not exist",
+      more_hints=[
+          "Looks like no lab was started from this directory",
+          "Use 'netlab status --all' to display labs running on this system"])
     sys.exit(1)
 
-  topology = _read.read_yaml(filename=args.snapshot)
+  topology = _read.read_yaml(filename=snapshot)
   if topology is None:
     print(f"Cannot read the topology snapshot file {args.snapshot}")
     sys.exit(1)
@@ -145,7 +205,7 @@ def load_snapshot(args: typing.Union[argparse.Namespace,Box],ghosts: bool = True
     topology = augment.nodes.ghost_buster(topology)
 
   global_vars.init(topology)
-  check_modified_source(args.snapshot,topology)
+  check_modified_source(snapshot,topology)
   return topology
 
 def check_modified_source(snapshot: str, topology: typing.Optional[Box] = None) -> None:

--- a/netsim/cli/capture.py
+++ b/netsim/cli/capture.py
@@ -7,7 +7,7 @@ import sys
 import typing
 import argparse
 
-from . import load_snapshot,_nodeset,external_commands,error_and_exit
+from . import load_snapshot,_nodeset,external_commands,error_and_exit,parser_lab_location
 from .. import providers
 from ..augment import devices
 from ..utils import strings,log
@@ -21,20 +21,13 @@ def capture_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
     description='Start a packet capture on the specified node/interface',
     epilog='All other arguments are passed directly to the packet-capturing utility')
   parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
-  parser.add_argument(
     dest='node', action='store',
     help='Node on which you want to capture traffic')
   parser.add_argument(
     dest='intf', action='store',
     nargs='?',
     help='Interface on which you want to capture traffic')
+  parser_lab_location(parser,instance=True,action='capture traffic in')
 
   return parser.parse_known_args(args)
 

--- a/netsim/cli/config.py
+++ b/netsim/cli/config.py
@@ -9,7 +9,7 @@ import os
 import glob
 from box import Box
 
-from . import parser_add_verbose,parser_add_snapshot,load_snapshot
+from . import parser_add_verbose,parser_lab_location,load_snapshot
 from .external_commands import set_ansible_flags
 from . import ansible
 from ..utils import log
@@ -30,8 +30,8 @@ def custom_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespa
   parser.add_argument(
     dest='template', action='store',
     help='Configuration template or a directory with templates')
-  parser_add_snapshot(parser,hide=True)
   parser_add_verbose(parser)
+  parser_lab_location(parser,instance=True,action='configure')
 
   return parser.parse_known_args(args)
 

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -19,7 +19,7 @@ class LogLevel(IntEnum):
 
 from box import Box
 
-from . import external_commands, set_dry_run, error_and_exit
+from . import external_commands, set_dry_run, error_and_exit, parser_lab_location
 
 from . import load_snapshot, parser_add_verbose
 from ..outputs import common as outputs_common
@@ -40,14 +40,6 @@ def connect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
     action='store_true',
     help='Print the commands that would be executed, but do not execute them')
   parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
-  parser.add_argument(
     dest='host', action='store',
     help='Device or tool to connect to')
   parser.add_argument(
@@ -56,6 +48,7 @@ def connect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
     action='store',
     nargs='+',
     help='Show command to execute on the device')
+  parser_lab_location(parser,instance=True,action='connect to')
 
   return parser.parse_known_args(args)
 

--- a/netsim/cli/exec.py
+++ b/netsim/cli/exec.py
@@ -13,7 +13,7 @@ from enum import IntEnum
 from box import Box
 
 from . import external_commands, set_dry_run
-from . import load_snapshot, _nodeset, parser_add_verbose
+from . import load_snapshot, _nodeset, parser_add_verbose, parser_lab_location
 from .connect import quote_list, docker_connect, ssh_connect, connect_to_node,\
   LogLevel, get_log_level
 
@@ -36,16 +36,10 @@ def exec_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typin
       action='store_true',
       help='Print the hosts and the commands that would be executed on them, but do not execute them')
   parser.add_argument(
-      '--snapshot',
-      dest='snapshot',
-      action='store',
-      nargs='?',
-      default='netlab.snapshot.yml',
-      const='netlab.snapshot.yml',
-      help='Transformed topology snapshot file')
-  parser.add_argument(
       dest='node', action='store',
       help='Node(s) to run command on')
+  parser_lab_location(parser,instance=True,action='execute commands in')
+
   return parser.parse_known_args(args)
       
 def run(cli_args: typing.List[str]) -> None:

--- a/netsim/cli/graph.py
+++ b/netsim/cli/graph.py
@@ -6,7 +6,7 @@
 import typing
 import argparse
 
-from . import load_snapshot
+from . import load_snapshot,parser_lab_location
 from ..outputs import _TopologyOutput
 from ..utils import strings,log
 
@@ -17,14 +17,6 @@ def graph_parse(args: typing.List[str]) -> argparse.Namespace:
   parser = argparse.ArgumentParser(
     prog="netlab graph",
     description='Create a graph description in Graphviz or D2 format')
-  parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
   parser.add_argument(
     '-t','--type',
     dest='g_type', action='store',
@@ -41,6 +33,7 @@ def graph_parse(args: typing.List[str]) -> argparse.Namespace:
     nargs='?',
     help='Optional: Output file name')
 
+  parser_lab_location(parser,instance=True,snapshot=True,action='create a graph from')
   return parser.parse_args(args)
 
 def run(cli_args: typing.List[str]) -> None:

--- a/netsim/cli/initial.py
+++ b/netsim/cli/initial.py
@@ -7,7 +7,7 @@ import typing
 import os
 import argparse
 
-from . import common_parse_args,get_message,load_snapshot,lab_status_change,parser_add_snapshot
+from . import common_parse_args,get_message,load_snapshot,lab_status_change,parser_lab_location
 from . import external_commands
 from . import ansible
 from ..utils import log,status as _status
@@ -52,12 +52,14 @@ def initial_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namesp
     '--no-message',
     dest='no_message', action='store_true',
     help=argparse.SUPPRESS)
-  parser_add_snapshot(parser,hide=True)
+  parser_lab_location(parser,instance=True,i_used=True,action='configure')
 
   return parser.parse_known_args(args)
 
 def run_initial(cli_args: typing.List[str]) -> None:
   (args,rest) = initial_config_parse(cli_args)
+  if args.output:
+    rest = ['-e',f'config_dir="{os.path.abspath(args.output)}"' ] + rest
 
   topology = load_snapshot(args)
 
@@ -83,9 +85,6 @@ def run_initial(cli_args: typing.List[str]) -> None:
   if args.custom:
     deploy_parts.append("custom")
     rest = ['-t','custom'] + rest
-
-  if args.output:
-    rest = ['-e',f'config_dir="{os.path.abspath(args.output)}"' ] + rest
 
   if args.fast or os.environ.get('NETLAB_FAST_CONFIG',None):
     rest = ['-e','netlab_strategy=free'] + rest

--- a/netsim/cli/inspect.py
+++ b/netsim/cli/inspect.py
@@ -10,7 +10,7 @@ import argparse
 
 from box import Box,BoxList
 
-from . import load_snapshot,_nodeset
+from . import load_snapshot,_nodeset,parser_lab_location,parser_add_verbose
 from ..outputs import _TopologyOutput
 from ..outputs import common as outputs_common
 from ..utils import strings,log
@@ -24,14 +24,6 @@ def inspect_parse(args: typing.List[str]) -> argparse.Namespace:
   parser = argparse.ArgumentParser(
     prog="netlab inspect",
     description='Inspect data structures in transformed lab topology')
-  parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
   parser.add_argument(
     '--node',
     dest='node', action='store',
@@ -50,6 +42,8 @@ def inspect_parse(args: typing.List[str]) -> argparse.Namespace:
     dest='expr', action='store',
     nargs='?',
     help='Data selection expression')
+  parser_add_verbose(parser,verbose=False)
+  parser_lab_location(parser,instance=True,snapshot=True,action='inspect')
 
   return parser.parse_args(args)
 

--- a/netsim/cli/report.py
+++ b/netsim/cli/report.py
@@ -6,7 +6,7 @@
 import typing
 import argparse
 
-from . import load_snapshot,_nodeset
+from . import load_snapshot,_nodeset,parser_lab_location,parser_add_verbose
 from ..outputs import _TopologyOutput, common as outputs_common
 from ..utils import strings,log
 
@@ -18,14 +18,6 @@ def report_parse(args: typing.List[str]) -> argparse.Namespace:
     prog="netlab report",
     description='Create a report from the transformed lab topology data')
   parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
-  parser.add_argument(
     '--node',
     dest='node', action='store',
     help='Limit the report to selected node(s)')
@@ -36,6 +28,8 @@ def report_parse(args: typing.List[str]) -> argparse.Namespace:
     dest='output', action='store',
     nargs='?',
     help='Output file name (default: stdout)')
+  parser_add_verbose(parser,verbose=False)
+  parser_lab_location(parser,instance=True,snapshot=True,action='report on')
 
   return parser.parse_args(args)
 

--- a/netsim/cli/restart.py
+++ b/netsim/cli/restart.py
@@ -9,7 +9,7 @@ import argparse
 from box import Box
 
 from . import down, up
-from . import common_parse_args
+from . import common_parse_args,parser_lab_location
 
 #
 # Extra arguments for 'netlab up' command
@@ -30,21 +30,15 @@ def restart_parse_args() -> argparse.ArgumentParser:
     action='store_true',
     help='Use fast device configuration (Ansible strategy = free)')
   parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    const='netlab.snapshot.yml',
-    help='Use netlab snapshot file created by a previous lab run to start the lab')
-  parser.add_argument(
     dest='topology', action='store', nargs='?',
     help='Topology file (default: topology.yml)')
+  parser_lab_location(parser,snapshot=True,action='restart')
   return parser
 
 def run(cli_args: typing.List[str]) -> None:
   parser = restart_parse_args()
   args = parser.parse_args(cli_args)
-  up_only_args = ['--fast-config','--no-config']
+  up_only_args = ['--fast-config','--no-config','--snapshot']
 
   down.run([ arg for arg in cli_args if arg not in up_only_args ])
   up.run(cli_args)

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -16,17 +16,12 @@ from ..outputs import common as outputs_common
 from ..data import get_empty_box
 from .. import providers
 
-from . import parser_add_verbose
+from . import parser_add_verbose,parser_lab_location
 
 def status_parse(args: typing.List[str]) -> argparse.Namespace:
   parser = argparse.ArgumentParser(
     prog='netlab status',
     description='Display lab status')
-  parser.add_argument(
-    '-i','--instance',
-    dest='instance',
-    action='store',
-    help='Display or cleanup specific lab instance(s)')
   parser.add_argument(
     '-l','--log',
     dest='log',
@@ -48,6 +43,7 @@ def status_parse(args: typing.List[str]) -> argparse.Namespace:
     action='store_true',
     help='Display an overview of all lab instance(s)')
   parser_add_verbose(parser)
+  parser_lab_location(parser,instance=True,action='inspect')
   return parser.parse_args(args)
 
 Lab_Instance_ID = typing.Union[str,int]

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -14,7 +14,7 @@ import traceback
 
 from box import Box,BoxList
 
-from . import load_snapshot, parser_add_debug, parser_add_verbose, external_commands
+from . import load_snapshot, parser_add_debug, parser_add_verbose, external_commands, parser_lab_location
 from ..utils import log, templates, strings, status as _status, files as _files
 from ..data import global_vars,get_box
 from ..augment import devices
@@ -30,14 +30,6 @@ def validate_parse(args: typing.List[str]) -> argparse.Namespace:
     description='Inspect data structures in transformed lab topology')
   parser_add_debug(parser)                                # Add debugging options
   parser_add_verbose(parser)                              # ... and verbosity flag
-  parser.add_argument(
-    '--snapshot',
-    dest='snapshot',
-    action='store',
-    nargs='?',
-    default='netlab.snapshot.yml',
-    const='netlab.snapshot.yml',
-    help='Transformed topology snapshot file')
   parser.add_argument(
     '--list',
     dest='list',
@@ -70,6 +62,7 @@ def validate_parse(args: typing.List[str]) -> argparse.Namespace:
     dest='tests', action='store',
     nargs='*',
     help='Validation test(s) to execute (default: all)')
+  parser_lab_location(parser,instance=True,action='validate')
 
   return parser.parse_args(args)
 

--- a/netsim/cli/version.py
+++ b/netsim/cli/version.py
@@ -8,4 +8,4 @@ import typing
 import netsim
 
 def run(args: typing.List[str]) -> None:
-  print("netlab version %s" % netsim.__version__)
+  print(f"netlab version {netsim.__version__}")


### PR DESCRIPTION
* Add '--instance' parameter to most netlab commands
* Add 'change to instance directory' processing to the 'load snapshot' function
* Allow '--snapshot' parameter only in read-only commands that do not access lab devices

Closes #1784