### PR TITLE
vJunos-switch: ebgp-ebgp evpn overlay

### DIFF
--- a/docs/module/evpn.md
+++ b/docs/module/evpn.md
@@ -84,7 +84,7 @@ With additional nerd knobs ([more details](evpn-weird-designs)), it's possible t
 | FRR                | ✅  | ✅  |
 | Nokia SR Linux     | ✅  | ❌   |
 | Nokia SR OS        | ✅  | ❌   |
-| vJunos-switch      | ✅  | ❌   |
+| vJunos-switch      | ✅  | ✅   |
 | VyOS               | ✅  | ❌   |
 
 Most EVPN/VXLAN implementations support only IPv4 VXLAN transport; some can run VXLAN-over-IPv6:

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -79,7 +79,7 @@ protocols {
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
       neighbor {{ n[af] }} {
         description {{ n.name }};
-{%     if n.activate[af]|default(true) %}
+{%     if n.activate[af]|default(false) %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }
@@ -100,7 +100,7 @@ protocols {
 {%     if n.local_as is defined %}
         local-as {{ n.local_as }}{% if n.replace_global_as|default(True) %} no-prepend-global-as{% endif +%};
 {%     endif %}
-{%     if n.activate[af]|default(true) %}
+{%     if n.activate[af]|default(false) %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -19,6 +19,7 @@ protocols {
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         accept-remote-nexthop;
+        multihop no-nexthop-change;
         family evpn {
           signaling;
         }

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -101,11 +101,13 @@ def check_multiple_loopbacks(node: Box, topology: Box) -> None:
 def check_evpn_ebgp(node: Box, topology: Box) -> None:
   for ngb in node.get('bgp.neighbors',[]):
     if ngb.type == 'ebgp' and ngb.get('evpn',False):
-      report_quirk(
-        f'EVPN is not supported on EBGP sessions (node {node.name} neighbor {ngb.name})',
-        node=node,
-        category=log.IncorrectType,
-        quirk='evpn_ebgp')
+      ngb_activate = ngb.get('activate', {})
+      if ngb_activate.get('ipv4', False) or ngb_activate.get('ipv6', False):
+        report_quirk(
+          f'EVPN is not supported on EBGP sessions together with other address families (node {node.name} neighbor {ngb.name})',
+          node=node,
+          category=log.IncorrectType,
+          quirk='evpn_ebgp')
 
 class JUNOS(_Quirks):
 


### PR DESCRIPTION
Cleaner proposal instead of #2003 - no workaround needed here, and quirk implemented to allow only ebgp-on-ebgp, as per Juniper validated designs.