### PR TITLE
Integration test EVPN 20-vxlan-irb-ospf.yml: Use clab for Linux hosts

### DIFF
--- a/tests/integration/evpn/20-vxlan-irb-ospf.yml
+++ b/tests/integration/evpn/20-vxlan-irb-ospf.yml
@@ -34,6 +34,7 @@ groups:
     members: [ h1, h2, h3, h4 ]
     module: []
     device: linux
+    provider: clab
   switches:
     members: [ s1, s2 ]
     vlans:


### PR DESCRIPTION
Libvirt causes unnecessary overhead