### PR TITLE
Add "integration" parameter to device-module-test

### DIFF
--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -63,7 +63,11 @@ def docker_connect(
   if not isinstance(shell,list):
     shell = str(shell).split(' ')
 
-  c_args = ['docker','exec','-it',host] + shell
+  c_args = [ 'docker','exec' ]
+  if sys.__stdin__ is not None and sys.__stdin__.isatty():
+    c_args += [ '-it']
+  c_args += [ host ] + shell
+
   if rest:
     c_args.extend(['-c',' '.join(rest)])
 

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -80,6 +80,11 @@ def test_parse(args: typing.List[str], topology: Box) -> argparse.Namespace:
     action='store',
     default='create,up,initial,validate',
     help='List of steps to execute')
+  parser.add_argument(
+    '--integration',
+    dest='integration',
+    action='store',
+    help='GitHub comment triggering the integration test run')
   parser_add_verbose(parser)
 
   return parser.parse_args(args)
@@ -95,6 +100,16 @@ def load_system_defaults() -> Box:
 def check_device_provider(args: argparse.Namespace, topology: Box) -> None:
   if args.platform:
     return
+
+  if args.integration:
+    i_list = args.integration.replace('  ',' ').split(' ')
+    if len(i_list) < 4:
+      log.fatal('Start the test with /integration provider device test(s) [ limit ]')
+    args.provider = i_list[1]
+    args.device = i_list[2]
+    args.tests = i_list[3].split(',')
+    if len(i_list) >= 5:
+      args.limit = i_list[4]
 
   if args.device:
     os.environ['NETLAB_DEVICE'] = args.device


### PR DESCRIPTION
This extra parameter allows the integration tests to be run from GitHub PR comments