### PR TITLE
Use report_quirk to for consistent reporting of device quirks

### DIFF
--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -19,8 +19,8 @@ report:
     package-, system-, user- or current directory. You can also specify a report in a
     defaults.outputs.report setting.
 
-quirks:
-  junos_lb: >
+junos:
+  single_lb: >
     Junos devices cannot have more than one loopback interface per routing instance
 
 vlan:

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -25,7 +25,7 @@ class Cumulus(_Quirks):
         text=f"We do not test Cumulus containers ({node.name}). They might not work correctly",
         node=node,
         category=Warning,
-        quirk="container",
+        quirk="unsupported_container",
         more_hints=[ "See https://netlab.tools/caveats/#caveats-cumulus for more details "])
 
     mods = node.get('module',[])

--- a/netsim/devices/cumulus.py
+++ b/netsim/devices/cumulus.py
@@ -3,22 +3,31 @@
 #
 from box import Box
 
-from . import _Quirks
+from . import _Quirks,report_quirk
 from ..utils import log
 from ..augment import devices
 
 def check_ospf_vrf_default(node: Box) -> None:
   for vname,vdata in node.get('vrfs',{}).items():
     if vdata.get('ospf.default',None):
-      log.error(
-        f"VRF OSPF default route is not working on Cumulus Linux (node {node.name}, vrf {vname})",
-        category=log.IncorrectType,
-        module='quirks')
+      report_quirk(
+        text=f"VRF OSPF default route is not working (node {node.name}, vrf {vname})",
+        node=node,
+        quirk='ospf_default',
+        category=log.IncorrectType)
 
 class Cumulus(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
+    if devices.get_provider(node,topology) == 'clab':
+      report_quirk(
+        text=f"We do not test Cumulus containers ({node.name}). They might not work correctly",
+        node=node,
+        category=Warning,
+        quirk="container",
+        more_hints=[ "See https://netlab.tools/caveats/#caveats-cumulus for more details "])
+
     mods = node.get('module',[])
     if 'ospf' in mods and 'vrfs' in node:
       check_ospf_vrf_default(node)

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -158,5 +158,5 @@ class Cumulus_Nvue(_Quirks):
         text=f"Cumulus VX 5.x container used for node {node.name} is not supported and might not work correctly",
         node=node,
         category=Warning,
-        quirk="container",
+        quirk="unsupported_container",
         more_hints=[ "See https://netlab.tools/caveats/#caveats-cumulus-nvue for more details "])

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -44,10 +44,11 @@ Checks for OSPFv3 which is not supported by NVUE configuration command
 """
 def nvue_check_ospfv3(node: Box) -> None:
   if node.get('ospf.af.ipv6',False):
-    log.error(f"Node '{node.name}' uses OSPFv3 which cannot be configured through Cumulus NVUE; use a regular 'cumulus' node instead",
-      category=log.FatalError,
-      module='ospf',
-      hint='ospfv3')
+    report_quirk(
+      text=f"Node '{node.name}' uses OSPFv3 which cannot be configured through Cumulus NVUE",
+      more_hints=[ "Use a regular 'cumulus' node instead" ],
+      node=node,
+      category=log.IncorrectType)
 
 """
 Checks for mixed trunk interfaces with native routed vlan. That doesn't work because the parent interface gets added
@@ -153,8 +154,9 @@ class Cumulus_Nvue(_Quirks):
       nvue_check_native_routed_on_mixed_trunk(node,topology)
 
     if devices.get_provider(node,topology) == 'clab':
-      log.error(
-        f"Cumulus VX 5.x container used for node {node.name} is not supported and might not work correctly",
+      report_quirk(
+        text=f"Cumulus VX 5.x container used for node {node.name} is not supported and might not work correctly",
+        node=node,
         category=Warning,
-        module='cumulus_nvue',
+        quirk="container",
         more_hints=[ "See https://netlab.tools/caveats/#caveats-cumulus-nvue for more details "])

--- a/netsim/devices/eos.py
+++ b/netsim/devices/eos.py
@@ -36,6 +36,7 @@ def check_mpls_clab(node: Box, topology: Box) -> None:
         text=f'Arista cEOS ({node.name}) versions earlier than 4.32.1F do not support MPLS data plane',
         more_hints = 'To use MPLS with older EOS versions, use vEOS VM with libvirt provider',
         node=node,
+        quirk='mpls_data_plane',
         category=Warning)
 
 def check_shared_mac(node: Box, topology: Box) -> None:
@@ -65,6 +66,7 @@ def check_dhcp_clients(node: Box, topology: Box) -> None:
       continue
     report_quirk(
       text=f"Arista cEOS containers (node {node.name}) cannot run DHCP clients",
+      more_hints="Use vEOS VM with libvirt provider",
       node=node,
       category=log.IncorrectType)
 

--- a/netsim/devices/eos.py
+++ b/netsim/devices/eos.py
@@ -17,10 +17,10 @@ def check_mlps_vlan_bundle(node: Box) -> None:
     if not vdata.get('evpn.bundle',False):                              # Check only VLANs within a bundle
       continue
     if vdata.get('mode','') != 'bridge':                                # They must be in pure bridging mode
-      log.error(
-        f'Arista EOS supports only bridge VLANs in an EVPN/MPLS VLAN bundle ({vname} on {node.name})',
-        log.IncorrectType,
-        'quirks')
+      report_quirk(
+        text=f'Arista EOS supports only bridge VLANs in an EVPN/MPLS VLAN bundle ({vname} on {node.name})',
+        node=node,
+        category=log.IncorrectType)
     ifname = f'Vlan{vdata.id}'                                          # Now remove the VLAN interface
     node.interfaces = [ intf for intf in node.interfaces if intf.ifname != ifname ]
 
@@ -32,11 +32,11 @@ def check_mpls_clab(node: Box, topology: Box) -> None:
       ceos_version = ''
 
     if ceos_version < '4.32.1F':
-      log.error(
-        f'Arista cEOS ({node.name}) versions earlier than 4.32.1F do not support MPLS data plane',
+      report_quirk(
+        text=f'Arista cEOS ({node.name}) versions earlier than 4.32.1F do not support MPLS data plane',
         more_hints = 'To use MPLS with older EOS versions, use vEOS VM with libvirt provider',
-        category=Warning,
-        module='quirks')
+        node=node,
+        category=Warning)
 
 def check_shared_mac(node: Box, topology: Box) -> None:
   if devices.get_provider(node,topology) != 'clab':
@@ -49,10 +49,11 @@ def check_shared_mac(node: Box, topology: Box) -> None:
     if intf.get('vlan',None):                                           # Anycast works on VLAN cEOS interfaces
       continue
 
-    log.error(
-      f'Anycast gateway (VARP) on non-VLAN interfaces does not work on Arista cEOS ({node.name}).\n.. Use vEOS VM with libvirt provider',
-      log.IncorrectType,
-      'quirks')
+    report_quirk(
+      text=f'Anycast gateway (VARP) on non-VLAN interfaces does not work on Arista cEOS ({node.name})',
+      more_hints="Use vEOS VM with libvirt provider",
+      node=node,
+      category=log.IncorrectType)
     return
 
 def check_dhcp_clients(node: Box, topology: Box) -> None:
@@ -62,10 +63,10 @@ def check_dhcp_clients(node: Box, topology: Box) -> None:
   for intf in node.interfaces:
     if not intf.get('dhcp.client',False):
       continue
-    log.error(
-      f"Arista cEOS containers (node {node.name}) cannot run DHCP clients.",
-      category=log.IncorrectType,
-      module='quirks')
+    report_quirk(
+      text=f"Arista cEOS containers (node {node.name}) cannot run DHCP clients",
+      node=node,
+      category=log.IncorrectType)
 
 def configure_ceos_attributes(node: Box, topology: Box) -> None:
   serialnumber = node.eos.get('serialnumber',None)
@@ -74,20 +75,21 @@ def configure_ceos_attributes(node: Box, topology: Box) -> None:
     return
 
   if 'clab' not in node or node.clab.kind != "ceos":
-    log.error(
+    report_quirk(
       f"eos.serialnumber and eos.systemmacaddr can only be set for Arista cEOS containers (node {node.name}).",
-      category=Warning,
       more_hints=['Use libvirt.uuid to influence serial number on EOS virtual machines'],
-      module='quirks')
+      node=node,
+      category=Warning,
+      quirk='serialnumber')
     return
   
   mnt_config = '/mnt/flash/ceos-config'
   for ct in node.get('clab.binds',[]):
     if mnt_config in ct:
-      log.error(
-        f"{mnt_config} file is already mapped, unable to configure eos.serialnumber (node {node.name}).",
-        category=log.Skipped,
-        module='quirks')
+      report_quirk(
+        text=f"{mnt_config} file is already mapped, unable to configure eos.serialnumber (node {node.name}).",
+        node=node,
+        category=Warning)
       return
 
   data.append_to_list(node.clab,'binds',f'clab_files/{node.name}/ceos-config:{mnt_config}')

--- a/netsim/devices/iosv.py
+++ b/netsim/devices/iosv.py
@@ -17,10 +17,11 @@ def check_vrrp_bvi(node: Box, topology: Box) -> None:
     if intf.get('type',None) != 'svi':                                  # Not a BVI interface, move on
       continue
 
-    log.error(
-      f'Cisco IOSv cannot run VRRP on BVI interfaces.',
-      log.IncorrectType,
-      'quirks')
+    report_quirk(
+      text=f'Cisco IOSv cannot run VRRP on BVI interfaces.',
+      node=node,
+      category=log.IncorrectType,
+      quirk='vrrp_bvi')
     return
 
 '''

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -13,9 +13,11 @@ from .iosv import IOS as _IOS,common_ios_quirks
 def check_reserved_vlans(node: Box, topology: Box) -> None:
   for vname,vdata in node.get('vlans',{}).items():
     if vdata.id in range(1002,1006):
-      log.error(
-        f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 or IOLL2 for historic reasons',
+      report_quirk(
+        text=f'Cannot use VLAN ID {vdata.id} (VLAN {vname}) on Cisco IOSvL2 or IOLL2 for historic reasons',
+        node=node,
         category=log.IncorrectValue,
+        quirk='vlan.reserved',
         module='quirks')
 
 '''

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -92,11 +92,13 @@ def check_multiple_loopbacks(node: Box, topology: Box) -> None:
   for vname,vcnt in vrf_count.items():
     if vcnt <= 1:
       continue
-    log.error(
-      f'Node {node.name} (device {node.device}) has {vcnt} loopbacks in vrf {vname}',
+    report_quirk(
+      text=f'Node {node.name} (device {node.device}) has {vcnt} loopbacks in vrf {vname}',
+      node=node,
       category=log.IncorrectValue,
-      module='quirks',
-      hint='junos_lb')
+      quirk='multi_loopback',
+      hint='single_lb',
+      module='junos')
 
 def check_evpn_ebgp(node: Box, topology: Box) -> None:
   for ngb in node.get('bgp.neighbors',[]):

--- a/netsim/devices/linux.py
+++ b/netsim/devices/linux.py
@@ -3,7 +3,7 @@
 #
 from box import Box
 
-from . import _Quirks
+from . import _Quirks,report_quirk
 from ._common import check_indirect_static_routes
 from ..utils import log
 from ..augment import devices
@@ -39,9 +39,9 @@ class Linux(_Quirks):
       return
 
     if 'dhcp' in node.get('module',[]):
-      log.error(
-        f"netlab does not support DHCP functionality in Linux containers",
+      report_quirk(
+        text=f"netlab does not support DHCP functionality in Linux containers (node {node.name})",
+        node=node,
         more_hints=[ "Use 'cumulus' for DHCP client or 'dnsmasq' for DHCP server" ],
         category=log.IncorrectType,
-        module='quirks')
-
+        quirk='clab_dhcp_client')


### PR DESCRIPTION
Changed 'log.error' to 'report_quirk' for Aruba, ASAv, CL NVUE, CL, EOS, IOSv, IOSvL2, Junos, and Linux