### PR TITLE
Cumulus NVUE: Add EVPN support

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -205,7 +205,7 @@ ansible-galaxy collection install git+https://github.com/jmussmann/ansible_colle
 
 * The Cumulus VX 4.4.0 Vagrant box for VirtualBox is broken. *netlab* is using Cumulus VX 4.3.0 with *virtualbox* virtualization provider.
 * The Cumulus VX 4.x uses Python version 3.7, which recent versions of Ansible refuse to work with. The permanent fix is coming in release 1.9.3. Until then, use the **frrouting** device or [Cumulus VX 5.x image](caveats-cumulus-5x).
-* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed, is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
+* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
 
 _netlab_ uses the VLAN-aware bridge paradigm to configure VLANs on Cumulus Linux. That decision results in the following restrictions:
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -205,7 +205,7 @@ ansible-galaxy collection install git+https://github.com/jmussmann/ansible_colle
 
 * The Cumulus VX 4.4.0 Vagrant box for VirtualBox is broken. *netlab* is using Cumulus VX 4.3.0 with *virtualbox* virtualization provider.
 * The Cumulus VX 4.x uses Python version 3.7, which recent versions of Ansible refuse to work with. The permanent fix is coming in release 1.9.3. Until then, use the **frrouting** device or [Cumulus VX 5.x image](caveats-cumulus-5x).
-* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
+* Both Cumulus VX 4.x and 5.x use relatively old versions of FRR (7.5 on 4.x, 8.4.3 on 5.x). One issue that was observed, is that these older versions don't support OSPF passive interfaces inside VRFs (the config in the FRR template is silently ignored)
 
 _netlab_ uses the VLAN-aware bridge paradigm to configure VLANs on Cumulus Linux. That decision results in the following restrictions:
 

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -26,7 +26,8 @@ The following table describes per-platform support of individual EVPN/VXLAN feat
 | Arista EOS         | ✅  | ✅  | ✅  | ✅  |
 | Aruba AOS-CX       | ✅  |  ❌  |  ✅  | ✅[❗](caveats-aruba)  |
 | Cisco Nexus OS     | ✅  |  ❌  | ✅  | ✅  |
-| Cumulus Linux      | ✅  |  ❌  | ✅  | ✅  |
+| Cumulus Linux 4.x  | ✅  |  ❌  | ✅  | ✅  |
+| Cumulus 5.x (NVUE) | ✅  |  ❌  | ✅ |  ✅ |
 | Dell OS 10         | ✅  |  ❌  | ✅  | ✅  |
 | FRR                | ✅  |  ❌  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  |  ✅ | ✅  | ✅  |
@@ -57,7 +58,8 @@ EVPN module supports IBGP- and EBGP-based EVPN:
 | Arista EOS         | ✅  | ✅  | ✅  | ✅  |
 | Aruba AOS-CX       | ✅  | ✅  | ❌   | ❌   |
 | Cisco Nexus OS     | ✅  | ✅  | ✅  | ❌   |
-| Cumulus Linux      | ✅  | ✅  | ✅  | ✅  |
+| Cumulus Linux 4.x  | ✅  | ✅  | ✅  | ✅  |
+| Cumulus 5.x (NVUE) | ✅  | ✅  | ✅  | ✅  |
 | Dell OS 10 [❗](caveats-os10) | ✅  | ✅  | ✅  | ✅  |
 | FRR                | ✅  | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  |
@@ -74,7 +76,8 @@ With additional nerd knobs ([more details](evpn-weird-designs)), it's possible t
 | Arista EOS         | ✅  | ✅  |
 | Aruba AOS-CX       | ✅  | ❌   |
 | Cisco Nexus OS     | ❌   | ❌   |
-| Cumulus Linux      | ✅  | ✅  |
+| Cumulus Linux 4.x  | ✅  | ✅  |
+| Cumulus 5.x (NVUE) | ✅  | ✅  |
 | Dell OS 10         | ✅  | ❌   |
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |
@@ -88,7 +91,8 @@ Most EVPN/VXLAN implementations support only IPv4 VXLAN transport; some can run 
 | Arista EOS         | ✅  | ❌   |
 | Aruba AOS-CX       | ✅  | ❌   |
 | Cisco Nexus OS     | ✅  | ❌   |
-| Cumulus Linux      | ✅  | ❌   |
+| Cumulus Linux 4.x  | ✅  | ❌   |
+| Cumulus 5.x (NVUE) | ✅  | ❌   |
 | Dell OS 10         | ✅  | ❌   |
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -27,7 +27,7 @@ The following table describes per-platform support of individual EVPN/VXLAN feat
 | Aruba AOS-CX       | ✅  |  ❌  |  ✅  | ✅[❗](caveats-aruba)  |
 | Cisco Nexus OS     | ✅  |  ❌  | ✅  | ✅  |
 | Cumulus Linux 4.x  | ✅  |  ❌  | ✅  | ✅  |
-| Cumulus 5.x (NVUE) | ✅  |  ❌  | ✅ |  ✅ |
+| Cumulus 5.x (NVUE) | ✅  |  ❌  | ✅ |  ❌ |
 | Dell OS 10         | ✅  |  ❌  | ✅  | ✅  |
 | FRR                | ✅  |  ❌  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  |  ✅ | ✅  | ✅  |

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -1,0 +1,1 @@
+# Configure EVPN RTs    

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -29,10 +29,13 @@
       enable: on
       # dad                    Duplicate Address Detection (DAD) configuration parameters
       # mac-vrf-soo            EVPN MAC VRF Site-of-Origin VPN extended community in ASN:NN or IP-ADDRESS:NN format.
+{% if vxlan._shared_vtep is defined %}
+      mac-vrf-soo: {{ vxlan.vtep }}:{{ interfaces|json_query('[*].lag.mlag.peergroup')|first }}
+{% endif %}
       # multihoming            Multihoming global configuration parameters
       # route-advertise        Route advertising
       route-advertise:
-        nexthop-setting: {{ 'shared-ip-mac' if lag.mlag.vtep is defined else 'system-ip-mac' }}
+        nexthop-setting: {{ 'shared-ip-mac' if vxlan._shared_vtep is defined else 'system-ip-mac' }}
         svi-ip: on
       # vni                    VNI
 
@@ -48,6 +51,17 @@
             import:
               '{{ vlan.evpn.import[0] }}': {}
 {% endfor %}
+
+{% if vxlan.flooding|default("") == "evpn" %}
+- set:
+    nve:
+      vxlan:
+        mac-learning: off
+        flooding:
+          enable: on
+          head-end-replication: 
+            evpn: {}
+{% endif %}
 
 {# L3 VRF EVPN handling #}
 {% if vrfs is defined %}
@@ -70,10 +84,23 @@
            route-export:
              to-evpn:
                route-target:
-                 auto: {}
+                 {{ vdata.export[0] }}: {}
            route-import:
              from-evpn:
                route-target:
-                 auto: {}
+                 {{ vdata.import[0] }}: {}
+{%     for _af in ['ipv4','ipv6'] if _af in vdata.af %}
+{%       if loop.first %}
+           address-family:
+{%       endif %}
+             {{ _af }}-unicast:
+               enable: on
+               redistribute:
+                 connected:
+                   enable: on
+               route-export:
+                 to-evpn:
+                   enable: on
+{%     endfor %}
 {%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -7,6 +7,13 @@
             address-family:
               l2vpn-evpn:
                 enable: on
+{% for _af in ['ipv4','ipv6'] if _af in bgp %}
+              {{ _af }}-unicast:
+                route-export:
+                  to-evpn:
+{# Currently has no effect due to BUG #}
+                    enable: on
+{% endfor %}
 {% for n in bgp.neighbors if n.evpn|default(False) %}
 {%   if loop.first %}
             neighbor:
@@ -22,6 +29,18 @@
                     route-reflector-client: on
 {%     endif %}
 {%   endfor %}
+{% endfor %}
+
+{# Workaround for an omission in NVUE that causes route-export to-evpn in the default VRF to fail #}
+- set:
+    system:
+      config:
+        snippet:
+          frr.conf: |
+            router bgp {{ bgp.as }}
+              address-family l2vpn evpn
+{% for _af in ['ipv4','ipv6'] if _af in bgp %}
+                advertise {{ _af }} unicast
 {% endfor %}
 
 - set:
@@ -94,15 +113,6 @@
            address-family:
 {%       endif %}
              {{ _af }}-unicast:
-               enable: on
-               redistribute:
-                 connected:
-                   enable: on
-{# XXX this belongs in vrf template #}
-{%       if 'ospf' in vdata %}
-                 ospf:
-                   enable: on
-{%       endif %}
                route-export:
                  to-evpn:
                    enable: on

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -65,7 +65,7 @@
 
 {# L3 VRF EVPN handling #}
 {% if vrfs is defined %}
-{%   for vname,vdata in vrfs.items() if 'evpn' in vdata %}
+{%   for vname,vdata in vrfs.items() if vname in evpn.vrfs|default([]) %}
 - set:
    vrf:   
      {{ vname }}:
@@ -98,6 +98,11 @@
                redistribute:
                  connected:
                    enable: on
+{# XXX this belongs in vrf template #}
+{%       if 'ospf' in vdata %}
+                 ospf:
+                   enable: on
+{%       endif %}
                route-export:
                  to-evpn:
                    enable: on

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -49,3 +49,31 @@
               '{{ vlan.evpn.import[0] }}': {}
 {% endfor %}
 
+{# L3 VRF EVPN handling #}
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if 'evpn' in vdata %}
+- set:
+   vrf:   
+     {{ vname }}:
+       evpn:
+         enable: on
+         vlan: auto
+{%     if vdata.evpn.transit_vni is defined %}
+         vni: 
+           '{{ vdata.evpn.transit_vni }}': {}
+{%     endif %}
+       router:
+         bgp:
+           autonomous-system: {{ vdata.as|default(bgp.as) }}
+           enable: on
+           rd: {{ vdata.rd }}
+           route-export:
+             to-evpn:
+               route-target:
+                 auto: {}
+           route-import:
+             from-evpn:
+               route-target:
+                 auto: {}
+{%   endfor %}
+{% endif %}

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -1,1 +1,51 @@
-# Configure EVPN RTs    
+---
+- set:
+    vrf:
+      default:
+        router:
+          bgp:
+            address-family:
+              l2vpn-evpn:
+                enable: on
+{% for n in bgp.neighbors if n.evpn|default(False) %}
+{%   if loop.first %}
+            neighbor:
+{%   endif %}
+{%   for af in ['ipv4','ipv6'] if af in n %}
+{%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
+              {{ peer }}:
+                address-family:
+                  l2vpn-evpn:
+                    enable: on
+                    soft-reconfiguration: on
+{%     if bgp.rr|default('') and not n.rr|default('') %}
+                    route-reflector-client: on
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
+- set:
+    evpn:
+      enable: on
+      # dad                    Duplicate Address Detection (DAD) configuration parameters
+      # mac-vrf-soo            EVPN MAC VRF Site-of-Origin VPN extended community in ASN:NN or IP-ADDRESS:NN format.
+      # multihoming            Multihoming global configuration parameters
+      # route-advertise        Route advertising
+      route-advertise:
+        nexthop-setting: {{ 'shared-ip-mac' if lag.mlag.vtep is defined else 'system-ip-mac' }}
+        svi-ip: on
+      # vni                    VNI
+
+{% for vlan in (vlans|default({})).values() if 'vni' in vlan and 'evpn' in vlan %}
+{%   if loop.first %}
+      vni:
+{%   endif %}
+        '{{ vlan.vni }}':
+          rd: {{ vlan.evpn.rd }} # not 'auto'
+          route-target:
+            export:
+              '{{ vlan.evpn.export[0] }}': {}
+            import:
+              '{{ vlan.evpn.import[0] }}': {}
+{% endfor %}
+

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -14,7 +14,7 @@
                   flooding:
                     enable: on
                     head-end-replication:
-{%    for remote_vtep in vlan.vtep_list %}
+{%     for remote_vtep in vlan.vtep_list %}
                       {{ remote_vtep }}: {}
 {%     endfor %}
 {%   else %}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -3,10 +3,10 @@
       vxlan:
         enable: on
         mac-learning: {{ 'on' if vxlan.flooding|default("") != "evpn" else 'off' }}
-{%   if vxlan._shared_vtep is defined %}
+{% if vxlan._shared_vtep is defined %}
         mlag:
           shared-address: {{ vxlan.vtep }}
-{%   endif %}
+{% endif %}
         source:
           address: {{ vxlan.vtep }}
 

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -1,27 +1,3 @@
-{% for vname in vxlan.vlans if vlans[vname].vni is defined %}
-{%   set vlan = vlans[vname] %}
-{%   if loop.first %}
-- set:
-    bridge:
-      domain:
-        br_default:
-          vlan:
-{%   endif %}
-            '{{ vlan.id }}':
-              vni:
-{%   if vlan.vtep_list|default([]) %}
-                '{{ vlan.vni }}':
-                  flooding:
-                    enable: on
-                    head-end-replication:
-{%     for remote_vtep in vlan.vtep_list %}
-                      {{ remote_vtep }}: {}
-{%     endfor %}
-{%   else %}
-                '{{ vlan.vni }}': {}
-{%   endif %}
-{% endfor %}
-{% if vxlan.vlans is defined %}
 - set:
     nve:
       vxlan:
@@ -33,4 +9,29 @@
 {%   endif %}
         source:
           address: {{ vxlan.vtep }}
+
+{% if vxlan.vlans is defined %}
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%     set vlan = vlans[vname] %}
+{%     if loop.first %}
+- set:
+    bridge:
+      domain:
+        br_default:
+          vlan:
+{%     endif %}
+            '{{ vlan.id }}':
+              vni:
+{%     if vlan.vtep_list|default([]) %}
+                '{{ vlan.vni }}':
+                  flooding:
+                    enable: on
+                    head-end-replication:
+{%       for remote_vtep in vlan.vtep_list %}
+                      {{ remote_vtep }}: {}
+{%       endfor %}
+{%     else %}
+                '{{ vlan.vni }}': {}
+{%     endif %}
+{%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -14,7 +14,7 @@
                   flooding:
                     enable: on
                     head-end-replication:
-{%     for remote_vtep in vlan.vtep_list %}
+{%    for remote_vtep in vlan.vtep_list %}
                       {{ remote_vtep }}: {}
 {%     endfor %}
 {%   else %}

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -34,6 +34,9 @@ features:
     local_as: True
     local_as_ibgp: True
     vrf_local_as: False
+  evpn:
+    irb: True
+    asymmetrical_irb: True
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -35,7 +35,7 @@ features:
     local_as_ibgp: True
     vrf_local_as: False
   evpn:
-    irb: True
+    irb: False
     asymmetrical_irb: True
   gateway:
     protocol: [ anycast, vrrp ]


### PR DESCRIPTION
I ran ```NETLAB_DEVICE=cumulus_nvue NETLAB_PROVIDER=libvirt ./device-module-test evpn```

8/14 tests validate ok. Some are failing due to missing bits that aren't part of EVPN (like missing 'redistribute connected' for VRFs); I could easily fix that, but this isn't the right place

Main things still missing:
* generalized redistribution of routes (separate PR)
* BGP in VRFs