### PR TITLE
Shutdown the unused BGP neighbors on Junos

### DIFF
--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -85,6 +85,8 @@ protocols {
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }
+{%     else %}
+        shutdown;
 {%     endif %}
       }
 {%   endfor %}
@@ -106,6 +108,8 @@ protocols {
         family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
           unicast;
         }
+{%     else %}
+        shutdown;
 {%     endif %}
       }
 {%   endfor %}

--- a/netsim/ansible/templates/evpn/vjunos-switch.j2
+++ b/netsim/ansible/templates/evpn/vjunos-switch.j2
@@ -7,6 +7,7 @@ protocols {
     group ibgp-peers-{{ af }} {
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' and n.evpn|default(false) %}
       neighbor {{ n[af] }} {
+        delete: shutdown;
         family evpn {
           signaling;
         }
@@ -20,6 +21,7 @@ protocols {
       neighbor {{ n[af] }} {
         accept-remote-nexthop;
         multihop no-nexthop-change;
+        delete: shutdown;
         family evpn {
           signaling;
         }

--- a/netsim/ansible/templates/mpls/junos.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/junos.mplsvpn.j2
@@ -16,6 +16,7 @@ protocols {
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
 {%     for vpnaf in ['vpnv4','vpnv6'] if n[vpnaf] is defined %}
       neighbor {{ n[af] }} {
+        delete: shutdown;
         family inet{{ "6" if vpnaf == 'vpnv6' }}-vpn {
           unicast;
         }


### PR DESCRIPTION
Junos cannot create a BGP neighbor that has no active AF. As a workaround, this change shuts down the neighbors that have no active IPv4/IPv6 AF, and reenables them when they're used for EVPN or MPLS/VPN AF.

Closes #2007, replaces #2009 and #2010