### PR TITLE
Dell OS10: Add 'netlab_save_config' (default:True) to control whether initial config is saved to startup

### DIFF
--- a/netsim/ansible/tasks/deploy-config/dellos10.yml
+++ b/netsim/ansible/tasks/deploy-config/dellos10.yml
@@ -3,10 +3,12 @@
   when: |
     node_provider == 'clab' and ansible_connection == 'network_cli'
 
-- name: "dellos10_config: deploying {{ netsim_action }} from {{ config_template }}"
+- name: "dellos10_config: deploying {{ netsim_action }} from {{ config_template }}, save to startup={{ _save }}"
+  vars:
+    _save: "{{ 'yes' if netlab_save_config|default(True) else 'no' }}"
   dellemc.os10.os10_config:
     match: "none"
     src: "{{ config_template }}"
-    save: "yes"
+    save: "{{ _save }}"
   tags: [ print_action, always ]
   register: os10_output

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -73,6 +73,7 @@ group_vars:
   ansible_connection: network_cli
   ansible_user: vagrant
   ansible_ssh_pass: vagrant
+  netlab_save_config: True   # Whether to save the initial config to startup, default True
 external:
   image: none
 graphite.icon: switch


### PR DESCRIPTION
Test: ```netlab up integration/vlan/41-vlan-bridge-native.yml -p clab -d dellos10 -v -s defaults.devices.dellos10.group_vars.netlab_save_config=False```

```
TASK [dellos10_config: deploying initial from /home/jeroen/Projects/netlab/netsim/ansible/templates/initial/dellos10.j2, save to startup=no]

s1# show diff running-configuration startup-configuration 
!
interface ethernet1/1/1
 switchport mode trunk
 switchport access vlan 700
 switchport trunk allowed vlan 701
 switchport
!
interface ethernet1/1/2
 no ipv6 enable
 description "[Access VLAN red] s1 -> h1"
 switchport access vlan 700
 switchport
!

etc.
```

Fixes https://github.com/ipspace/netlab/issues/1987 (for Dell OS10)