### PR TITLE
Cumulus NVUE: Place mlag backup IP in mgmt vrf when applicable

### DIFF
--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -22,7 +22,12 @@
     mlag:
       init-delay: 10
       backup:
+{% if pools.mgmt.ipv4 | ansible.netcommon.network_in_usable(lag.mlag.peer_backup_ip) %}
+        {{ lag.mlag.peer_backup_ip }}:
+          vrf: mgmt
+{% else %}
         {{ lag.mlag.peer_backup_ip }}: {}
+{% endif %}
       enable: on
       mac-address: {{ lag.mlag.mac | hwaddr('linux') }}
       peer-ip: {{ lag.mlag.peer }}


### PR DESCRIPTION
For a backup connection to mgmt (eth0) to work, it needs to be placed in the ```mgmt``` vrf