### PR TITLE
Complete the support for multi-role devices acting as hosts (IOS, EOS)

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -122,6 +122,7 @@ These caveats are common to all Cisco IOS/IOS-XE platforms:
 * It's impossible to configure RIPv2 on individual subnets on Cisco IOS. RIPv2 might be running on more interfaces than intended. _netlab_ configures those interfaces to be *passive*.
 * Cisco IOS does not support passive interfaces in RIPng.
 * Cisco IOS requires a *default metric* when redistributing routes into RIPv2. The RIPv2 configuration template sets the default metric to the value of the **netlab_ripv2_default_metric** node parameter (default: 5)
+* Cisco IOS behaves like an awful IP host from the 1980s with the **no ip routing** configuration; it does not use static routes and relies only on the **ip default-gateway**. IPv4 routing is thus enabled even when a Cisco IOS device has **role** set to *host*.
 
 These caveats apply only to Cisco IOSv and IOSvL2
 

--- a/docs/dev/config/index.md
+++ b/docs/dev/config/index.md
@@ -1,3 +1,4 @@
+(dev-config-implementation)=
 # Implementation Notes
 
 The following implementation nodes for configuration deployment, initial device configurations, and select configuration modules should make new device implementations easier. Please contact us if you need implementation notes for other configuration modules.

--- a/docs/dev/device-features.md
+++ b/docs/dev/device-features.md
@@ -13,14 +13,4 @@ If you want to add support for a new configuration module (example: MPLS segment
 * Update the [supported platforms](../platforms.md) documentation and add [caveats](../caveats.md) (if needed).
 * [Submit a PR](guidelines.md).
 
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-   :caption: Implementation Notes
-
-   config/initial.md
-   config/ospf.md
-   config/bfd.md
-   config/vlan.md
-   config/vrf.md
-```
+You'll find more details in the [](dev-config-implementation).

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -50,6 +50,17 @@
 | BIRD Internet Routing Daemon [❗](caveats-bird) | bird               |
 | dnsmasq DHCP server [❗](caveats-dnsmasq)       | dnsmasq            |
 
+(platform-host)=
+Most devices behave as routers (or layer-3 switches); the following devices can take multiple roles or behave as [IP hosts](node-router-host):
+
+| Device | router | host |
+|-----------------------|:--:|:--:|
+| Arista EOS            | ✅ | ✅ |
+| Bird                  | ✅ | ✅ |
+| Cisco IOS/IOS XE[^18v]| ✅ | ✅ |
+| dnsmasq               | ❌  | ✅ |
+| Generic Linux         | ❌  | ✅ |
+
 **Notes:**
 
 * Use the **[netlab show devices](netlab-show-devices)** command to display the list of supported devices and daemons.
@@ -245,7 +256,8 @@ The following interface addresses are supported on various platforms:
 | VyOS                  | ✅  | ✅  | ✅  |
 
 ```{tip}
-See [Initial Configuration Integration Tests Results](https://release.netlab.tools/_html/coverage.initial) for more details.
+* Use **‌netlab show modules -m initial** to display optional initial configuration features supported by individual devices
+* See [Initial Configuration Integration Tests Results](https://release.netlab.tools/_html/coverage.initial) for up-to-date details.
 ```
 
 ## Supported Configuration Modules

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -4,11 +4,15 @@ logging monitor debugging
 aaa authorization exec default local
 !
 lldp run
-{% if af.ipv4|default(False) %}
+{% if af.ipv4|default(False) and role != 'host' %}
 ip routing
+{% else %}
+no ip routing
 {% endif %}
-{% if af.ipv6|default(False) %}
+{% if af.ipv6|default(False) and role != 'host' %}
 ipv6 unicast-routing
+{% else %}
+no ipv6 unicast-routing
 {% endif %}
 !
 {% if vrfs is defined %}
@@ -66,7 +70,11 @@ interface {{ l.ifname }}
     Set interface IPv6 addresses
 #}
 {% if 'ipv6' in l %}
+{%   if role != 'host' %}
  ipv6 nd ra interval 5
+{%   else %}
+ ipv6 nd ra rx accept default-route
+{%   endif %}
 {%   if l.ipv6 is sameas True %}
  ipv6 enable
 {%   elif l.ipv6 is string and l.ipv6|ipv6 %}

--- a/netsim/ansible/templates/initial/eos.vrf.j2
+++ b/netsim/ansible/templates/initial/eos.vrf.j2
@@ -2,11 +2,11 @@
 vrf instance {{ vname }}
  rd {{ vdata.rd }}
 !
-{% if 'ipv4' in vdata.af|default({}) %}
+{% if 'ipv4' in vdata.af|default({}) and role != 'host' %}
 ip routing vrf {{ vname }}
 !
 {% endif %}
-{% if 'ipv6' in vdata.af|default({}) %}
+{% if 'ipv6' in vdata.af|default({}) and role != 'host' %}
 ipv6 unicast-routing vrf {{ vname }}
 !
 {% endif %}

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -14,12 +14,16 @@ ip host {{ hname }} {{ addr_list|join (' ') }}
 !
 {% if af.ipv4|default(False) %}
 ip routing
-!
+{% else %}
+no ip routing
 {% endif %}
-{% if af.ipv6|default(False) %}
+!
+{% if af.ipv6|default(False) and role != 'host' %}
 ipv6 unicast-routing
-!
+{% else %}
+no ipv6 unicast-routing
 {% endif %}
+!
 {% if vrfs is defined %}
 {% include 'ios.vrf.j2' +%}
 !
@@ -86,12 +90,14 @@ interface {{ l.ifname }}
     Set interface addresses: IPv6
 #}
 {% if 'ipv6' in l %}
+{%   if role == 'host' %}
+ ipv6 nd ra suppress all
+ ipv6 nd autoconfig default-route
+{%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable
 {%   elif l.ipv6|ipv6 %}
  ipv6 address {{ l.ipv6|upper }}
-{%   else %}
-! Invalid IPv6 address {{ l.ipv6 }}
 {%   endif %}
 {% endif %}
 {% if l.type == 'svi' and netlab_device_type in ['iosvl2','ioll2'] %}

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -504,7 +504,7 @@ def add_host_static_routes(topology: Box) -> None:
       sr_list = default_static_route_list(topology)
     
     features = devices.get_device_features(n_data,topology.defaults)
-    host_af_list = [ af for af in n_data.af if af != 'ipv6' or not features.initial.ipv6_use_ra ]
+    host_af_list = [ af for af in n_data.af if af != 'ipv6' or not features.initial.ipv6.use_ra ]
     if 'dhcp' in topology.get('module',[]):       # If we use DHCP module, we have to scan for the DHCP clients
       for af in list(host_af_list):          
         if n_data.get('dhcp.server',False):       # ... unfortunately before the DHCP module post-transform cleanup

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -5,6 +5,7 @@ mgmt_if: Management1
 loopback_interface_name: Loopback{ifindex}
 tunnel_interface_name: Tunnel{ifindex}
 lag_interface_name: "port-channel{lag.ifindex}"
+role: router
 virtualbox:
   image: arista/veos
 group_vars:
@@ -19,6 +20,7 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+      use_ra: true
     max_mtu: 9194
     min_mtu: 68
     roles: [ host, router ]

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -11,6 +11,7 @@ group_vars:
   # yamllint disable-line rule:line-length
   netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
 
+role: router
 routing:
   _rm_per_af: True
 features:
@@ -38,6 +39,7 @@ features:
       unnumbered: false
     ipv6:
       lla: true
+      use_ra: true
     roles: [ host, router ]
     mgmt_vrf: true
   isis:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -16,7 +16,8 @@ features:
   routing:
     static: true
   initial:
-    ipv6_use_ra: true
+    ipv6:
+      use_ra: true
     roles: [ host ]
 libvirt:
   image: bento/ubuntu-24.04

--- a/netsim/modules/initial.yml
+++ b/netsim/modules/initial.yml
@@ -4,6 +4,8 @@ features:
     unnumbered: Unnumbered IPv4 interfaces
   ipv6:
     lla: IPv6 LLA-only interfaces
+    use_ra: Listen to RA messages when running as a host
   min_mtu: "Minimum layer-3 MTU supported by the device"
   max_mtu: "Maximum layer-3 MTU supported by the device"
   min_phy_mtu: "Minimum MTU that can be configured with 'mtu' command. Lower MTU settings use 'ip mtu'"
+  roles: Valid device roles

--- a/tests/integration/initial/05-host.yml
+++ b/tests/integration/initial/05-host.yml
@@ -1,0 +1,92 @@
+---
+message:
+  This scenario tests basic interface, IPv4, and IPv6 configuration,
+  including generation of IPv6 Router Advertisements
+
+addressing:
+  loopback:
+    ipv6: 2001:db8:0::/48
+  lan:
+    ipv6: 2001:db8:1::/48
+
+groups:
+  hosts:
+    members: [ h1, h2, h3, h4 ]
+    module: [ routing ]
+    device: linux
+    provider: clab
+
+nodes:
+  dut:
+    role: host
+  rtr:
+    device: frr
+    provider: clab
+  h1:                           # H1 and H3 are used to test packet forwarding capability of DUT
+    routing.static:
+    - prefix: lan_2
+      nexthop.node: dut
+  h2:                           # H2 is used to test default routing on DUT
+    routing.static:
+    - prefix: lan_1
+      nexthop.node: rtr
+  h3:
+    routing.static:
+    - prefix: lan_1
+      nexthop.node: dut
+  h4:
+
+prefix:
+  lan_1:
+    ipv4: 192.168.42.0/24
+    ipv6: 2001:db8:cafe:1::/64
+  lan_2:
+    ipv4: 192.168.43.0/24
+    ipv6: 2001:db8:cafe:2::/64
+
+links:
+- interfaces: [ rtr, h1, dut ]
+  prefix: lan_1
+- rtr-h2
+- interfaces: [ dut, h3, h4 ]
+  prefix: lan_2
+
+validate:
+  ping_dut_v4:
+    description: IPv4 ping H2 => DUT
+    wait: 10
+    wait_msg: Wait for IPv4 interfaces to become operational
+    nodes: [ h2 ]
+    plugin: ping(nodes.dut.interfaces[0].ipv4,af='ipv4')
+  ping_dut_v6:
+    description: IPv6 ping H2 => DUT
+    wait: 10
+    wait_msg: Wait for IPv6 interfaces to become operational
+    nodes: [ h2 ]
+    plugin: ping(nodes.dut.interfaces[0].ipv6,af='ipv6')
+  fwd_dut_v4:
+    description: IPv4 ping H1 <=> H3
+    pass: DUT is not forwarding packets between its interfaces
+    fail: DUT is forwarding traffic between H1 and H3
+    nodes: [ h3 ]
+    plugin: ping('h1',af='ipv4',expect='fail')
+    level: warning
+  fwd_dut_v6:
+    description: IPv6 ping H1 <=> H3
+    pass: DUT is not forwarding packets between its interfaces
+    fail: DUT is forwarding traffic between H1 and H3
+    nodes: [ h3 ]
+    plugin: ping('h1',af='ipv6',expect='fail')
+    level: warning
+  wait_ra:
+    wait: 30
+    description: Wait for the IPv6 RA messages
+  ra_suppress:
+    description: Check for RA-generated default route
+    nodes: [ h4 ]
+    devices: [ linux ]
+    exec: ip -6 route list default
+    pass: DUT is not sending IPv6 RA messages
+    fail: DUT is sending IPv6 RA, H4 got a default route
+    valid: >-
+      'default' not in stdout

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -189,6 +189,7 @@ nodes:
     module:
     - bgp
     name: ce1
+    role: router
   ce2:
     af:
       ipv4: true
@@ -251,6 +252,7 @@ nodes:
     module:
     - bgp
     name: ce2
+    role: router
   cr:
     af:
       ipv4: true
@@ -319,6 +321,7 @@ nodes:
     - mpls
     mpls: {}
     name: cr
+    role: router
   pe1:
     af:
       ipv4: true
@@ -431,6 +434,7 @@ nodes:
       - ibgp
       bgp: {}
     name: pe1
+    role: router
   pe2:
     af:
       ipv4: true
@@ -543,4 +547,5 @@ nodes:
       - ibgp
       bgp: {}
     name: pe2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -256,6 +256,7 @@ nodes:
     - isis
     - bgp
     name: r1
+    role: router
     router_id: 10.0.0.7
   r2:
     af:
@@ -405,6 +406,7 @@ nodes:
     - isis
     - bgp
     name: r2
+    role: router
     router_id: 10.0.0.21
   r3:
     af:
@@ -532,6 +534,7 @@ nodes:
     - isis
     - bgp
     name: r3
+    role: router
     router_id: 10.0.0.42
   r4:
     af:
@@ -643,5 +646,6 @@ nodes:
     - isis
     - bgp
     name: r4
+    role: router
     router_id: 10.0.0.1
 provider: libvirt

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -208,6 +208,7 @@ nodes:
     - isis
     - bgp
     name: r1
+    role: router
     router_id: 10.0.0.7
   r2:
     af:
@@ -347,6 +348,7 @@ nodes:
     - isis
     - bgp
     name: r2
+    role: router
     router_id: 10.0.0.21
   r3:
     af:
@@ -473,6 +475,7 @@ nodes:
     - isis
     - bgp
     name: r3
+    role: router
     router_id: 10.0.0.42
   r4:
     af:
@@ -555,5 +558,6 @@ nodes:
     module:
     - bgp
     name: r4
+    role: router
     router_id: 10.0.0.1
 provider: libvirt

--- a/tests/topology/expected/addressing-lan.yml
+++ b/tests/topology/expected/addressing-lan.yml
@@ -581,6 +581,7 @@ nodes:
       mac: 08:4f:a9:07:00:00
     min_mtu: 1500
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -817,6 +818,7 @@ nodes:
       mac: 08:4f:a9:15:00:00
     min_mtu: 1500
     name: r2
+    role: router
   r3:
     af:
       ipv4: true
@@ -1044,6 +1046,7 @@ nodes:
       mac: 08:4f:a9:2a:00:00
     min_mtu: 1500
     name: r3
+    role: router
   r4:
     af:
       ipv4: true
@@ -1106,4 +1109,5 @@ nodes:
       mac: 08:4f:a9:01:00:00
     min_mtu: 1500
     name: r4
+    role: router
 provider: libvirt

--- a/tests/topology/expected/addressing-p2p.yml
+++ b/tests/topology/expected/addressing-p2p.yml
@@ -451,6 +451,7 @@ nodes:
       mac: 08:4f:a9:07:00:00
     min_mtu: 1500
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -647,4 +648,5 @@ nodes:
       mac: 08:4f:a9:15:00:00
     min_mtu: 1500
     name: r2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -886,6 +886,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -1098,6 +1099,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -1167,6 +1169,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.4
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -102,6 +102,7 @@ nodes:
     module:
     - bgp
     name: lb1
+    role: router
   lb2:
     af:
       ipv4: true
@@ -158,6 +159,7 @@ nodes:
     module:
     - bgp
     name: lb2
+    role: router
   nl1:
     af:
       ipv4: true
@@ -205,6 +207,7 @@ nodes:
     module:
     - bgp
     name: nl1
+    role: router
   nl2:
     af:
       ipv4: true
@@ -261,6 +264,7 @@ nodes:
     module:
     - bgp
     name: nl2
+    role: router
   nl3:
     af:
       ipv4: true
@@ -305,4 +309,5 @@ nodes:
     module:
     - bgp
     name: nl3
+    role: router
 provider: libvirt

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -113,6 +113,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   l2:
     af:
       ipv4: true
@@ -190,6 +191,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -227,6 +227,7 @@ nodes:
     module:
     - bgp
     name: a1
+    role: router
   a2:
     af:
       ipv4: true
@@ -314,6 +315,7 @@ nodes:
     module:
     - bgp
     name: a2
+    role: router
   a3:
     af:
       ipv4: true
@@ -401,6 +403,7 @@ nodes:
     module:
     - bgp
     name: a3
+    role: router
   l1:
     af:
       ipv4: true
@@ -478,6 +481,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   l2:
     af:
       ipv4: true
@@ -591,6 +595,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   l3:
     af:
       ipv4: true
@@ -686,6 +691,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
   s1:
     af:
       ipv4: true
@@ -824,6 +830,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.4
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -146,6 +146,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -243,6 +244,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   r3:
     af:
       ipv4: true
@@ -366,6 +368,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -302,6 +302,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.2
       unnumbered: true
+    role: router
   s1:
     af:
       ipv4: true

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -153,6 +153,7 @@ nodes:
     module:
     - bgp
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -239,4 +240,5 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -188,6 +188,7 @@ nodes:
     module:
     - bgp
     name: e1
+    role: router
   e2:
     af:
       ipv4: true
@@ -243,6 +244,7 @@ nodes:
     module:
     - bgp
     name: e2
+    role: router
   pe1:
     af:
       ipv4: true
@@ -346,6 +348,7 @@ nodes:
     module:
     - bgp
     name: pe1
+    role: router
   pe2:
     af:
       ipv4: true
@@ -449,6 +452,7 @@ nodes:
     module:
     - bgp
     name: pe2
+    role: router
   rr1:
     af:
       ipv4: true
@@ -548,6 +552,7 @@ nodes:
     module:
     - bgp
     name: rr1
+    role: router
   rr2:
     af:
       ipv4: true
@@ -647,4 +652,5 @@ nodes:
     module:
     - bgp
     name: rr2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -184,6 +184,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   r2:
     af:
       ipv4: true
@@ -278,6 +279,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
   x1:
     af:
       ipv4: true
@@ -356,6 +358,7 @@ nodes:
     module:
     - bgp
     name: x1
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -208,6 +208,7 @@ nodes:
     - bgp
     - vrf
     name: r1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -460,6 +461,7 @@ nodes:
     - bgp
     - vrf
     name: r2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -658,6 +660,7 @@ nodes:
     - bgp
     - vrf
     name: r3
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -273,6 +273,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.5
+    role: router
   e2:
     af:
       ipv4: true
@@ -384,6 +385,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.6
+    role: router
   nar:
     af:
       ipv4: true
@@ -418,6 +420,7 @@ nodes:
       mac: 08:4f:a9:07:00:00
     module: []
     name: nar
+    role: router
   pe1:
     af:
       ipv4: true
@@ -552,6 +555,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
   pe2:
     af:
       ipv4: true
@@ -686,6 +690,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.4
+    role: router
   rr1:
     af:
       ipv4: true
@@ -819,6 +824,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   rr2:
     af:
       ipv4: true
@@ -952,6 +958,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -133,6 +133,7 @@ nodes:
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
     name: a_eos
+    role: router
   c_csr:
     af:
       ipv4: true
@@ -190,6 +191,7 @@ nodes:
       mac: 08:4f:a9:02:00:00
     min_mtu: 1500
     name: c_csr
+    role: router
   c_ios:
     af:
       ipv4: true
@@ -246,6 +248,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: c_ios
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -286,6 +286,7 @@ nodes:
     - bgp
     - vrf
     name: r1
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -436,6 +437,7 @@ nodes:
     - bgp
     - vrf
     name: r2
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -570,6 +572,7 @@ nodes:
     module:
     - bgp
     name: r3
+    role: router
   rr:
     af:
       ipv4: true
@@ -656,6 +659,7 @@ nodes:
     module:
     - bgp
     name: rr
+    role: router
 plugin:
 - bgp.session
 - ebgp.multihop

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -212,6 +212,7 @@ nodes:
     module:
     - eigrp
     name: c_csr
+    role: router
   c_ios:
     af:
       ipv4: true
@@ -312,6 +313,7 @@ nodes:
     module:
     - eigrp
     name: c_ios
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -538,6 +538,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -863,6 +864,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -121,6 +121,7 @@ nodes:
     - vrf
     - evpn
     name: a
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -113,6 +113,7 @@ nodes:
     - bgp
     - evpn
     name: a
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -510,6 +510,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -683,6 +684,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -840,6 +842,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/extra-attr-link.yml
+++ b/tests/topology/expected/extra-attr-link.yml
@@ -147,6 +147,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   e2:
     af:
       ipv4: true
@@ -201,6 +202,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: e2
+    role: router
   pe1:
     af:
       ipv4: true
@@ -262,6 +264,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -672,6 +672,7 @@ nodes:
     module:
     - bgp
     name: l1
+    role: router
   l2:
     _fabric_count: 2
     af:
@@ -768,6 +769,7 @@ nodes:
     module:
     - bgp
     name: l2
+    role: router
   l3:
     _fabric_count: 3
     af:
@@ -850,6 +852,7 @@ nodes:
     module:
     - bgp
     name: l3
+    role: router
   l4:
     _fabric_count: 4
     af:
@@ -932,6 +935,7 @@ nodes:
     module:
     - bgp
     name: l4
+    role: router
 plugin:
 - fabric
 provider: libvirt

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -194,6 +194,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -331,6 +332,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -447,6 +449,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -93,6 +93,7 @@ nodes:
     - ospf
     - vrf
     name: r1
+    role: router
     vrf:
       as: 65000
       loopback: true
@@ -216,6 +217,7 @@ nodes:
     - ospf
     - vrf
     name: r2
+    role: router
     vrf:
       as: 65000
       loopback: true

--- a/tests/topology/expected/groups-auto-create.yml
+++ b/tests/topology/expected/groups-auto-create.yml
@@ -39,6 +39,7 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     name: c
+    role: router
   d:
     _auto_create: true
     af:
@@ -59,6 +60,7 @@ nodes:
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
     name: d
+    role: router
   e:
     af:
       ipv4: true

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -155,6 +155,7 @@ nodes:
       mac: 08:4f:a9:03:00:00
     module: []
     name: c
+    role: router
   d:
     af:
       ipv4: true
@@ -246,6 +247,7 @@ nodes:
         ipv4: true
       area: 0.0.0.51
       router_id: 10.0.0.5
+    role: router
   f:
     af:
       ipv4: true

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -119,6 +119,7 @@ nodes:
     module:
     - bgp
     name: a
+    role: router
   b:
     af:
       ipv4: true

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -185,6 +185,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.1
       unnumbered: true
+    role: router
   r2:
     af:
       ipv4: true
@@ -249,6 +250,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.2
       unnumbered: true
+    role: router
   r3:
     af:
       ipv4: true
@@ -333,6 +335,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.3
       unnumbered: true
+    role: router
   r4:
     af:
       ipv4: true
@@ -418,6 +421,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.4
       unnumbered: true
+    role: router
   r5:
     af:
       ipv4: true
@@ -510,6 +514,7 @@ nodes:
       area: 0.0.0.0
       router_id: 10.0.0.5
       unnumbered: true
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
+++ b/tests/topology/expected/igp-ospf-isis-eigrp-disable.yml
@@ -153,6 +153,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -247,6 +248,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -415,6 +415,7 @@ nodes:
     module:
     - isis
     name: a_eos
+    role: router
   c_csr:
     af:
       ipv4: true
@@ -565,6 +566,7 @@ nodes:
     module:
     - isis
     name: c_csr
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -240,6 +240,7 @@ nodes:
     - lag
     - vlan
     name: a1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -348,6 +349,7 @@ nodes:
     - lag
     - vlan
     name: a2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -456,6 +458,7 @@ nodes:
     - lag
     - vlan
     name: b1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -577,6 +580,7 @@ nodes:
     - lag
     - vlan
     name: b2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -343,6 +343,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -418,6 +419,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   r3:
     af:
       ipv4: true

--- a/tests/topology/expected/link-bw.yml
+++ b/tests/topology/expected/link-bw.yml
@@ -56,6 +56,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: e1
+    role: router
   e2:
     af:
       ipv4: true
@@ -89,4 +90,5 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: e2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/link-empty.yml
+++ b/tests/topology/expected/link-empty.yml
@@ -23,6 +23,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: e1
+    role: router
   e2:
     af:
       ipv4: true
@@ -42,4 +43,5 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: e2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/link-formats.yml
+++ b/tests/topology/expected/link-formats.yml
@@ -428,6 +428,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -616,6 +617,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   r3:
     af:
       ipv4: true
@@ -722,6 +724,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/link-group.yml
+++ b/tests/topology/expected/link-group.yml
@@ -174,6 +174,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -246,6 +247,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   r3:
     af:
       ipv4: true
@@ -318,6 +320,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -149,6 +149,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -185,4 +186,5 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: r2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/link-tunnel.yml
+++ b/tests/topology/expected/link-tunnel.yml
@@ -120,6 +120,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -178,6 +179,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: r2
+    role: router
   r3:
     af:
       ipv4: true
@@ -245,4 +247,5 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     name: r3
+    role: router
 provider: libvirt

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -129,6 +129,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -191,6 +192,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: r2
+    role: router
   r3:
     af:
       ipv4: true
@@ -235,4 +237,5 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     name: r3
+    role: router
 provider: libvirt

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -79,6 +79,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -126,6 +127,7 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -41,6 +41,7 @@ nodes:
       mac: 08:4f:a9:01:00:00
     module: []
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -78,6 +79,7 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/module-node-only.yml
+++ b/tests/topology/expected/module-node-only.yml
@@ -46,6 +46,7 @@ nodes:
     module:
     - bfd
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -83,4 +84,5 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -80,6 +80,7 @@ nodes:
       area: 0.0.0.1
       process: 1
       router_id: 0.0.0.17
+    role: router
   r2:
     af:
       ipv4: true
@@ -117,6 +118,7 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
   r3:
     af:
       ipv4: true
@@ -161,6 +163,7 @@ nodes:
       area: 0.0.0.1
       process: 1
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
   process: 1

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -188,6 +188,7 @@ nodes:
     - isis
     - sr
     name: c1
+    role: router
   c2:
     af:
       ipv4: true
@@ -245,6 +246,7 @@ nodes:
     - isis
     - sr
     name: c2
+    role: router
   e1:
     af:
       ipv4: true
@@ -346,6 +348,7 @@ nodes:
     - isis
     - sr
     name: e1
+    role: router
   e2:
     af:
       ipv4: true
@@ -458,4 +461,5 @@ nodes:
     - bgp
     - sr
     name: e2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -202,6 +202,7 @@ nodes:
         - ibgp
         - ebgp
     name: ce1
+    role: router
   ce2:
     af:
       ipv4: true
@@ -275,6 +276,7 @@ nodes:
         ipv6:
         - ebgp
     name: ce2
+    role: router
   p:
     af:
       ipv4: true
@@ -367,6 +369,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
   pe1:
     af:
       ipv4: true
@@ -506,6 +509,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
   pe2:
     af:
       ipv4: true
@@ -643,6 +647,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
   rr:
     af:
       ipv4: true
@@ -756,6 +761,7 @@ nodes:
         ipv6: true
       area: 0.0.0.0
       router_id: 10.0.0.4
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/node.clone-plugin-lag.yml
+++ b/tests/topology/expected/node.clone-plugin-lag.yml
@@ -758,6 +758,7 @@ nodes:
     - lag
     - vlan
     name: r1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -971,6 +972,7 @@ nodes:
     - lag
     - vlan
     name: r2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/nodes-strings.yml
+++ b/tests/topology/expected/nodes-strings.yml
@@ -22,6 +22,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: e1
+    role: router
   e2:
     af:
       ipv4: true
@@ -41,6 +42,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: e2
+    role: router
   e3:
     af:
       ipv4: true
@@ -60,4 +62,5 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     name: e3
+    role: router
 provider: libvirt

--- a/tests/topology/expected/ospf-bfd-test.yml
+++ b/tests/topology/expected/ospf-bfd-test.yml
@@ -174,6 +174,7 @@ nodes:
       area: 0.0.0.0
       bfd: true
       router_id: 10.0.0.1
+    role: router
   r2:
     af:
       ipv4: true
@@ -265,6 +266,7 @@ nodes:
       area: 0.0.0.0
       bfd: true
       router_id: 10.0.0.2
+    role: router
   r3:
     af:
       ipv4: true
@@ -311,6 +313,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
 ospf:
   area: 0.0.0.0
 provider: libvirt

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -361,6 +361,7 @@ nodes:
       area: 0.0.0.1
       router_id: 172.18.1.3
       unnumbered: true
+    role: router
   c_csr:
     af:
       ipv4: true
@@ -505,6 +506,7 @@ nodes:
       area: 0.0.0.1
       router_id: 172.18.1.2
       unnumbered: true
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -240,6 +240,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -313,6 +314,7 @@ nodes:
     - vlan
     - gateway
     name: s2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -112,6 +112,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 2
       mode: route
@@ -198,6 +199,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/rt-vlan-no-gateway.yml
+++ b/tests/topology/expected/rt-vlan-no-gateway.yml
@@ -179,6 +179,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -106,6 +106,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -190,6 +191,7 @@ nodes:
     module:
     - vlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -274,6 +276,7 @@ nodes:
     module:
     - vlan
     name: s3
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -518,6 +518,7 @@ nodes:
     - vlan
     - stp
     name: s1
+    role: router
     stp:
       enable: true
       protocol: stp
@@ -669,6 +670,7 @@ nodes:
     - vlan
     - stp
     name: s2
+    role: router
     stp:
       enable: true
       protocol: stp
@@ -779,6 +781,7 @@ nodes:
     - vlan
     - stp
     name: s3
+    role: router
     stp:
       enable: true
       port_type: edge

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -517,6 +517,7 @@ nodes:
     - vlan
     - stp
     name: s1
+    role: router
     stp:
       enable: true
       protocol: pvrst
@@ -661,6 +662,7 @@ nodes:
     - vlan
     - stp
     name: s2
+    role: router
     stp:
       enable: true
       protocol: pvrst
@@ -797,6 +799,7 @@ nodes:
     - vlan
     - stp
     name: s3
+    role: router
     stp:
       enable: true
       protocol: pvrst

--- a/tests/topology/expected/tools.yml
+++ b/tests/topology/expected/tools.yml
@@ -22,6 +22,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: a_eos
+    role: router
 provider: libvirt
 tools:
   graphite:

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -127,4 +127,5 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: r1
+    role: router
 provider: libvirt

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -153,6 +153,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: a_eos
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -82,6 +82,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     name: a_eos
+    role: router
   a_eos_2:
     af:
       ipv4: true
@@ -115,6 +116,7 @@ nodes:
       ipv4: 192.168.121.103
       mac: 08:4f:a9:03:00:00
     name: a_eos_2
+    role: router
   c_nxos:
     af:
       ipv4: true

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -300,6 +300,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -402,6 +403,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -137,6 +137,7 @@ nodes:
     module:
     - bgp
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -211,6 +212,7 @@ nodes:
     module:
     - bgp
     name: r2
+    role: router
   s1:
     af:
       ipv4: true
@@ -285,6 +287,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -243,6 +243,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -318,6 +319,7 @@ nodes:
     module:
     - vlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -332,6 +332,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -437,6 +438,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -514,6 +516,7 @@ nodes:
     module:
     - vlan
     name: s3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -277,6 +277,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: 08:4f:a9:01:00:00
     name: r1
+    role: router
   s1:
     af:
       ipv4: true
@@ -375,6 +376,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -490,6 +492,7 @@ nodes:
     module:
     - vlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -302,6 +302,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -416,6 +417,7 @@ nodes:
     module:
     - vlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -197,6 +197,7 @@ nodes:
     module:
     - vlan
     name: r1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -314,6 +315,7 @@ nodes:
     module:
     - vlan
     name: r2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -123,6 +123,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -185,6 +186,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -281,6 +283,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -102,6 +102,7 @@ nodes:
     module:
     - vlan
     name: r
+    role: router
     vlan:
       max_bridge_group: 2
       mode: route

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -837,6 +837,7 @@ nodes:
     - vlan
     - vrf
     name: s1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -202,6 +202,7 @@ nodes:
     module:
     - vlan
     name: r1
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -160,6 +160,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
   r2:
     af:
       ipv4: true
@@ -209,6 +210,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.4
+    role: router
   ros:
     af:
       ipv4: true
@@ -300,6 +302,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.5
+    role: router
     vlan:
       max_bridge_group: 2
       mode: route
@@ -422,6 +425,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
       mode: bridge
@@ -529,6 +533,7 @@ nodes:
     module:
     - vlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -697,6 +697,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -906,6 +907,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -422,6 +422,7 @@ nodes:
       ipv4: 192.168.121.108
       mac: 08:4f:a9:08:00:00
     name: h5
+    role: router
   r1:
     af:
       ipv4: true
@@ -544,6 +545,7 @@ nodes:
     - ospf
     - vrf
     name: r1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -863,6 +865,7 @@ nodes:
     - ospf
     - vrf
     name: r2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -1131,6 +1134,7 @@ nodes:
     - ospf
     - vrf
     name: r3
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -405,6 +405,7 @@ nodes:
     - vlan
     - gateway
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -533,6 +534,7 @@ nodes:
     - vlan
     - gateway
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -218,6 +218,7 @@ nodes:
     - ospf
     - vrf
     name: r1
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -438,6 +439,7 @@ nodes:
     - ospf
     - vrf
     name: r2
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -627,6 +629,7 @@ nodes:
     - ospf
     - vrf
     name: r3
+    role: router
     vrf:
       as: 65000
     vrfs:

--- a/tests/topology/expected/vrf-loopback.yml
+++ b/tests/topology/expected/vrf-loopback.yml
@@ -42,6 +42,7 @@ nodes:
     module:
     - vrf
     name: r1
+    role: router
     vrf:
       as: 65000
       loopback: true

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -389,6 +389,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -783,6 +784,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vrf:
       as: 65000
     vrfs:
@@ -1034,6 +1036,7 @@ nodes:
     - bgp
     - vrf
     name: x
+    role: router
     vrf:
       as: 65000
     vrfs:

--- a/tests/topology/expected/vrrp-interface-granularity.yml
+++ b/tests/topology/expected/vrrp-interface-granularity.yml
@@ -174,6 +174,7 @@ nodes:
     module:
     - gateway
     name: r1
+    role: router
   r2:
     af:
       ipv4: true
@@ -254,4 +255,5 @@ nodes:
     module:
     - gateway
     name: r2
+    role: router
 provider: libvirt

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -149,6 +149,7 @@ nodes:
     - vlan
     - vxlan
     name: r1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -370,6 +371,7 @@ nodes:
     module:
     - vlan
     name: s1
+    role: router
     vlan:
       max_bridge_group: 2
       mode: bridge
@@ -495,6 +497,7 @@ nodes:
     - vlan
     - vxlan
     name: s2
+    role: router
     vlan:
       max_bridge_group: 2
       mode: bridge

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -367,6 +367,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.1
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -510,6 +511,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.2
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -605,6 +607,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.3
+    role: router
     vlans:
       blue:
         id: 1001

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -360,6 +360,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.9
+    role: router
   rh1:
     af:
       ipv4: true
@@ -616,6 +617,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.6
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -876,6 +878,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.7
+    role: router
     vlan:
       max_bridge_group: 2
     vlans:
@@ -1108,6 +1111,7 @@ nodes:
         ipv4: true
       area: 0.0.0.0
       router_id: 10.0.0.8
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:


### PR DESCRIPTION
* Modify IOS and EOS configuration templates to suppress IPv6 RA, listen to RA messages to generate IPv6 default route, and disable packet forwarding (when available)
* Add default role (router) and enable 'ipv6.use_ra' in EOS and IOS device parameters

Other changes:

* Add 'host role' integration test
* Rename 'ipv6_use_ra' feature to 'ipv6.use_ra'
* Display 'ipv6.use_ra' and 'roles' features in 'netlab show modules -m initial' support table
* Update transformation test results -- every instance of IOS or EOS device has 'role' attribute in node data

Documentation:

* Add 'role support' table to platform overview

Developer documentation:

* Move 'initial configuration features' section to 'device parameters'
* Add a section on device roles to 'initial device configuration' document

Off-topic but still relevant:

* Remove duplicate indices of 'implementation guidelines' in developer documentation