### PR TITLE
vJunos-switch: VXLAN and EVPN

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -336,6 +336,10 @@ See also [](caveats-junos).
 
 * You can run Juniper vJunos-switch as a container packaged by Roman Dodin's fork of [vrnetlab](https://github.com/hellt/vrnetlab/). See [_containerlab_ documentation](https://containerlab.dev/manual/kinds/vr-vjunosswitch/) for further details.
 * Use a recent *vrnetlab* release that places the management interface into the **mgmt_junos** routing instance to avoid the conflict between [management IP subnet](clab-vrnetlab) `10.0.0.0/24` and **netlab** loopback addressing.
+* vJunos-switch VLAN configuration uses the so-called *Enterprise Style VLAN configuration* (which uses `family ethernet-switching` on unit 0 of interfaces).
+* For the above reason, the current netlab implementation of vJunos-switch EVPN configuration uses the `switch-options` (*default-switch*) configuration stanza, which leads to some drawbacks/limitations:
+    * All EVPN routes are announced with the same RD (configured under `switch-options`). A RT is configured as well under `switch-options`, but then it is overwritten per-VNI under the `protocol evpn` configuration.
+    * It is not possible to use multiple import/export RT. The *first* import RT is used on the configuration templates as the VNI RT.
 
 See also [](caveats-junos).
 

--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -32,6 +32,7 @@ The following table describes per-platform support of individual EVPN/VXLAN feat
 | FRR                | ✅  |  ❌  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  |  ✅  | ✅  | ✅  |
 | Nokia SR OS        | ✅  |  ❌  | ✅  | ✅  |
+| vJunos-switch [❗](caveats-vjunos-switch) | ✅  |  ❌  | ✅  | ✅  |
 | VyOS               | ✅  |  ❌  | ✅  | ✅  |
 
 The following table describes per-platform support of individual EVPN/MPLS features:
@@ -64,6 +65,7 @@ EVPN module supports IBGP- and EBGP-based EVPN:
 | FRR                | ✅  | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  |
 | Nokia SR OS        | ✅  | ✅  | ✅  | ✅  |
+| vJunos-switch      | ✅  | ✅  |  ❌  |  ❌  |
 | VyOS               | ✅  | ✅  |  ❌  |  ❌  |
 
 With additional nerd knobs ([more details](evpn-weird-designs)), it's possible to implement the more convoluted designs, including:
@@ -82,6 +84,7 @@ With additional nerd knobs ([more details](evpn-weird-designs)), it's possible t
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |
 | Nokia SR OS        | ✅  | ❌   |
+| vJunos-switch      | ✅  | ❌   |
 | VyOS               | ✅  | ❌   |
 
 Most EVPN/VXLAN implementations support only IPv4 VXLAN transport; some can run VXLAN-over-IPv6:
@@ -97,6 +100,7 @@ Most EVPN/VXLAN implementations support only IPv4 VXLAN transport; some can run 
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |
 | Nokia SR OS        | ✅  | ❌   |
+| vJunos-switch      | ✅  | ❌   |
 | VyOS               | ✅  | ❌ [❗](caveats-vyos)   |
 
 (evpn-global-parameters)=

--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -35,6 +35,7 @@ The following table describes per-platform support of individual VXLAN features:
 | FRR                | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅ [❗](caveats-srlinux)  |  ❌  |  ❌  |
 | Nokia SR OS        | ✅  |  ❌  |  ❌  |
+| vJunos-switch      | ✅  | ✅  |  ❌ |
 | VyOS               | ✅  | ✅  | ✅  |
 
 ```{tip}

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -1,0 +1,84 @@
+{# EVPN config using mac-vrf & co #}
+
+{# Enable BGP EVPN for specific neighbors #}
+protocols {
+  bgp {
+{% for af in ['ipv4','ipv6'] if bgp[af] is defined and loopback[af] is defined %}
+    group ibgp-peers-{{ af }} {
+{%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' and n.evpn|default(false) %}
+      neighbor {{ n[af] }} {
+        family evpn {
+          signaling;
+        }
+      }
+{%   endfor %}
+    }
+{% endfor %}
+    group ebgp-peers {
+{% for n in bgp.neighbors if n.type == 'ebgp' and n.evpn|default(false) %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+      neighbor {{ n[af] }} {
+        family evpn {
+          signaling;
+        }
+      }
+{%   endfor %}
+{% endfor %}
+    }
+  }
+}
+
+{# VERY DIRTY HACK here for initial testing - since we can specify only one vrf-target per vni-option, let's use the first import one #}
+protocols {
+  evpn {
+    encapsulation vxlan;
+    default-gateway no-gateway-community;
+    extended-vni-list all;
+{% if vxlan.vlans is defined %}
+    vni-options {
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%     set vlan = vlans[vname] %}
+        vni {{ vlan.vni }} {
+            vrf-target target:{{ vlan.evpn.import[0] }};
+        }
+{%   endfor %}
+    }
+{% endif %}
+  }
+}
+
+
+{# define L3VNI on vrf routing-instance #}
+{% if vrfs is defined %}
+routing-instances {
+
+{%   for n,v in vrfs.items() if v.af is defined and v.evpn is defined %}
+    {{ n }} {
+        protocols {
+            evpn {
+                irb-symmetric-routing {
+                    vni {{ v.evpn.transit_vni }};
+                }
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni {{ v.evpn.transit_vni }};
+                }
+            }
+        }
+        route-distinguisher {{ v.evpn.rd }};
+    }
+{%   endfor %}
+
+}
+
+{%   for vname in vxlan.vlans|default([]) if vlans[vname].vni is defined and vlans[vname].mode|default('') == 'irb' and vlans[vname].vrf is defined %}
+{%     set vlan = vlans[vname] %}
+interfaces {
+    irb.{{ vlan.id }} {
+        proxy-macip-advertisement;
+    }
+}
+{%   endfor %}
+
+{% endif %}

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -67,6 +67,7 @@ routing-instances {
                     advertise direct-nexthop;
                     encapsulation vxlan;
                     vni {{ v.evpn.transit_vni }};
+                    export vrf-{{n}}-ebgp-export;
                 }
             }
         }
@@ -74,6 +75,34 @@ routing-instances {
     }
 {%   endfor %}
 
+}
+
+{# update ospf, ibgp and ebgp export policy options for VRFs #}
+policy-options {
+{%   for n,v in vrfs.items() if v.af is defined and v.evpn is defined %}
+    policy-statement vrf-{{n}}-ospf-export {
+        term redis_evpn {
+            from protocol evpn;
+            then accept;
+        }
+    }
+    policy-statement vrf-{{n}}-ibgp-export {
+        term redis_evpn {
+            from protocol evpn;
+            then accept;
+        }
+    }
+    policy-statement vrf-{{n}}-ebgp-export {
+        term redis_evpn {
+            from protocol evpn;
+            then accept;
+        }
+        term redis_bgp {
+            from protocol bgp;
+            then accept;
+        }
+    }
+{%   endfor %}
 }
 
 {# according to JunOS doc, in case NO ANYCAST GATEWAY is configured, enable 'proxy-macip-advertisement' on central IRB interfaces #}

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -18,6 +18,7 @@ protocols {
 {% for n in bgp.neighbors if n.type == 'ebgp' and n.evpn|default(false) %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
+        accept-remote-nexthop;
         family evpn {
           signaling;
         }
@@ -29,6 +30,8 @@ protocols {
 }
 
 {# VERY DIRTY HACK here for initial testing - since we can specify only one vrf-target per vni-option, let's use the first import one #}
+{# - do it only if vxlan is defined - no need if we are RR only #}
+{% if vxlan is defined %}
 protocols {
   evpn {
     encapsulation vxlan;
@@ -46,6 +49,7 @@ protocols {
 {% endif %}
   }
 }
+{% endif %}
 
 
 {# define L3VNI on vrf routing-instance #}
@@ -72,13 +76,16 @@ routing-instances {
 
 }
 
+{# according to JunOS doc, in case NO ANYCAST GATEWAY is configured, enable 'proxy-macip-advertisement' on central IRB interfaces #}
+interfaces {
 {%   for vname in vxlan.vlans|default([]) if vlans[vname].vni is defined and vlans[vname].mode|default('') == 'irb' and vlans[vname].vrf is defined %}
 {%     set vlan = vlans[vname] %}
-interfaces {
+{%     if not vlan.gateway|default(false) %}
     irb.{{ vlan.id }} {
         proxy-macip-advertisement;
     }
-}
+{%     endif %}
 {%   endfor %}
+}
 
 {% endif %}

--- a/netsim/ansible/templates/vlan/vjunos-switch.j2
+++ b/netsim/ansible/templates/vlan/vjunos-switch.j2
@@ -1,7 +1,7 @@
 
 {# for any vlan != route, define it #}
 vlans {
-{% for vlan,vdata in vlans.items() if vdata.mode != 'route' %}
+{% for vlan,vdata in (vlans|default({})).items() if vdata.mode != 'route' %}
   {{ vlan }} {
     vlan-id {{ vdata.id }};
 

--- a/netsim/ansible/templates/vxlan/vjunos-switch.j2
+++ b/netsim/ansible/templates/vxlan/vjunos-switch.j2
@@ -16,18 +16,12 @@ routing-options {
     }
 }
 
-{% if vxlan.flooding|default('') == 'static' %}
-
 {# define basic VXLAN config in switch-options stanza #}
 switch-options {
     vtep-source-interface {{ vxlan.vtep_interface }};
-{# need to list all possible static vtep here - fine tuning will be done per-vlan #}
-{%   for remote_vtep in vxlan.vtep_list %}
-    remote-vtep-list {{ remote_vtep }};
-{%   endfor %}
 }
 
-{# define VLAN to VXLAN mapping and remote vteps #}
+{# define basic VLAN to VXLAN mapping #}
 {%   if vxlan.vlans is defined %}
 vlans {
 {%     for vname in vxlan.vlans if vlans[vname].vni is defined %}
@@ -35,6 +29,30 @@ vlans {
     {{ vname }} {
         vxlan {
             vni {{ vlan.vni }};
+        }
+    }
+{%     endfor %}
+}
+{%   endif %}
+
+{# different options for vxlan flooding types (static vs evpn) #}
+
+{% if vxlan.flooding|default('') == 'static' %}
+
+switch-options {
+{# need to list all possible static vtep here - fine tuning will be done per-vlan #}
+{%   for remote_vtep in vxlan.vtep_list %}
+    remote-vtep-list {{ remote_vtep }};
+{%   endfor %}
+}
+
+{# define static remote vteps for VXLANs #}
+{%   if vxlan.vlans is defined %}
+vlans {
+{%     for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%       set vlan = vlans[vname] %}
+    {{ vname }} {
+        vxlan {
             ingress-node-replication;
 {%       if vlan.vtep_list is defined %}
 {%         for vtep in vlan.vtep_list %}
@@ -47,34 +65,17 @@ vlans {
 }
 {%   endif %}
 
-
 {% endif %}
-
 
 {% if vxlan.flooding|default('') == 'evpn' %}
 
 {# use switch-options with "fake" RD and RT - the RT will be overwritten per-vni on the protocols->evpn #}
 switch-options {
-    vtep-source-interface {{ vxlan.vtep_interface }};
     route-distinguisher {{ vxlan.vtep }}:65535;
     vrf-target target:{{ bgp.as|default(65535) }}:65535;
 }
 
 {# need to define this to avoid validation errors #}
 protocols evpn encapsulation vxlan;
-
-{# define VLAN to VXLAN mapping #}
-{%   if vxlan.vlans is defined %}
-vlans {
-{%     for vname in vxlan.vlans if vlans[vname].vni is defined %}
-{%       set vlan = vlans[vname] %}
-    {{ vname }} {
-        vxlan {
-            vni {{ vlan.vni }};
-        }
-    }
-{%     endfor %}
-}
-{%   endif %}
 
 {% endif %}

--- a/netsim/ansible/templates/vxlan/vjunos-switch.j2
+++ b/netsim/ansible/templates/vxlan/vjunos-switch.j2
@@ -1,0 +1,51 @@
+{# 
+   vJunos Switch VXLAN: different configuration required if VXLAN static flooding or EVPN-based
+#}
+
+{# first of all, in any case, better to explicitly ECMP load balance per-flow #}
+policy-options {
+    policy-statement ecmp {
+        then {
+            load-balance per-flow;
+        }
+    }
+}
+routing-options {
+    forwarding-table {
+        export ecmp;
+    }
+}
+
+{% if vxlan.flooding|default('') == 'static' %}
+
+{# define basic VXLAN config in switch-options stanza #}
+switch-options {
+    vtep-source-interface {{ vxlan.vtep_interface }};
+{# need to list all possible static vtep here - fine tuning will be done per-vlan #}
+{%   for remote_vtep in vxlan.vtep_list %}
+    remote-vtep-list {{ remote_vtep }};
+{%   endfor %}
+}
+
+{# define VLAN to VXLAN mapping and remote vteps #}
+{%   if vxlan.vlans is defined %}
+vlans {
+{%     for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%       set vlan = vlans[vname] %}
+    {{ vname }} {
+        vxlan {
+            vni {{ vlan.vni }};
+            ingress-node-replication;
+{%       if vlan.vtep_list is defined %}
+{%         for vtep in vlan.vtep_list %}
+            static-remote-vtep-list {{ vtep }};
+{%         endfor %}
+{%       endif %}
+        }
+    }
+{%     endfor %}
+}
+{%   endif %}
+
+
+{% endif %}

--- a/netsim/ansible/templates/vxlan/vjunos-switch.j2
+++ b/netsim/ansible/templates/vxlan/vjunos-switch.j2
@@ -49,3 +49,32 @@ vlans {
 
 
 {% endif %}
+
+
+{% if vxlan.flooding|default('') == 'evpn' %}
+
+{# use switch-options with "fake" RD and RT - the RT will be overwritten per-vni on the protocols->evpn #}
+switch-options {
+    vtep-source-interface {{ vxlan.vtep_interface }};
+    route-distinguisher {{ vxlan.vtep }}:65535;
+    vrf-target target:{{ bgp.as|default(65535) }}:65535;
+}
+
+{# need to define this to avoid validation errors #}
+protocols evpn encapsulation vxlan;
+
+{# define VLAN to VXLAN mapping #}
+{%   if vxlan.vlans is defined %}
+vlans {
+{%     for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%       set vlan = vlans[vname] %}
+    {{ vname }} {
+        vxlan {
+            vni {{ vlan.vni }};
+        }
+    }
+{%     endfor %}
+}
+{%   endif %}
+
+{% endif %}

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -6,6 +6,9 @@ group_vars:
   netlab_device_type: vjunos-switch
 
 features:
+  evpn:
+    asymmetrical_irb: true
+    irb: true
   vlan:
     model: l3-switch
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -11,6 +11,7 @@ features:
     svi_interface_name: irb.{vlan}
     subif_name: "{ifname}.{vlan.access_id}"
     native_routed: true
+  vxlan: true
 
 clab:
   image: vrnetlab/juniper_vjunos-switch:23.4R2-S2.1


### PR DESCRIPTION
This PR uses the "simplistic" default switch options to configure vxlan+evpn on vJunos-switch, which uses the so-called "Enterprise Style VLAN configuration".

Caveats documented.

Despite the drawback of using a single RD for all the announced routes (as required when using switch-options), the supported tests are passing succesfully.

Tests:

* vxlan/01-vxlan-bridging **OK**
* vxlan/02-vxlan-bridging-multinode **OK**
* vxlan/03-vxlan-irb **OK**
* vxlan/04-vxlan-irb-ospf **OK**
* vxlan/05-vxlan-router-stick **OK**
* vxlan/06-vxlan-bridging-multivendor **OK**
* vxlan/07-vxlan-bridging-v6only **not supported**
* vxlan/08-vxlan-alt-vtep **not supported**

* evpn/01-vxlan-bridging **OK**
* evpn/02-vxlan-asymmetric-irb **OK**
* evpn/03-vxlan-symmetric-irb **OK**
* evpn/04-vxlan-central-routing **OK**
* evpn/05-vxlan-l3only **OK**
* evpn/10-vxlan-rr **OK**
* evpn/11-vxlan-ebgp **not supported**
* evpn/12-vxlan-ibgp-ebgp **OK**
* evpn/13-vxlan-ebgp-allowas **not supported**
* evpn/14-vxlan-ebgp-ebgp **not supported**
* evpn/15-vxlan-ebgp-unnumbered **not supported**
* evpn/20-vxlan-irb-ospf **OK**
* evpn/21-bgp-ce-router **OK**
* evpn/22-ospf-ce-router **OK**


Note: merge after #1992 