### PR TITLE
Allow custom bash scripts to run against cEOS containers

### DIFF
--- a/netsim/ansible/tasks/deploy-config/eos.yml
+++ b/netsim/ansible/tasks/deploy-config/eos.yml
@@ -1,4 +1,24 @@
+- set_fact: deployed_config={{ lookup('template',config_template) }}
+- set_fact: bash_script={{ "#!/bin/bash" in deployed_config }}
+
+- template:
+    src: "{{ config_template }}"
+    dest: /tmp/config.sh
+  when: bash_script
+  vars:
+    ansible_user: root
+    ansible_connection: docker
+
+- name: "run /tmp/config.sh to deploy {{netsim_action}} config from {{ config_template }}"
+  command: bash /tmp/config.sh
+  when: not ansible_check_mode and bash_script
+  become: true
+  vars:
+    ansible_user: root
+    ansible_connection: docker
+
 - name: "eos_config: deploying {{ netsim_action }} from {{ config_template }}"
   eos_config:
     src: "{{ config_template }}"
+  when: not ansible_check_mode and not bash_script
   tags: [ print_action, always ]


### PR DESCRIPTION
Hey, me again. 

I was trying to get sflow export working from cEOS and after much pain, realized that it doesn't support packet sampling. 

As a workaround, I figured I'd install hsflowd directly in the cEOS container, but then found I couldn't run custom bash scripts like I can for FRR containers.

I'm pretty new to ansible (and ultra new to netlab), so maybe there's a better way to to do this?
I'm open to suggestions.