### PR TITLE
ansible playbook for SONiC platform backup (for use with `netlab collect`)

### DIFF
--- a/netsim/ansible/tasks/fetch-config/sonic.yml
+++ b/netsim/ansible/tasks/fetch-config/sonic.yml
@@ -1,4 +1,3 @@
-
 # get the core SONiC config file
 - name: save current SONiC configuration to config_db.json
   command: sudo config save -y
@@ -26,7 +25,7 @@
   become: true
   register: file_content
   loop: "{{ sonic_files.files }}"
-  
+
 - name: Save files from /etc/sonic/
   copy:
     content: "{{ item.stdout }}"
@@ -52,7 +51,7 @@
   become: true
   register: frr_file_content
   loop: "{{ frr_files.files }}"
-  
+
 - name: Save files from /etc/sonic/frr/
   copy:
     content: "{{ item.stdout }}"

--- a/netsim/ansible/tasks/fetch-config/sonic.yml
+++ b/netsim/ansible/tasks/fetch-config/sonic.yml
@@ -3,8 +3,8 @@
   command: sudo config save -y
   become: true
 
-# Create inventory-specific frr directory if it doesn't exist
-- name: Create inventory-specific frr directory
+# Create node-specific frr directory if it doesn't exist
+- name: Create node-specific frr directory
   file:
     path: "{{ config_dir }}/{{ inventory_hostname }}-frr"
     state: directory

--- a/netsim/ansible/tasks/fetch-config/sonic.yml
+++ b/netsim/ansible/tasks/fetch-config/sonic.yml
@@ -3,13 +3,12 @@
   command: sudo config save -y
   become: true
 
-# Create frr directory if it doesn't exist
-- name: Create frr directory if it doesn't exist
+# Create inventory-specific frr directory if it doesn't exist
+- name: Create inventory-specific frr directory
   file:
-    path: "{{ config_dir }}/frr"
+    path: "{{ config_dir }}/{{ inventory_hostname }}-frr"
     state: directory
   delegate_to: localhost
-  run_once: true
 
 # Capture all files in /etc/sonic/ directory
 - name: Find all files in /etc/sonic/ directory
@@ -55,6 +54,6 @@
 - name: Save files from /etc/sonic/frr/
   copy:
     content: "{{ item.stdout }}"
-    dest: "{{ config_dir }}/frr/{{ inventory_hostname }}-{{ item.item.path | basename }}"
+    dest: "{{ config_dir }}/{{ inventory_hostname }}-frr/{{ item.item.path | basename }}"
   delegate_to: localhost
   loop: "{{ frr_file_content.results }}"

--- a/netsim/ansible/tasks/fetch-config/sonic.yml
+++ b/netsim/ansible/tasks/fetch-config/sonic.yml
@@ -1,0 +1,61 @@
+
+# get the core SONiC config file
+- name: save current SONiC configuration to config_db.json
+  command: sudo config save -y
+  become: true
+
+# Create frr directory if it doesn't exist
+- name: Create frr directory if it doesn't exist
+  file:
+    path: "{{ config_dir }}/frr"
+    state: directory
+  delegate_to: localhost
+  run_once: true
+
+# Capture all files in /etc/sonic/ directory
+- name: Find all files in /etc/sonic/ directory
+  find:
+    paths: /etc/sonic/
+    recurse: no
+    file_type: file
+  become: true
+  register: sonic_files
+
+- name: Get content of file from /etc/sonic/
+  command: cat {{ item.path }}
+  become: true
+  register: file_content
+  loop: "{{ sonic_files.files }}"
+  
+- name: Save files from /etc/sonic/
+  copy:
+    content: "{{ item.stdout }}"
+    dest: "{{ config_dir }}/{{ inventory_hostname }}-{{ item.item.path | basename }}"
+  delegate_to: localhost
+  loop: "{{ file_content.results }}"
+
+# Capture all files in /etc/sonic/frr directory
+- name: Save FRR running configuration to frr.conf
+  command: vtysh -c 'write'
+  become: true
+
+- name: Find all files in /etc/sonic/frr/ directory
+  find:
+    paths: /etc/sonic/frr/
+    recurse: no
+    file_type: file
+  become: true
+  register: frr_files
+
+- name: Get content of file from /etc/sonic/frr/
+  command: cat {{ item.path }}
+  become: true
+  register: frr_file_content
+  loop: "{{ frr_files.files }}"
+  
+- name: Save files from /etc/sonic/frr/
+  copy:
+    content: "{{ item.stdout }}"
+    dest: "{{ config_dir }}/frr/{{ inventory_hostname }}-{{ item.item.path | basename }}"
+  delegate_to: localhost
+  loop: "{{ frr_file_content.results }}"


### PR DESCRIPTION
## PR overview

this PR adds a SONiC-specific ansible playbook for use with the `netlab collect` process.

currently, when `netlab collect` command is run against a SONiC node, it only attempts to backup the FRR configuration. (and only the `frr.conf` file)  this extends the backup process to do the following:

- save both the SONiC and the FRR configs to their respective storage locations.
- capture the contents of the `/etc/sonic` directory to the host environment.
- capture the contents of the `/etc/sonic/frr` directory to the host environment.

an `frr` subdirectory is created in the `config_dir` to separate these configurations.  the current naming structure (`<config-file>-<inventory_hostname>`) is retained.

## test coverage

- all tests run clean.  though, in reviewing `tests/run-tests.sh` it doesn't look like ansible elements are touched on here. 
