### PR TITLE
Gateway: Remove node level protocol attribute

### DIFF
--- a/netsim/modules/gateway.yml
+++ b/netsim/modules/gateway.yml
@@ -22,7 +22,6 @@ attributes:
       priority: int
       preempt: bool
   node:
-    protocol:
     anycast:
     vrrp:
   can_be_true: [ link ]


### PR DESCRIPTION
Fixes https://github.com/ipspace/netlab/issues/1981

The documentation does not list ```protocol``` as a valid node level attribute, and the code ignores it