### PR TITLE
Cumulus NVUE: Add EVPN symmetric IRB support

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -23,16 +23,16 @@ The following table describes per-platform support of individual EVPN/VXLAN feat
 
 | Operating system   | VLAN-based<br>service | VLAN Bundle<br>service | Asymmetric<br>IRB | Symmetric<br>IRB |
 | ------------------ | :-: | :-: | :-: | :-: |
-| Arista EOS         | ✅  | ✅  | ✅  | ✅  |
-| Aruba AOS-CX       | ✅  |  ❌  |  ✅  | ✅[❗](caveats-aruba)  |
+| Arista EOS         | ✅  |  ✅  | ✅  | ✅  |
+| Aruba AOS-CX       | ✅  |  ❌  | ✅  | ✅[❗](caveats-aruba)  |
 | Cisco Nexus OS     | ✅  |  ❌  | ✅  | ✅  |
 | Cumulus Linux 4.x  | ✅  |  ❌  | ✅  | ✅  |
-| Cumulus 5.x (NVUE) | ✅  |  ❌  | ✅ |  ❌ |
+| Cumulus 5.x (NVUE) | ✅  |  ❌  | ✅  | ✅  |
 | Dell OS 10         | ✅  |  ❌  | ✅  | ✅  |
 | FRR                | ✅  |  ❌  | ✅  | ✅  |
-| Nokia SR Linux     | ✅  |  ✅ | ✅  | ✅  |
+| Nokia SR Linux     | ✅  |  ✅  | ✅  | ✅  |
 | Nokia SR OS        | ✅  |  ❌  | ✅  | ✅  |
-| VyOS               | ✅  |  ❌  |  ✅ | ✅  |
+| VyOS               | ✅  |  ❌  | ✅  | ✅  |
 
 The following table describes per-platform support of individual EVPN/MPLS features:
 

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -18,9 +18,8 @@
 {%   if loop.first %}
             neighbor:
 {%   endif %}
-{%   for af in ['ipv4','ipv6'] if af in n %}
-{%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
-              {{ peer }}:
+{%   for a in ['ipv4','ipv6','local_if'] if a in n and n[a] is string %}
+              {{ n[a] }}:
                 address-family:
                   l2vpn-evpn:
                     enable: on
@@ -116,6 +115,15 @@
                route-export:
                  to-evpn:
                    enable: on
+{# This part belongs in the VRF or BGP template, to be moved #}
+               enable: on
+               redistribute:
+                 connected:
+                   enable: on
+{%       if 'ospf' in vdata %}
+                 ospf:
+                   enable: on
+{%       endif %}
 {%     endfor %}
 {%   endfor %}
 {% endif %}

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -35,7 +35,7 @@ features:
     local_as_ibgp: True
     vrf_local_as: False
   evpn:
-    irb: False
+    irb: True
     asymmetrical_irb: True
   gateway:
     protocol: [ anycast, vrrp ]


### PR DESCRIPTION
Together with the other 2 PRs this now passes all EVPN tests except for ```21-bgp-ce-router``` (which is unsupported for now, due to lack of VRF BGP support)