### PR TITLE
Change the L3 LAG integration test to use static routing

### DIFF
--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -2,24 +2,54 @@ message: |
   The device under is a router with a L3 LAG link connected to a FRR device. The
   FRR device should be able to ping the loopback interface of DUT.
 
-nodes:
-  dut:
-    module: [ lag ]
-    role: router
-  xr:
-    device: frr
+groups:
+  probes:
+    device: eos
     module: [ lag, routing ]
+    members: [ x1, x2 ]
     routing.static:
     - ipv4: 0.0.0.0/0
       nexthop.node: dut
 
+nodes:
+  dut:
+    module: [ lag ]
+    role: router
+  x1:
+    role: host
+  x2:
+    role: host
+
 links:
-- lag.members: [dut-xr, dut-xr]
+- lag.members: [dut-x1, dut-x1]
   mtu: 1500
+- lag.members: [dut-x2, dut-x2]
+  mtu: 1400
 
 validate:
+  lag:
+    description: Check LAG link with DUT
+    wait: 10
+    wait_msg: Waiting for LAG to start
+    nodes: [ x1, x2 ]
+    devices: [ eos ]
+    pass: The LAG with DUT is active
+    fail: The LAG did not start correctly
+    show: port-channel | json
+    valid: >-
+      len(portChannels['Port-Channel1'].activePorts) == 2
   ping:
-    wait_msg: Waiting for LAG to be established
-    wait: 15
-    nodes: [ xr ]
-    plugin: ping(nodes.dut.loopback.ipv4)
+    description: Initial IPv4 ping
+    nodes: [ x1 ]
+    exec:
+      eos: ping x2
+    valid: |
+      'bytes from' in stdout
+  ping_ptb:
+    description: IPv4 ping with large packet (expecting Frag Needed)
+    nodes: [ x1 ]
+    level: warning
+    exec:
+      eos: ping x2 df-bit size 1420
+    valid: |
+      'Frag needed and DF set' in stdout

--- a/tests/integration/lag/01-l3-lag.yml
+++ b/tests/integration/lag/01-l3-lag.yml
@@ -1,25 +1,25 @@
 message: |
   The device under is a router with a L3 LAG link connected to a FRR device. The
-  devices should be able to establish an OSPF adjacency.
-
-groups:
-  switches:
-    members: [dut, xr]
-    module: [lag, ospf]
+  FRR device should be able to ping the loopback interface of DUT.
 
 nodes:
   dut:
+    module: [ lag ]
+    role: router
   xr:
     device: frr
+    module: [ lag, routing ]
+    routing.static:
+    - ipv4: 0.0.0.0/0
+      nexthop.node: dut
 
 links:
 - lag.members: [dut-xr, dut-xr]
   mtu: 1500
 
 validate:
-  adj:
-    description: Check OSPF adjacencies
-    wait_msg: Waiting for OSPF adjacency process to complete
-    wait: 50
-    nodes: [xr]
-    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+  ping:
+    wait_msg: Waiting for LAG to be established
+    wait: 15
+    nodes: [ xr ]
+    plugin: ping(nodes.dut.loopback.ipv4)


### PR DESCRIPTION
The current L3 LAG integration test uses OSPF and thus fails on Linux. This change replaces OSPF with static routing on the probe, testing just pure L3 forwarding functionality over LAG.