### PR TITLE
Fix: Do not create BGP clist 'path' attribute when 'list' is present

### DIFF
--- a/netsim/modules/routing.py
+++ b/netsim/modules/routing.py
@@ -85,12 +85,13 @@ def normalize_aspath_entry(p_entry: typing.Any, p_idx: int) -> Box:
   if not isinstance(p_entry,Box):
     p_entry = get_box({ 'path': p_entry })
 
-  if 'path' not in p_entry:
+  if 'path' not in p_entry and 'list' not in p_entry:
     p_entry.path = '.*'
 
-  if isinstance(p_entry.path,list):
-    p_list = [ str(p) for p in p_entry.path ]
-    p_entry.path = ' '.join(p_list)
+  if 'path' in p_entry:
+    if isinstance(p_entry.path,list):
+      p_list = [ str(p) for p in p_entry.path ]
+      p_entry.path = ' '.join(p_list)
 
   normalize_routing_entry(p_entry,p_idx)
   return p_entry


### PR DESCRIPTION
The aspath ACL normalization code (also used for clist) was always creating the 'path' attribute which did not work well with the stricter 'valid_with' checking.

Changed the normalization code to add 'path' attribute only if the 'list' attribute is not present.