### PR TITLE
Make the behavior of hosts more controlled

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -73,7 +73,7 @@ nodes:
 * BIRD is implemented as a pure control-plane daemon running as a container with a single external interface. You can set the node **role** to **router** to turn a BIRD instance into a more traditional networking device with a loopback interface.
 * _netlab_ installs BIRD software in a container image running Ubuntu 24.04. The current version of BIRD shipping with Ubuntu 24.04 is 2.14.
 * BIRD supports a single router ID used for BGP and OSPF.
-* The VM or container running BIRD in host mode starts with static routes pointing to one of the adjacent routers (see [host routes on Linux](linux-routes)). After establishing routing adjacencies, BIRD copies BGP and OSPF into the kernel IP routing table.
+* The VM or container running BIRD in host mode starts with static routes pointing to one of the adjacent routers (see [](linux-forwarding)). After establishing routing adjacencies, BIRD copies BGP and OSPF into the kernel IP routing table.
 
 ### OSPF Caveats
 

--- a/docs/example/linux.md
+++ b/docs/example/linux.md
@@ -39,7 +39,7 @@ links: [ rtr-h1, rtr-h2 ]
 
 Linux containers are configured with host commands executed within the container networking namespace. _netlab_ does not expect to have Python (or any other CLI command) in a Linux container; you can use whatever Linux container you wish.
 
-On Linux hosts, the _netlab_ initial configuration process adds the `/etc/hosts` file, configures IP addresses on management and lab interfaces, installs LLDP and `net-tools` on Ubuntu virtual machines, and creates static routes pointing to the first-hop gateway on the first lab interface ([more details](linux-routes)). The default route (managed by Vagrant or containerlab) always points to the management interface, allowing you to connect to the Internet and install additional software on Linux hosts.
+On Linux hosts, the _netlab_ initial configuration process adds the `/etc/hosts` file, configures IP addresses on management and lab interfaces, installs LLDP and `net-tools` on Ubuntu virtual machines, and creates static routes pointing to the first-hop gateway on the first lab interface ([more details](linux-forwarding)). The default route (managed by Vagrant or containerlab) always points to the management interface, allowing you to connect to the Internet and install additional software on Linux hosts.
 
 ## Custom Containers or Virtual Machines
 

--- a/docs/labs/linux.md
+++ b/docs/labs/linux.md
@@ -51,27 +51,16 @@ On a VRF-enabled router, you might get the following entries (the router has onl
 
 The netlab-generated entries are *appended* to the existing `/etc/hosts` file on virtual machines. The container `/etc/hosts` file is generated from scratch to remove the management IP addresses *containerlab* inserted into the `/etc/hosts` file.
 
-(linux-routes)=
-## Host Routing
-
-Generic Linux device is an IP host that by default does not support IP forwarding or IP routing protocols. It uses static routes set up as follows:
-
-* IPv4 default route points to Vagrant- or containerlab management interface (set by Vagrant/DHCP or containerlab).
-* IPv6 default route points to whichever adjacent device is sending IPv6 Route Advertisement messages (default Linux behavior).
-* IPv4 static routes for all IPv4 address pools defined in lab topology point to the subnet default gateway on the first non-management interface.
-
-The default gateway on a subnet is set by the [gateway module](../module/gateway.md). If you're not using that module, _netlab_ sets the default gateway to the interface IP address of the first non-host[^NH] device connected to the subnet.
-
-[^NH]: A device that does not have **role** set to **host**. A Linux node is usually a **host** and cannot be used as a default gateway.
-
 (linux-forwarding)=
-## Packet Forwarding on Linux Hosts
+## Static Routes and Packet Forwarding on Linux
 
-IPv4 and IPv6 packet forwarding on Linux devices is controlled with the **role** node parameter:
+Linux devices are usually hosts using [static routes](node-router-host) toward the [default gateway](links-gateway).
+
+IPv4 and IPv6 packet forwarding on Linux devices also is controlled with the **role** node parameter:
 
 * **host** (default): a Linux device does not perform packet forwarding and cannot be the default gateway for other hosts.
 * **gateway**: a Linux device does not perform packet forwarding but acts as the default gateway for other hosts. You will have to install a proxy (or a similar solution) for inter-subnet packet forwarding.
-* **router**: A Linux device performs packet forwarding but does not run routing protocols. Use **frr** or **cumulus** device if you want to run routing protocols on a Linux server.
+* **router**: A Linux device performs packet forwarding but does not run routing protocols. Use **frr** device if you want to run routing protocols on a Linux server.
 
 (linux-loopback)=
 ## Loopback Interface
@@ -145,7 +134,7 @@ _netlab_ initial configuration script will skip Ubuntu package installation if i
 The initial configuration process (**[netlab initial](../netlab/initial.md)**) does not rely on commands executed within Linux containers:
 
 * The `/etc/hosts` file is generated during the **[netlab create](../netlab/create.md)** process from the ```templates/provider/clab/frr/hosts.j2``` template (see [](clab-config-template)).
-* Interface IP addresses, static routes to the default gateway (see [](linux-routes)) and any lag bonding interfaces are configured with **ip** commands executed on the Linux host but within the container network namespace.
+* Interface IP addresses, static routes to the default gateway (see [](linux-forwarding)), and any lag bonding interfaces are configured with **ip** commands executed on the Linux host but within the container network namespace.
 * Static default route points to the management interface.
 
 You can, therefore, use any container image as a Linux node.

--- a/docs/links.md
+++ b/docs/links.md
@@ -420,7 +420,7 @@ A lab device could be a networking device or a host[^HOST]. Links with attached 
 
 * The link type is set to **lan** regardless of the number of attached nodes.
 * If the link **role** is not defined in the topology file, it's set to **stub**  to turn the attached router interfaces into *passive* interfaces[^NOPASS].
-* If the link **gateway** attribute is not defined, it's set to the IP address of the first attached non-host device. You can set the link **gateway** to any value you wish; the value is not checked.
+* If the link **gateway** attribute is not defined (for example, by the [gateway module](module-gateway)), it's set to the IP address of the first attached non-host device. You can set the link **gateway** to any value you wish; the value is not checked.
 * The link **gateway** attribute is copied into the interface data of host nodes and is used to create static routes pointing to the default gateway during the initial device configuration.
 
 [^HOST]: Host devices are identified by **role: host** node attribute. **linux** is the only built-in host device available at the moment.

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -76,7 +76,7 @@ nodes:
 * **mgmt** -- management IPv4/IPv6 addresses. Used primarily with the [**external** provider](labs/external.md)
 * **mtu** -- sets device-wide (*system*) MTU. This MTU is applied to all interfaces that don't have an explicit MTU ([more details](links-mtu)).
 * **provider** -- virtualization provider used by this node (see [](labs/multi-provider.md) for more details).
-* **role** -- when set to **host**, the device does not get a loopback IP address and uses static routing toward the [default gateway](links.md#hosts-and-default-gateways). The only supported host device is *linux*, for which the host **role** is set in system device defaults.
+* **role** -- when set to **host**, the device does not get a loopback IP address and [uses static routing](node-router-host) toward the [default gateway](links-gateway) ([more details](node-router-host))
 * **unmanaged** -- when set to *True*, the node is not managed or configured by *netlab*. Use this parameter when integrating *netlab* topologies with additional external devices, which should not be configured by *netlab* ([more details](external-unmanaged)).
 
 ```{tip}
@@ -84,7 +84,22 @@ nodes:
 * You still have to specify the device type (either in the node or as the [default device type](default-device-type)) for unmanaged nodes. _netlab_ uses the device type to determine which features a node supports. If you want to use an unsupported unmanaged device, set **‌device** to **‌none**.
 ```
 
+(node-router-host)=
+## Hosts and Routers
+
+Most _netlab_-supported devices act as *routers*: they have at least one [loopback interface](node-loopback) and run routing protocols to find the best path(s) toward remote destinations.
+
+Hosts do not have loopback interfaces (it's easiest if they have a single interface) and use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab set up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
+
+Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route in the global VRF.
+
+Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ can add an IPv6 default route[^SRv6] on devices that do not listen to RA messages.
+
+[^SRv6]: Or a set of static IPv6 routes for address pool prefixes on devices without a management VRF
+
 (node-loopback)=
+## Loopbacks
+
 You can use the **loopback** node attribute to change the [default allocation of loopback addresses](addressing-loopback). It's a dictionary that can contain static loopback prefixes (**ipv4** and/or **ipv6** attributes) or an alternate addressing pool (**pool** attribute[^LBIN]).
 
 [^LBIN]: The alternate pool you use for IPv4 loopback addresses should have **loopback** in its name (to tell _netlab_ to set the allocated prefix length to /32) or a [**prefix** attribute](address-pool-specs), preferably set to 32. The IPv6 prefix length is automatically set to /64 unless you specify it with the **prefix6** attribute.

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -25,3 +25,5 @@ features:
   ospf:
     unnumbered: false
   dhcp: false
+  initial:
+    roles: [ host, router ]

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -19,6 +19,8 @@ virtualbox:
 features:
   dhcp:
     server: true
+  initial:
+    roles: [ host ]
 dhcp:
   server: true
 module: [ dhcp ]

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -92,7 +92,7 @@ node:
   id: { type: int, min_value: 1, max_value: 150 }
   config: list
   group: list
-  role: id
+  role: { type: str, valid_values: [ router, host, bridge, gateway ] }
   mgmt:
     ipv4: { type: ipv4, use: address }
     ipv6: { type: ipv6, use: address }

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -21,6 +21,8 @@ features:
       lla: true
     max_mtu: 9194
     min_mtu: 68
+    roles: [ host, router ]
+    mgmt_vrf: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -55,6 +55,7 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+    roles: [ host, router ]
   bfd: True
   bgp:
     activate_af: true

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -38,6 +38,8 @@ features:
       unnumbered: false
     ipv6:
       lla: true
+    roles: [ host, router ]
+    mgmt_vrf: true
   isis:
     import: [ bgp, ospf, ripv2, connected ]
     unnumbered:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -17,6 +17,7 @@ features:
     static: true
   initial:
     ipv6_use_ra: true
+    roles: [ host ]
 libvirt:
   image: bento/ubuntu-24.04
   group_vars:

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -63,6 +63,8 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    mgmt_vrf: True
+    roles: [ router, bridge, host ]
   isis:
     import: [ bgp, ospf, ripv2, connected, vrf ]
     vrf: True

--- a/tests/errors/ia-node.log
+++ b/tests/errors/ia-node.log
@@ -4,10 +4,11 @@ IncorrectAttr in bgp: Invalid bgp node attribute 'wrong' found in nodes.r1.bgp
 IncorrectAttr in nodes: nodes.r1 uses an attribute from module ospf which is not enabled in nodes.r1
 IncorrectAttr in nodes: Invalid node attribute 'also_wrong' found in nodes.r1
 ... use 'netlab show attributes node' to display valid attributes
-IncorrectType in nodes: attribute 'nodes.r1.role' must be a 16-character identifier, found BoxList
-... FYI: a 16-character identifier is a string starting with a letter or
-... an underscore and containing up to 16 letters, numbers, or underscores
+IncorrectType in nodes: attribute 'nodes.r1.role' must be a string, found BoxList
 IncorrectValue in nodes: attribute 'nodes.r1.mtu' must be an integer between 64 and 9216
 IncorrectValue in nodes: attribute 'nodes.r1.id' must be an integer between 1 and 150
 IncorrectType in nodes: attribute 'nodes.r1.memory' must be an integer, found str
+IncorrectValue in nodes: attribute nodes.r2.role has invalid value(s): unknown
+... valid values are: router, host, bridge, gateway
+MissingValue in bgp: Mandatory attribute 'nodes.r2.bgp.as' is missing
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/ia-node.yml
+++ b/tests/errors/ia-node.yml
@@ -17,3 +17,5 @@ nodes:
     id: 1230
     cpu: [ unknown ]
     memory: 2M
+  r2:
+    role: unknown

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -171,6 +171,9 @@ nodes:
           intf: eth1
           ipv4: 172.16.0.2
   h2:
+    _features:
+      initial:
+        mgmt_vrf: true
     af:
       ipv4: true
     box: none
@@ -216,22 +219,7 @@ nodes:
     role: host
     routing:
       static:
-      - ipv4: 172.16.0.0/16
-        nexthop:
-          idx: 0
-          intf: eth1
-          ipv4: 172.16.0.2
-      - ipv4: 10.0.0.0/24
-        nexthop:
-          idx: 0
-          intf: eth1
-          ipv4: 172.16.0.2
-      - ipv4: 10.1.0.0/16
-        nexthop:
-          idx: 0
-          intf: eth1
-          ipv4: 172.16.0.2
-      - ipv4: 10.2.0.0/24
+      - ipv4: 0.0.0.0/0
         nexthop:
           idx: 0
           intf: eth1

--- a/tests/topology/input/vlan-access-single.yml
+++ b/tests/topology/input/vlan-access-single.yml
@@ -31,6 +31,7 @@ nodes:
 
   h2:
     device: linux
+    _features.initial.mgmt_vrf: True
 
 links:
 - h1:


### PR DESCRIPTION
* Each device (apart from routers) must have its valid roles defined
* A node can become a host only if the device allows the 'host' role
* Static routing for hosts checks the 'mgmt_vrf' feature and uses either default route or specific routes for address pool prefixes.

Note:
* We cannot use 'mgmt_vrf' for FRR containers, as we don't know whether we'll manage to load the 'vrf' module during the initial configuration