### PR TITLE
JunOS: support for ebgp multihop and bgp allowas-in

### DIFF
--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -113,7 +113,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Cumulus Linux 4.x   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| Junos[^Junos]       |   ❌  |  ✅  |   ❌  |   ❌  |   ❌  |
+| Junos[^Junos]       |   ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |   ❌  |  ✅  |
 | Nokia SR OS         |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |

--- a/docs/plugins/ebgp.multihop.md
+++ b/docs/plugins/ebgp.multihop.md
@@ -17,6 +17,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Cumulus Linux 4.x   |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |
+| JunOS               |  ✅  |  ✅  |
 | Nokia SR Linux      |  ✅  |  ❌   |
 | Nokia SR OS         |  ✅  |  ❌   |
 

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -66,18 +66,23 @@ devices:
     password: True
     remove_private_as: True
     timers: True
-  vptx.features.bgp:
+  junos.features.bgp:
+    allowas_in: True
     as_override: True
     bfd: True
     password: True
     passive: True
     timers: True
+  vptx:
+    copy: junos
   vsrx:
-    copy: vptx
+    copy: junos
   vmx:
-    copy: vptx
+    copy: junos
   vjunos-switch:
-    copy: vptx
+    copy: junos
+  vjunos-router:
+    copy: junos
   routeros7.features.bgp:
     default_originate: True
     allowas_in: True

--- a/netsim/extra/bgp.session/junos.j2
+++ b/netsim/extra/bgp.session/junos.j2
@@ -3,9 +3,12 @@
 {#
    Macro for neighbor attributes
 #}
-{% macro bgp_neighbor(n,bfd) %}
+{% macro bgp_neighbor(n,bfd,af) %}
 {%   if n.as_override|default(false) %}
   as-override;
+{%   endif %}
+{%   if n.allowas_in is defined %}
+  family {{ 'inet' if af == 'ipv4' else 'inet6' }} unicast loops {{ n.allowas_in }};
 {%   endif %}
 {%   if n.bfd|default(False) %}
 {%     if bfd %}
@@ -43,7 +46,7 @@ protocols {
 {%     endif %}
       neighbor {{ n[af] }} {
         {# IBGP neighbor within an address family #}
-        {{ bgp_neighbor(n,bfd) }}
+        {{ bgp_neighbor(n,bfd,af) }}
       }
 {%     if loop.last %}
     }
@@ -57,7 +60,7 @@ protocols {
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         {# EBGP neighbor #}
-        {{ bgp_neighbor(n,bfd) }}
+        {{ bgp_neighbor(n,bfd,af) }}
       }
 {%   endfor %}
 {%     if loop.last %}
@@ -81,7 +84,7 @@ routing-instances {
 {%       endif %}
           neighbor {{ n[af] }} {
             {# THIS HERE IS THE NEIGHBOR (VRF->iBGP) #}
-            {{ bgp_neighbor(n,bfd) }}
+            {{ bgp_neighbor(n,bfd,af) }}
           }
 {%       if loop.last %}
         }
@@ -96,7 +99,7 @@ routing-instances {
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
           neighbor {{ n[af] }} {
             {# THIS HERE IS THE NEIGHBOR (VRF->eBGP) #}
-            {{ bgp_neighbor(n,bfd) }}
+            {{ bgp_neighbor(n,bfd,af) }}
           }
 {%     endfor %}
 {%     if loop.last %}

--- a/netsim/extra/ebgp.multihop/defaults.yml
+++ b/netsim/extra/ebgp.multihop/defaults.yml
@@ -10,6 +10,18 @@ devices:
     copy: frr
   cumulus_nvue.features.bgp:
     multihop: True
+  junos.features.bgp:
+    multihop.vrf: True
+  vjunos-switch:
+    copy: junos
+  vjunos-router:
+    copy: junos
+  vptx:
+    copy: junos
+  vsrx:
+    copy: junos
+  vmx:
+    copy: junos
   iosv.features.bgp:
     multihop.vrf: True
   cat8000v:

--- a/netsim/extra/ebgp.multihop/junos.j2
+++ b/netsim/extra/ebgp.multihop/junos.j2
@@ -5,7 +5,7 @@ protocols {
 {% for n in bgp.neighbors if n.type == 'ebgp' and n.multihop is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
-        multihop;
+        multihop ttl {{ n.multihop }};
 {%     if n._source_lb_data[af] is defined %}
         local-address {{ n._source_lb_data[af]|ipaddr('address') }}
 {%     endif %}
@@ -27,7 +27,7 @@ routing-instances {
 {%   for n in vdata.bgp.neighbors|default([]) if n.type == 'ebgp' and n.multihop is defined %}
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
           neighbor {{ n[af] }} {
-            multihop;
+            multihop ttl {{ n.multihop }};
 {%       if n._source_lb_data[af] is defined %}
         local-address {{ n._source_lb_data[af]|ipaddr('address') }}
 {%       endif %}

--- a/netsim/extra/ebgp.multihop/junos.j2
+++ b/netsim/extra/ebgp.multihop/junos.j2
@@ -1,0 +1,43 @@
+{# global #}
+protocols {
+  bgp {
+    group ebgp-peers {
+{% for n in bgp.neighbors if n.type == 'ebgp' and n.multihop is defined %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+      neighbor {{ n[af] }} {
+        multihop;
+{%     if n._source_lb_data[af] is defined %}
+        local-address {{ n._source_lb_data[af]|ipaddr('address') }}
+{%     endif %}
+      }
+{%   endfor %}
+{% endfor %}
+    }
+  }
+}
+
+{# VRF #}
+routing-instances {
+{% for vname,vdata in (vrfs|default({})).items() %}
+
+  {{vname}} {
+    protocols {
+      bgp {
+        group ebgp-peers {
+{%   for n in vdata.bgp.neighbors|default([]) if n.type == 'ebgp' and n.multihop is defined %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined %}
+          neighbor {{ n[af] }} {
+            multihop;
+{%       if n._source_lb_data[af] is defined %}
+        local-address {{ n._source_lb_data[af]|ipaddr('address') }}
+{%       endif %}
+          }
+{%     endfor %}
+{%   endfor %}
+        }
+      }
+    }
+  }
+
+{% endfor %}
+}

--- a/netsim/extra/ebgp.multihop/plugin.py
+++ b/netsim/extra/ebgp.multihop/plugin.py
@@ -197,9 +197,11 @@ def fix_vrf_loopbacks(ndata: Box, topology: Box) -> None:
         continue
 
       ngb._source_ifname = lb.ifname
+      ngb._source_lb_data = lb
 
     else:
       ngb._source_ifname = ndata.loopback.ifname
+      ngb._source_lb_data = ndata.loopback
 
 '''
 post_transform processing:

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -351,6 +351,13 @@ nodes:
           keepalive: 3
         type: ebgp
       - _source_ifname: Loopback0
+        _source_lb_data:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 456
@@ -492,6 +499,13 @@ nodes:
           keepalive: 3
         type: ebgp
       - _source_ifname: Loopback0
+        _source_lb_data:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 123


### PR DESCRIPTION
Added an additional neigh attribute from the `ebgp.multihop` plugin to expose the entire source loopback data, in order to extract the IP addresses as well (and not only the source interface).

Updated transformation tests as well.

Tests passed:

* bgp.session/01-allowas-in.yml
* bgp.multihop/01-global.yml
* bgp.multihop/02-vrf.yml
