### PR TITLE
Add the 'activate' dictionary to VRF EBGP neighbors

### DIFF
--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -234,7 +234,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65000
+          - activate:
+              ipv4: true
+            as: 65000
             ifindex: 2
             ipv4: 10.1.0.6
             name: r2
@@ -254,7 +256,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65000
+          - activate:
+              ipv4: true
+            as: 65000
             ifindex: 3
             ipv4: 10.1.0.10
             name: r2
@@ -486,18 +490,24 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65001
+          - activate:
+              ipv4: true
+            as: 65001
             ifindex: 4
             ipv4: 10.1.0.1
             local_as: 65002
             name: r2
             type: ebgp
-          - as: 65100
+          - activate:
+              ipv4: true
+            as: 65100
             ifindex: 5
             ipv4: 10.1.0.5
             name: r1
             type: ebgp
-          - as: 65101
+          - activate:
+              ipv4: true
+            as: 65101
             ifindex: 7
             ipv4: 10.1.0.14
             name: r3
@@ -518,18 +528,24 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65002
+          - activate:
+              ipv4: true
+            as: 65002
             ifindex: 3
             ipv4: 10.1.0.2
             local_as: 65001
             name: r2
             type: ebgp
-          - as: 65100
+          - activate:
+              ipv4: true
+            as: 65100
             ifindex: 6
             ipv4: 10.1.0.9
             name: r1
             type: ebgp
-          - as: 65101
+          - activate:
+              ipv4: true
+            as: 65101
             ifindex: 8
             ipv4: 10.1.0.18
             name: r3
@@ -668,7 +684,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65000
+          - activate:
+              ipv4: true
+            as: 65000
             ifindex: 2
             ipv4: 10.1.0.13
             name: r2
@@ -688,7 +706,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65000
+          - activate:
+              ipv4: true
+            as: 65000
             ifindex: 3
             ipv4: 10.1.0.17
             name: r2

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -298,6 +298,8 @@ nodes:
               auto: true
           neighbors:
           - _src_vrf: red
+            activate:
+              ipv4: true
             as: 65002
             default_originate: true
             ifindex: 4
@@ -446,6 +448,8 @@ nodes:
               auto: true
           neighbors:
           - _src_vrf: red
+            activate:
+              ipv4: true
             allowas_in: 1
             as: 65001
             ifindex: 2

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -355,7 +355,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65001
+          - activate:
+              ipv4: true
+            as: 65001
             ifindex: 2
             ipv4: 10.1.0.6
             name: r2

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -400,7 +400,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65001
+          - activate:
+              ipv4: true
+            as: 65001
             ifindex: 7
             ipv4: 10.1.0.22
             name: x
@@ -1043,7 +1045,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65000
+          - activate:
+              ipv4: true
+            as: 65000
             ifindex: 1
             ipv4: 10.1.0.21
             name: r1

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -23,34 +23,37 @@ links:
   interfaces:
   - ifindex: 1
     ifname: eth1
-    ipv4: 10.1.0.1/30
+    ipv4: 10.42.1.1/24
+    ipv6: 2001:db8:cafe::1/64
     node: r1
     vrf: red
   - ifindex: 1
     ifname: eth1
-    ipv4: 10.1.0.2/30
+    ipv4: 10.42.1.2/24
+    ipv6: 2001:db8:cafe::2/64
     node: r2
   linkindex: 1
   node_count: 2
   prefix:
-    ipv4: 10.1.0.0/30
+    ipv4: 10.42.1.0/24
+    ipv6: 2001:db8:cafe::/64
   role: external
   type: p2p
 - _linkname: links[2]
   interfaces:
   - ifindex: 2
     ifname: eth2
-    ipv4: 10.1.0.5/30
+    ipv4: 10.1.0.1/30
     node: r1
     vrf: blue
   - ifindex: 1
     ifname: eth1
-    ipv4: 10.1.0.6/30
+    ipv4: 10.1.0.2/30
     node: r3
   linkindex: 2
   node_count: 2
   prefix:
-    ipv4: 10.1.0.4/30
+    ipv4: 10.1.0.0/30
   type: p2p
 - _linkname: links[3]
   bridge: input_3
@@ -89,7 +92,9 @@ nodes:
   r1:
     af:
       ipv4: true
+      ipv6: true
       vpnv4: true
+      vpnv6: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -113,24 +118,26 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: eth1
-      ipv4: 10.1.0.1/30
+      ipv4: 10.42.1.1/24
+      ipv6: 2001:db8:cafe::1/64
       linkindex: 1
       name: r1 -> r2
       neighbors:
       - ifname: eth1
-        ipv4: 10.1.0.2/30
+        ipv4: 10.42.1.2/24
+        ipv6: 2001:db8:cafe::2/64
         node: r2
       role: external
       type: p2p
       vrf: red
     - ifindex: 2
       ifname: eth2
-      ipv4: 10.1.0.5/30
+      ipv4: 10.1.0.1/30
       linkindex: 2
       name: r1 -> r3
       neighbors:
       - ifname: eth1
-        ipv4: 10.1.0.6/30
+        ipv4: 10.1.0.2/30
         node: r3
       type: p2p
       vrf: blue
@@ -204,12 +211,12 @@ nodes:
           interfaces:
           - ifindex: 2
             ifname: eth2
-            ipv4: 10.1.0.5/30
+            ipv4: 10.1.0.1/30
             linkindex: 2
             name: r1 -> r3
             neighbors:
             - ifname: eth1
-              ipv4: 10.1.0.6/30
+              ipv4: 10.1.0.2/30
               node: r3
             ospf:
               area: 0.0.0.0
@@ -234,6 +241,7 @@ nodes:
       red:
         af:
           ipv4: true
+          ipv6: true
         bgp:
           import:
             connected:
@@ -241,9 +249,11 @@ nodes:
           neighbors:
           - activate:
               ipv4: true
+              ipv6: true
             as: 65001
             ifindex: 1
-            ipv4: 10.1.0.2
+            ipv4: 10.42.1.2
+            ipv6: 2001:db8:cafe::2
             name: r2
             type: ebgp
         export:
@@ -260,6 +270,7 @@ nodes:
   r2:
     af:
       ipv4: true
+      ipv6: true
       vpnv4: true
     bgp:
       advertise_loopback: true
@@ -274,12 +285,15 @@ nodes:
         - standard
         - extended
       ipv4: true
+      ipv6: true
       neighbors:
       - activate:
           ipv4: true
+          ipv6: true
         as: 65000
         ifindex: 1
-        ipv4: 10.1.0.1
+        ipv4: 10.42.1.1
+        ipv6: 2001:db8:cafe::1
         name: r1
         type: ebgp
       next_hop_self: true
@@ -291,12 +305,14 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: eth1
-      ipv4: 10.1.0.2/30
+      ipv4: 10.42.1.2/24
+      ipv6: 2001:db8:cafe::2/64
       linkindex: 1
       name: r2 -> r1
       neighbors:
       - ifname: eth1
-        ipv4: 10.1.0.1/30
+        ipv4: 10.42.1.1/24
+        ipv6: 2001:db8:cafe::1/64
         node: r1
         vrf: red
       role: external
@@ -396,12 +412,12 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: eth1
-      ipv4: 10.1.0.6/30
+      ipv4: 10.1.0.2/30
       linkindex: 2
       name: r3 -> r1
       neighbors:
       - ifname: eth2
-        ipv4: 10.1.0.5/30
+        ipv4: 10.1.0.1/30
         node: r1
         vrf: blue
       ospf:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -239,7 +239,9 @@ nodes:
             connected:
               auto: true
           neighbors:
-          - as: 65001
+          - activate:
+              ipv4: true
+            as: 65001
             ifindex: 1
             ipv4: 10.1.0.2
             name: r2

--- a/tests/topology/input/vrf.yml
+++ b/tests/topology/input/vrf.yml
@@ -37,6 +37,9 @@ links:
 - r1:
     vrf: red
   r2:
+  prefix:
+    ipv4: 10.42.1.0/24
+    ipv6: 2001:db8:cafe::/64
 - r1:
     vrf: blue
   r3:


### PR DESCRIPTION
This makes the data structures more consistent between VRF and global BGP neighbors and makes it easier to write the device configuration templates as we no longer have to check whether the 'activate' dictionary is defined.