### PR TITLE
Add restart-policy to allowed clab attributes

### DIFF
--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -44,6 +44,7 @@ attributes:
       license: str
       runtime: str
       startup-delay: int
+      restart-policy: str
   interface:
     name: str
   link:


### PR DESCRIPTION
Without this, we get an error when trying to use `clab.restart-policy`:
```
[ERRORS]  Errors found in topology.yml
[ATTR]    groups: Incorrect node_group attribute 'restart-policy' in topology.groups.kagents.clab
[FATAL]   Cannot proceed beyond this point due to errors, exiting
```