### PR TITLE
SR Linux: Fix bgp af activation

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -25,4 +25,4 @@ updates:
         policy-result: accept
 
 {% from "srlinux.macro.j2" import bgp_config with context %}
-{{ bgp_config('default',bgp.as,bgp.router_id,bgp,{ 'af' : af }) }}
+{{ bgp_config('default',bgp.as,bgp.router_id,bgp,{ 'af' : { 'ipv4': 'ipv4' in bgp, 'ipv6': 'ipv6' in bgp } }) }}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -74,15 +74,15 @@
 {%   endfor %}
 {% endmacro %}
 
-{% macro bgp_families(neighbor,af,import=None,export=None,group=False) %}
-{%   if neighbor.activate is defined and not group %}
+{% macro bgp_families(neighbor,af) %}
+{%   if neighbor.activate is defined %}
 {%     set _a = neighbor.activate %}
 {%     set activate = {'ipv4': af=='ipv4' and _a[af],'ipv6': af=='ipv6' and _a[af] } %}
 {%   else %}
-{%     set activate = {'ipv4': af=='ipv4' or group,'ipv6': af=='ipv6' or group } %}
+{%     set activate = {'ipv4': af=='ipv4','ipv6': af=='ipv6' } %}
 {%   endif %}
 # bgp_families af={{af}} activate={{activate}}
-{%   if not activate | dict2items | map(attribute='value') | select and not neighbor.evpn|default(False) %}
+{%   if not activate | dict2items | map(attribute='value') | select %}
     admin-state: disable
 {%   else %}
     afi-safi:
@@ -94,30 +94,14 @@
         advertise-ipv6-next-hops: True
         receive-ipv6-next-hops: True
 {%       endif %}
-{%       if import %}
-      import-policy: {{ import }}
-{%       endif %}
-{%       if export %}
-      export-policy: {{ export }}
-{%       endif %}
 {%     else %}
       admin-state: 'disable'
 {%     endif %}
     - afi-safi-name: ipv6-unicast
 {%     if activate.ipv6|default(False) and af=='ipv6' %}
       admin-state: 'enable'
-{%       if import %}
-      import-policy: {{ import }}
-{%       endif %}
-{%       if export %}
-      export-policy: {{ export }}
-{%       endif %}
 {%     else %}
       admin-state: 'disable'
-{%     endif %}
-{%     if 'evpn' in neighbor and neighbor.evpn %}
-    - afi-safi-name: evpn
-      admin-state: enable
 {%     endif %}
 {%   endif %}
 {% endmacro %}
@@ -126,10 +110,13 @@
 - path: /network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
   value:
     admin-state: enable
-{% set nh_self = bgp.next_hop_self|default(False) and 'ibgp' in type %}
-{% set nh_self_rr = nh_self and vrf_bgp.rr|default(False) %}
-{% set ep_name = (vrf + "_ibgp-nhs_export") if nh_self_rr else (vrf + "_bgp_export") %}
-{{ bgp_families(neighbor,af,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name, 'accept_all' ],group=True) }}
+{%  set nh_self = bgp.next_hop_self|default(False) and 'ibgp' in type %}
+{%  set nh_self_rr = nh_self and vrf_bgp.rr|default(False) %}
+{%  set ep_name = (vrf + "_ibgp-nhs_export") if nh_self_rr else (vrf + "_bgp_export") %}
+    afi-safi:
+    - afi-safi-name: {{ af }}-unicast
+      export-policy: [ {{ ep_name }}, 'accept_all' ]
+      import-policy: {{ [ "ibgp-mark" if nh_self_rr else "accept_all" ] }}
     timers:
       connect-retry: 10
       _annotate_connect-retry: "Reduce default 120s to 10s"

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -74,37 +74,51 @@
 {%   endfor %}
 {% endmacro %}
 
-{% macro bgp_families(neighbor,ipv4=True,ipv6=True,import=None,export=None) %}
-{%   set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
+{% macro bgp_families(neighbor,af,import=None,export=None,group=False) %}
+{%   if neighbor.activate is defined and not group %}
+{%     set _a = neighbor.activate %}
+{%     set activate = {'ipv4': af=='ipv4' and _a[af],'ipv6': af=='ipv6' and _a[af] } %}
+{%   else %}
+{%     set activate = {'ipv4': af=='ipv4' or group,'ipv6': af=='ipv6' or group } %}
+{%   endif %}
+# bgp_families af={{af}} activate={{activate}}
+{%   if not activate | dict2items | map(attribute='value') | select and not neighbor.evpn|default(False) %}
+    admin-state: disable
+{%   else %}
     afi-safi:
-{%   if ipv4 %}
     - afi-safi-name: ipv4-unicast
-      admin-state: {{ 'enable' if activate.ipv4|default(False) else 'disable' }}
-{%     if neighbor.ipv4_rfc8950|default(False) %}
+{%     if activate.ipv4|default(False) and (af=='ipv4' or neighbor.ipv4_rfc8950|default(False)) %}
+      admin-state: 'enable'
+{%       if neighbor.ipv4_rfc8950|default(False) %}
       ipv4-unicast:
         advertise-ipv6-next-hops: True
         receive-ipv6-next-hops: True
-{%     endif %}
-{%     if import %}
+{%       endif %}
+{%       if import %}
       import-policy: {{ import }}
-{%     endif %}
-{%     if export %}
+{%       endif %}
+{%       if export %}
       export-policy: {{ export }}
+{%       endif %}
+{%     else %}
+      admin-state: 'disable'
 {%     endif %}
-{%   endif %}
-{%   if ipv6 %}
     - afi-safi-name: ipv6-unicast
-      admin-state: {{ 'enable' if activate.ipv6|default(False) else 'disable' }}
-{%     if import %}
+{%     if activate.ipv6|default(False) and af=='ipv6' %}
+      admin-state: 'enable'
+{%       if import %}
       import-policy: {{ import }}
-{%     endif %}
-{%     if export %}
+{%       endif %}
+{%       if export %}
       export-policy: {{ export }}
+{%       endif %}
+{%     else %}
+      admin-state: 'disable'
 {%     endif %}
-{%   endif %}
-{%   if 'evpn' in neighbor and neighbor.evpn %}
+{%     if 'evpn' in neighbor and neighbor.evpn %}
     - afi-safi-name: evpn
       admin-state: enable
+{%     endif %}
 {%   endif %}
 {% endmacro %}
 
@@ -112,10 +126,10 @@
 - path: /network-instance[name={{vrf}}]/protocols/bgp/group[group-name={{name}}]
   value:
     admin-state: enable
-{% set nh_self = bgp.next_hop_self|default(False) and type == 'ibgp' %}
+{% set nh_self = bgp.next_hop_self|default(False) and 'ibgp' in type %}
 {% set nh_self_rr = nh_self and vrf_bgp.rr|default(False) %}
 {% set ep_name = (vrf + "_ibgp-nhs_export") if nh_self_rr else (vrf + "_bgp_export") %}
-{{ bgp_families(neighbor,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name, 'accept_all' ]) }}
+{{ bgp_families(neighbor,af,import=[ "ibgp-mark" if nh_self_rr else "accept_all" ],export=[ ep_name, 'accept_all' ],group=True) }}
     timers:
       connect-retry: 10
       _annotate_connect-retry: "Reduce default 120s to 10s"
@@ -168,7 +182,7 @@
       export-reject-all: False
       import-reject-all: False
 
-{# Configure BGP address families globally #}
+{# Configure BGP address families globally, at least one must be enabled #}
 {% for af in ['ipv4','ipv6'] if vrf_context.af[af]|default(False) %}
     afi-safi:
     - afi-safi-name: {{ af }}-unicast
@@ -207,7 +221,7 @@
     - peer-address: "{{ n[af] }}"
       description: {{ n.name }}
       peer-group: {{ peer_group }}
-  {{ bgp_families(n,ipv4=(af=='ipv4' or 'ipv4' not in n),ipv6=(af=='ipv6')) | indent(2) }}
+  {{ bgp_families(n,af) | indent(2) }}
 {%       if 'ebgp' in n.type %}
       peer-as: {{ n.as }}
 {%       elif n.type=='localas_ibgp' %}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -171,7 +171,9 @@
 
 {# Configure BGP address families globally, at least one must be enabled #}
 {% for af in ['ipv4','ipv6'] if vrf_context.af[af]|default(False) %}
+{%   if loop.first %}
     afi-safi:
+{%   endif %}
     - afi-safi-name: {{ af }}-unicast
       admin-state: enable
 {% endfor %}

--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -49,7 +49,7 @@ updates:
       afi-safi:
       - afi-safi-name: evpn
         admin-state: 'enable'
-{%     elif n[af] is True %}
+{%     elif n[af] == True %}
 {#       interface EBGP session #}
 {%       set peer_group = 'intf-'+n.local_if %}
 - path: /network-instance[name=default]/protocols/bgp/group[group-name={{peer_group}}]

--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -42,10 +42,11 @@ updates:
 {% for n in bgp.neighbors|default([]) if n.evpn is defined %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
 {%     if n[af] is string %}
-- path: /network-instance[name={{vrf}}]/protocols/bgp
+- path: /network-instance[name=default]/protocols/bgp
   value:
     neighbor:
     - peer-address: "{{ n[af] }}"
+      admin-state: 'enable'
       afi-safi:
       - afi-safi-name: evpn
         admin-state: 'enable'

--- a/netsim/ansible/templates/evpn/srlinux.j2
+++ b/netsim/ansible/templates/evpn/srlinux.j2
@@ -38,6 +38,29 @@ updates:
 {%   endfor %}
 {% endfor %}
 
+{# Enable EVPN AF for neighbors #}
+{% for n in bgp.neighbors|default([]) if n.evpn is defined %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+{%     if n[af] is string %}
+- path: /network-instance[name={{vrf}}]/protocols/bgp
+  value:
+    neighbor:
+    - peer-address: "{{ n[af] }}"
+      afi-safi:
+      - afi-safi-name: evpn
+        admin-state: 'enable'
+{%     elif n[af] is True %}
+{#       interface EBGP session #}
+{%       set peer_group = 'intf-'+n.local_if %}
+- path: /network-instance[name=default]/protocols/bgp/group[group-name={{peer_group}}]
+  value:
+    afi-safi:
+    - afi-safi-name: evpn
+      admin-state: 'enable'
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
 {# Enable IP advertisement for all irb interfaces in EVPN vlans #}
 {% if vrfs is defined and vrfs %}
 {% for i in interfaces if i.vrf is defined and i.type=='svi' and i.vlan.mode|default('irb')=='irb' %}


### PR DESCRIPTION
* Move EVPN activation to EVPN module
* Rewrite AF activation logic; disable neighbor when no address families are activated

Fixes https://github.com/ipspace/netlab/issues/2059

Tested:
* ```NETLAB_DEVICE=srlinux NETLAB_PROVIDER=clab ./device-module-test -v bgp```
* ```NETLAB_DEVICE=srlinux NETLAB_PROVIDER=clab ./device-module-test -v evpn``` (with latest EVPN tests)

Not all EVPN tests pass, but the ones that used to work continue to work

Note: Test case 03 would require https://documentation.nokia.com/srlinux/24-3/books/evpn-vxlan/evpn-vxlan-tunnels-layer-3.html#evpn-ifl-interoperability-with-evpn-iff to interop with FRR