### PR TITLE
Check the validity of management IP addresses

### DIFF
--- a/netsim/augment/addressing.py
+++ b/netsim/augment/addressing.py
@@ -198,9 +198,9 @@ def validate_pools(addrs: Box, topology: Box) -> None:
               module='addressing')
 
     if 'ipv6' in pfx and 'ipv6_pfx' in pfx:
-      if pfx.ipv6_pfx.prefixlen > 56:
+      if pfx.ipv6_pfx.prefixlen > 56 and pool != 'mgmt':
         log.error(
-          "Error in '%s' addressing pool: IPv6 pool prefix cannot be longer than /56" % pool,
+          f"Error in '{pool}' addressing pool: IPv6 pool prefix cannot be longer than /56",
           category=log.IncorrectValue,
           module='addressing')
 

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -7,7 +7,7 @@ from box import Box
 import pathlib
 import argparse
 
-from . import _Provider,get_forwarded_ports
+from . import _Provider,get_forwarded_ports,validate_mgmt_ip
 from ..utils import log, strings, linuxbridge
 from ..data import filemaps, get_empty_box, append_to_list
 from ..data.types import must_be_dict
@@ -183,6 +183,7 @@ class Containerlab(_Provider):
   def node_post_transform(self, node: Box, topology: Box) -> None:
     add_daemon_filemaps(node,topology)
     normalize_clab_filemaps(node)
+    validate_mgmt_ip(node,required=True,provider='clab',mgmt=topology.addressing.mgmt)
 
     self.create_extra_files_mappings(node,topology)
 

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -16,7 +16,7 @@ import argparse
 from ..data import types,get_empty_box,get_box
 from ..utils import log,strings,linuxbridge
 from ..utils import files as _files
-from . import _Provider
+from . import _Provider,validate_mgmt_ip
 from ..augment import devices
 from ..augment.links import get_link_by_index
 from ..cli import is_dry_run,external_commands
@@ -263,7 +263,7 @@ def create_vagrant_batches(topology: Box) -> None:
 class Libvirt(_Provider):
 
   """
-  post_transform hook: mark multi-provider links as LAN links
+  pre_transform hook: mark multi-provider links as LAN links
   """
   def pre_transform(self, topology: Box) -> None:
     if not 'links' in topology:
@@ -295,6 +295,7 @@ class Libvirt(_Provider):
   def node_post_transform(self, node: Box, topology: Box) -> None:
     if node.get('_set_ifindex'):
       pad_node_interfaces(node,topology)
+    validate_mgmt_ip(node,required=True,v4only=True,provider='libvirt',mgmt=topology.addressing.mgmt)
 
   def transform_node_images(self, topology: Box) -> None:
     self.node_image_version(topology)

--- a/tests/errors/mgmt-subnet.log
+++ b/tests/errors/mgmt-subnet.log
@@ -1,0 +1,4 @@
+IncorrectValue in libvirt: Management ipv4 address of node a (192.168.44.1) is not part of the management subnet
+MissingValue in libvirt: Node b must have ipv4 management address
+IncorrectValue in clab: Management ipv6 address of node d (2001:db8:43::3) is not part of the management subnet
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/mgmt-subnet.yml
+++ b/tests/errors/mgmt-subnet.yml
@@ -1,0 +1,22 @@
+defaults.device: none
+addressing.mgmt:
+  ipv4: 192.168.42.0/24
+  ipv6: 2001:db8:42::/64
+
+nodes:
+  a:
+    provider: libvirt
+    mgmt.ipv4: 192.168.44.1
+  b:
+    provider: libvirt
+    mgmt.ipv6: 2001:db8:42::2
+  c:
+    provider: libvirt
+    mgmt.ipv4: 192.168.42.3
+    mgmt.ipv6: 2001:db8:42::3
+  d:
+    provider: clab
+    mgmt.ipv6: 2001:db8:43::3
+  e:
+    provider: clab
+    mgmt.ipv6: 2001:db8:42::5


### PR DESCRIPTION
clab and libvirt management IP addresses must be within the management subnet and the AF used on the node must be defined in the management pool.

Furthermore, libvirt nodes need IPv4 management address.

Closes #1957