### PR TITLE
vJunos-switch: ebgp evpn overlay

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -65,7 +65,7 @@ EVPN module supports IBGP- and EBGP-based EVPN:
 | FRR                | ✅  | ✅  | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ✅  |  ❌  |  ❌  |
 | Nokia SR OS        | ✅  | ✅  | ✅  | ✅  |
-| vJunos-switch      | ✅  | ✅  |  ❌  |  ❌  |
+| vJunos-switch      | ✅  | ✅  |  ✅  |  ❌  |
 | VyOS               | ✅  | ✅  |  ❌  |  ❌  |
 
 With additional nerd knobs ([more details](evpn-weird-designs)), it's possible to implement the more convoluted designs, including:
@@ -84,7 +84,7 @@ With additional nerd knobs ([more details](evpn-weird-designs)), it's possible t
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |
 | Nokia SR OS        | ✅  | ❌   |
-| vJunos-switch      | ✅  | ❌   |
+| vJunos-switch      | ✅  | ✅   |
 | VyOS               | ✅  | ❌   |
 
 Most EVPN/VXLAN implementations support only IPv4 VXLAN transport; some can run VXLAN-over-IPv6:

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -19,8 +19,15 @@ protocols {
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         accept-remote-nexthop;
+{# EVPN ebgp-based overlay: no-nexthop-change needs to be defined per-neighbor, but we still need to have NHS for inet and inet6.
+# This can be forced on the 'ebgp-export' policy. #}
+        multihop no-nexthop-change;
         family evpn {
-          signaling;
+          signaling {
+{%     if n.allowas_in is defined %}
+            loops {{ n.allowas_in }};
+{%     endif %}
+          }
         }
       }
 {%   endfor %}
@@ -28,6 +35,27 @@ protocols {
     }
   }
 }
+
+{# in case of EVPN ebgp-based overlay, force NHS for inet and inet6 bgp routes #}
+{% for n in bgp.neighbors if n.type == 'ebgp' and n.evpn|default(false) %}
+{%   if loop.first %}
+policy-options {
+    policy-statement ebgp-export {
+{%     for f in [ 'inet', 'inet6' ] %}
+        term bgp_{{ f }}_nhs {
+            from {
+                family {{ f }};
+                protocol bgp;
+            }
+            then {
+                next-hop self;
+            }
+        }
+{%     endfor %}
+    }
+}
+{%   endif %}
+{% endfor %}
 
 {# VERY DIRTY HACK here for initial testing - since we can specify only one vrf-target per vni-option, let's use the first import one #}
 {# - do it only if vxlan is defined - no need if we are RR only #}

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -115,4 +115,4 @@ class JUNOS(_Quirks):
       print("*** DEVICE QUIRKS FOR JUNOS {}".format(node.name))
     fix_unit_0(node,topology)
     check_multiple_loopbacks(node,topology)
-    check_evpn_ebgp(node,topology)
+    #check_evpn_ebgp(node,topology)


### PR DESCRIPTION
Found workarounds for eBGP-based evpn overlay. next-hop-unchanged is not applicable per AF, but per neighbor (and "hidden" under the multihop hierarchy).
Workaround for that is to set the nh unchanged for the peer, and then on the ebgp export filter force next hop to self for bgp inet and inet6 routes.

Now passing tests:
* evpn/11-vxlan-ebgp.yml
* evpn/14-vxlan-ebgp-ebgp.yml

Test evpn/13-vxlan-ebgp-allowas.yml is still under investigation.

To be merged after #2002