### PR TITLE
proposal: global shutdown flag for bgp neigh with no af

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -6,6 +6,7 @@ from ..utils import log
 from .. import data
 from ..data.validate import must_be_int,must_be_dict,must_be_string
 from ..augment import devices
+from .bgp import prune_shutdown_flag
 
 """
 validate_evpn_list
@@ -51,6 +52,10 @@ def enable_evpn_af(node: Box, topology: Box) -> None:
   for bn in node.bgp.get('neighbors',[]):
     if bn.type in bgp_session and 'evpn' in topology.nodes[bn.name].get('module'):
       bn.evpn = True
+      # Additionally, remove neigh shutdown flag for neigh AF
+      for af in ['ipv4','ipv6']:
+        if bn.get(af, False):
+          prune_shutdown_flag(bn, af)
 
 def get_usable_evpn_asn(topology: Box) -> int:
   asn = ( topology.get('evpn.as',None) or


### PR DESCRIPTION
Proposal for #2007

Tested topology data result with:

**bgp/20-dual-stack-activate.yml**

```
bgp:
  neighbors:
  - name: x1
    as: 65000
    type: ibgp
    ipv4: 10.0.0.2
    ipv6: 2001:db8:1:2::1
    activate:
      ipv4: false
      ipv6: true
    shutdown:
      ipv4: true
  - name: x2
    as: 65100
    type: ebgp
    ipv4: 10.1.0.6
    ipv6: 2001:db8:3:1::2
    activate:
      ipv4: true
      ipv6: false
    shutdown:
      ipv6: true
  ipv4: true
  ipv6: true
```


**evpn/12-vxlan-ibgp-ebgp.yml**

```
bgp:
  neighbors:
  - rr: true
    name: spine
    as: 65000
    type: ibgp
    ipv4: 10.0.0.5
    activate:
      ipv4: false
    evpn: true
  - ifindex: 0
    local_as: 65201
    name: spine
    as: 65100
    type: ebgp
    ipv4: 10.1.0.2
    activate:
      ipv4: true
  ipv4: true
```


Tested also with:

* mpls/10-vpn-connected.yml
* mpls/20-vpnv6-connected.yml

to check backward compatibility, even if no actual result can be tested.

No tests for BGP-LU and 6PE, but I expect these to work as well.
