### PR TITLE
Cumulus NVUE: Restore VXLAN support accidentally deleted by #1881

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -29,7 +29,8 @@ The following table describes per-platform support of individual VXLAN features:
 | Aruba AOS-CX       | ✅  | ✅  |  ❌  |
 | Cisco CSR 1000v    | ✅  | ✅  |  ❌  |
 | Cisco Nexus OS     | ✅  | ✅  |  ❌  |
-| Cumulus Linux      | ✅  | ✅  |  ❌  |
+| Cumulus Linux 4.x  | ✅  | ✅  |  ❌  |
+| Cumulus 5.x (NVUE) | ✅  | ✅  |  ❌  |
 | Dell OS10          | ✅  | ✅  |  ❌  |
 | FRR                | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅ [❗](caveats-srlinux)  |  ❌  |  ❌  |

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -65,6 +65,8 @@ features:
     subif_name: "{ifname}.{vlan.access_id}"
   vrf:
     ospfv2: True
+  vxlan: True
+  # vtep6: true                                # Waiting for https://github.com/CumulusNetworks/ifupdown2/pull/315
 clab:
   kmods:
     initial: [ ebtables ]


### PR DESCRIPTION
While rebasing #1881 I accidentally canceled out these changes