### PR TITLE
fix indent in list of docker commands in edgetools.yml

### DIFF
--- a/netsim/tools/edgeshark.yml
+++ b/netsim/tools/edgeshark.yml
@@ -32,7 +32,7 @@ docker:
         "--initialcgroup"
         "--brand=Edgeshark"
 
-    - docker run -d
+  - docker run -d
         --name edgeshark
         --publish "5001:5001"
         --restart "unless-stopped"


### PR DESCRIPTION
The additional space of indent was causing a linefeed and the next docker command to be inserted into the ex variable. This caused the eval to see the string in ex as two lines of code to evaluate. The first line ended without a ' causing the SyntaxError  

run_command executing: ['bash', '-c', 'docker network inspect "ghost-in-da-edge" >/dev/null 2>&1 || docker network create "ghost-in-da-edge"']
Traceback (most recent call last):
  File "/usr/local/bin/netlab", line 14, in <module>
    netsim.cli.lab_commands(__file__)
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/__init__.py", line 356, in lab_commands
    mod.run(sys.argv[arg_start:])   # type: ignore
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/up.py", line 368, in run
    run_up(cli_args)
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/up.py", line 346, in run_up
    start_external_tools(args,topology)
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/up.py", line 278, in start_external_tools
    external_commands.execute_tool_commands(cmds,topology)
  File "/usr/local/lib/python3.10/dist-packages/netsim/cli/external_commands.py", line 261, in execute_tool_commands
    cmd = strings.eval_format(cmd,topology)
  File "/usr/local/lib/python3.10/dist-packages/netsim/utils/strings.py", line 116, in eval_format
    return str(eval(ex,dict(data)))      # An awful hack to use f-string specified in a string variable
  File "<string>", line 1
    f'docker run -d --name gostwire --restart "unless-stopped" --pull "always" --read-only --user 65534 --cap-drop ALL --cap-add SYS_ADMIN --cap-add SYS_CHROOT --cap-add SYS_PTRACE --cap-add DAC_READ_SEARCH --cap-add DAC_OVERRIDE --cap-add NET_RAW --cap-add NET_ADMIN --security-opt "apparmor:unconfined" --pid "host" --network "ghost-in-da-edge" --label "com.docker.compose.project=edgeshark" --entrypoint "/gostwire" ghcr.io/siemens/ghostwire "--http=[::]:5000" "--initialcgroup" "--brand=Edgeshark"
    ^
SyntaxError: unterminated string literal (detected at line 1)
