### PR TITLE
FRR: Only configure active LDP address families

### DIFF
--- a/netsim/ansible/templates/mpls/frr.ldp.j2
+++ b/netsim/ansible/templates/mpls/frr.ldp.j2
@@ -4,7 +4,7 @@ mpls ldp
 {% if not 'ipv6' in loopback %}
   dual-stack transport-connection prefer ipv4
 {% endif %}
-{% for af in ['ipv4','ipv6'] %}
+{% for af in ['ipv4','ipv6'] if ldp.af[af] is defined %}
   address-family {{ af }}
 {%   if loopback[af] is defined %}
     discovery transport-address {{ loopback[af]|ipaddr('address') }}


### PR DESCRIPTION
Still passes all MPLS tests - without this, FRR complains about incomplete ipv6 configuration