### PR TITLE
Fix the SR Linux BGP AF activation

### DIFF
--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -76,6 +76,9 @@
 
 {% macro bgp_families(neighbor,ipv4=True,ipv6=True,import=None,export=None) %}
 {%   set activate = neighbor.activate|default( {'ipv4': True,'ipv6': True } ) %}
+# neighbor: {{ neighbor }}
+# ipv4: {{ ipv4 }}
+# ipv6: {{ ipv6 }}
     afi-safi:
 {%   if ipv4 %}
     - afi-safi-name: ipv4-unicast
@@ -91,6 +94,9 @@
 {%     if export %}
       export-policy: {{ export }}
 {%     endif %}
+{%   else %}
+    - afi-safi-name: ipv4-unicast
+      admin-state: disable
 {%   endif %}
 {%   if ipv6 %}
     - afi-safi-name: ipv6-unicast
@@ -101,6 +107,9 @@
 {%     if export %}
       export-policy: {{ export }}
 {%     endif %}
+{%   else %}
+    - afi-safi-name: ipv6-unicast
+      admin-state: disable
 {%   endif %}
 {%   if 'evpn' in neighbor and neighbor.evpn %}
     - afi-safi-name: evpn


### PR DESCRIPTION
This is a minimal set of changes that ensures the BGP address families are activated as expected -- the address families that are not explicitely enabled are disabled.

This approach results in a situation where a BGP neighbor might not have any address families. That's rejected by SR Linux, so we need an extra device quirk that cleans up the neighbor transport IP addresses based on the AFs we'll need with the neighbor.

Fixes #2059