### PR TITLE
device-module-test: Replace deprecated utcnow()

### DIFF
--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -209,7 +209,7 @@ def log_result(
   else:
     RESULTS[test][stage] = result
     RESULTS[test]._version = __version__
-    RESULTS[test]._timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+    RESULTS[test]._timestamp = datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%d %H:%M:%S')
     if image:
       RESULTS[test]._image = image
 

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -209,7 +209,7 @@ def log_result(
   else:
     RESULTS[test][stage] = result
     RESULTS[test]._version = __version__
-    RESULTS[test]._timestamp = datetime.datetime.now(datetime.UTC).strftime('%Y-%m-%d %H:%M:%S')
+    RESULTS[test]._timestamp = datetime.datetime.now(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
     if image:
       RESULTS[test]._image = image
 


### PR DESCRIPTION
Every test generates a warning like this:
```
09:37:23 bgp/01-ebgp-session.yml: create(ok) /home/jeroen/Projects/netlab/tests/integration/./device-module-test:212: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  RESULTS[test]._timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
up(ok) /home/jeroen/Projects/netlab/tests/integration/./device-module-test:212: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  RESULTS[test]._timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
```