### PR TITLE
Add pointer to relevant loopback interface to BGP neighbor data

### DIFF
--- a/netsim/ansible/templates/bgp/arubacx.macro.j2
+++ b/netsim/ansible/templates/bgp/arubacx.macro.j2
@@ -12,8 +12,8 @@
     if n.replace_global_as|default(True) and n.type != 'localas_ibgp' %} no-prepend replace-as{% endif +%}
 {% endif %}
   neighbor {{ ip }} description {{ n.name }}
-{% if n._source_ifname is defined %}
-  neighbor {{ ip }} update-source {{ n._source_ifname }}
+{% if n._source_intf is defined %}
+  neighbor {{ ip }} update-source {{ n._source_intf.ifname }}
 {% endif %}
 {%- endmacro %}
 {#

--- a/netsim/ansible/templates/bgp/cumulus_nvue.macro.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.macro.j2
@@ -76,8 +76,8 @@
                 capabilities:
                   extended-nexthop: on
 {%       endif %}
-{%       if n._source_ifname is defined %}
-                update-source: {{ n._source_ifname }}
+{%       if n._source_intf is defined %}
+                update-source: {{ n._source_intf.ifname }}
 {%       endif %}
                 remote-as: {{ 'internal' if n.as==bgp.as else n.as }}
 {%       if n.local_as is defined %}

--- a/netsim/ansible/templates/bgp/dellos10.macro.j2
+++ b/netsim/ansible/templates/bgp/dellos10.macro.j2
@@ -17,8 +17,8 @@
 {%   if n.local_as is defined %}
     local-as {{ n.local_as }}{{ ' no-prepend replace-as' if n.replace_global_as|default(True) else '' }}
 {%   endif %}
-{%   if n._source_ifname is defined %}
-    update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+    update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%   if 'ibgp' in n.type %}
 {%     if bgp.next_hop_self is defined and bgp.next_hop_self %}

--- a/netsim/ansible/templates/bgp/eos.macro.j2
+++ b/netsim/ansible/templates/bgp/eos.macro.j2
@@ -13,8 +13,8 @@
 {%   if n.local_as is defined %}
   neighbor {{ peer }} local-as {{ n.local_as }} no-prepend replace-as
 {%   endif %}
-{%   if n._source_ifname is defined %}
-  neighbor {{ peer }} update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+  neighbor {{ peer }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%   if n.type == 'localas_ibgp' %}
   neighbor {{ peer }} next-hop-peer

--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -24,8 +24,8 @@ router bgp {{ bgp.as }}
 {%     set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }}{{ ' interface' if peer!=n[af] else '' }} remote-as {{ n.as }}
   neighbor {{ peer }} description {{ n.name }}
-{%     if n._source_ifname is defined %}
-  neighbor {{ peer }} update-source {{ n._source_ifname }}
+{%     if n._source_intf is defined %}
+  neighbor {{ peer }} update-source {{ n._source_intf.ifname }}
 {%     endif %}
 {%     if n.local_as is defined %}
   neighbor {{ peer }} local-as {{ n.local_as }} {{ 'no-prepend replace-as' if n.replace_global_as|default(True) else '' }}

--- a/netsim/ansible/templates/bgp/ios.macro.j2
+++ b/netsim/ansible/templates/bgp/ios.macro.j2
@@ -9,8 +9,8 @@
     if n.replace_global_as|default(True) and n.type != 'localas_ibgp' %} no-prepend replace-as{% endif +%}
 {% endif %}
   neighbor {{ ip }} description {{ n.name }}
-{% if n._source_ifname is defined %}
-  neighbor {{ ip }} update-source {{ n._source_ifname }}
+{% if n._source_intf is defined %}
+  neighbor {{ ip }} update-source {{ n._source_intf.ifname }}
 {% endif %}
 {%- endmacro %}
 {#

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -72,12 +72,14 @@ protocols {
       type internal;
       export ibgp-export;
       advertise-inactive;
-      local-address {{ loopback[af]|ipaddr('address') }};
 {% if bgp.rr|default(False) %}
       cluster {{ bgp.rr_cluster_id|default(False) or bgp.router_id }};
 {% endif %}
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
       neighbor {{ n[af] }} {
+{%     if n._source_intf[af] is defined %}
+        local-address {{ n._source_intf[af]|ipaddr('address') }};
+{%     endif %}
         description {{ n.name }};
 {%     if n.activate[af]|default(false) %}
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {

--- a/netsim/ansible/templates/bgp/nxos.j2
+++ b/netsim/ansible/templates/bgp/nxos.j2
@@ -32,8 +32,8 @@ router bgp {{ bgp.as }}
 {%   for n in bgp.neighbors if n[af] is defined %}
  neighbor {{ n[af] }} remote-as {{ n.as }}
   description {{ n.name }}
-{%     if n.type == 'ibgp' %}
-  update-source loopback0
+{%     if n.type == 'ibgp' and n._source_intf.ifname is defined %}
+  update-source {{ n._source_intf.ifname }}
 {%     endif %}
   address-family {{ af }} unicast
 {%     if n.type == 'ibgp' %}

--- a/netsim/ansible/templates/bgp/vyos.macro.j2
+++ b/netsim/ansible/templates/bgp/vyos.macro.j2
@@ -8,8 +8,8 @@
 set protocols bgp neighbor {{ peer }}{{ ' interface' if peer!=n[af] else '' }} remote-as {{ n.as }}
 set protocols bgp neighbor {{ peer }} description '{{ n.name }}'
  
-{%   if n.type == 'ibgp' %}
-set protocols bgp neighbor {{ peer }} update-source dum0
+{%   if n.type == 'ibgp' and n._source_intf.ifname is defined %}
+set protocols bgp neighbor {{ peer }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 
 {%   if n.local_as is defined %}

--- a/netsim/extra/ebgp.multihop/arubacx.j2
+++ b/netsim/extra/ebgp.multihop/arubacx.j2
@@ -2,8 +2,8 @@
 {%   if n.multihop is defined %}
   neighbor {{ n[af] }} ebgp-multihop {{ n.multihop if n.multihop < 255 else '255' }}
 {%   endif %}
-{%   if n._source_ifname is defined %}
-  neighbor {{ n[af] }} update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+  neighbor {{ n[af] }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%- endmacro %}
 !

--- a/netsim/extra/ebgp.multihop/eos.j2
+++ b/netsim/extra/ebgp.multihop/eos.j2
@@ -2,8 +2,8 @@
 {%   if n.multihop is defined %}
   neighbor {{ n[af] }} ebgp-multihop {{ n.multihop if n.multihop < 255 else '' }}
 {%   endif %}
-{%   if n._source_ifname is defined %}
-  neighbor {{ n[af] }} update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+  neighbor {{ n[af] }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%- endmacro %}
 !

--- a/netsim/extra/ebgp.multihop/frr.j2
+++ b/netsim/extra/ebgp.multihop/frr.j2
@@ -2,8 +2,8 @@
 {%   if n.multihop is defined %}
   neighbor {{ n[af] }} ebgp-multihop {{ n.multihop if n.multihop < 255 else '' }}
 {%   endif %}
-{%   if n._source_ifname is defined %}
-  neighbor {{ n[af] }} update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+  neighbor {{ n[af] }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%- endmacro %}
 !

--- a/netsim/extra/ebgp.multihop/ios.j2
+++ b/netsim/extra/ebgp.multihop/ios.j2
@@ -2,8 +2,8 @@
 {%   if n.multihop is defined %}
   neighbor {{ n[af] }} ebgp-multihop {{ n.multihop if n.multihop < 255 else '' }}
 {%   endif %}
-{%   if n._source_ifname is defined %}
-  neighbor {{ n[af] }} update-source {{ n._source_ifname }}
+{%   if n._source_intf is defined %}
+  neighbor {{ n[af] }} update-source {{ n._source_intf.ifname }}
 {%   endif %}
 {%- endmacro %}
 !

--- a/netsim/extra/ebgp.multihop/junos.j2
+++ b/netsim/extra/ebgp.multihop/junos.j2
@@ -6,9 +6,9 @@ protocols {
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         multihop ttl {{ n.multihop }};
-{%     if n._source_lb_data[af] is defined %}
-        local-address {{ n._source_lb_data[af]|ipaddr('address') }}
-{%     endif %}
+{%       if n._source_intf[af] is defined %}
+        local-address {{ n._source_intf[af]|ipaddr('address') }}
+{%       endif %}
       }
 {%   endfor %}
 {% endfor %}

--- a/netsim/extra/ebgp.multihop/junos.j2
+++ b/netsim/extra/ebgp.multihop/junos.j2
@@ -28,8 +28,8 @@ routing-instances {
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
           neighbor {{ n[af] }} {
             multihop ttl {{ n.multihop }};
-{%       if n._source_lb_data[af] is defined %}
-        local-address {{ n._source_lb_data[af]|ipaddr('address') }}
+{%       if n._source_intf[af] is defined %}
+        local-address {{ n._source_intf[af]|ipaddr('address') }}
 {%       endif %}
           }
 {%     endfor %}

--- a/netsim/extra/ebgp.multihop/plugin.py
+++ b/netsim/extra/ebgp.multihop/plugin.py
@@ -196,12 +196,10 @@ def fix_vrf_loopbacks(ndata: Box, topology: Box) -> None:
           module='ebgp.multihop')
         continue
 
-      ngb._source_ifname = lb.ifname
-      ngb._source_lb_data = lb
+      ngb._source_intf = lb
 
     else:
-      ngb._source_ifname = ndata.loopback.ifname
-      ngb._source_lb_data = ndata.loopback
+      ngb._source_intf = ndata.loopback
 
 '''
 post_transform processing:

--- a/netsim/extra/ebgp.multihop/srlinux.j2
+++ b/netsim/extra/ebgp.multihop/srlinux.j2
@@ -8,7 +8,7 @@
         admin-state: enable
         maximum-hops: {{ n.multihop|int }}
       transport:
-        local-address: "{{ loopback[af]|ipaddr('address') }}"
+        local-address: "{{ n.source_intf[af]|ipaddr('address') }}"
       description: "{{ n.name }} (multihop={{n.multihop|int}})"
 {%   endif %}
 {%- endmacro %}

--- a/netsim/extra/ebgp.multihop/srlinux.j2
+++ b/netsim/extra/ebgp.multihop/srlinux.j2
@@ -7,8 +7,10 @@
       multihop:
         admin-state: enable
         maximum-hops: {{ n.multihop|int }}
+{%     if n._source_intf[af] is defined  %}
       transport:
-        local-address: "{{ n.source_intf[af]|ipaddr('address') }}"
+        local-address: "{{ n._source_intf[af]|ipaddr('address') }}"
+{%     endif %}
       description: "{{ n.name }} (multihop={{n.multihop|int}})"
 {%   endif %}
 {%- endmacro %}

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -160,7 +160,7 @@ def build_ibgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
           neighbor_data = bgp_neighbor(n,n_intf,'ibgp',sessions,get_neighbor_rr(n))
           if not neighbor_data is None:
             if 'loopback' in node:
-              neighbor_data._source_ifname = node.loopback.ifname
+              neighbor_data._source_intf = node.loopback
             node.bgp.neighbors.append(neighbor_data)
             has_ibgp = True
 
@@ -174,7 +174,7 @@ def build_ibgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
         neighbor_data = bgp_neighbor(n,n_intf,'ibgp',sessions,get_neighbor_rr(n))
         if not neighbor_data is None:
           if 'loopback' in node:
-            neighbor_data._source_ifname = node.loopback.ifname
+            neighbor_data._source_intf = node.loopback
           node.bgp.neighbors.append(neighbor_data)
           has_ibgp = True
 

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -337,7 +337,14 @@ nodes:
       ipv6: true
       neighbors:
       - 6pe: true
-        _source_ifname: Loopback0
+        _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -440,7 +447,14 @@ nodes:
       ipv6: true
       neighbors:
       - 6pe: true
-        _source_ifname: Loopback0
+        _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -122,21 +122,39 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:7::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:7::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:7::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -248,21 +266,39 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:15::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:15::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:15::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -371,21 +407,39 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:2a::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:2a::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:2a::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -472,21 +526,39 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -101,21 +101,42 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::7/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::15
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::7/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::7/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -198,21 +219,42 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::15/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::7
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::15/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::15/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -308,21 +350,42 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::2a/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::7
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::2a/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::15
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::2a/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -405,21 +468,42 @@ nodes:
         - extended
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::1/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::7
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::1/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
         ipv6: 2001:db8::15
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv6: 2001:db8::1/128
+          neighbors: []
+          prefix6: '128'
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -54,7 +54,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -121,7 +129,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -157,14 +157,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.5/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.6
         name: a2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.5/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -228,14 +244,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.5
         name: a1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -299,14 +331,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.7/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.5
         name: a1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.7/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -370,7 +418,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -437,7 +493,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -540,7 +604,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -625,21 +697,45 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: l1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.2
         name: l2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -70,14 +70,26 @@ nodes:
         - standard
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001
         ipv4: 10.0.0.2
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001
@@ -151,14 +163,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001
@@ -235,14 +259,26 @@ nodes:
       ipv4: true
       local_as: 65001
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 4259840001

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -97,7 +97,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -105,7 +111,13 @@ nodes:
         name: s1
         rr: true
         type: ibgp
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -199,7 +211,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -207,7 +225,13 @@ nodes:
         name: s1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -293,21 +317,39 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: l1
         type: ibgp
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.2
         name: l2
         type: ibgp
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -395,21 +437,39 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: l1
         type: ibgp
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.2
         name: l2
         type: ibgp
-      - _source_ifname: loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -260,7 +260,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -268,7 +274,13 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -351,7 +363,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -359,7 +377,13 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -442,7 +466,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -450,14 +480,26 @@ nodes:
         name: rr2
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -523,7 +565,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -531,14 +579,26 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -95,7 +95,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000
@@ -203,7 +210,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          ipv6: 2001:db8:0:3::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv6: true
         as: 65000

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -435,7 +435,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          ipv6: 2001:db8:0:3::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -445,7 +452,14 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          ipv6: 2001:db8:0:3::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -554,7 +568,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          ipv6: 2001:db8:0:4::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -564,7 +585,14 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          ipv6: 2001:db8:0:4::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -673,7 +701,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -683,7 +718,14 @@ nodes:
         name: rr2
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -692,7 +734,14 @@ nodes:
         ipv6: 2001:db8:0:3::1
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -784,7 +833,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -794,7 +850,14 @@ nodes:
         name: rr1
         rr: true
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -803,7 +866,14 @@ nodes:
         ipv6: 2001:db8:0:3::1
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -360,7 +360,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65100
@@ -441,7 +447,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65100
@@ -522,14 +534,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.7
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -687,14 +715,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.7
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -852,21 +896,45 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.7/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.4
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.7/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.6
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.7/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -965,21 +1033,45 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.8/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.4
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.8/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
         ipv4: 10.0.0.6
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.8/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65101
@@ -1078,14 +1170,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.10/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.13
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.10/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
@@ -1243,14 +1351,30 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.12/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.13
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.12/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
@@ -1408,21 +1532,45 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.13/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.10
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.13/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.12
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.13/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
@@ -1521,21 +1669,45 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.14/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.10
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.14/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102
         ipv4: 10.0.0.12
         name: leaf
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.14/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65102

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -350,8 +350,7 @@ nodes:
           hold: 10
           keepalive: 3
         type: ebgp
-      - _source_ifname: Loopback0
-        _source_lb_data:
+      - _source_intf:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.2/32
@@ -498,8 +497,7 @@ nodes:
           hold: 10
           keepalive: 3
         type: ebgp
-      - _source_ifname: Loopback0
-        _source_lb_data:
+      - _source_intf:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.3/32

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -159,7 +159,13 @@ nodes:
       default_originate: true
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
@@ -587,7 +593,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -400,7 +400,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -718,7 +724,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -64,7 +64,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -151,7 +157,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -92,7 +92,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -210,7 +216,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -373,7 +373,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -381,7 +389,15 @@ nodes:
         ipv4: 10.0.0.2
         name: s2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -564,7 +580,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -572,7 +596,15 @@ nodes:
         ipv4: 10.0.0.1
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -702,7 +734,15 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -710,7 +750,15 @@ nodes:
         ipv4: 10.0.0.1
         name: s1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          ospf:
+            area: 0.0.0.0
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -248,7 +248,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.5/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65100
@@ -369,7 +375,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65100

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -73,14 +73,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.2
         name: b
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -127,14 +139,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: a
         type: ibgp
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -182,14 +206,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: a
         type: ibgp
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -237,14 +273,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
         ipv4: 10.0.0.5
         name: e
         type: ibgp
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
@@ -292,14 +340,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.5/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
         ipv4: 10.0.0.4
         name: d
         type: ibgp
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.5/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
@@ -347,14 +407,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
         ipv4: 10.0.0.4
         name: d
         type: ibgp
-      - _source_ifname: lo
+      - _source_intf:
+          ifindex: 0
+          ifname: lo
+          ipv4: 10.0.0.6/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -104,14 +104,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.3
         name: e1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -246,14 +258,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: c1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -341,14 +365,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: c1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -92,7 +92,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001
@@ -213,7 +219,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65001

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -385,7 +385,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -396,7 +403,14 @@ nodes:
         ipv6_label: true
         name: pe2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:0:1::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -509,7 +523,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -520,7 +541,14 @@ nodes:
         ipv6_label: true
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:0:2::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -631,7 +659,14 @@ nodes:
       ipv4: true
       ipv6: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          ipv6: 2001:db8:0:4::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true
@@ -641,7 +676,14 @@ nodes:
         ipv6: 2001:db8:0:1::1
         name: pe1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          ipv6: 2001:db8:0:4::1/64
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
           ipv6: true

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -60,7 +60,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -139,7 +145,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -144,7 +144,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -376,7 +382,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -122,14 +122,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.2
         name: r2
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -340,14 +352,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -505,14 +529,26 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
         ipv4: 10.0.0.1
         name: r1
         type: ibgp
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -210,7 +210,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000
@@ -645,7 +651,13 @@ nodes:
         - extended
       ipv4: true
       neighbors:
-      - _source_ifname: Loopback0
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
         activate:
           ipv4: true
         as: 65000


### PR DESCRIPTION
* Replace multiple values copied into neighbor data by the ebgp.multihop plugin with a pointer to the relevant (global or VRF) loopback interface
* Adjust ebgp multihop templates

Closes #2004 after fixing the related core BGP parameter