### PR TITLE
Rewrite the default gateway processing

### DIFF
--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -84,10 +84,10 @@ def transform_data(topology: Box) -> None:
     augment.plugin.execute('post_link_transform',topology)
 
   modules.post_link_transform(topology)
+  augment.nodes.post_link_transform(topology)
 
 def post_transform(topology: Box) -> None:
   augment.validate.process_validation(topology)
-  augment.nodes.post_transform(topology)
   modules.post_transform(topology)
   augment.plugin.execute('post_transform',topology)
   augment.groups.node_config_templates(topology)

--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -50,6 +50,10 @@ routing:
       A routing policy 'match.prefix' condition can match a single address
       family. Use 'match.af' parameter to specify the address family you want to
       match.
+  host_gw:
+    Hosts attached to routers need a shared gateway or a gateway of last resort.
+    In both cases, at least one adjacent router needs a real (not unnumbered/LLA)
+    IP address.
 
 validation:
   nodes:

--- a/netsim/devices/linux.py
+++ b/netsim/devices/linux.py
@@ -8,11 +8,32 @@ from ._common import check_indirect_static_routes
 from ..utils import log
 from ..augment import devices
 
+"""
+The "routing" module is used to configure static routes pointing to the default
+gateway. Linux configuration creates static routes as part of the initial
+configuration template, so it makes no sense to keep the "routing" module active
+on a Linux host if it's only used for static routes.
+"""
+def check_routing_module(node: Box) -> None:
+  if 'routing' not in node.get('module',[]):      # The node is not using the routing module, nothing to do
+    return
+
+  if 'routing' not in node:                       # No routing data in the node
+    return
+  
+  if 'routing' in node and list(node.routing.keys()) != [ 'static' ]:
+    return                                        # There's other routing information, not just static routes
+
+  node.module.remove('routing')                   # Remove the routing module from the node
+  if not node.module:
+    node.pop('module',None)
+
 class Linux(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     check_indirect_static_routes(node)
+    check_routing_module(node)
 
     if devices.get_provider(node,topology) != 'clab':
       return
@@ -23,3 +44,4 @@ class Linux(_Quirks):
         more_hints=[ "Use 'cumulus' for DHCP client or 'dnsmasq' for DHCP server" ],
         category=log.IncorrectType,
         module='quirks')
+

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -15,6 +15,8 @@ features:
     passive: False
   routing:
     static: true
+  initial:
+    ipv6_use_ra: true
 libvirt:
   image: bento/ubuntu-24.04
   group_vars:

--- a/tests/errors/unnumbered-gw.log
+++ b/tests/errors/unnumbered-gw.log
@@ -1,2 +1,5 @@
-IncorrectValue in links: Hosts cannot be attached to subnets where all routers have unnumbered interfaces (found in links[1])
+MissingValue in routing: Host h1 is attached only to subnets where all routers have unnumbered interfaces
+... Set defaults.routing.warnings.host_gw to False to disable this check
+... Hosts attached to routers need a shared gateway or a gateway of last resort. In both
+    cases, at least one adjacent router needs a real (not unnumbered/LLA) IP address.
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -51,11 +51,29 @@ links:
     ifname: Ethernet1
     ipv4: 172.16.1.3/24
     node: r2
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: false
+      id: -2
+      ipv4: 172.16.1.254/24
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.1.5/24
     node: h1
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: false
+      id: -2
+      ipv4: 172.16.1.254/24
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.1.6/24
     node: h2
@@ -85,7 +103,16 @@ links:
     node: r1
     vlan:
       access: red
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 172.16.0.1/24
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.0.7/24
     node: h3
@@ -118,7 +145,16 @@ links:
     node: r2
     vlan:
       access: red
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 172.16.0.1/24
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.0.13/24
     node: h4
@@ -148,7 +184,16 @@ links:
     ifname: Ethernet3
     ipv4: 10.42.42.1/28
     node: r2
-  - ifindex: 2
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: -3
+      ipv4: 10.42.42.13/28
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 2
     ifname: eth2
     ipv4: 10.42.42.2/28
     node: h4
@@ -165,25 +210,34 @@ links:
       mac: 0200.cafe.00ff
       unicast: true
     id: 1
-    ipv4: 10.42.42.1/29
+    ipv4: 10.42.43.1/29
     protocol: anycast
     vrrp:
       group: 1
   interfaces:
   - gateway:
-      ipv4: 10.42.42.1/29
+      ipv4: 10.42.43.1/29
     ifindex: 4
     ifname: Ethernet4
-    ipv4: 10.42.42.2/29
+    ipv4: 10.42.43.2/29
     node: r2
-  - ifindex: 3
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 10.42.43.1/29
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 3
     ifname: eth3
-    ipv4: 10.42.42.3/29
+    ipv4: 10.42.43.3/29
     node: h4
   linkindex: 5
   node_count: 2
   prefix:
-    ipv4: 10.42.42.0/29
+    ipv4: 10.42.43.0/29
   role: stub
   type: lan
 - _linkname: links[6]
@@ -207,7 +261,17 @@ links:
     ipv4: 172.31.31.3/24
     ipv6: 2001:db8:cafe:1::3/64
     node: r2
-  - ifindex: 4
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 172.31.31.1/24
+      ipv6: 2001:db8:cafe:1::1/64
+      protocol: anycast
+      vrrp:
+        group: 1
+    ifindex: 4
     ifname: eth4
     ipv4: 172.31.31.13/24
     ipv6: 2001:db8:cafe:1::d/64
@@ -544,13 +608,13 @@ nodes:
           mac: 0200.cafe.00ff
           unicast: true
         id: 1
-        ipv4: 10.42.42.1/29
+        ipv4: 10.42.43.1/29
         protocol: anycast
         vrrp:
           group: 1
       ifindex: 3
       ifname: eth3
-      ipv4: 10.42.42.3/29
+      ipv4: 10.42.43.3/29
       linkindex: 5
       name: h4 -> r2
       neighbors:
@@ -559,12 +623,12 @@ nodes:
             mac: 0200.cafe.00ff
             unicast: true
           id: 1
-          ipv4: 10.42.42.1/29
+          ipv4: 10.42.43.1/29
           protocol: anycast
           vrrp:
             group: 1
         ifname: Ethernet4
-        ipv4: 10.42.42.2/29
+        ipv4: 10.42.43.2/29
         node: r2
       role: stub
       type: lan
@@ -613,24 +677,84 @@ nodes:
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          idx: 1
+          intf: eth2
+          ipv4: 10.42.42.13
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.42.43.1
+      - ipv4: 172.16.0.0/16
+        nexthop:
+          idx: 3
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          idx: 1
+          intf: eth2
+          ipv4: 10.42.42.13
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.42.43.1
+      - ipv4: 10.0.0.0/24
+        nexthop:
+          idx: 3
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          idx: 1
+          intf: eth2
+          ipv4: 10.42.42.13
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.42.43.1
+      - ipv4: 10.1.0.0/16
+        nexthop:
+          idx: 3
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          idx: 1
+          intf: eth2
+          ipv4: 10.42.42.13
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.42.43.1
+      - ipv4: 10.2.0.0/24
+        nexthop:
+          idx: 3
           intf: eth4
           ipv4: 172.31.31.1
           ipv6: 2001:db8:cafe:1::1
@@ -861,16 +985,16 @@ nodes:
           mac: 0200.cafe.00ff
           unicast: true
         id: 1
-        ipv4: 10.42.42.1/29
+        ipv4: 10.42.43.1/29
         protocol: anycast
       ifindex: 4
       ifname: Ethernet4
-      ipv4: 10.42.42.2/29
+      ipv4: 10.42.43.2/29
       linkindex: 5
       name: r2 -> h4
       neighbors:
       - ifname: eth3
-        ipv4: 10.42.42.3/29
+        ipv4: 10.42.43.3/29
         node: h4
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -144,8 +144,6 @@ links:
   type: p2p
 - _linkname: pod_1_l1_components.tor.links[1]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.0.4/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -163,8 +161,6 @@ links:
   type: lan
 - _linkname: pod_1_l2_components.tor.links[1]
   bridge: input_6
-  gateway:
-    ipv4: 172.16.1.6/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -242,8 +238,6 @@ links:
   type: p2p
 - _linkname: pod_2_l1_components.tor.links[1]
   bridge: input_11
-  gateway:
-    ipv4: 172.16.2.10/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -261,8 +255,6 @@ links:
   type: lan
 - _linkname: pod_2_l2_components.tor.links[1]
   bridge: input_12
-  gateway:
-    ipv4: 172.16.3.12/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -675,7 +667,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
-    module: []
     mtu: 1500
     name: srv
     role: host
@@ -859,7 +850,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.105
       mac: 08:4f:a9:05:00:00
-    module: []
     mtu: 1500
     name: srv
     role: host
@@ -1325,7 +1315,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.109
       mac: 08:4f:a9:09:00:00
-    module: []
     mtu: 1500
     name: srv
     role: host
@@ -1509,7 +1498,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.111
       mac: 08:4f:a9:0b:00:00
-    module: []
     mtu: 1500
     name: srv
     role: host

--- a/tests/topology/expected/device-node-defaults.yml
+++ b/tests/topology/expected/device-node-defaults.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -23,8 +21,6 @@ links:
   type: lan
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -102,10 +102,13 @@ nodes:
       mac: 08:4f:a9:02:00:00
     module:
     - dhcp
+    - routing
     mtu: 1500
     name: dhs
     provider: clab
     role: host
+    routing:
+      static: []
   h1:
     af:
       ipv4: true
@@ -138,4 +141,6 @@ nodes:
     - dhcp
     name: h1
     role: host
+    routing:
+      static: []
 provider: libvirt

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -38,8 +38,6 @@ libvirt:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 192.168.42.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -78,7 +76,9 @@ links:
   interfaces:
   - _vlan_mode: irb
     gateway:
+      id: 1
       ipv6: 2001:db8:cafe:1::1/64
+      protocol: anycast
     ifindex: 2
     ifname: eth2
     ipv6: 2001:db8:cafe:1::2/64
@@ -89,6 +89,15 @@ links:
       client:
         ipv4: true
         ipv6: true
+    gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv6: 2001:db8:cafe:1::1/64
+      protocol: anycast
+      vrrp:
+        group: 1
     ifindex: 1
     ifname: eth1
     ipv6: 2001:db8:cafe:1::5/64
@@ -108,8 +117,6 @@ links:
       ipv4: true
     subnet:
       ipv4: true
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 3
@@ -140,8 +147,6 @@ links:
       ipv4: true
     subnet:
       ipv4: true
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 4
@@ -171,8 +176,21 @@ links:
     subnet:
       ipv4: true
       ipv6: true
+  gateway:
+    anycast:
+      mac: 0200.cafe.00ff
+      unicast: true
+    id: 1
+    ipv6: 2001:db8:cafe:1::1/64
+    protocol: anycast
+    vrrp:
+      group: 1
   interfaces:
   - _vlan_mode: irb
+    gateway:
+      id: 1
+      ipv6: 2001:db8:cafe:1::1/64
+      protocol: anycast
     ifindex: 5
     ifname: eth5
     ipv6: 2001:db8:cafe:1::2/64
@@ -248,6 +266,7 @@ nodes:
     - bridge: input_1
       gateway:
         ipv4: 192.168.42.2/24
+        ipv6: 2001:db8:cafe:d001::2/64
       ifindex: 1
       ifname: eth1
       ipv4: 192.168.42.7/24
@@ -267,6 +286,7 @@ nodes:
       mac: 08:4f:a9:07:00:00
     module:
     - dhcp
+    - routing
     mtu: 1500
     name: dhs
     provider: clab
@@ -278,21 +298,25 @@ nodes:
           idx: 0
           intf: eth1
           ipv4: 192.168.42.2
+          ipv6: 2001:db8:cafe:d001::2
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
           ipv4: 192.168.42.2
+          ipv6: 2001:db8:cafe:d001::2
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
           ipv4: 192.168.42.2
+          ipv6: 2001:db8:cafe:d001::2
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
           ipv4: 192.168.42.2
+          ipv6: 2001:db8:cafe:d001::2
   h1:
     af:
       ipv4: true
@@ -423,6 +447,15 @@ nodes:
         client:
           ipv4: true
           ipv6: true
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv6: 2001:db8:cafe:1::1/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       linkindex: 2
@@ -447,6 +480,8 @@ nodes:
     - dhcp
     name: h3
     role: host
+    routing:
+      static: []
   r1:
     af:
       ipv4: true
@@ -690,6 +725,10 @@ nodes:
         dhcp:
           server:
           - dhs
+        gateway:
+          id: 1
+          ipv6: 2001:db8:cafe:1::1/64
+          protocol: anycast
         id: 1001
         mode: irb
         prefix:
@@ -712,6 +751,10 @@ ospf:
 provider: libvirt
 vlans:
   blue:
+    gateway:
+      id: 1
+      ipv6: 2001:db8:cafe:1::1/64
+      protocol: anycast
     host_count: 1
     id: 1001
     neighbors:

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -44,8 +44,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -67,8 +65,6 @@ links:
   vrf: tenant
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.1.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -90,8 +86,6 @@ links:
   vrf: tenant
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.2.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -113,8 +107,6 @@ links:
   vrf: tenant
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.3.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -197,7 +189,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
-    module: []
     name: h1
     role: host
     routing:
@@ -231,7 +222,7 @@ nodes:
     interfaces:
     - bridge: input_2
       gateway:
-        ipv4: 172.16.1.2/24
+        ipv4: 172.16.1.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.4/24
@@ -249,7 +240,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
-    module: []
     name: h2
     role: host
     routing:
@@ -258,22 +248,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
   h3:
     af:
       ipv4: true
@@ -299,7 +289,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.105
       mac: 08:4f:a9:05:00:00
-    module: []
     name: h3
     role: host
     routing:
@@ -349,7 +338,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.106
       mac: 08:4f:a9:06:00:00
-    module: []
     name: h4
     role: host
     routing:

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -38,8 +38,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -60,8 +58,6 @@ links:
   type: lan
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -82,8 +78,6 @@ links:
   type: lan
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -104,8 +98,6 @@ links:
   type: lan
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.1.3/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -249,7 +241,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.6/24
@@ -278,22 +270,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
   h4:
     af:
       ipv4: true
@@ -303,7 +295,7 @@ nodes:
     interfaces:
     - bridge: input_4
       gateway:
-        ipv4: 172.16.1.3/24
+        ipv4: 172.16.1.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.7/24
@@ -332,22 +324,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.3
+          ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.3
+          ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.3
+          ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.3
+          ipv4: 172.16.1.1
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -187,8 +187,6 @@ links:
   type: p2p
 - _linkname: links[9]
   bridge: input_9
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -206,8 +204,6 @@ links:
   type: lan
 - _linkname: links[10]
   bridge: input_10
-  gateway:
-    ipv4: 172.16.1.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/group-ansible-variables.yml
+++ b/tests/topology/expected/group-ansible-variables.yml
@@ -30,6 +30,8 @@ nodes:
     name: h1
     netlab_device_type: hx
     role: host
+    routing:
+      static: []
   h2:
     af: {}
     ansible_connection: ac
@@ -53,6 +55,8 @@ nodes:
     netlab_device_type: ac2
     provider: clab
     role: host
+    routing:
+      static: []
   h3:
     af: {}
     ansible_connection: ac3
@@ -76,4 +80,6 @@ nodes:
     netlab_device_type: hx
     provider: clab
     role: host
+    routing:
+      static: []
 provider: libvirt

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -31,8 +31,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.1.4/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -60,8 +58,6 @@ links:
   vrf: red_vrf
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.2.4/24
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -81,8 +81,6 @@ links:
   type: p2p
 - _linkname: vlans.red.links[1]
   bridge: input_6
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 3
@@ -105,8 +103,6 @@ links:
     access: red
 - _linkname: vlans.red.links[2]
   bridge: input_7
-  gateway:
-    ipv4: 172.16.0.4/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 3
@@ -659,7 +655,7 @@ nodes:
     interfaces:
     - bridge: input_7
       gateway:
-        ipv4: 172.16.0.4/24
+        ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.6/24
@@ -694,22 +690,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.4
+          ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.4
+          ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.4
+          ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.4
+          ipv4: 172.16.0.1
 provider: libvirt
 vlans:
   red:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -23,8 +23,6 @@ libvirt:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -82,8 +80,6 @@ links:
   type: lan
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.1.3/24
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -104,8 +100,6 @@ links:
   type: lan
 - _linkname: links[5]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.2.3/24
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -166,8 +160,6 @@ nodes:
         node: r2
       type: lan
     - bridge: input_5
-      gateway:
-        ipv4: 172.16.2.3/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.2.4/24
@@ -196,23 +188,23 @@ nodes:
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -245,8 +237,6 @@ nodes:
       role: stub
       type: lan
     - bridge: input_5
-      gateway:
-        ipv4: 172.16.2.3/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.2.5/24
@@ -275,23 +265,23 @@ nodes:
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.1.3
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.1.3
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.1.3
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.3
+          intf: eth1
+          ipv4: 172.16.1.3
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -98,6 +98,8 @@ nodes:
       mac: 08:4f:a9:03:00:00
     name: h1
     role: host
+    routing:
+      static: []
   r1:
     af:
       ipv4: true

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -44,8 +44,6 @@ links:
   type: p2p
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -63,8 +61,6 @@ links:
   type: lan
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.2.1/24
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -82,8 +78,6 @@ links:
   type: lan
 - _linkname: links[5]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.3.1/24
   interfaces:
   - ifindex: 3
     ifname: eth3

--- a/tests/topology/expected/rp-static-gw.yml
+++ b/tests/topology/expected/rp-static-gw.yml
@@ -198,6 +198,16 @@ nodes:
     id: 2
     interfaces:
     - bridge: input_1
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.0.1/24
+        ipv6: 2001:db8:1::1/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.2/24
@@ -235,6 +245,16 @@ nodes:
         node: s2
       type: lan
     - bridge: input_2
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 1
+        ipv4: 172.16.1.1/24
+        ipv6: 2001:db8:1:1::1/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.1.2/24
@@ -322,6 +342,16 @@ nodes:
     id: 3
     interfaces:
     - bridge: input_3
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 17
+        ipv4: 172.16.2.17/24
+        ipv6: 2001:db8:1:2::11/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.2.3/24
@@ -359,6 +389,16 @@ nodes:
         node: s2
       type: lan
     - bridge: input_4
+      gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: 18
+        ipv4: 172.16.3.18/24
+        ipv6: 2001:db8:1:3::12/64
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.3.3/24

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -83,8 +83,6 @@ nodes:
     id: 1
     interfaces:
     - bridge: input_1
-      gateway:
-        ipv4: 172.16.1.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.1/24
@@ -98,7 +96,14 @@ nodes:
       type: lan
     - bridge: input_2
       gateway:
+        anycast:
+          mac: 0200.cafe.00ff
+          unicast: true
+        id: -2
         ipv4: 172.16.0.254/24
+        protocol: anycast
+        vrrp:
+          group: 1
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.0.1/24

--- a/tests/topology/expected/rt-vlan-mode-link-route.yml
+++ b/tests/topology/expected/rt-vlan-mode-link-route.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.3.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -647,8 +645,6 @@ nodes:
       role: stub
       type: lan
     - bridge: input_2
-      gateway:
-        ipv4: 172.16.0.2/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.0.1/24
@@ -664,8 +660,6 @@ nodes:
         node: br
       type: lan
     - bridge: input_3
-      gateway:
-        ipv4: 172.16.0.2/24
       ifindex: 3
       ifname: eth3
       ipv4: 172.16.0.1/24
@@ -691,23 +685,23 @@ nodes:
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 172.16.0.2
+          intf: eth1
+          ipv4: 172.16.3.2
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 172.16.0.2
+          intf: eth1
+          ipv4: 172.16.3.2
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 172.16.0.2
+          intf: eth1
+          ipv4: 172.16.3.2
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 172.16.0.2
+          intf: eth1
+          ipv4: 172.16.3.2
   rt:
     af:
       ipv4: true

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -83,6 +83,8 @@ nodes:
       mac: 08:4f:a9:01:00:00
     name: h1
     role: host
+    routing:
+      static: []
   h2:
     af:
       ipv4: true
@@ -110,6 +112,8 @@ nodes:
       mac: 08:4f:a9:02:00:00
     name: h2
     role: host
+    routing:
+      static: []
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -273,6 +273,8 @@ nodes:
     name: h1
     provider: clab
     role: host
+    routing:
+      static: []
   h2:
     af:
       ipv4: true
@@ -311,6 +313,8 @@ nodes:
     name: h2
     provider: clab
     role: host
+    routing:
+      static: []
   h3:
     af:
       ipv4: true
@@ -346,6 +350,8 @@ nodes:
     name: h3
     provider: clab
     role: host
+    routing:
+      static: []
   h4:
     af:
       ipv4: true
@@ -381,6 +387,8 @@ nodes:
     name: h4
     provider: clab
     role: host
+    routing:
+      static: []
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -262,6 +262,8 @@ nodes:
     name: h1
     provider: clab
     role: host
+    routing:
+      static: []
   h2:
     af:
       ipv4: true
@@ -302,6 +304,8 @@ nodes:
     name: h2
     provider: clab
     role: host
+    routing:
+      static: []
   h3:
     af:
       ipv4: true
@@ -342,6 +346,8 @@ nodes:
     name: h3
     provider: clab
     role: host
+    routing:
+      static: []
   h4:
     af:
       ipv4: true
@@ -382,6 +388,8 @@ nodes:
     name: h4
     provider: clab
     role: host
+    routing:
+      static: []
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -17,8 +17,6 @@ links:
   type: stub
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 2
     ifname: Ethernet2

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: vlans.red.links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -57,8 +55,6 @@ links:
     access: red
 - _linkname: vlans.red.links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -166,7 +162,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.17/24
@@ -197,22 +193,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -17,8 +17,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -59,8 +57,6 @@ links:
   type: lan
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.1.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -141,7 +137,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.1.2/24
+        ipv4: 172.16.1.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.4/24
@@ -167,22 +163,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -55,8 +53,6 @@ links:
     access: red
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -189,7 +185,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.5/24
@@ -223,22 +219,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -51,8 +49,6 @@ links:
     access: red
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.3/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -172,7 +168,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.0.3/24
+        ipv4: 172.16.0.2/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.4/24
@@ -212,22 +208,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.3
+          ipv4: 172.16.0.2
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.2.1/24
   interfaces:
   - _vlan_mode: route
     ifindex: 1
@@ -78,7 +76,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
-    module: []
     name: h1
     role: host
     routing:

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - _vlan_mode: route
     ifindex: 1
@@ -29,8 +27,6 @@ links:
     mode: route
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - _vlan_mode: route
     ifindex: 2

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -4,8 +4,6 @@ input:
 links:
 - _linkname: links[1]
   bridge: input_1
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -28,8 +26,6 @@ links:
   type: lan
 - _linkname: links[2]
   bridge: input_2
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -50,8 +46,6 @@ links:
   type: lan
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 1
@@ -74,8 +68,6 @@ links:
   type: lan
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.1.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 2
@@ -96,8 +88,6 @@ links:
   type: lan
 - _linkname: links[5]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.2.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 3
@@ -118,8 +108,6 @@ links:
   type: lan
 - _linkname: links[6]
   bridge: input_6
-  gateway:
-    ipv4: 172.16.2.2/24
   interfaces:
   - _vlan_mode: irb
     ifindex: 3
@@ -223,8 +211,6 @@ nodes:
         node: h3
       type: lan
     - bridge: input_6
-      gateway:
-        ipv4: 172.16.2.2/24
       ifindex: 2
       ifname: eth2
       ipv4: 172.16.2.3/24
@@ -252,23 +238,23 @@ nodes:
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.2
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.2
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.2
+          intf: eth1
+          ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 172.16.2.2
+          intf: eth1
+          ipv4: 172.16.0.1
   h2:
     af:
       ipv4: true
@@ -332,7 +318,7 @@ nodes:
     interfaces:
     - bridge: input_3
       gateway:
-        ipv4: 172.16.0.2/24
+        ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.5/24
@@ -361,22 +347,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.0.2
+          ipv4: 172.16.0.1
   h4:
     af:
       ipv4: true
@@ -386,7 +372,7 @@ nodes:
     interfaces:
     - bridge: input_4
       gateway:
-        ipv4: 172.16.1.2/24
+        ipv4: 172.16.1.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.1.6/24
@@ -415,22 +401,22 @@ nodes:
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.0.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.1.0.0/16
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
       - ipv4: 10.2.0.0/24
         nexthop:
           idx: 0
           intf: eth1
-          ipv4: 172.16.1.2
+          ipv4: 172.16.1.1
   h5:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -69,8 +69,6 @@ links:
       red: {}
 - _linkname: links[3]
   bridge: input_3
-  gateway:
-    ipv4: 172.16.0.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -95,8 +93,6 @@ links:
   vrf: red
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.1.1/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -121,8 +117,6 @@ links:
   vrf: blue
 - _linkname: links[5]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.2.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -147,8 +141,6 @@ links:
   vrf: red
 - _linkname: links[6]
   bridge: input_6
-  gateway:
-    ipv4: 172.16.3.2/24
   interfaces:
   - ifindex: 1
     ifname: eth1

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -71,7 +71,16 @@ links:
     node: s1
     vlan:
       access: red
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 172.16.0.1/24
+      protocol: vrrp
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.0.4/24
     node: h1
@@ -108,7 +117,16 @@ links:
     node: s2
     vlan:
       access: red
-  - ifindex: 1
+  - gateway:
+      anycast:
+        mac: 0200.cafe.00ff
+        unicast: true
+      id: 1
+      ipv4: 172.16.0.1/24
+      protocol: vrrp
+      vrrp:
+        group: 1
+    ifindex: 1
     ifname: eth1
     ipv4: 172.16.0.5/24
     node: h2

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -167,6 +167,8 @@ nodes:
       mac: 08:4f:a9:04:00:00
     name: h1
     role: host
+    routing:
+      static: []
   h2:
     af:
       ipv4: true
@@ -195,6 +197,8 @@ nodes:
       mac: 08:4f:a9:05:00:00
     name: h2
     role: host
+    routing:
+      static: []
   h3:
     af:
       ipv4: true
@@ -223,6 +227,8 @@ nodes:
       mac: 08:4f:a9:06:00:00
     name: h3
     role: host
+    routing:
+      static: []
   h4:
     af:
       ipv4: true
@@ -251,6 +257,8 @@ nodes:
       mac: 08:4f:a9:07:00:00
     name: h4
     role: host
+    routing:
+      static: []
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -93,8 +93,6 @@ links:
   type: p2p
 - _linkname: links[4]
   bridge: input_4
-  gateway:
-    ipv4: 172.16.2.6/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -113,8 +111,6 @@ links:
   vrf: red
 - _linkname: links[5]
   bridge: input_5
-  gateway:
-    ipv4: 172.16.3.7/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -133,8 +129,6 @@ links:
   vrf: red
 - _linkname: links[6]
   bridge: input_6
-  gateway:
-    ipv4: 172.16.4.8/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -153,8 +147,6 @@ links:
   vrf: red
 - _linkname: links[7]
   bridge: input_7
-  gateway:
-    ipv4: 172.16.5.6/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -173,8 +165,6 @@ links:
   vrf: blue
 - _linkname: links[8]
   bridge: input_8
-  gateway:
-    ipv4: 172.16.6.7/24
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -224,7 +214,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
-    module: []
     name: bh1
     role: host
     routing:
@@ -275,7 +264,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.105
       mac: 08:4f:a9:05:00:00
-    module: []
     name: bh2
     role: host
     routing:
@@ -397,7 +385,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
-    module: []
     name: rh1
     role: host
     routing:
@@ -448,7 +435,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
-    module: []
     name: rh2
     role: host
     routing:
@@ -499,7 +485,6 @@ nodes:
       ifname: eth0
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
-    module: []
     name: rh3
     role: host
     routing:

--- a/tests/topology/input/anycast-gateway.yml
+++ b/tests/topology/input/anycast-gateway.yml
@@ -50,7 +50,7 @@ links:
 - r2:
   h4:
   prefix:
-    ipv4: 10.42.42.0/29
+    ipv4: 10.42.43.0/29
   gateway: true
 - r2:
   h4:

--- a/tests/topology/input/dhcp-vlan.yml
+++ b/tests/topology/input/dhcp-vlan.yml
@@ -17,6 +17,8 @@ vlans:
     links: [s1-h1, s1-h2]
   blue:
     prefix.ipv6: 2001:db8:cafe:1::/64
+    gateway.id: 1
+    gateway.protocol: anycast
     links:
     - s1:
       r1:
@@ -32,9 +34,7 @@ nodes:
       blue:
         dhcp.server: dhs
   h1:
-    device: linux
   h2:
-    device: linux
   h3:
   r1:
     device: none
@@ -54,5 +54,3 @@ links:
     ipv4: dhcp
     ipv6: dhcp
   vlan.access: blue
-  gateway.id: 1
-  gateway.protocol: anycast


### PR DESCRIPTION
* Use the 'gateway' next hop when creating host default routes
* Create host default routes for IPv6 if the host does not use RA
* Add 'create GW of last resort' functionality to the static route processing
* Remove the 'add link/vlan gateway' code as this is now handled by the static route processing