### PR TITLE
'loopback' attribute in global VRF definition must be a bool

### DIFF
--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -79,7 +79,7 @@ The keys of the **vrfs** dictionary are VRF names; the values are VRF definition
 * **rd** -- route distinguisher (integer or string)
 * **import** -- a list of import route targets
 * **export** -- a list of export route targets
-* **loopback** (bool or prefix) -- Create a loopback interface for this VRF.
+* **loopback** (bool or prefix) -- Create a loopback interface for this VRF ([more details](vrf-loopback)).
 * **links** - a [list of links](module-vrf-links) within this VRF.
 * A VRF definition can also contain other link- or interface-level parameters (for example, OSPF cost).
 
@@ -116,7 +116,7 @@ A loopback interface is created for a VRF whenever you set the **vrfs.*name*.loo
 * A dictionary of address families specifying IPv4 and/or IPv6 prefixes to be used on the loopback interface
 
 ```{warning}
-The explicit IPv4/IPv6 loopback addresses should be used only in the node VRF definition, not in the global VRF definition.
+The explicit IPv4/IPv6 loopback addresses can be used only in the node VRF definition, not in the global VRF definition.
 ```
 
 ### RD and RT Values

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -125,6 +125,13 @@ def normalize_vrf_dict(obj: Box, topology: Box) -> None:
         category=log.IncorrectValue,
         module='vrf')
 
+    if obj is topology and 'loopback' in vdata:
+      if not isinstance(vdata.loopback,bool):
+        log.error(f'The "loopback" attribute in the global VRF "{vname}" must be a bool',
+        more_hints=[ 'You can specify specific IP address for a VRF loopback interface in the node VRF data'],
+        category=log.IncorrectType,
+        module='vrf')
+
     if 'rd' in vdata:
       if vdata.rd is None:      # RD set to None can be used to auto-generate RD while preventing RD inheritance
         continue                # ... skip the rest of the checks

--- a/tests/errors/vrf-loopback-global.log
+++ b/tests/errors/vrf-loopback-global.log
@@ -1,0 +1,3 @@
+IncorrectType in vrf: The "loopback" attribute in the global VRF "blue" must be a bool
+... You can specify specific IP address for a VRF loopback interface in the node VRF data
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/vrf-loopback-global.yml
+++ b/tests/errors/vrf-loopback-global.yml
@@ -1,0 +1,20 @@
+#
+# Global VRF loopback cannot be an IP address
+#
+---
+defaults:
+  device: iosv
+
+module: [ vrf ]
+
+vrfs:
+  red:
+    loopback: True
+  blue:
+    loopback: 10.0.0.1/32
+
+nodes:
+  r1:
+    vrfs:
+      red:
+      blue:

--- a/tests/integration/vrf/03-multi-vrf-loopback.yml
+++ b/tests/integration/vrf/03-multi-vrf-loopback.yml
@@ -19,11 +19,15 @@ groups:
 
 vrfs:
   red:
-    loopback: 10.0.0.42/32
     links: [ dut-h1, dut-h2 ]
   blue:
-    loopback: 10.0.0.43/32
     links: [ dut-h3, dut-h4 ]
+
+nodes:
+  dut:
+    vrfs:
+      red.loopback: 10.0.0.42/32
+      blue.loopback: 10.0.0.43/32
 
 validate:
   red:

--- a/tests/integration/vrf/04-multi-vrf-loopback-ipv6.yml
+++ b/tests/integration/vrf/04-multi-vrf-loopback-ipv6.yml
@@ -21,13 +21,15 @@ groups:
 
 vrfs:
   red:
-    loopback:
-      ipv6: 2001:db8:c001:cafe::/64
     links: [ dut-h1, dut-h2 ]
   blue:
-    loopback:
-      ipv6: 2001:db8:c001:cafe::/64
     links: [ dut-h3, dut-h4 ]
+
+nodes:
+  dut:
+    vrfs:
+      red.loopback.ipv6: 2001:db8:c001:cafe::/64
+      blue.loopback.ipv6: 2001:db8:c001:cafe::/64
 
 validate:
   red:

--- a/tests/integration/vrf/22-multi-vrf-bgp-ipv6.yml
+++ b/tests/integration/vrf/22-multi-vrf-bgp-ipv6.yml
@@ -37,14 +37,15 @@ groups:
 
 vrfs:
   red:
-    loopback.ipv6: 2001:db8:c001:cafe::/64
     links: [ dut-r1, dut-r2 ]
   blue:
-    loopback.ipv6: 2001:db8:c001:cafe::/64
     links: [ dut-r3, dut-r4 ]
 
 nodes:
   dut:
+    vrfs:
+      red.loopback.ipv6: 2001:db8:c001:cafe::/64
+      blue.loopback.ipv6: 2001:db8:c001:cafe::/64
   r1:
     bgp.as: 65101
   r2:


### PR DESCRIPTION
Fixes #2068