### PR TITLE
Use Vagrant private key instead of username for FRR

### DIFF
--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -23,7 +23,7 @@ from . import external_commands, set_dry_run, error_and_exit, parser_lab_locatio
 
 from . import load_snapshot, parser_add_verbose
 from ..outputs import common as outputs_common
-from ..utils import strings, log
+from ..utils import strings, log, templates
 
 #
 # CLI parser for 'netlab initial' command
@@ -98,6 +98,10 @@ def ssh_connect(
 
   if data.ansible_ssh_pass:
     c_args = ['sshpass','-p',data.ansible_ssh_pass ] + c_args
+
+  if data.ansible_ssh_private_key_file:
+    data.inventory_hostname = data.host
+    c_args.extend(['-i', templates.render_template(data,j2_text=data.ansible_ssh_private_key_file)])
 
   if data.ansible_port:
     c_args.extend(['-p',str(data.ansible_port)])

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -29,21 +29,24 @@ clab:
     config_templates:
       daemons: /etc/frr/daemons
       hosts: /etc/hosts
+
 libvirt:
-  image: debian/bookworm64 #generic/ubuntu2004
+  image: debian/bookworm64
+  group_vars:
+    ansible_connection: paramiko
+    ansible_user: vagrant
+    ansible_ssh_pass: vagrant
+    ansible_ssh_private_key_file: .vagrant/machines/{{ inventory_hostname }}/libvirt/private_key
+    netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
+
+virtualbox:
+  image: generic/ubuntu2004
   group_vars:
     ansible_connection: paramiko
     ansible_user: vagrant
     ansible_ssh_pass: vagrant
     netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
 
-virtualbox:
-  image: debian/bookworm64 #generic/ubuntu2004
-  group_vars:
-    ansible_connection: paramiko
-    ansible_user: vagrant
-    ansible_ssh_pass: vagrant
-    netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
 external:
   image: none
 features:

--- a/netsim/templates/provider/libvirt/_debian_vagrant_password.j2
+++ b/netsim/templates/provider/libvirt/_debian_vagrant_password.j2
@@ -1,0 +1,6 @@
+echo "Setting password for user Vagrant"
+echo vagrant:{{ n.ansible_ssh_pass|default }} | chpasswd
+
+echo "Enabling SSH password authentication"
+sed -i -e "s#PasswordAuthentication no#PasswordAuthentication yes#" /etc/ssh/sshd_config
+service sshd restart

--- a/netsim/templates/provider/libvirt/frr-domain.j2
+++ b/netsim/templates/provider/libvirt/frr-domain.j2
@@ -1,15 +1,6 @@
 {% if _vagrant_scripts.frr is not defined %}
 {%   set _vagrant_scripts.frr = True %}
 
-    $frr_script = <<-SCRIPT
-echo "Setting password for user Vagrant"
-echo vagrant:{{ n.ansible_ssh_pass }} | chpasswd
-
-echo "Enabling SSH password authentication"
-sed -i -e "s#PasswordAuthentication no#PasswordAuthentication yes#" /etc/ssh/sshd_config
-service sshd restart
-    SCRIPT
-
     $frr_install_script = <<-SCRIPT
 set -e
 if which /usr/lib/frr/frrinit.sh; then
@@ -36,7 +27,15 @@ fi
       domain.memory = 1024
     end
 
-    # Run debian-specific provisioning script
+    # Run debian-specific provisioning script.
     #
-    {{ name }}.vm.provision :shell, :inline => $frr_script{% 
+    # Password change has to be inline as the password might be different for each VM
+    #
+    $frr_password = <<-SCRIPT
+{% if n.ansible_ssh_pass|default(False) %}
+{%   include '_debian_vagrant_password.j2' +%}
+{% endif +%}
+    SCRIPT
+
+    {{ name }}.vm.provision :shell, :inline => $frr_password{%
       if not (n.netlab_quick_start|default(False)) %} + $frr_install_script {% endif +%}

--- a/tests/platform-integration/libvirt/03-authentication.yml
+++ b/tests/platform-integration/libvirt/03-authentication.yml
@@ -1,0 +1,35 @@
+message: |
+  The test checks different combinations of Vagrant user authentication:
+
+  * SSH password + SSH private key (default)
+  * SSH password only
+  * SSH private key only
+
+  Ansible access is checked during the configuration phase, netlab access
+  during the validation phase
+
+provider: libvirt
+defaults.device: frr
+module: [ ospf ]
+ospf.timers.hello: 1
+
+nodes:
+  r1:                                 # password + private key
+  r2:
+    ansible_ssh_private_key_file:     # No private key file
+  r3:
+    ansible_ssh_pass:                 # No password
+  r4:
+    ansible_ssh_pass:
+    netlab_quick_start: True          # Combination of no password + no install
+
+links: [ r1-r2, r2-r3, r2-r4 ]
+
+validate:
+  adj_r2:
+    plugin: ospf_neighbor(nodes.r2.ospf.router_id)
+    wait: 15
+    nodes: [ r1, r3, r4 ]
+  adj_r1:
+    plugin: ospf_neighbor(nodes.r1.ospf.router_id)
+    nodes: [ r2 ]


### PR DESCRIPTION
This is a proof-of-concept for the 'use Vagrant private key' VM authentication. FRR is used as an example because it already uses Debian Bookworm; other devices that could use the same approach are Cumulus (4/5), VyOS, and Linux.

We're adding private-key-based-authentication functionality to netlab while retaining the password-based authentication that might be needed for network management tools.

The Vagrant provisioning script adds the commands to set the password for the 'vagrant' user (unless it's not defined) and change the Debian default SSH authentication policy.

The Debian-specific provisioning steps are stored in a separate template as we'll need them when migrating Linux node to Debian.