### PR TITLE
Cumulus NVUE: VRF local_as works given that the same BGP template is used

### DIFF
--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -34,7 +34,7 @@ features:
     rfc8950: true
     local_as: True
     local_as_ibgp: True
-    vrf_local_as: False
+    vrf_local_as: True
   evpn:
     irb: True
     asymmetrical_irb: True


### PR DESCRIPTION
Passes test ```bgp/09-vrf-localas```, couldn't find a documentation checkbox for it?