### PR TITLE
Cumulus NVUE: Fix untagged vlan on br_default

### DIFF
--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -6,7 +6,7 @@
       domain:
         br_default:
           type: vlan-aware
-{% set native_vlans = interfaces|selectattr('_vlan_native','defined')|map(attribute='_vlan_native')|list %}
+{% set native_vlans = interfaces|json_query('[*].vlan.native')|list %}
           untagged: {{ vlans[native_vlans|first].id if native_vlans else 'none' }}
           vlan:
 {%     endif %}


### PR DESCRIPTION
```_native_vlan``` is only set for routed interfaces, which aren't connected to the bridge. Need to look at ```vlan.native``` attribute instead

Since the untagged VLAN also gets added as a tagged VLAN, connectivity is not affected