### PR TITLE
Dell OS10: Add support for originated default routes in OSPF

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -60,7 +60,7 @@ The following table describes per-platform support of individual router-level OS
 | Cisco Nexus OS           | ✅| ✅| ✅| ❌ | ❌ |
 | Cumulus Linux            | ✅| ✅| ✅| ✅| ✅|
 | Cumulus Linux 5.x (NVUE) | ✅| ✅| ❌ | ✅ | ❌ |
-| Dell OS10 ([❗](caveats-os10)) | | ✅| ✅| ✅| ❌ | ❌ |
+| Dell OS10 ([❗](caveats-os10)) | | ✅| ✅| ✅| ❌ | ✅|
 | Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ❌ | ❌ | ❌ |
 | FRR                      | ✅| ✅| ✅| ✅| ✅|
 | Junos[^Junos]            | ✅| ✅| ✅| ❌ | ❌ |

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -27,6 +27,7 @@ The following table describes high-level per-platform support of generic routing
 | Aruba AOS-CX       | ✅ | ✅ | ✅ | ✅ |
 | Cisco IOS/XE[^18v] | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux      | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |
 | Nokia SR Linux     |  ✅ |  ✅ [❗](caveats-srlinux) |
@@ -103,6 +104,7 @@ You can use these routing policy **match** parameters on devices supported by th
 | Aruba AOS-CX        | ✅ | ❌  | ✅ | ✅ |
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ |
+| Dell OS10           | ✅ | ❌  | ✅ | ✅ |
 | FRR                 | ✅ | ❌  | ✅ | ✅ |
 | Nokia SR Linux      | ✅ |
 | VyOS                | ✅ | ❌  | ✅ | ✅ |
@@ -115,6 +117,7 @@ You can use these routing policy **set** parameters on devices supported by the 
 | Aruba AOS-CX        | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Dell OS10           | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux      | ❌  | ✅ | ✅ | ❌  | ❌  |
 | Nokia SR OS         | ❌  | ✅ | ✅ | ❌  | ❌  |
@@ -128,6 +131,7 @@ The **set.community** attribute can be used to set these BGP communities on supp
 | Aruba AOS-CX        | ✅ | ❌  | ❌  | ✅ | ✅ |
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
+| Dell OS10           | ✅ | ❌ | ✅ | ✅ | ❌  |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
 | VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
 

--- a/netsim/ansible/templates/ospf/dellos10.macro.j2
+++ b/netsim/ansible/templates/ospf/dellos10.macro.j2
@@ -28,3 +28,11 @@ interface {{ l.ifname }}
 {%   endif %}
 !
 {% endmacro %}
+
+{% macro configure_ospf_default(ospf_data) %}
+{% if ospf_data.default is defined %}
+{%   set dfd = ospf_data.default %}
+ default-information originate{%
+     if dfd.always|default(False) %} always{% endif %}
+{% endif %}
+{% endmacro %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
@@ -1,4 +1,4 @@
-{% from "dellos10.macro.j2" import configure_ospf_interface %}
+{% from "dellos10.macro.j2" import configure_ospf_interface,configure_ospf_default %}
 
 router ospf {{ pid }}
 {% if ospf.router_id|ipv4 %}
@@ -8,6 +8,11 @@ router ospf {{ pid }}
  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
 
+{{ configure_ospf_default(ospf) }}
+
+ timers lsa arrival 100
+ timers spf 10 50 500
+ timers throttle lsa all 100
 !
 interface loopback0
  ip ospf {{ pid }} area {{ ospf.area }}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv3.j2
@@ -1,4 +1,4 @@
-{% from "dellos10.macro.j2" import configure_ospf_interface %}
+{% from "dellos10.macro.j2" import configure_ospf_interface,configure_ospf_default %}
 
 router ospfv3 {{ pid }}
  router-id {{ ospf.router_id }}
@@ -6,6 +6,9 @@ router ospfv3 {{ pid }}
  auto-cost reference-bandwidth {{ ospf.reference_bandwidth }}
 {% endif %}
 
+{{ configure_ospf_default(ospf) }}
+
+timers spf 10 50 500
 !
 {% if 'ipv6' in loopback %}
 interface loopback0

--- a/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/dellos10.ospfv2-vrf.j2
@@ -1,4 +1,4 @@
-{% from "templates/ospf/dellos10.macro.j2" import configure_ospf_interface %}
+{% from "templates/ospf/dellos10.macro.j2" import configure_ospf_interface,configure_ospf_default %}
 
 router ospf {{ vdata.vrfidx }} vrf {{ vname }}
  router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
@@ -13,6 +13,12 @@ router ospf {{ vdata.vrfidx }} vrf {{ vname }}
 {% if vdata.ospf.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ vdata.ospf.reference_bandwidth }}
 {% endif %}
+
+{{ configure_ospf_default(vdata.ospf) }}
+
+ timers lsa arrival 100
+ timers spf 10 50 500
+ timers throttle lsa all 100
 !
 {% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
 {{   configure_ospf_interface(l,vdata.vrfidx) }}

--- a/netsim/devices/dellos10.py
+++ b/netsim/devices/dellos10.py
@@ -23,6 +23,20 @@ def check_vlan_ospf(node: Box, iflist: BoxList, vname: str) -> None:
       node=node)
 
 """
+check_ospf_originate_default - Check if the topology is using custom 'cost' or 'type' attributes for originated
+                               OSPF default routes, if so warn about lack of support
+"""
+def check_ospf_originate_default(node: Box) -> None:
+  ospf_default = node.get('ospf.default',{})
+  unsupported_atts = ospf_default.keys() - set(['always'])
+  if unsupported_atts:
+    report_quirk( f'node {node.name} uses unsupported ospf.default originate attributes that will be ignored',
+      quirk='ospf_default_unsupported_attributes',
+      category=Warning,
+      more_data=sorted(unsupported_atts),
+      node=node)
+
+"""
 check_anycast_gateways - check that anycast gateways are only used on SVI interfaces, not p2p links
 
 See https://infohub.delltechnologies.com/en-us/l/dell-emc-smartfabric-os10-virtual-link-trunking-reference-architecture-guide-1/ip-anycast-gateway-support-2/
@@ -83,6 +97,7 @@ class OS10(_Quirks):
       check_vlan_ospf(node,node.interfaces,'default')
       for vname,vdata in node.get('vrfs',{}).items():
         check_vlan_ospf(node,vdata.get('ospf.interfaces',[]),vname)
+      check_ospf_originate_default(node)
     
     if 'gateway' in mods:
       if 'anycast' in node.get('gateway',{}):

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -31,6 +31,7 @@ features:
         ip: loopback.ipv4    # Use loopback.ipv4 for peer IP address
     passive: True
   ospf:
+    default: True
     timers: True
     password: True
     priority: True


### PR DESCRIPTION
* Tweak OSPF timers to avoid instabilities in FRR neighbors during ```ospf/ospfv2/20-default.yml```
* Add quirk about limited attribute support

Testing: ```NETLAB_DEVICE=dellos10 NETLAB_PROVIDER=libvirt ./device-module-test -v ospf/ospfv2```

+ Test ```ospf/ospfv2/20-default.yml``` now passes with warnings (no support for cost on originated default route)
+ Test ```ospf/ospfv2/22-default-vrf.yml``` passes