### PR TITLE
Implement 'host' functionality for FRRouting

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -59,6 +59,7 @@ Most devices behave as routers (or layer-3 switches); the following devices can 
 | Bird                  | ✅ | ✅ |
 | Cisco IOS/IOS XE[^18v]| ✅ | ✅ |
 | dnsmasq               | ❌  | ✅ |
+| FRRouting             | ✅ | ✅ |
 | Generic Linux         | ❌  | ✅ |
 
 **Notes:**

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -14,9 +14,13 @@ echo
 echo "Use vtysh to connect to FRR daemon"
 echo
 SCRIPT
-{% set fwd_flag = '0' if role == 'host' else '1' %}
-sysctl -w net.ipv4.ip_forward={{ fwd_flag }}
-sysctl -w net.ipv6.conf.all.forwarding={{ fwd_flag }}
+#
+# This is an artifact of unknown provenance that should be removed in a year or two (= 2026/2027)
+#
+# FRR controls these parameters with 'ip forwarding' and 'ipv6 forwarding' commands
+#
+sysctl -w net.ipv4.ip_forward={{ '1' if 'ipv4' in af and role == 'router' else '0' }}
+sysctl -w net.ipv6.conf.all.forwarding={{ '1' if 'ipv6' in af and role == 'router' else '0' }}
 #
 {% if clab is not defined %}
 cat <<SCRIPT >.bash_profile
@@ -119,11 +123,21 @@ echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
+{#
+  These commands set the corresponding net.ipv4 / net.ipv6 variables.
+  As we don't want to assume the default values, we set them explicitly
+  based on device role and configured address families.
+#}
 {% if role == 'host' %}
 no ip forwarding
 no ipv6 forwarding
-{% elif 'ipv6' in af %}
+{% else %}
+{%   if 'ipv4' in af %}
+ip forwarding
+{%   endif %}
+{%   if 'ipv6' in af %}
 ipv6 forwarding
+{%   endif %}
 {% endif %}
 {% if clab is defined and netlab_mgmt_vrf|default(False) %}
 vrf mgmt

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -14,6 +14,10 @@ echo
 echo "Use vtysh to connect to FRR daemon"
 echo
 SCRIPT
+{% set fwd_flag = '0' if role == 'host' else '1' %}
+sysctl -w net.ipv4.ip_forward={{ fwd_flag }}
+sysctl -w net.ipv6.conf.all.forwarding={{ fwd_flag }}
+#
 {% if clab is not defined %}
 cat <<SCRIPT >.bash_profile
 #!/bin/bash
@@ -29,8 +33,6 @@ SCRIPT
 # Configure system defaults on Ubuntu
 #
 hostnamectl set-hostname {{ inventory_hostname }}
-sysctl -w net.ipv4.ip_forward=1
-sysctl -w net.ipv6.conf.all.forwarding=1
 {% include 'linux/packages.j2' %}
 #
 # Install FRR on a Ubuntu VM if needed
@@ -93,17 +95,18 @@ fi
 # Disable IPv6 (for IPv4-only interfaces) or SLAAC (if the device is a router)
 #
 {% for i in interfaces if i.type in ['lan','p2p','stub','lag','bond'] %}
+ip link set {{ i.ifname }} down
 {%   if i.ipv6 is not defined %}
 sysctl -qw net.ipv6.conf.{{ i.ifname }}.disable_ipv6=1
-{%   elif role|default('router') != 'host' %}
-sysctl -qw net.ipv6.conf.{{ i.ifname }}.autoconf=0
-sysctl -qw net.ipv6.conf.{{ i.ifname }}.accept_ra=0
-ip link set {{ i.ifname }} down
-ip link set {{ i.ifname }} up
+{%   else %}
+{%     set ra_flag = '0' if role == 'router' else '1' %}
+sysctl -qw net.ipv6.conf.{{ i.ifname }}.autoconf={{ ra_flag }}
+sysctl -qw net.ipv6.conf.{{ i.ifname }}.accept_ra={{ ra_flag }}
 {%   endif %}
 {%   if i.mtu is defined %}
 ip link set dev {{ i.ifname }} mtu {{ i.mtu }}
 {%   endif %}
+ip link set {{ i.ifname }} up
 {% endfor %}
 
 #
@@ -116,13 +119,16 @@ echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
+{% if role == 'host' %}
+no ip forwarding
+no ipv6 forwarding
+{% elif 'ipv6' in af %}
+ipv6 forwarding
+{% endif %}
 {% if clab is defined and netlab_mgmt_vrf|default(False) %}
 vrf mgmt
  exit-vrf
 !
-{% endif %}
-{% if 'ipv6' in af %}
-ipv6 forwarding
 {% endif %}
 {% set frr_defaults = netlab_frr_defaults|default('datacenter') %}
 frr defaults {{ frr_defaults }}
@@ -144,7 +150,7 @@ interface {{ i.ifname }}
 {%  if i.ipv6 is string and i.ipv6|ipv6 %}
  ipv6 address {{ i.ipv6 }}
 {%  endif %}
-{%  if i.type != 'loopback' %}
+{%  if i.type != 'loopback' and role == 'router' %}
  ipv6 nd ra-interval 5
  no ipv6 nd suppress-ra
 {%  endif %}

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -5,6 +5,7 @@ mgmt_if: eth0
 loopback_interface_name: lo{ifindex if ifindex else ""}
 tunnel_interface_name: "tun{ifindex}"
 lag_interface_name: "bond{lag.ifindex}"
+role: router
 routing:
   _rm_per_af: True
 group_vars:
@@ -55,6 +56,7 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+      use_ra: true
     roles: [ host, router ]
   bfd: True
   bgp:

--- a/tests/topology/expected/clab-attributes.yml
+++ b/tests/topology/expected/clab-attributes.yml
@@ -43,4 +43,5 @@ nodes:
       mac: 08:4f:a9:01:00:00
     mtu: 1500
     name: n
+    role: router
 provider: clab

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -106,6 +106,7 @@ nodes:
     - bgp
     mtu: 1500
     name: l1
+    role: router
   l2:
     af:
       ipv4: true

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -261,6 +261,7 @@ nodes:
     - vrf
     mtu: 1500
     name: h-03
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -364,6 +365,7 @@ nodes:
     - vrf
     mtu: 1500
     name: h-07
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:
@@ -750,6 +752,7 @@ nodes:
     - vrf
     mtu: 1500
     name: r
+    role: router
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -222,6 +222,7 @@ nodes:
     mtu: 1500
     name: s
     provider: clab
+    role: router
     vlan:
       max_bridge_group: 2
       mode: irb

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -423,6 +423,7 @@ nodes:
     - vrf
     mtu: 1500
     name: r1
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -617,6 +618,7 @@ nodes:
     - vrf
     mtu: 1500
     name: r2
+    role: router
     vlan:
       max_bridge_group: 3
     vlans:
@@ -1141,6 +1143,7 @@ nodes:
     - vrf
     mtu: 1500
     name: s2
+    role: router
     vlan:
       max_bridge_group: 3
       mode: bridge


### PR DESCRIPTION
* Enable SLAAC and RA-derived default route
* Disable IPv4 and IPv6 forwarding
* Disable RA generation in host mode
* Minor tweaks to the interface config process (ifdown at start, ifup at the end of interface sysctl modification)