### PR TITLE
Remove dependence on EOS image from transformation tests

### DIFF
--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -16,15 +16,15 @@ links:
   bridge: input_1
   interfaces:
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 172.16.0.1/24
     node: r1
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 172.16.0.2/24
     node: r2
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 172.16.0.5/24
     node: n6
   linkindex: 1
@@ -36,12 +36,12 @@ links:
 - _linkname: links[2]
   interfaces:
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 10.1.0.1/30
     ipv6: 2001:db8:1::1/64
     node: r1
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 10.1.0.2/30
     ipv6: 2001:db8:1::2/64
     node: r2
@@ -56,12 +56,12 @@ links:
   bfd: false
   interfaces:
   - ifindex: 3
-    ifname: Ethernet3
+    ifname: eth3
     ipv4: 10.1.0.5/30
     ipv6: 2001:db8:1:1::1/64
     node: r1
   - ifindex: 3
-    ifname: Ethernet3
+    ifname: eth3
     ipv4: 10.1.0.6/30
     ipv6: 2001:db8:1:1::2/64
     node: r2
@@ -75,12 +75,12 @@ links:
 - _linkname: links[4]
   interfaces:
   - ifindex: 4
-    ifname: Ethernet4
+    ifname: eth4
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
     node: r1
   - ifindex: 4
-    ifname: Ethernet4
+    ifname: eth4
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
     node: r2
@@ -96,12 +96,12 @@ links:
 - _linkname: links[5]
   interfaces:
   - ifindex: 5
-    ifname: Ethernet5
+    ifname: eth5
     ipv4: 10.1.0.13/30
     ipv6: 2001:db8:1:3::1/64
     node: r1
   - ifindex: 5
-    ifname: Ethernet5
+    ifname: eth5
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
     node: r2
@@ -116,12 +116,12 @@ links:
 - _linkname: links[6]
   interfaces:
   - ifindex: 6
-    ifname: Ethernet6
+    ifname: eth6
     ipv4: 10.1.0.17/30
     ipv6: 2001:db8:1:4::1/64
     node: r1
   - ifindex: 6
-    ifname: Ethernet6
+    ifname: eth6
     ipv4: 10.1.0.18/30
     ipv6: 2001:db8:1:4::2/64
     node: r2
@@ -139,12 +139,12 @@ links:
 - _linkname: links[7]
   interfaces:
   - ifindex: 7
-    ifname: Ethernet7
+    ifname: eth7
     ipv4: 10.1.0.21/30
     ipv6: 2001:db8:1:5::1/64
     node: r1
   - ifindex: 7
-    ifname: Ethernet7
+    ifname: eth7
     ipv4: 10.1.0.22/30
     ipv6: 2001:db8:1:5::2/64
     node: r2
@@ -162,11 +162,11 @@ links:
 - _linkname: links[8]
   interfaces:
   - ifindex: 8
-    ifname: Ethernet8
+    ifname: eth8
     ipv4: 10.42.42.1/24
     node: r1
   - ifindex: 8
-    ifname: Ethernet8
+    ifname: eth8
     ipv4: 10.42.42.2/24
     isis:
       bfd: true
@@ -180,11 +180,11 @@ links:
 - _linkname: links[9]
   interfaces:
   - ifindex: 9
-    ifname: Ethernet9
+    ifname: eth9
     ipv6: 2001:db8:42:1::1/64
     node: r1
   - ifindex: 9
-    ifname: Ethernet9
+    ifname: eth9
     ipv6: 2001:db8:42:1::2/64
     node: r2
   linkindex: 9
@@ -196,11 +196,11 @@ links:
 - _linkname: links[10]
   interfaces:
   - ifindex: 10
-    ifname: Ethernet10
+    ifname: eth10
     ipv4: 10.42.43.1/24
     node: r1
   - ifindex: 10
-    ifname: Ethernet10
+    ifname: eth10
     ipv4: 10.42.43.2/24
     isis:
       bfd:
@@ -218,12 +218,12 @@ links:
 - _linkname: links[11]
   interfaces:
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.25/30
     ipv6: 2001:db8:1:6::1/64
     node: n4
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.26/30
     ipv6: 2001:db8:1:6::2/64
     node: n5
@@ -242,20 +242,13 @@ nodes:
     af:
       ipv4: true
       ipv6: true
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-n4
     id: 3
     interfaces:
-    - clab:
-        name: et1
-      ifindex: 1
-      ifname: Ethernet1
+    - ifindex: 1
+      ifname: eth1
       ipv4: 10.1.0.25/30
       ipv6: 2001:db8:1:6::1/64
       isis:
@@ -264,7 +257,7 @@ nodes:
       linkindex: 11
       name: n4 -> n5
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.26/30
         ipv6: 2001:db8:1:6::2/64
         node: n5
@@ -284,7 +277,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     module:
@@ -297,20 +290,13 @@ nodes:
     bfd:
       min_echo_rx: 0
       multiplier: 3
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-n5
     id: 4
     interfaces:
-    - clab:
-        name: et1
-      ifindex: 1
-      ifname: Ethernet1
+    - ifindex: 1
+      ifname: eth1
       ipv4: 10.1.0.26/30
       ipv6: 2001:db8:1:6::2/64
       isis:
@@ -322,7 +308,7 @@ nodes:
       linkindex: 11
       name: n5 -> n4
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.25/30
         ipv6: 2001:db8:1:6::1/64
         node: n4
@@ -345,7 +331,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
     module:
@@ -358,31 +344,24 @@ nodes:
     bfd:
       min_echo_rx: 0
       multiplier: 3
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-n6
     id: 5
     interfaces:
     - bridge: input_1
-      clab:
-        name: et1
       ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
       ipv4: 172.16.0.5/24
       isis:
         passive: false
       linkindex: 1
       name: Regular (IPv4-only) link, BFD enabled
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.1/24
         node: r1
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.2/24
         node: r2
       type: lan
@@ -400,7 +379,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.105
       mac: 08:4f:a9:05:00:00
     module:
@@ -414,21 +393,14 @@ nodes:
     bfd:
       min_echo_rx: 0
       multiplier: 3
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-r1
     id: 1
     interfaces:
     - bridge: input_1
-      clab:
-        name: et1
       ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
       ipv4: 172.16.0.1/24
       isis:
         bfd:
@@ -437,17 +409,15 @@ nodes:
       linkindex: 1
       name: Regular (IPv4-only) link, BFD enabled
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.2/24
         node: r2
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.5/24
         node: n6
       type: lan
-    - clab:
-        name: et2
-      ifindex: 2
-      ifname: Ethernet2
+    - ifindex: 2
+      ifname: eth2
       ipv4: 10.1.0.1/30
       ipv6: 2001:db8:1::1/64
       isis:
@@ -459,16 +429,14 @@ nodes:
       linkindex: 2
       name: Regular (dual-stack) P2P link, BFD enabled
       neighbors:
-      - ifname: Ethernet2
+      - ifname: eth2
         ipv4: 10.1.0.2/30
         ipv6: 2001:db8:1::2/64
         node: r2
       type: p2p
     - bfd: false
-      clab:
-        name: et3
       ifindex: 3
-      ifname: Ethernet3
+      ifname: eth3
       ipv4: 10.1.0.5/30
       ipv6: 2001:db8:1:1::1/64
       isis:
@@ -477,15 +445,13 @@ nodes:
       linkindex: 3
       name: Link with BFD disabled
       neighbors:
-      - ifname: Ethernet3
+      - ifname: eth3
         ipv4: 10.1.0.6/30
         ipv6: 2001:db8:1:1::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et4
-      ifindex: 4
-      ifname: Ethernet4
+    - ifindex: 4
+      ifname: eth4
       ipv4: 10.1.0.9/30
       ipv6: 2001:db8:1:2::1/64
       isis:
@@ -494,29 +460,25 @@ nodes:
       linkindex: 4
       name: Link with ISIS BFD disabled
       neighbors:
-      - ifname: Ethernet4
+      - ifname: eth4
         ipv4: 10.1.0.10/30
         ipv6: 2001:db8:1:2::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et5
-      ifindex: 5
-      ifname: Ethernet5
+    - ifindex: 5
+      ifname: eth5
       ipv4: 10.1.0.13/30
       ipv6: 2001:db8:1:3::1/64
       linkindex: 5
       name: Link with ISIS disabled
       neighbors:
-      - ifname: Ethernet5
+      - ifname: eth5
         ipv4: 10.1.0.14/30
         ipv6: 2001:db8:1:3::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et6
-      ifindex: 6
-      ifname: Ethernet6
+    - ifindex: 6
+      ifname: eth6
       ipv4: 10.1.0.17/30
       ipv6: 2001:db8:1:4::1/64
       isis:
@@ -528,15 +490,13 @@ nodes:
       linkindex: 6
       name: Link with IPv4-only BFD
       neighbors:
-      - ifname: Ethernet6
+      - ifname: eth6
         ipv4: 10.1.0.18/30
         ipv6: 2001:db8:1:4::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et7
-      ifindex: 7
-      ifname: Ethernet7
+    - ifindex: 7
+      ifname: eth7
       ipv4: 10.1.0.21/30
       ipv6: 2001:db8:1:5::1/64
       isis:
@@ -548,15 +508,13 @@ nodes:
       linkindex: 7
       name: Link with IPv6-only BFD
       neighbors:
-      - ifname: Ethernet7
+      - ifname: eth7
         ipv4: 10.1.0.22/30
         ipv6: 2001:db8:1:5::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et8
-      ifindex: 8
-      ifname: Ethernet8
+    - ifindex: 8
+      ifname: eth8
       ipv4: 10.42.42.1/24
       isis:
         bfd:
@@ -566,14 +524,12 @@ nodes:
       linkindex: 8
       name: IPv4-only link with BFD
       neighbors:
-      - ifname: Ethernet8
+      - ifname: eth8
         ipv4: 10.42.42.2/24
         node: r2
       type: p2p
-    - clab:
-        name: et9
-      ifindex: 9
-      ifname: Ethernet9
+    - ifindex: 9
+      ifname: eth9
       ipv6: 2001:db8:42:1::1/64
       isis:
         bfd:
@@ -583,14 +539,12 @@ nodes:
       linkindex: 9
       name: IPv6-only link with BFD
       neighbors:
-      - ifname: Ethernet9
+      - ifname: eth9
         ipv6: 2001:db8:42:1::2/64
         node: r2
       type: p2p
-    - clab:
-        name: et10
-      ifindex: 10
-      ifname: Ethernet10
+    - ifindex: 10
+      ifname: eth10
       ipv4: 10.42.43.1/24
       isis:
         network_type: point-to-point
@@ -598,7 +552,7 @@ nodes:
       linkindex: 10
       name: IPv4-only link with IPv6-only BFD
       neighbors:
-      - ifname: Ethernet10
+      - ifname: eth10
         ipv4: 10.42.43.2/24
         node: r2
       type: p2p
@@ -620,7 +574,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     module:
@@ -634,38 +588,29 @@ nodes:
     bfd:
       min_echo_rx: 0
       multiplier: 3
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-r2
     id: 2
     interfaces:
     - bridge: input_1
-      clab:
-        name: et1
       ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
       ipv4: 172.16.0.2/24
       isis:
         passive: false
       linkindex: 1
       name: Regular (IPv4-only) link, BFD enabled
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.1/24
         node: r1
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 172.16.0.5/24
         node: n6
       type: lan
-    - clab:
-        name: et2
-      ifindex: 2
-      ifname: Ethernet2
+    - ifindex: 2
+      ifname: eth2
       ipv4: 10.1.0.2/30
       ipv6: 2001:db8:1::2/64
       isis:
@@ -674,16 +619,14 @@ nodes:
       linkindex: 2
       name: Regular (dual-stack) P2P link, BFD enabled
       neighbors:
-      - ifname: Ethernet2
+      - ifname: eth2
         ipv4: 10.1.0.1/30
         ipv6: 2001:db8:1::1/64
         node: r1
       type: p2p
     - bfd: false
-      clab:
-        name: et3
       ifindex: 3
-      ifname: Ethernet3
+      ifname: eth3
       ipv4: 10.1.0.6/30
       ipv6: 2001:db8:1:1::2/64
       isis:
@@ -692,15 +635,13 @@ nodes:
       linkindex: 3
       name: Link with BFD disabled
       neighbors:
-      - ifname: Ethernet3
+      - ifname: eth3
         ipv4: 10.1.0.5/30
         ipv6: 2001:db8:1:1::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et4
-      ifindex: 4
-      ifname: Ethernet4
+    - ifindex: 4
+      ifname: eth4
       ipv4: 10.1.0.10/30
       ipv6: 2001:db8:1:2::2/64
       isis:
@@ -709,29 +650,25 @@ nodes:
       linkindex: 4
       name: Link with ISIS BFD disabled
       neighbors:
-      - ifname: Ethernet4
+      - ifname: eth4
         ipv4: 10.1.0.9/30
         ipv6: 2001:db8:1:2::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et5
-      ifindex: 5
-      ifname: Ethernet5
+    - ifindex: 5
+      ifname: eth5
       ipv4: 10.1.0.14/30
       ipv6: 2001:db8:1:3::2/64
       linkindex: 5
       name: Link with ISIS disabled
       neighbors:
-      - ifname: Ethernet5
+      - ifname: eth5
         ipv4: 10.1.0.13/30
         ipv6: 2001:db8:1:3::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et6
-      ifindex: 6
-      ifname: Ethernet6
+    - ifindex: 6
+      ifname: eth6
       ipv4: 10.1.0.18/30
       ipv6: 2001:db8:1:4::2/64
       isis:
@@ -743,15 +680,13 @@ nodes:
       linkindex: 6
       name: Link with IPv4-only BFD
       neighbors:
-      - ifname: Ethernet6
+      - ifname: eth6
         ipv4: 10.1.0.17/30
         ipv6: 2001:db8:1:4::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et7
-      ifindex: 7
-      ifname: Ethernet7
+    - ifindex: 7
+      ifname: eth7
       ipv4: 10.1.0.22/30
       ipv6: 2001:db8:1:5::2/64
       isis:
@@ -763,15 +698,13 @@ nodes:
       linkindex: 7
       name: Link with IPv6-only BFD
       neighbors:
-      - ifname: Ethernet7
+      - ifname: eth7
         ipv4: 10.1.0.21/30
         ipv6: 2001:db8:1:5::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et8
-      ifindex: 8
-      ifname: Ethernet8
+    - ifindex: 8
+      ifname: eth8
       ipv4: 10.42.42.2/24
       isis:
         network_type: point-to-point
@@ -779,14 +712,12 @@ nodes:
       linkindex: 8
       name: IPv4-only link with BFD
       neighbors:
-      - ifname: Ethernet8
+      - ifname: eth8
         ipv4: 10.42.42.1/24
         node: r1
       type: p2p
-    - clab:
-        name: et9
-      ifindex: 9
-      ifname: Ethernet9
+    - ifindex: 9
+      ifname: eth9
       ipv6: 2001:db8:42:1::2/64
       isis:
         network_type: point-to-point
@@ -794,14 +725,12 @@ nodes:
       linkindex: 9
       name: IPv6-only link with BFD
       neighbors:
-      - ifname: Ethernet9
+      - ifname: eth9
         ipv6: 2001:db8:42:1::1/64
         node: r1
       type: p2p
-    - clab:
-        name: et10
-      ifindex: 10
-      ifname: Ethernet10
+    - ifindex: 10
+      ifname: eth10
       ipv4: 10.42.43.2/24
       isis:
         network_type: point-to-point
@@ -809,7 +738,7 @@ nodes:
       linkindex: 10
       name: IPv4-only link with IPv6-only BFD
       neighbors:
-      - ifname: Ethernet10
+      - ifname: eth10
         ipv4: 10.42.43.1/24
         node: r1
       type: p2p
@@ -826,7 +755,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     module:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -5,6 +5,7 @@ groups:
     - h1
     - h2
     node_data:
+      box: none
       provider: clab
   routers:
     members:
@@ -68,7 +69,7 @@ links:
     ipv4: 10.1.0.5/30
     node: r2
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.6/30
     node: r3
   libvirt:
@@ -85,7 +86,7 @@ links:
     ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 172.16.1.3/24
     node: r3
   - ifindex: 1
@@ -111,7 +112,7 @@ links:
     ipv4: 172.16.2.4/24
     node: h1
   - ifindex: 3
-    ifname: Ethernet3
+    ifname: eth3
     ipv4: 172.16.2.3/24
     node: r3
   - ifindex: 2
@@ -134,7 +135,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -174,7 +175,7 @@ nodes:
       mtu: 1500
       name: h1 -> [r3,h2]
       neighbors:
-      - ifname: Ethernet3
+      - ifname: eth3
         ipv4: 172.16.2.3/24
         node: r3
       - ifname: eth2
@@ -215,7 +216,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts
@@ -238,7 +239,7 @@ nodes:
       mtu: 1500
       name: h2 -> r3
       neighbors:
-      - ifname: Ethernet2
+      - ifname: eth2
         ipv4: 172.16.1.3/24
         node: r3
       role: stub
@@ -256,7 +257,7 @@ nodes:
       - ifname: eth2
         ipv4: 172.16.2.4/24
         node: h1
-      - ifname: Ethernet3
+      - ifname: eth3
         ipv4: 172.16.2.3/24
         node: r3
       role: stub
@@ -395,7 +396,7 @@ nodes:
       linkindex: 3
       name: r2 -> r3
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.6/30
         node: r3
       ospf:
@@ -427,25 +428,20 @@ nodes:
   r3:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
       ports:
       - '2003:22'
-    device: eos
+    device: none
     hostname: clab-input-r3
     id: 3
     interfaces:
     - bridge: input_3
-      clab:
-        name: et1
       ifindex: 1
-      ifname: Ethernet1
+      ifname: eth1
       ipv4: 10.1.0.6/30
       linkindex: 3
+      mtu: 1500
       name: r3 -> r2
       neighbors:
       - ifname: GigabitEthernet0/3
@@ -457,12 +453,11 @@ nodes:
         passive: false
       type: lan
     - bridge: input_4
-      clab:
-        name: et2
       ifindex: 2
-      ifname: Ethernet2
+      ifname: eth2
       ipv4: 172.16.1.3/24
       linkindex: 4
+      mtu: 1500
       name: r3 -> h2
       neighbors:
       - ifname: eth1
@@ -475,12 +470,11 @@ nodes:
       role: stub
       type: lan
     - bridge: input_5
-      clab:
-        name: et3
       ifindex: 3
-      ifname: Ethernet3
+      ifname: eth3
       ipv4: 172.16.2.3/24
       linkindex: 5
+      mtu: 1500
       name: r3 -> [h1,h2]
       neighbors:
       - ifname: eth2
@@ -504,7 +498,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     module:

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -89,7 +89,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -153,7 +153,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts
@@ -216,7 +216,7 @@ nodes:
   s1:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -317,7 +317,7 @@ nodes:
   s2:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -97,7 +97,7 @@ nodes:
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.1
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -171,7 +171,7 @@ nodes:
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.3
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -214,7 +214,7 @@ nodes:
   s1:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -110,7 +110,7 @@ nodes:
   h1:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h1/hosts:/etc/hosts
@@ -176,7 +176,7 @@ nodes:
   h2:
     af:
       ipv4: true
-    box: python:3.13-alpine
+    box: none
     clab:
       binds:
       - clab_files/h2/hosts:/etc/hosts
@@ -242,7 +242,7 @@ nodes:
   s1:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -361,7 +361,7 @@ nodes:
   s2:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -465,7 +465,7 @@ nodes:
   s3:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -684,7 +684,7 @@ nodes:
     af:
       ipv4: true
       vpnv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -138,7 +138,7 @@ nodes:
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -356,7 +356,7 @@ nodes:
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -521,7 +521,7 @@ nodes:
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -22,12 +22,12 @@ links:
 - _linkname: links[1]
   interfaces:
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.1/30
     node: r1
     vrf: red
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.2/30
     node: r2
   linkindex: 1
@@ -39,12 +39,12 @@ links:
 - _linkname: links[2]
   interfaces:
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 10.1.0.5/30
     node: r1
     vrf: blue
   - ifindex: 1
-    ifname: Ethernet1
+    ifname: eth1
     ipv4: 10.1.0.6/30
     node: r3
   linkindex: 2
@@ -56,7 +56,7 @@ links:
   bridge: input_3
   interfaces:
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 172.16.0.3/24
     node: r3
     vrf: yellow
@@ -70,7 +70,7 @@ links:
   bridge: input_4
   interfaces:
   - ifindex: 2
-    ifname: Ethernet2
+    ifname: eth2
     ipv4: 172.16.1.2/24
     node: r2
     vrf: black
@@ -91,62 +91,45 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
-      _cprop_order:
-      - standard
-      - extended
-      - large
-      - link-bandwidth
       advertise_loopback: true
       as: 65000
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         localas_ibgp:
         - standard
-        - large
         - extended
       ipv4: true
       neighbors: []
       next_hop_self: true
       router_id: 10.0.0.1
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-r1
     id: 1
     interfaces:
-    - clab:
-        name: et1
-      ifindex: 1
-      ifname: Ethernet1
+    - ifindex: 1
+      ifname: eth1
       ipv4: 10.1.0.1/30
       linkindex: 1
       name: r1 -> r2
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.2/30
         node: r2
       role: external
       type: p2p
       vrf: red
-    - clab:
-        name: et2
-      ifindex: 2
-      ifname: Ethernet2
+    - ifindex: 2
+      ifname: eth2
       ipv4: 10.1.0.5/30
       linkindex: 2
       name: r1 -> r3
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.6/30
         node: r3
       type: p2p
@@ -177,7 +160,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     module:
@@ -218,15 +201,13 @@ nodes:
             connected:
               auto: true
           interfaces:
-          - clab:
-              name: et2
-            ifindex: 2
-            ifname: Ethernet2
+          - ifindex: 2
+            ifname: eth2
             ipv4: 10.1.0.5/30
             linkindex: 2
             name: r1 -> r3
             neighbors:
-            - ifname: Ethernet1
+            - ifname: eth1
               ipv4: 10.1.0.6/30
               node: r3
             ospf:
@@ -278,24 +259,16 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
-      _cprop_order:
-      - standard
-      - extended
-      - large
-      - link-bandwidth
       advertise_loopback: true
       as: 65001
       community:
         ebgp:
         - standard
-        - large
         ibgp:
         - standard
-        - large
         - extended
         localas_ibgp:
         - standard
-        - large
         - extended
       ipv4: true
       neighbors:
@@ -308,25 +281,18 @@ nodes:
         type: ebgp
       next_hop_self: true
       router_id: 10.0.0.2
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-r2
     id: 2
     interfaces:
-    - clab:
-        name: et1
-      ifindex: 1
-      ifname: Ethernet1
+    - ifindex: 1
+      ifname: eth1
       ipv4: 10.1.0.2/30
       linkindex: 1
       name: r2 -> r1
       neighbors:
-      - ifname: Ethernet1
+      - ifname: eth1
         ipv4: 10.1.0.1/30
         node: r1
         vrf: red
@@ -335,10 +301,8 @@ nodes:
     - bgp:
         advertise: true
       bridge: input_4
-      clab:
-        name: et2
       ifindex: 2
-      ifname: Ethernet2
+      ifname: eth2
       ipv4: 172.16.1.2/24
       linkindex: 4
       name: r2 -> stub
@@ -364,7 +328,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     module:
@@ -422,25 +386,18 @@ nodes:
     af:
       ipv4: true
       vpnv4: true
-    box: ceos:4.33.1F
-    clab:
-      env:
-        CLAB_MGMT_VRF: management
-        INTFTYPE: et
-      kind: ceos
-    device: eos
+    box: none
+    device: none
     hostname: clab-input-r3
     id: 3
     interfaces:
-    - clab:
-        name: et1
-      ifindex: 1
-      ifname: Ethernet1
+    - ifindex: 1
+      ifname: eth1
       ipv4: 10.1.0.6/30
       linkindex: 2
       name: r3 -> r1
       neighbors:
-      - ifname: Ethernet2
+      - ifname: eth2
         ipv4: 10.1.0.5/30
         node: r1
         vrf: blue
@@ -450,10 +407,8 @@ nodes:
         passive: false
       type: p2p
     - bridge: input_3
-      clab:
-        name: et2
       ifindex: 2
-      ifname: Ethernet2
+      ifname: eth2
       ipv4: 172.16.0.3/24
       linkindex: 3
       name: r3 -> stub
@@ -471,7 +426,7 @@ nodes:
       type: loopback
       virtual_interface: true
     mgmt:
-      ifname: Management0
+      ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     module:

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -76,7 +76,7 @@ nodes:
   r1:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -293,7 +293,7 @@ nodes:
   s1:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management
@@ -393,7 +393,7 @@ nodes:
   s2:
     af:
       ipv4: true
-    box: ceos:4.33.1F
+    box: none
     clab:
       env:
         CLAB_MGMT_VRF: management

--- a/tests/topology/input/isis-bfd-test.yml
+++ b/tests/topology/input/isis-bfd-test.yml
@@ -17,12 +17,12 @@ module: [isis, bfd]
 
 provider: clab
 
-defaults.device: eos
+defaults.device: none
 defaults.isis.warnings.inactive: False
 
 nodes:
   r1:
-    device: eos
+    device: none
   r2:
     isis.bfd: true
   n4:

--- a/tests/topology/input/libvirt-clab-complex.yml
+++ b/tests/topology/input/libvirt-clab-complex.yml
@@ -5,6 +5,7 @@ groups:
   hosts:
     members: [h1, h2]
     device: linux
+    box: none
     provider: clab
 
   routers:
@@ -17,7 +18,7 @@ nodes:
   r2:
     device: iosv
   r3:
-    device: eos
+    device: none
     provider: clab
     mtu: 1500
   h1:

--- a/tests/topology/input/vlan-access-links.yml
+++ b/tests/topology/input/vlan-access-links.yml
@@ -1,4 +1,6 @@
 provider: clab
+defaults.devices.eos.clab.image: none
+defaults.devices.linux.clab.image: none
 
 defaults.const.ifname.neighbors: 2      # Regression test for 1709
 

--- a/tests/topology/input/vlan-access-neighbors.yml
+++ b/tests/topology/input/vlan-access-neighbors.yml
@@ -1,4 +1,5 @@
 defaults.device: eos
+defaults.devices.eos.clab.image: none
 provider: clab
 
 nodes:

--- a/tests/topology/input/vlan-access-single.yml
+++ b/tests/topology/input/vlan-access-single.yml
@@ -1,4 +1,6 @@
 provider: clab
+defaults.devices.eos.clab.image: none
+defaults.devices.linux.clab.image: none
 
 vlans:
   red:

--- a/tests/topology/input/vlan-routed-vrf.yml
+++ b/tests/topology/input/vlan-routed-vrf.yml
@@ -1,5 +1,6 @@
 defaults.vlan.warnings.mixed_fwd_check: false
 defaults.devices.frr.clab.image: quay.io/frrouting/frr:10.0.1
+defaults.devices.eos.clab.image: none
 
 addressing:
   unnumbered:

--- a/tests/topology/input/vrf-links.yml
+++ b/tests/topology/input/vrf-links.yml
@@ -1,5 +1,6 @@
 defaults.device: eos
 provider: clab
+defaults.devices.eos.clab.image: none
 
 module: [vrf, bgp, ospf]
 bgp.as: 65000

--- a/tests/topology/input/vrf.yml
+++ b/tests/topology/input/vrf.yml
@@ -1,4 +1,4 @@
-defaults.device: eos
+defaults.device: none
 provider: clab
 
 module: [vrf, bgp, ospf]

--- a/tests/topology/input/vxlan-router-stick.yml
+++ b/tests/topology/input/vxlan-router-stick.yml
@@ -6,6 +6,7 @@
 #
 defaults.device: eos
 provider: clab
+defaults.devices.eos.clab.image: none
 
 groups:
   router:


### PR DESCRIPTION
* Replaced 'eos' device with 'non' in non-VLAN transformation tests
* Set EOS 'clab.image' to 'none' in VLAN transformation tests

Closes #1948