### PR TITLE
Use anycast gateway in EVPN (a)symmetric IRB tests

### DIFF
--- a/tests/integration/evpn/02-vxlan-asymmetric-irb.yml
+++ b/tests/integration/evpn/02-vxlan-asymmetric-irb.yml
@@ -9,6 +9,8 @@ message: |
   Please note it might take a while for the lab to work due to STP learning
   phase.
 
+plugin: [ anycast-check ]
+
 groups:
   _auto_create: True
   hosts:

--- a/tests/integration/evpn/03-vxlan-symmetric-irb.yml
+++ b/tests/integration/evpn/03-vxlan-symmetric-irb.yml
@@ -9,6 +9,8 @@ message: |
   Please note it might take a while for the lab to work due to STP learning
   phase.
 
+plugin: [ anycast-check ]
+
 groups:
   _auto_create: True
   hosts:
@@ -17,13 +19,14 @@ groups:
     provider: clab
   switches:
     members: [ s1, s2 ]
-    module: [ vlan, vxlan, vrf, ospf, bgp, evpn ]
+    module: [ vlan, vxlan, vrf, ospf, bgp, evpn, gateway ]
   x_switches:
     members: [ s2 ]
-    device: frr
+    device: eos
     provider: clab
 
 bgp.as: 65000
+gateway.protocol: anycast
 
 vrfs:
   customer:
@@ -34,14 +37,17 @@ vlans:
     role: external
     links: [ s1-h1, s2-h2 ]
     vrf: customer
+    gateway: True
   blue:
     role: external
     links: [ s1-h3 ]
     vrf: customer
+    gateway: True
   green:
     role: external
     links: [ s2-h4 ]
     vrf: customer
+    gateway: True
 
 links:
 - s1:

--- a/tests/integration/evpn/anycast-check/plugin.py
+++ b/tests/integration/evpn/anycast-check/plugin.py
@@ -1,0 +1,38 @@
+"""
+This plugin deals with devices that do not support
+anycast gateway. It finds the default device, checks
+whether it supports anycast gateway, and removes
+"gateway" attribute from the VLANs if needed.
+"""
+
+from box import Box
+from netsim.augment.devices import get_device_features
+from netsim.data import get_box
+from netsim.modules import get_effective_module_attribute
+from netsim.utils import log
+
+def pre_transform(topology: Box) -> None:
+  gw_proto = get_effective_module_attribute('gateway.protocol',topology=topology,defaults=topology.defaults)
+  if gw_proto != 'anycast':
+    return
+
+  def_device = topology.defaults.device
+  node = get_box({'device': def_device})
+  features = get_device_features(node,topology.defaults)
+
+  if 'anycast' in features.get('gateway.protocol'):
+    return
+
+  for vname,vdata in topology.get('vlans',{}).items():
+    if not isinstance(vdata,Box):
+      continue
+    gw_data = vdata.get('gateway',None)
+    if gw_data is None:
+      continue
+
+    if gw_data is True:
+      log.warning(
+        text=f'Removing anycast gateway from VLAN {vname}',
+        more_hints=f'Device {def_device} does not support anycast gateways',
+        module='anycast')
+      vdata.pop('gateway',None)


### PR DESCRIPTION
* Use Arista EOS as a probe device in symmetric IRB test
* Use a plugin to remove the anycast gateway functionality for devices that do not support it (so they can still have a chance of passing the IRB tests, although with reduced functionality)