### PR TITLE
Treat custom config requests with .j2 suffix differently

### DIFF
--- a/netsim/ansible/tasks/deploy-custom-config.yml
+++ b/netsim/ansible/tasks/deploy-custom-config.yml
@@ -16,7 +16,7 @@
     node_provider: "{{ provider|default(netlab_provider) }}"
     params:
       paths: "{{ paths_custom.dirs }}"
-      files: "{{ paths_custom.files }}"
+      files: "{{ [ custom_config ] if custom_config.endswith('.j2') else paths_custom.files }}"
 
 - fail: msg="Cannot find configuration template {{ custom_config }} for device {{ inventory_hostname }}"
   when: config_template == ''

--- a/netsim/defaults/paths.yml
+++ b/netsim/defaults/paths.yml
@@ -34,7 +34,6 @@ custom:                         # Custom configuration templates
   - "{{ custom_config + '.' + inventory_hostname + '.j2' }}"
   - "{{ custom_config + '.' + netlab_device_type + '.j2' }}"
   - "{{ custom_config + '.' + ansible_network_os + '.j2' }}"
-  - "{{ custom_config }}"
   - "{{ custom_config + '.j2' }}"
   tasks:
   - "{{ custom_config }}/deploy-{{ inventory_hostname }}.yml"


### PR DESCRIPTION
The file search path for custom config templates included the bare filename because the config parameter could include a .j2 suffix.

That can result in a matching directory where we really want to find the .j2 template within the directory (#2051 provides an excellent example).

This modification removes the bare config filename from the search path and modifies the search logic -- if the config filename includes the '.j2' suffix, then we're searching only for that filename, otherwise we're searching for all potential combinations of things.

Fixes #2015