### PR TITLE
Replace calls to string.format with strings.eval_format

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -137,7 +137,7 @@ def adjust_link_list(
   elif isinstance(links,list):
     for l in links:
       link_cnt = link_cnt + 1
-      linkname = linkname_format.format(link_cnt=link_cnt)
+      linkname = strings.eval_format_args(linkname_format,link_cnt=link_cnt)
       link_data = adjust_link_object(l,linkname,nodes)
       if not link_data is None:
         if link_data.get('disable',False) is True:

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -18,7 +18,7 @@ def unit_0_trick(intf: Box, round: str ='global') -> None:
   oldname = intf.ifname
   newname = oldname + ".0"
   if log.debug_active('quirks'):
-    print(" - [{}] Found interface {}, renaming to {}".format(round, intf.ifname, newname))
+    print(f" - [{round}] Found interface {intf.ifname}, renaming to {newname}")
   intf.ifname = newname
   intf.junos_interface = oldname
   intf.junos_unit = '0'
@@ -64,15 +64,15 @@ def fix_unit_0(node: Box, topology: Box) -> None:
           set_junos_mtu(intf, JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH)
         elif junos_vlan_kind == 'l3-switch':
           # for a l3-switch, add it on vlan mode route or if no vlan structure is defined (flex vlan tagging with native only)
-          if 'vlan' not in intf or intf.get('vlan', {}).get('mode', '') == 'route':
+          if 'vlan' not in intf or intf.get('vlan.mode',None) == 'route':
             set_junos_mtu(intf, JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH)
   
   # need to append .0 unit trick to the interface list copied into vrf->ospf
   if 'vrf' in mods and 'ospf' in mods:
     for vname,vdata in node.vrfs.items():
-      for intf in vdata.get('ospf', {}).get('interfaces', []):
+      for intf in vdata.get('ospf.interfaces',[]):
         if not '.' in intf.ifname:
-          unit_0_trick(intf, "vrf({})/ospf".format(vname))
+          unit_0_trick(intf, f"vrf({vname})/ospf")
 
 def check_multiple_loopbacks(node: Box, topology: Box) -> None:
   vrf_count: dict = {}
@@ -114,7 +114,7 @@ class JUNOS(_Quirks):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     if log.debug_active('quirks'):
-      print("*** DEVICE QUIRKS FOR JUNOS {}".format(node.name))
+      print(f"*** DEVICE QUIRKS FOR JUNOS {node.name}")
     fix_unit_0(node,topology)
     check_multiple_loopbacks(node,topology)
     check_evpn_ebgp(node,topology)

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -5,7 +5,7 @@ import typing
 from box import Box
 
 from . import _Module,get_effective_module_attribute,_dataplane
-from ..utils import log
+from ..utils import log,strings
 from .. import data
 from ..data import get_empty_box,get_box,get_global_parameter
 from ..augment import devices,groups,links,addressing
@@ -878,7 +878,8 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
       vlan_ifdata.vlan.name = access_vlan
       vlan_ifdata.type = "svi"
       vlan_ifdata.ifindex = links.get_unique_ifindex(node,iftype='svi',start=SVI_IFINDEX_OFFSET)
-      vlan_ifdata.ifname = svi_name.format(                                 # ... ifindex, ifname, description
+      vlan_ifdata.ifname = strings.eval_format_args(
+                              fmt=svi_name,
                               vlan=vlan_data.id,
                               bvi=vlan_data.bridge_group,
                               ifname=ifdata.ifname)
@@ -1047,7 +1048,7 @@ def rename_vlan_subinterfaces(node: Box, topology: Box) -> None:
     ifname_data.ifname = parent_intf.ifname                           # ... making sure ifname is coming from parent interface
 
     old_intf = data.get_box({ 'ifname': intf.ifname })                # Create a fake interface with old interface name
-    intf.ifname = subif_name.format(**ifname_data)
+    intf.ifname = strings.eval_format(subif_name,ifname_data)
     intf.parent_ifindex = parent_intf.ifindex
     intf.parent_ifname = parent_intf.ifname
     intf.virtual_interface = True

--- a/netsim/tools/graphite.py
+++ b/netsim/tools/graphite.py
@@ -17,6 +17,8 @@ import json
 from box import Box
 
 from ..data import get_empty_box
+from ..utils import strings
+
 from . import _ToolOutput
 
 DEFAULT_NODE_ICON = "router"
@@ -47,9 +49,9 @@ def nodes_items(topology: Box) -> Box:
             DEFAULT_NODE_ICON )
         graph_level = n.get('graphite.level',1)
         node_group = "tier-1"
-        node_as = n.get('bgp', {}).get('as')
+        node_as = n.get('bgp.as',None)
         if node_as:
-            node_group = "as{}".format(node_as)
+            node_group = f"as{node_as}"
         r[name] = {
                 'name': name,
                 'kind': n.device,
@@ -71,13 +73,13 @@ def nodes_items(topology: Box) -> Box:
             node_item = topology.nodes[l.interfaces[0].node]
             graph_level = node_item.get('graphite.level',1)
             node_group = "tier-1"
-            node_as = node_item.get('bgp', {}).get('as')
+            node_as = node_item.get('bgp.as',None)
             if node_as:
-                node_group = "as{}".format(node_as)
-            name = HOST_BRIDGE_NODE_NAME.format(type=l.type, index=l.linkindex)
+                node_group = f"as{node_as}"
+            name = strings.eval_format_args(HOST_BRIDGE_NODE_NAME,type=l.type,index=l.linkindex)
             r[name] =  {
                     'name': name,
-                    'kind': "(host bridge: {})".format(l.bridge),
+                    'kind': f"(host bridge: {l.bridge})",
                     "ipv4_address": '',
                     "group": node_group,
                     "labels": {
@@ -114,7 +116,10 @@ def links_items(topology: Box) -> list:
         elif l.type == "lan" or l.type == "stub":
             for bridge_intf in l.interfaces:
                 ldata = get_empty_box()
-                bridge_node_name = HOST_BRIDGE_NODE_NAME.format(type=l.type, index=l.linkindex)
+                bridge_node_name = strings.eval_format_args(
+                                     HOST_BRIDGE_NODE_NAME,
+                                     type=l.type,
+                                     index=l.linkindex)
                 ldata.a = {
                     'node': bridge_intf.node,
                     'interface': short_ifname(bridge_intf.ifname),

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -123,6 +123,9 @@ def eval_format(fmt: str, data: dict) -> str:
   ex = "f'"+fmt+"'"                    # String to format-evaluate
   return str(eval(ex,dict(data)))      # An awful hack to use f-string specified in a string variable
 
+def eval_format_args(fmt: str, **kwargs: typing.Any) -> str:
+  return eval_format(fmt,kwargs)
+
 """
 eval_format_list: execute eval_format on a list
 """


### PR DESCRIPTION
This is a pure cleanup/consistency change, ensuring we can always use expressions in string formats.

Closes #1914