### PR TITLE
JunOS: support for BGP local-as

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -86,6 +86,7 @@ The following features are only supported on a subset of platforms:
 | Cumulus Linux 5.x (NVUE) |  ✅ |  ✅ |  ✅ |  ❌ |
 | Dell OS10                |  ✅ |  ❌  |  ❌  |  ❌  |
 | FRR                      |  ✅ |  ✅ |  ✅ |  ✅ |
+| JunOS                    |  ✅ |  ✅ |  ❌  |  ❌  |
 | Nokia SR Linux           |  ✅ |  ✅ |  ✅ [❗](caveats-srlinux) |  ✅ |
 | Nokia SR OS              |  ✅ |  ✅ |  ❌  |  ❌  |
 | Sonic                    |  ✅ |  ✅ |  ❌  |  ❌  |

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -89,11 +89,15 @@ protocols {
     group ebgp-peers {
       export ebgp-export;
       advertise-inactive;
-{% for n in bgp.neighbors if n.type == 'ebgp' %}
+{# treat localas_ibgp as ebgp session --> no usage of local address #}
+{% for n in bgp.neighbors if (n.type == 'ebgp' or n.type == 'localas_ibgp') %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         peer-as {{ n.as }};
         description {{ n.name }};
+{%     if n.local_as is defined %}
+        local-as {{ n.local_as }}{% if n.replace_global_as|default(True) %} no-prepend-global-as{% endif +%};
+{%     endif %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -79,9 +79,11 @@ protocols {
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
       neighbor {{ n[af] }} {
         description {{ n.name }};
+{%     if n.activate[af]|default(true) %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }
+{%     endif %}
       }
 {%   endfor %}
     }
@@ -98,9 +100,11 @@ protocols {
 {%     if n.local_as is defined %}
         local-as {{ n.local_as }}{% if n.replace_global_as|default(True) %} no-prepend-global-as{% endif +%};
 {%     endif %}
+{%     if n.activate[af]|default(true) %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }
+{%     endif %}
       }
 {%   endfor %}
 {% endfor %}

--- a/netsim/ansible/templates/vrf/junos.bgp.j2
+++ b/netsim/ansible/templates/vrf/junos.bgp.j2
@@ -94,11 +94,14 @@ routing-instances {
         group ebgp-peers {
           export vrf-{{vname}}-ebgp-export;
           advertise-inactive;
-{%   for n in vdata.bgp.neighbors|default([]) if n.type == 'ebgp' %}
+{%   for n in vdata.bgp.neighbors|default([]) if (n.type == 'ebgp' or n.type == 'localas_ibgp') %}
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
           neighbor {{ n[af] }} {
             peer-as {{ n.as }};
             description {{ n.name }};
+{%       if n.local_as is defined %}
+            local-as {{ n.local_as }}{% if n.replace_global_as|default(True) %} no-prepend-global-as{% endif +%};
+{%       endif %}
           }
 {%     endfor %}
 {%   endfor %}

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -20,6 +20,7 @@ features:
       lla: true
   bfd: true
   bgp:
+    activate_af: true
     local_as: true
     local_as_ibgp: true
     vrf_local_as: true

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -19,7 +19,10 @@ features:
     ipv6:
       lla: true
   bfd: true
-  bgp: true
+  bgp:
+    local_as: true
+    local_as_ibgp: true
+    vrf_local_as: true
   gateway:
     protocol: [ vrrp ]
   isis:


### PR DESCRIPTION
Support for BGP local-as and specific AF activate in JunOS.

Passed testing
- bgp/07
- bgp/08
- bgp/09
