### PR TITLE
Dell OS10: Move route-target setting to VRF module, only when bgp is used

### DIFF
--- a/netsim/ansible/templates/initial/dellos10.vrf.j2
+++ b/netsim/ansible/templates/initial/dellos10.vrf.j2
@@ -1,25 +1,4 @@
 {% for vname,vdata in vrfs.items() %}
 ip vrf {{ vname }}
-!
-{% if 'ipv4' in vdata.af|default({}) %}
-! ip route-import|export xxx
-{%   for rt in vdata.import %}
- ip route-import {{ rt }}
-{%   endfor %}
-{%   for rt in vdata.export %}
- ip route-export {{ rt }}
-{%   endfor %}
-!
-{% endif %}
-{% if 'ipv6' in vdata.af|default({}) %}
-! ipv6 route-import|export xxx
-{%   for rt in vdata.import %}
- ipv6 route-import {{ rt }}
-{%   endfor %}
-{%   for rt in vdata.export %}
- ipv6 route-export {{ rt }}
-{%   endfor %}
-!
-{% endif %}
 exit
 {% endfor %}

--- a/netsim/ansible/templates/vrf/dellos10.bgp.j2
+++ b/netsim/ansible/templates/vrf/dellos10.bgp.j2
@@ -1,5 +1,23 @@
 {% import "dellos10.bgp-macro.j2" as bgpcfg %}
+{% for vname,vdata in vrfs.items() +%}
 !
+ip vrf {{ vname }}
+!
+{%   for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}
+{%     set _ip = 'ip' if af=='ipv4' else 'ipv6' %}
+! {{ _ip }} route-import|export xxx
+{%     for rt in vdata.import %}
+ {{ _ip }} route-import {{ rt }}
+{%     endfor %}
+{%     for rt in vdata.export %}
+ {{ _ip }} route-export {{ rt }}
+{%     endfor %}
+{%   endfor %}
+!
+exit
+{% endfor %}
+!
+
 router bgp {{ bgp.as }}
 {% for vname,vdata in vrfs.items() %}
 !
@@ -9,7 +27,6 @@ router bgp {{ bgp.as }}
   template unnumbered_ebgp
     link-local-only-nexthop
     exit
-
 
 {%   for n in vdata.bgp.neighbors|default([]) %}
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -17,3 +17,4 @@ router ospf {{ vdata.vrfidx }} vrf {{ vname }}
 {% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
 {{   configure_ospf_interface(l,vdata.vrfidx) }}
 {% endfor %}
+exit


### PR DESCRIPTION
Tested: ```NETLAB_DEVICE=dellos10 NETLAB_PROVIDER=libvirt ./device-module-test -v vrf```

```vrf/16-vrf-bgp-community.yml``` continues to fail when run as ```device-module-test```
```
15:30:50 vrf/16-vrf-bgp-community.yml: create(ok) up(ok) config(ok) [WARNING]  Initial wait time extended by 30 seconds required by dellos10
[session]  Check BGP sessions with DUT [ node(s): x1,x2 ]
[PASS]     x1: Neighbor 10.1.0.1 (dut) is in state Established
[PASS]     x2: Neighbor 10.1.0.5 (dut) is in state Established
[PASS]     Test succeeded in 0.4 seconds

[prefix]   Check whether DUT propagates the beacon prefix [ node(s): x2 ]
[PASS]     x2: The prefix 172.0.42.0/24 is in the BGP table
[PASS]     Test succeeded in 0.2 seconds

[std_comm] Check standard community propagation on VRF EBGP sessions [ node(s): x2 ]
[FAIL]     Node x2: community community 65000:1 is not attached to 172.0.42.0/24

[ext_comm] Check extended community propagation on VRF EBGP sessions [ node(s): x2 ]
[PASS]     x2: The prefix 172.0.42.0/24 contains the expected communities
[PASS]     Test succeeded in 0.2 seconds

[FAIL]     5 tests completed, one test failed
```

However, running it as ```netlab up integration/vrf/16-vrf-bgp-community.yml -p libvirt -d dellos10 -v``` first fails, but then waiting a few seconds before running 'validate' again passes without issues:
```
jeroen@j:~/Projects/netlab/tests$ netlab validate -v
Read YAML data from netlab.snapshot.yml
[WARNING]  Initial wait time extended by 30 seconds required by dellos10
[session]  Check BGP sessions with DUT [ node(s): x1,x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x1', 'bash', '-c', 'vtysh -c "show bgp summary json"']
[PASS]     x1: Neighbor 10.1.0.1 (dut) is in state Established
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp summary json"']
[PASS]     x2: Neighbor 10.1.0.5 (dut) is in state Established
[PASS]     Test succeeded in 0.4 seconds

[prefix]   Check whether DUT propagates the beacon prefix [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[PASS]     x2: The prefix 172.0.42.0/24 is in the BGP table
[PASS]     Test succeeded in 0.2 seconds

[std_comm] Check standard community propagation on VRF EBGP sessions [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[FAIL]     Node x2: community community 65000:1 is not attached to 172.0.42.0/24
Input data: {"prefix": "172.0.42.0/24", "version": 3, "advertisedTo": {"10.1.0.5": {}}, "paths": [{"aspath": {"string": "65000 65010", "segments": [{"type": "as-sequence", "list": [65000, 65010]}], "length": 2}, "origin": "IGP", "valid": true, "version": 3, "bestpath": {"bestpathFromAs": 65000, "overall": true, "selectionReason": "First path received"}, "lastUpdate": {"epoch": 1742522736, "string": "Fri Mar 21 02:05:36 2025\n"}, "nexthops": [{"ip": "10.1.0.5", "afi": "ipv4", "metric": 0, "accessible": true, "used": true}], "peer": {"peerId": "10.1.0.5", "routerId": "10.0.0.1", "type": "external"}}]}
Plugin expression: bgp_prefix(
  '172.0.42.0/24',
  community={
    'community': '65000:1'})


Evaluated result False

[ext_comm] Check extended community propagation on VRF EBGP sessions [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[PASS]     x2: The prefix 172.0.42.0/24 contains the expected communities
[PASS]     Test succeeded in 0.2 seconds

[FAIL]     5 tests completed, one test failed
jeroen@j:~/Projects/netlab/tests$ netlab validate -v
Read YAML data from netlab.snapshot.yml
[WARNING]  Initial wait time extended by 30 seconds required by dellos10
[session]  Check BGP sessions with DUT [ node(s): x1,x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x1', 'bash', '-c', 'vtysh -c "show bgp summary json"']
[PASS]     x1: Neighbor 10.1.0.1 (dut) is in state Established
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp summary json"']
[PASS]     x2: Neighbor 10.1.0.5 (dut) is in state Established
[PASS]     Test succeeded in 0.4 seconds

[prefix]   Check whether DUT propagates the beacon prefix [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[PASS]     x2: The prefix 172.0.42.0/24 is in the BGP table
[PASS]     Test succeeded in 0.2 seconds

[std_comm] Check standard community propagation on VRF EBGP sessions [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[PASS]     x2: The prefix 172.0.42.0/24 contains the expected communities
[PASS]     Test succeeded in 0.2 seconds

[ext_comm] Check extended community propagation on VRF EBGP sessions [ node(s): x2 ]
run_command executing: ['docker', 'exec', '-it', 'clab-vrf-x2', 'bash', '-c', 'vtysh -c "show bgp ipv4 172.0.42.0/24 json"']
[PASS]     x2: The prefix 172.0.42.0/24 contains the expected communities
[PASS]     Test succeeded in 0.2 seconds

[SUCCESS]  Tests passed: 5
```