### PR TITLE
Use Vagrant private key instead of username for FRR

### DIFF
--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -23,7 +23,7 @@ from . import external_commands, set_dry_run, error_and_exit, parser_lab_locatio
 
 from . import load_snapshot, parser_add_verbose
 from ..outputs import common as outputs_common
-from ..utils import strings, log
+from ..utils import strings, log, templates
 
 #
 # CLI parser for 'netlab initial' command
@@ -98,6 +98,10 @@ def ssh_connect(
 
   if data.ansible_ssh_pass:
     c_args = ['sshpass','-p',data.ansible_ssh_pass ] + c_args
+
+  if data.ansible_ssh_private_key_file:
+    data.inventory_hostname = data.host
+    c_args.extend(['-i', templates.render_template(data,j2_text=data.ansible_ssh_private_key_file)])
 
   if data.ansible_port:
     c_args.extend(['-p',str(data.ansible_port)])

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -29,21 +29,23 @@ clab:
     config_templates:
       daemons: /etc/frr/daemons
       hosts: /etc/hosts
+
 libvirt:
-  image: debian/bookworm64 #generic/ubuntu2004
+  image: debian/bookworm64
+  group_vars:
+    ansible_connection: paramiko
+    ansible_user: vagrant
+    ansible_ssh_private_key_file: .vagrant/machines/{{ inventory_hostname }}/libvirt/private_key
+    netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
+
+virtualbox:
+  image: generic/ubuntu2004
   group_vars:
     ansible_connection: paramiko
     ansible_user: vagrant
     ansible_ssh_pass: vagrant
     netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
 
-virtualbox:
-  image: debian/bookworm64 #generic/ubuntu2004
-  group_vars:
-    ansible_connection: paramiko
-    ansible_user: vagrant
-    ansible_ssh_pass: vagrant
-    netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
 external:
   image: none
 features:

--- a/netsim/templates/provider/libvirt/frr-domain.j2
+++ b/netsim/templates/provider/libvirt/frr-domain.j2
@@ -1,15 +1,6 @@
 {% if _vagrant_scripts.frr is not defined %}
 {%   set _vagrant_scripts.frr = True %}
 
-    $frr_script = <<-SCRIPT
-echo "Setting password for user Vagrant"
-echo vagrant:{{ n.ansible_ssh_pass }} | chpasswd
-
-echo "Enabling SSH password authentication"
-sed -i -e "s#PasswordAuthentication no#PasswordAuthentication yes#" /etc/ssh/sshd_config
-service sshd restart
-    SCRIPT
-
     $frr_install_script = <<-SCRIPT
 set -e
 if which /usr/lib/frr/frrinit.sh; then
@@ -36,7 +27,8 @@ fi
       domain.memory = 1024
     end
 
-    # Run debian-specific provisioning script
+{% if not (n.netlab_quick_start|default(False)) %}
+    # Run FRR installation script
     #
-    {{ name }}.vm.provision :shell, :inline => $frr_script{% 
-      if not (n.netlab_quick_start|default(False)) %} + $frr_install_script {% endif +%}
+    {{ name }}.vm.provision :shell, :inline => $frr_install_script
+{% endif +%}


### PR DESCRIPTION
This is a proof-of-concept for the 'use Vagrant private key' VM authentication. FRR is used as an example because it already uses Debian Bookworm; other devices that could use the same approach are Cumulus (4/5), VyOS, and Linux.