### PR TITLE
Add IGP information to loopback interface

### DIFF
--- a/netsim/ansible/templates/eigrp/ios.j2
+++ b/netsim/ansible/templates/eigrp/ios.j2
@@ -8,10 +8,7 @@ router eigrp {{ eigrp.as }}
 {% if eigrp.router_id|ipv4 %}
  eigrp router-id {{ eigrp.router_id }}
 {% endif %}
-{% if 'ipv4' in loopback %}
- network {{ loopback.ipv4|ipaddr('address') }} 0.0.0.0
-{% endif %}
-{% for l in interfaces|default([]) if 'eigrp' in l and 'ipv4' in l  %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv4' in l  %}
  network {{ l.ipv4|ipaddr('address') }} 0.0.0.0
 {% endfor %}
 {% for l in interfaces|default([]) if 'eigrp' in l and l.eigrp.passive %}
@@ -33,16 +30,11 @@ ipv6 router eigrp {{ eigrp.as }}
  eigrp router-id {{ eigrp.router_id }}
 {% endif %}
 
-{% for l in interfaces|default([]) if 'eigrp' in l and l.eigrp.passive %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l and l.eigrp.passive %}
  passive-interface {{ l.ifname }}
 {% endfor %}
-{% if 'ipv6' in loopback and 'ipv6' in eigrp.af %}
 !
-interface Loopback0
- ipv6 eigrp {{ eigrp.as }}
-{% endif %}
-!
-{% for l in interfaces|default([]) if 'eigrp' in l and 'ipv6' in l and 'ipv6' in eigrp.af %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv6' in l and 'ipv6' in eigrp.af %}
 interface {{ l.ifname }}
  ipv6 eigrp {{ eigrp.as }}
 !

--- a/netsim/ansible/templates/eigrp/nxos.j2
+++ b/netsim/ansible/templates/eigrp/nxos.j2
@@ -8,15 +8,7 @@ router eigrp {{ eigrp.as }}
  address-family ipv6 unicast
 {% endif %}
 !
-interface loopback0
-{% if 'ipv4' in loopback and 'ipv4' in eigrp.af %}
- ip router eigrp {{ eigrp.as }}
-{% endif %}
-{% if 'ipv6' in loopback and 'ipv6' in eigrp.af %}
- ipv6 router eigrp {{ eigrp.as }}
-{% endif %}
-!
-{% for l in interfaces|default([]) if 'eigrp' in l %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l %}
 interface {{ l.ifname }}
 {%   if 'ipv4' in l and 'ipv4' in eigrp.af %}
  ip router eigrp {{ eigrp.as }}

--- a/netsim/ansible/templates/isis/eos.j2
+++ b/netsim/ansible/templates/isis/eos.j2
@@ -2,6 +2,6 @@
 {% import "eos.macro.j2" as isis_config with context %}
 !
 {% if isis is defined %}
-{{ isis_config.config(isis,interfaces) }}
+{{ isis_config.config(isis,netlab_interfaces) }}
 !
 {% endif %}

--- a/netsim/ansible/templates/isis/eos.j2
+++ b/netsim/ansible/templates/isis/eos.j2
@@ -4,6 +4,4 @@
 {% if isis is defined %}
 {{ isis_config.config(isis,interfaces) }}
 !
-interface Loopback0
-  isis enable {{ isis.instance }}
 {% endif %}

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -25,7 +25,7 @@ router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
     multi-topology
 {% endif %}
 !
-{% for l in netlab_interfaces|default([]) if 'isis' in l %}
+{% for l in interfaces|default([]) if 'isis' in l %}
 interface {{ l.ifname }}
 ! {{ l.name|default("") }}
   isis enable {{ isis.instance }}

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -25,7 +25,7 @@ router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
     multi-topology
 {% endif %}
 !
-{% for l in interfaces|default([]) if 'isis' in l %}
+{% for l in netlab_interfaces|default([]) if 'isis' in l %}
 interface {{ l.ifname }}
 ! {{ l.name|default("") }}
   isis enable {{ isis.instance }}

--- a/netsim/ansible/templates/isis/frr.j2
+++ b/netsim/ansible/templates/isis/frr.j2
@@ -2,7 +2,7 @@
 {% import "frr.macro.j2" as isis_config with context %}
 !
 {% if isis is defined %}
-{{ isis_config.config(isis,interfaces) }}
+{{ isis_config.config(isis,netlab_interfaces) }}
 !
 do write
 {% endif %}

--- a/netsim/ansible/templates/isis/frr.j2
+++ b/netsim/ansible/templates/isis/frr.j2
@@ -4,13 +4,5 @@
 {% if isis is defined %}
 {{ isis_config.config(isis,interfaces) }}
 !
-interface {{ loopback.ifname }}
-{%   if 'ipv4' in loopback and 'ipv4' in isis.af %}
- ip router isis {{ isis.instance }}
-{%   endif %}
-{%   if 'ipv6' in loopback and 'ipv6' in isis.af %}
- ipv6 router isis {{ isis.instance }}
-{%   endif %}
-!
 do write
 {% endif %}

--- a/netsim/ansible/templates/isis/frr.macro.j2
+++ b/netsim/ansible/templates/isis/frr.macro.j2
@@ -25,7 +25,7 @@ router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
 {%   endfor %}
 {% endfor %}
 !
-{% for l in interfaces|default([]) if 'isis' in l %}
+{% for l in netlab_interfaces|default([]) if 'isis' in l %}
 interface {{ l.ifname }}
 ! {{ l.name|default("") }}
 {%   if 'ipv4' in l and 'ipv4' in isis.af %}

--- a/netsim/ansible/templates/isis/frr.macro.j2
+++ b/netsim/ansible/templates/isis/frr.macro.j2
@@ -25,7 +25,7 @@ router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
 {%   endfor %}
 {% endfor %}
 !
-{% for l in netlab_interfaces|default([]) if 'isis' in l %}
+{% for l in interfaces|default([]) if 'isis' in l %}
 interface {{ l.ifname }}
 ! {{ l.name|default("") }}
 {%   if 'ipv4' in l and 'ipv4' in isis.af %}

--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -4,15 +4,7 @@
 ipv6 unicast-routing
 {% endif %}
 !
-interface Loopback0
-{% if 'ipv4' in loopback and 'ipv4' in isis.af %}
-  ip router isis {{ isis.instance }}
-{% endif %}
-{% if 'ipv6' in loopback and 'ipv6' in isis.af %}
-  ipv6 router isis {{ isis.instance }}
-{% endif %}
-!
-{% for l in interfaces|default([]) if 'isis' in l %}
+{% for l in netlab_interfaces|default([]) if 'isis' in l %}
 interface {{ l.ifname }}
 ! {{ l.name|default("") }}
 {%   if ('ipv4' in l or 'ipv4' in l.dhcp.client|default({})) and 'ipv4' in isis.af %}

--- a/netsim/modules/ripv2.py
+++ b/netsim/modules/ripv2.py
@@ -53,6 +53,3 @@ class RIPv2(_Module):
     _routing.check_vrf_protocol_support(node,proto='ripv2',af='ipv6',feature='ripng',topology=topology)
     for rip_data in _routing.routing_protocol_data(node,'ripv2'):
       adjust_rip_timers(rip_data)
-
-    if 'ripv2' in node and 'loopback' in node:
-      node.loopback.ripv2.passive = False

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -305,6 +305,8 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       ipv6: 2001:db8:0:3::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -411,6 +413,8 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       ipv6: 2001:db8:0:1::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -521,6 +525,8 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       ipv6: 2001:db8:0:2::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -126,6 +126,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:7::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -139,6 +141,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:7::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -152,6 +156,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:7::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -237,6 +243,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:7::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -270,6 +278,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:15::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -283,6 +293,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:15::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -296,6 +308,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:15::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -378,6 +392,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:15::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -411,6 +427,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:2a::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -424,6 +442,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:2a::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -437,6 +457,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:2a::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -497,6 +519,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:2a::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -530,6 +554,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:1::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -543,6 +569,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:1::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -556,6 +584,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8:0:1::1/64
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -600,6 +630,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:1::1/64
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -105,6 +105,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::7/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -119,6 +121,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::7/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -133,6 +137,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::7/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -188,6 +194,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::7/128
+      isis:
+        passive: false
       neighbors: []
       prefix6: '128'
       type: loopback
@@ -223,6 +231,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::15/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -237,6 +247,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::15/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -251,6 +263,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::15/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -319,6 +333,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::15/128
+      isis:
+        passive: false
       neighbors: []
       prefix6: '128'
       type: loopback
@@ -354,6 +370,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::2a/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -368,6 +386,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::2a/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -382,6 +402,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::2a/128
+          isis:
+            passive: false
           neighbors: []
           prefix6: '128'
           type: loopback
@@ -437,6 +459,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::2a/128
+      isis:
+        passive: false
       neighbors: []
       prefix6: '128'
       type: loopback

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -744,6 +744,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -954,6 +955,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1024,6 +1026,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -61,6 +61,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -96,6 +97,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -136,6 +138,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -171,6 +174,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -425,6 +425,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -461,6 +462,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -500,6 +502,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -572,6 +575,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -611,6 +615,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -665,6 +670,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -704,6 +710,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -719,6 +726,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -734,6 +742,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -799,6 +808,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -130,6 +130,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -226,6 +227,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -348,6 +350,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -170,6 +170,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -284,6 +285,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -404,6 +406,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -524,6 +527,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -167,6 +167,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -260,6 +261,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -256,6 +256,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -366,6 +367,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -533,6 +535,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -666,6 +669,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -798,6 +802,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -930,6 +935,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -541,6 +541,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -556,6 +557,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -624,6 +626,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -722,6 +725,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -737,6 +741,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -805,6 +810,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -903,6 +909,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -918,6 +925,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -933,6 +941,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1001,6 +1010,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1040,6 +1050,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1055,6 +1066,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1070,6 +1082,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1138,6 +1151,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1177,6 +1191,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1192,6 +1207,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1260,6 +1276,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1358,6 +1375,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1373,6 +1391,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1441,6 +1460,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1539,6 +1559,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1554,6 +1575,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1569,6 +1591,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1637,6 +1660,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1676,6 +1700,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1691,6 +1716,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1706,6 +1732,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -1774,6 +1801,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -218,6 +218,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -486,6 +486,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -196,6 +196,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      eigrp:
+        passive: false
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -295,6 +297,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      eigrp:
+        passive: false
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -380,6 +384,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      eigrp:
+        passive: false
       ifindex: 0
       ifname: loopback0
       ipv4: 10.0.0.1/32

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -529,6 +529,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -853,6 +854,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -151,6 +151,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -275,6 +276,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -380,6 +380,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -396,6 +397,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -496,6 +498,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -587,6 +590,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -603,6 +607,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -666,6 +671,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -741,6 +747,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -757,6 +764,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -820,6 +828,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -131,6 +131,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -244,6 +245,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -178,6 +178,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -314,6 +315,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -429,6 +431,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -82,6 +82,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -204,6 +205,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -92,6 +92,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.42
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -229,6 +230,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.51
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -352,6 +352,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -595,6 +596,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/id.yml
+++ b/tests/topology/expected/id.yml
@@ -95,6 +95,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -153,6 +154,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -210,6 +212,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -162,9 +162,12 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       ipv6: 2001:db8:0:1::1/64
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -223,9 +226,12 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       ipv6: 2001:db8:0:2::1/64
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -304,9 +310,12 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       ipv6: 2001:db8:0:3::1/64
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -386,9 +395,12 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.4/32
       ipv6: 2001:db8:0:4::1/64
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -475,9 +487,12 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.5/32
       ipv6: 2001:db8:0:5::1/64
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
+++ b/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
@@ -126,12 +126,17 @@ nodes:
       instance: Gandalf
       type: level-2
     loopback:
+      eigrp:
+        passive: false
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -215,12 +220,17 @@ nodes:
       instance: Gandalf
       type: level-2
     loopback:
+      eigrp:
+        passive: false
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -273,6 +273,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -327,6 +329,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -375,6 +379,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -570,6 +576,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -403,6 +403,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -550,6 +552,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -707,6 +711,8 @@ nodes:
       ifindex: 0
       ifname: loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -864,6 +870,8 @@ nodes:
       ifindex: 0
       ifname: lo0.0
       ipv4: 10.0.0.4/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -337,6 +337,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -411,6 +412,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -495,6 +497,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -413,6 +413,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -600,6 +601,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -705,6 +707,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/link-group.yml
+++ b/tests/topology/expected/link-group.yml
@@ -159,6 +159,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -230,6 +231,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -301,6 +303,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -64,6 +64,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -64,6 +64,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -144,6 +145,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -173,6 +173,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -230,6 +232,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -327,6 +331,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -369,6 +375,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.4/32
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -382,6 +390,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.4/32
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -434,6 +444,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -162,6 +162,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -289,6 +291,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -349,6 +349,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -480,6 +481,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -617,6 +619,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -731,6 +734,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -157,6 +157,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -247,6 +248,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -294,6 +296,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -343,6 +343,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -486,6 +487,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -639,6 +641,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -792,6 +795,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.1
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -96,6 +96,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -287,6 +287,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -388,6 +389,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -331,6 +331,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -435,6 +436,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -107,6 +107,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -168,6 +169,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -263,6 +265,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -145,6 +145,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -193,6 +194,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -282,6 +284,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -690,6 +690,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -898,6 +899,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -539,6 +539,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -863,6 +864,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1136,6 +1138,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -221,9 +221,12 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -458,9 +461,12 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -719,6 +725,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -206,6 +206,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -425,6 +426,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -613,6 +615,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -366,9 +366,12 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -755,9 +758,12 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -157,6 +157,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -423,6 +424,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -341,6 +341,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -483,6 +484,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -577,6 +579,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -356,6 +356,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -611,6 +612,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -870,6 +872,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1101,6 +1104,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:


### PR DESCRIPTION
* At the end of common IGP processing, add IGP dictionary to the loopback interface
* The data in the IGP dictionary can be merged with the IGP 'loopback' device feature

Updated templates use 'netlab_interfaces' instead of 'interfaces' and a separate handling of the loopback interface:

* EIGRP
* ISIS for EOS, FRR, IOS

RIPv2 templates already use 'netlab_interface' and just have to be retested. OSPF data (area) was already present on the loopback interface, so there's no extra risk to the existing templates.

Closes #1937