### PR TITLE
Cumulus NVUE: Add initial limited bgp.session support for allowas_in

### DIFF
--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -110,7 +110,8 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Cisco IOSv/IOSvL2   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco Nexus OS      |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
-| Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| Cumulus Linux 4.x   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| Cumulus 5.x (NVUE)  |  ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Junos[^Junos]       |   ❌  |  ✅  |   ❌  |   ❌  |   ❌  |
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |

--- a/netsim/extra/bgp.session/cumulus_nvue.j2
+++ b/netsim/extra/bgp.session/cumulus_nvue.j2
@@ -1,0 +1,42 @@
+---
+{% macro ebgp_neighbor(n) -%}
+aspath:
+  allow-my-asn:
+    enable: {{ 'on' if n.allowas_in|default(False) else 'off' }}
+{%   if n.allowas_in|default(0) > 0 %}
+    occurrences: {{ n.allowas_in }}
+{%   endif %}
+{% endmacro %}
+
+{% macro ebgp_config(vrf,vrf_bgp) -%}
+{%   for n in vrf_bgp.neighbors %}
+{%     if loop.first %}
+- set:
+    vrf:
+      {{ vrf }}:
+        router:
+          bgp:
+            neighbor:
+{%     endif %}
+{%     for a in ['ipv4','ipv6','local_if'] if a in n and n[a] is string %}
+              {{ n[a] }}:
+                address-family:
+{%       for af in ['ipv4','ipv6'] if af in vrf_bgp %}
+                  {{ af }}-unicast:
+{{         ebgp_neighbor(n)|indent(20,first=True) }}
+{%       endfor %}
+{%       if 'evpn' in n %}
+                  l2vpn-evpn:
+{{         ebgp_neighbor(n)|indent(20,first=True) }}
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+{% endmacro %}
+
+{{ ebgp_config('default',bgp) }}
+
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined and vdata.bgp.neighbors is defined %}
+{{ ebgp_config(vname,vdata.bgp) }}
+{%   endfor %}
+{% endif %}

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -35,6 +35,8 @@ devices:
     timers: True
   cumulus:
     copy: frr
+  cumulus_nvue.features.bgp:
+    allowas_in: True
   iosv.features.bgp:
     allowas_in: True
     as_override: True


### PR DESCRIPTION
Used by EVPN test case ```13-vxlan-ebgp-allowas``` (passes)