### PR TITLE
Cumulus NVUE: Avoid generating invalid YAML when there are no bgp neighbors

### DIFF
--- a/netsim/ansible/templates/bgp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.j2
@@ -42,8 +42,10 @@
 {%   endif %}
 {% endfor %}
             autonomous-system: {{ bgp.as }}
-            neighbor:
 {% for n in bgp.neighbors %}
+{%   if loop.first %}
+            neighbor:
+{%   endif %}
 {%   if n.local_if is defined %}
               {{ n.local_if }}:
                 type: unnumbered


### PR DESCRIPTION
Empty ```bgp.neighbors``` list throws an error