### PR TITLE
Cumulus NVUE: Generalized redistribute of OSPF/BGP/connected routes

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -83,7 +83,7 @@ The following features are only supported on a subset of platforms:
 | BIRD                     |  ✅ |  ✅ |  ❌  |  ❌  |
 | Cisco IOS/IOS XE[^18v]   |  ✅ |  ✅ |  ✅ |  ✅ |
 | Cumulus Linux 4.x        |  ✅ |  ✅ |  ✅ |  ✅ |
-| Cumulus Linux 5.x (NVUE) |  ✅ |  ✅ |  ❌ |  ❌ |
+| Cumulus Linux 5.x (NVUE) |  ✅ |  ✅ |  ✅ |  ❌ |
 | Dell OS10                |  ✅ |  ❌  |  ❌  |  ❌  |
 | FRR                      |  ✅ |  ✅ |  ✅ |  ✅ |
 | Nokia SR Linux           |  ✅ |  ✅ |  ✅ [❗](caveats-srlinux) |  ✅ |

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -59,7 +59,7 @@ The following table describes per-platform support of individual router-level OS
 | Cisco IOS XE[^18v]       | ✅| ✅| ✅| ✅| ✅|
 | Cisco Nexus OS           | ✅| ✅| ✅| ❌ | ❌ |
 | Cumulus Linux            | ✅| ✅| ✅| ✅| ✅|
-| Cumulus Linux 5.x (NVUE) | ✅| ✅| ❌ | ❌ | ❌ |
+| Cumulus Linux 5.x (NVUE) | ✅| ✅| ❌ | ✅ | ❌ |
 | Dell OS10 ([❗](caveats-os10)) | | ✅| ✅| ✅| ❌ | ❌ |
 | Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ❌ | ❌ | ❌ |
 | FRR                      | ✅| ✅| ✅| ✅| ✅|

--- a/netsim/ansible/templates/bgp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.j2
@@ -1,3 +1,4 @@
+{% import "templates/routing/_redistribute.cumulus_nvue.j2" as redistribute with context %}
 {% macro advertise_communities(comms) %}
                     community-advertise:
 {%   for c in ['standard', 'extended', 'large'] %}
@@ -26,6 +27,7 @@
 {%   endif %}
               {{ af }}-unicast:
                 enable: on
+{{              redistribute.config(bgp,af=af)|indent(16,first=True) }}
 {%   set _loopback = [ loopback[af] ] if loopback[af] is defined and bgp.advertise_loopback else [] %}
 {%   set data = namespace(networks=_loopback) %}
 {%   for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}

--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -1,3 +1,4 @@
+{% import "templates/routing/_redistribute.cumulus_nvue.j2" as redistribute with context %}
 - set:
     router:
       ospf:
@@ -13,9 +14,7 @@
         router:
           ospf:
             enable: on
-            redistribute:
-              connected:
-                enable: on
+{{     redistribute.config(_ospf,af='ipv4')|indent(12,first=True) }}
 {%     if _ospf.reference_bandwidth is defined %}
             reference-bandwidth: {{ _ospf.reference_bandwidth }}
 {%     endif %}

--- a/netsim/ansible/templates/routing/_redistribute.cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/_redistribute.cumulus_nvue.j2
@@ -1,0 +1,14 @@
+{% macro config(pdata,af) -%}
+{%   if pdata.import is defined %}
+{%     for s_proto,s_data in pdata.import.items() %}
+{%       if loop.first %}
+redistribute:
+{%       endif %}
+  {{ s_proto }}:
+    enable: on
+{%       if 'policy' in s_data %}
+    route-map: {{ s_data.policy }}-{{ af }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{%- endmacro %}

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -29,6 +29,7 @@ features:
       lla: True
   bgp:
     activate_af: True
+    import: [ connected, ospf ]
     ipv6_lla: True
     local_as: True
     local_as_ibgp: True
@@ -45,6 +46,7 @@ features:
         ip: linklocal             # Use this IP subnet
         backup_ip: loopback.ipv4  # Use loopback.ipv4 as a backup IP address for peerlink
   ospf:
+    import: [ bgp, connected ]
     unnumbered: True
     timers: True
     priority: True

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -46,10 +46,12 @@ features:
         ip: linklocal             # Use this IP subnet
         backup_ip: loopback.ipv4  # Use loopback.ipv4 as a backup IP address for peerlink
   ospf:
-    import: [ bgp, connected ]
+    import: [ bgp, connected, vrf ]
     unnumbered: True
     timers: True
     priority: True
+  routing: 
+    prefix: True
   stp:
     supported_protocols: [ stp, rstp, pvrst ]  # PVRST requires release 5.6.0 or higher
     enable_per_port: True

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -50,8 +50,6 @@ features:
     unnumbered: True
     timers: True
     priority: True
-  routing: 
-    prefix: True
   stp:
     supported_protocols: [ stp, rstp, pvrst ]  # PVRST requires release 5.6.0 or higher
     enable_per_port: True


### PR DESCRIPTION
Small tweak to redistribute configs, still missing BGP in VRFs but will adjust when that gets added

Tested: ```integration/ospf/ospfv2/10-import.yml```