### PR TITLE
JunOS: support for anycast gateway

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -302,6 +302,9 @@ diag debug application httpsd -1
 * Junos cannot have more than one loopback interface per routing instance. Using **loopback** links on Junos devices will result in configuration errors.
 * Junos configuration template configures BFD timers within routing protocol configuration, not on individual interfaces
 * Requires `ncclient` Python package and its dependencies to be installed (`python3 -m pip install ncclient`).
+* Anycast Gateway is not working properly on vSRX and vPTX:
+    * On vPTX, virtual MAC address is ignored, hence the integration test is failing. Removing the support for anycast gateway for now.
+    * On vSRX, not supporting properly vlan configuration (irb), Anycast Gateway cannot be tested.
 
 (caveats-vptx)=
 ## Juniper vPTX

--- a/docs/module/gateway.md
+++ b/docs/module/gateway.md
@@ -27,7 +27,7 @@ The module is supported on these platforms:
 | Cumulus 5.x (NVUE)    | ✅ | ✅ |  ✅ |
 | Dell OS10             | ✅ [❗](caveats-os10) | ✅ [❗](caveats-os10) | ✅ [❗](caveats-os10)  |
 | FRRouting             | ✅  | ✅  | ✅  |
-| Junos[^Junos]         | ❌  | ✅  | ✅  |
+| Junos[^Junos]         | ✅ [❗](caveats-junos)  | ✅  | ✅  |
 | Nokia SR OS           | ✅  | ✅  | ✅  |
 | Nokia SR Linux        | ✅  | ❌  | ❌  |
 | VyOS                  | ❌  | ✅  | ✅  |

--- a/netsim/ansible/templates/gateway/junos.j2
+++ b/netsim/ansible/templates/gateway/junos.j2
@@ -4,6 +4,7 @@ protocols {
   }
 }
 
+{# VRRP interfaces #}
 {% for intf in interfaces if intf.gateway.protocol|default('none') == 'vrrp' %}
 {%   if loop.first %}
 interfaces {
@@ -21,6 +22,28 @@ interfaces {
           no-preempt;
 {%     endif %}
         }
+      }
+    }
+{%   endfor %}
+  }
+{%   if loop.last %}
+}
+{%   endif %}
+{% endfor %}
+
+{# anycast gateway interfaces #}
+{% for intf in interfaces if intf.gateway.protocol|default('none') == 'anycast' %}
+{%   if loop.first %}
+interfaces {
+{%   endif %}
+  {{ intf.ifname }} {
+    virtual-gateway-accept-data;
+{%   for af in 'ipv4','ipv6' if af in intf.gateway and af in intf and intf[af] is string %}
+{# define v4 or v6 mac address #}
+    virtual-gateway-{{ af[2:] }}-mac {{ gateway.anycast.mac|hwaddr('linux') }};
+    family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
+      address {{ intf[af] }} {
+        virtual-gateway-address {{ intf.gateway[af]|ipaddr('address') }};
       }
     }
 {%   endfor %}

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -25,7 +25,7 @@ features:
     local_as_ibgp: true
     vrf_local_as: true
   gateway:
-    protocol: [ vrrp ]
+    protocol: [ anycast, vrrp ]
   isis:
     unnumbered:
       ipv4: true

--- a/netsim/devices/vptx.yml
+++ b/netsim/devices/vptx.yml
@@ -7,6 +7,8 @@ group_vars:
   netlab_device_type: vptx
 
 features:
+  gateway:
+    protocol: [ vrrp ]
   vlan:
     model: l3-switch
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -5,6 +5,8 @@ group_vars:
   netlab_device_type: vsrx
 
 features:
+  gateway:
+    protocol: [ vrrp ]
   vlan:
     model: router
     subif_name: "{ifname}.{vlan.access_id}"

--- a/tests/integration/gateway/01-anycast.yml
+++ b/tests/integration/gateway/01-anycast.yml
@@ -50,6 +50,8 @@ links:
 - interfaces: [ dut, x1, th ]
   prefix: target
 
+defaults.devices.vjunos-router.netlab_validate.ping_h1_v4.wait: 120
+
 validate:
   x1_gw_down:
     description: Shut down IPv6 on the X1 anycast interface so it cannot respond to ND requests


### PR DESCRIPTION
Anycast gateway support for JunOS.

Tested with vJunos-switch, vJunos-router.

On vPTX, reachability test is ok, but the gateway "virtual" MAC address is not used - hence the test is failing. Removing the support for anycast on vPTX for now.

vSRX, not supporting vlan irb cannot be tested.

(caveats documented)

Note: on vJunos-router the test required some additional sleep time before being able to ping hosts - added test param.
