### PR TITLE
Cumulus NVUE: Reject routed native vlan on a mixed trunk as unsupported

### DIFF
--- a/netsim/ansible/templates/vlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vlan/cumulus_nvue.j2
@@ -6,8 +6,6 @@
       domain:
         br_default:
           type: vlan-aware
-{% set native_vlans = interfaces|json_query('[*].vlan.native')|list %}
-          untagged: {{ vlans[native_vlans|first].id if native_vlans else 'none' }}
           vlan:
 {%     endif %}
             '{{ vdata.id }}': {}
@@ -17,7 +15,7 @@
 {# Note: interface.xyz.vlan is only used for SVI interfaces in case of multiple bridges #}
 
 {% for i in interfaces if (i.vlan.access_id is defined or i.subif_index is defined) and
-                           i.vlan.mode|default(None) != 'route' and
+                          i.vlan.mode|default(None) != 'route' and
                           (i.virtual_interface is not defined or i.type in ["vlan_member","lag"]) %}
 - set:
     interface:

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -65,7 +65,7 @@ def nvue_check_native_routed_on_mixed_trunk(node: Box, topology: Box) -> None:
         continue
       if j.get('vlan.mode','irb') in ['bridge','irb']:          # Are we dealing with a mixed trunk?
         report_quirk(
-          f'Node {node.name} uses a mixed trunk with a routed native VLAN, which is not supported',
+          f"Node {node.name} uses a mixed trunk with a routed native VLAN, which is not supported; suggested to use 'mode: irb' instead",
           quirk='native_routed_on_mixed_trunk',
           category=log.FatalError,
           node=node)

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -65,9 +65,11 @@ def nvue_check_native_routed_on_mixed_trunk(node: Box, topology: Box) -> None:
         continue
       if j.get('vlan.mode','irb') in ['bridge','irb']:          # Are we dealing with a mixed trunk?
         report_quirk(
-          f"Node {node.name} uses a mixed trunk with a routed native VLAN, which is not supported; suggested to use 'mode: irb' instead",
+          f"You cannot use a mixed trunk with a routed native VLAN",
+          more_data=[ f"node {node.name} interface {i.ifname} ({i.name}) vlan {i._vlan_native}" ],
+          more_hints=[ "Use 'mode: irb' instead for the native VLAN" ],
           quirk='native_routed_on_mixed_trunk',
-          category=log.FatalError,
+          category=log.IncorrectType,
           node=node)
 
 """


### PR DESCRIPTION
Better fix for https://github.com/ipspace/netlab/pull/2026

* Leave 'untagged' VLAN on the bridge untouched
* Declare routed native VLAN on mixed trunks as unsupported (test case 61 with all routed vlans works fine)

I considered changing the mode from "route" to "irb" under the hood, but I figured it's better to reject and let the user do that themselves (as it impacts IP address allocation for example)

Tested: ```NETLAB_DEVICE=cumulus_nvue NETLAB_PROVIDER=libvirt ./device-module-test -v vlan```

Confirmed that ```netlab up integration/vlan/63-vlan-mixed-native.yml -p libvirt -d cumulus_nvue -v -s vlans.blue.mode=irb``` works just fine