### PR TITLE
Use anycast gateway in EVPN asymmetric IRB integration test

### DIFF
--- a/tests/integration/evpn/02-vxlan-asymmetric-irb.yml
+++ b/tests/integration/evpn/02-vxlan-asymmetric-irb.yml
@@ -17,23 +17,26 @@ groups:
     provider: clab
   switches:
     members: [ s1, s2 ]
-    module: [ vlan, vxlan, ospf, bgp, evpn ]
+    module: [ vlan, vxlan, ospf, bgp, evpn, gateway ]
   x_switches:
     members: [ s2 ]
     device: frr
     provider: clab
 
 bgp.as: 65000
+gateway.protocol: anycast
 
 vlans:
   red:
     role: external
     links: [ s1-h1, s2-h2 ]
     vni: 1000
+    gateway: True
   blue:
     role: external
     links: [ s1-h3, s2-h4 ]
     vni: 1001
+    gateway: True
 
 links:
 - s1:
@@ -41,10 +44,49 @@ links:
   mtu: 1600
 
 validate:
-  ping_h4:
+  ospf_adj_s1:
+    description: Check OSPF adjacencies with S1
+    wait: 40
+    nodes: [ s2 ]
+    wait_msg: Waiting for OSPF adjacency process to complete
+    plugin: ospf_neighbor(nodes.s1.ospf.router_id)
+
+  ibgp_adj_s1:
+    description: Check IBGP adjacencies with S1
+    wait: 40
+    nodes: [ s2 ]
+    wait_msg: Waiting for IGBP session
+    plugin: bgp_neighbor(node.bgp.neighbors,'s1')
+
+  ipv4_adj_s1:
+    description: Check IPv4 AF on IBGP adjacencies with S1
+    nodes: [ s2 ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'s1',activate='ipv4')
+
+  evpn_adj_s1:
+    description: Check EVPN AF on IBGP adjacencies with S1
+    nodes: [ s2 ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'s1',activate='evpn')
+    stop_on_error: True
+
+  ping_gw_red:
+    description: Pinging default gateway in red VLAN
+    nodes: [ h1, h2 ]
+    wait: 40
+    wait_msg: Waiting for STP and IRB interfaces to wake up
+    plugin: ping(nodes.h1.interfaces[0].gateway.ipv4)
+
+  ping_gw_blue:
+    description: Pinging default gateway in blue VLAN
+    nodes: [ h3, h4 ]
+    wait: 20
+    wait_msg: Waiting for STP and IRB interfaces to wake up
+    plugin: ping(nodes.h3.interfaces[0].gateway.ipv4)
+
+  ping_h3:
     description: Host-to-host ping-based reachability test
-    wait_msg: Waiting for OSFP and STP to wake up
-    wait: 50
+    wait_msg: We might have to wait a bit longer
+    wait: 10
     nodes: [ h1, h2 ]
     plugin: ping('h3')
 


### PR DESCRIPTION
The original calculation of default gateways in VLANs resulted in every host using the nearest switch as the default GW. With the new approach to default gateways, all hosts in an IP subnet get the same default gateway, destroying the whole idea of asymmetrical IRB.

The only correct solution out of this conundrum is the use of anycast gateway that ensures we always get routing on ingress.

Interestingly, some devices (Junos, SR Linux) fail to route packets between VLANs in asymmetrical IRB scenario unless the hosts ping the default gateway first (effectively priming the ARP cache). Go figure :(

Closes #1930