### PR TITLE
Refactor the role-specific node transformation into a separate subsystem

### DIFF
--- a/netsim/augment/__init__.py
+++ b/netsim/augment/__init__.py
@@ -1,13 +1,13 @@
 # Import the whole augmentation tree
 
+from . import devices
 from . import nodes
 from . import groups
 from . import links
-from . import devices
 from . import plugin
 from . import topology
-from . import main
 from . import config
 from . import components
 from . import tools
 from . import validate
+from . import main

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -13,6 +13,7 @@ from .. import modules
 from .. import devices as quirks
 from ..data import global_vars,validate
 from . import addressing
+from .. import roles
 
 def topology_init(topology: Box) -> None:
   global_vars.init(topology)
@@ -27,6 +28,7 @@ def transform_setup(topology: Box) -> None:
   topology.nodes = augment.nodes.create_node_dict(topology.nodes)
   augment.groups.precheck_groups(topology)
   augment.plugin.init(topology)                                         # Initialize plugins very early on in case they modify extra attributes
+  roles.init(topology)                                                  # Initialize node roles
   augment.plugin.execute('topology_expand',topology)                    # topology-expanding plugins must be called before link checks
 
   if 'links' in topology:
@@ -72,6 +74,7 @@ def transform_data(topology: Box) -> None:
   log.exit_on_error()
   augment.plugin.execute('post_node_transform',topology)
   modules.post_node_transform(topology)
+  log.exit_on_error()
 
   if 'links' in topology:
     augment.links.validate(topology)
@@ -84,7 +87,6 @@ def transform_data(topology: Box) -> None:
     augment.plugin.execute('post_link_transform',topology)
 
   modules.post_link_transform(topology)
-  augment.nodes.post_link_transform(topology)
 
 def post_transform(topology: Box) -> None:
   augment.validate.process_validation(topology)

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -1,9 +1,9 @@
 '''
 Create detailed node-level data structures from topology
 
-* Discover desired imagex (boxes)
+* Discover desired images (boxes)
 * Add default module list to nodes without specific modules
-* Set loopback and management interface data
+* Set management interface data
 '''
 import typing
 
@@ -383,7 +383,6 @@ def augment_node_device_data(n: Box, defaults: Box) -> None:
 Main node transformation code
 
 * set node ID
-* set loopback address(es)
 * copy device data from defaults
 * set management IP and MAC addresses
 '''
@@ -415,83 +414,6 @@ def transform(topology: Box, defaults: Box, pools: Box) -> None:
     providers.execute_node("augment_node_data",n,topology)
 
   check_duplicate_mgmt_addr(topology)
-
-'''
-Create the default static route list from pool prefixes
-'''
-def default_static_route_list(topology: Box) -> list:
-  sr_list = []
-
-  for ap_name,ap_data in topology.addressing.items():
-    if ap_name in ['mgmt','router_id']:
-      continue
-
-    for af in ['ipv4','ipv6']:
-      if not isinstance(ap_data.get(af,False),str):
-        continue
-      sr_list.append(data.get_box({ af: ap_data[af], '_skip_missing': True, 'nexthop.gateway': True }))
-
-  return sr_list
-
-'''
-For all hosts, create 'routing.static' table (unless it exists) that contains
-static routes to the first usable default gateway for all pool prefixes or for global
-static routes.
-
-* The IPv4 static routes are generated if the node uses IPv4 AF
-* The IPv6 static routes are generated if the node uses IPv6 AF and does not listen
-  to Router Advertisements
-
-Hosts that have management VRF will get the default static routes, other hosts will
-get static routes configured in the 'routing.static.host' parameter or generated from
-the address pools.
-'''
-def add_host_static_routes(topology: Box) -> None:
-  sr_list = topology.get('routing.static.host',None)
-  sr_default = [ 
-    { 'ipv4': '0.0.0.0/0', '_skip_missing': True, 'nexthop.gateway': True },
-    { 'ipv6': '::/0', '_skip_missing': True, 'nexthop.gateway': True } ]
-
-  for n_name, n_data in topology.nodes.items():
-    if n_data.get('role',None) != 'host':         # Not a host, no need for static routes
-      continue
-
-    if n_data.get('routing.static',None):         # Host already has static routes, move on
-      continue
-
-    # Premature optimization: create the default static route list only when encountering the first host
-    if sr_list is None:
-      sr_list = default_static_route_list(topology)
-    
-    features = devices.get_device_features(n_data,topology.defaults)
-    host_af_list = [ af for af in n_data.af if af != 'ipv6' or not features.initial.ipv6.use_ra ]
-    if 'dhcp' in topology.get('module',[]):       # If we use DHCP module, we have to scan for the DHCP clients
-      for af in list(host_af_list):          
-        if n_data.get('dhcp.server',False):       # ... unfortunately before the DHCP module post-transform cleanup
-          continue                                # ... so we have to skip known DHCP servers
-        for intf in n_data.interfaces:            
-          if intf.get(f'dhcp.server',None):       # ... as well as DHCP relays
-            continue
-          if intf.get(f'dhcp.client.{af}',None):  # Now check for the DHCP clients
-            host_af_list.remove(af)               # Found a DHCP client interface, remove the AF
-
-    if not host_af_list:                          # Is there anything left to do?
-      continue                                    # Nope, no need to muddy the waters
-
-    n_data.routing.static = []
-    sr_data = sr_default if features.initial.mgmt_vrf else sr_list
-    for af in host_af_list:
-      n_data.routing.static += [ data.get_box(sr_entry) for sr_entry in sr_data if af in sr_entry ]
-
-    data.append_to_list(n_data,'module','routing')
-    data.append_to_list(topology,'module','routing')
-
-'''
-Final node transformation step, executed after the link transformation is done and the
-node interfaces have been created.
-'''
-def post_link_transform(topology: Box) -> None:
-  add_host_static_routes(topology)
 
 '''
 Cleanup daemon configuration file data -- remove all daemon config mappings that

--- a/netsim/roles/__init__.py
+++ b/netsim/roles/__init__.py
@@ -13,7 +13,7 @@ Return all nodes matching the specified role(s)
 def select_nodes_by_role(topology: Box, select: typing.Union[str,list]) -> typing.Generator:
   roles = select if isinstance(select,list) else [ select ]
   for node in topology.nodes.values():
-    if node.get('role','router') in select:
+    if node.get('role','router') in roles:
       yield node
   
 """

--- a/netsim/roles/__init__.py
+++ b/netsim/roles/__init__.py
@@ -1,0 +1,26 @@
+#
+# The "node roles" subsystem appends known (statically defined) node roles modules
+# to the topology Plugins (after the user-defined plugins)
+#
+import typing
+from box import Box
+
+from ..data import append_to_list
+
+"""
+Return all nodes matching the specified role(s)
+"""
+def select_nodes_by_role(topology: Box, select: typing.Union[str,list]) -> typing.Generator:
+  roles = select if isinstance(select,list) else [ select ]
+  for node in topology.nodes.values():
+    if node.get('role','router') in select:
+      yield node
+  
+"""
+Initialize the node role subsystem: append all node-handling modules to topology plugins
+"""
+def init(topology: Box) -> None:
+  from . import host,router
+
+  for role in [ host, router ]:
+    append_to_list(topology,'Plugin',role)

--- a/netsim/roles/host.py
+++ b/netsim/roles/host.py
@@ -1,0 +1,87 @@
+'''
+Create detailed node-level data structures from topology
+
+* Discover desired imagex (boxes)
+* Add default module list to nodes without specific modules
+* Set loopback and management interface data
+'''
+import typing
+
+from box import Box, BoxList
+import netaddr
+
+from ..utils import log
+from .. import data
+from ..augment import devices
+
+from . import select_nodes_by_role
+
+'''
+Create the default static route list from pool prefixes
+'''
+def default_static_route_list(topology: Box) -> list:
+  sr_list = []
+
+  for ap_name,ap_data in topology.addressing.items():
+    if ap_name in ['mgmt','router_id']:
+      continue
+
+    for af in ['ipv4','ipv6']:
+      if not isinstance(ap_data.get(af,False),str):
+        continue
+      sr_list.append(data.get_box({ af: ap_data[af], '_skip_missing': True, 'nexthop.gateway': True }))
+
+  return sr_list
+
+'''
+For all hosts, create 'routing.static' table (unless it exists) that contains
+static routes to the first usable default gateway for all pool prefixes or for global
+static routes.
+
+* The IPv4 static routes are generated if the node uses IPv4 AF
+* The IPv6 static routes are generated if the node uses IPv6 AF and does not listen
+  to Router Advertisements
+
+Hosts that have management VRF will get the default static routes, other hosts will
+get static routes configured in the 'routing.static.host' parameter or generated from
+the address pools.
+'''
+def add_host_static_routes(topology: Box) -> None:
+  sr_list = topology.get('routing.static.host',None)
+  sr_default = [ 
+    { 'ipv4': '0.0.0.0/0', '_skip_missing': True, 'nexthop.gateway': True },
+    { 'ipv6': '::/0', '_skip_missing': True, 'nexthop.gateway': True } ]
+
+  for n_data in select_nodes_by_role(topology,'host'):
+    if n_data.get('routing.static',None):         # Host already has static routes, move on
+      continue
+
+    # Premature optimization: create the default static route list only when encountering the first host
+    if sr_list is None:
+      sr_list = default_static_route_list(topology)
+    
+    features = devices.get_device_features(n_data,topology.defaults)
+    host_af_list = [ af for af in n_data.af if af != 'ipv6' or not features.initial.ipv6.use_ra ]
+    if 'dhcp' in topology.get('module',[]):       # If we use DHCP module, we have to scan for the DHCP clients
+      for af in list(host_af_list):          
+        if n_data.get('dhcp.server',False):       # ... unfortunately before the DHCP module post-transform cleanup
+          continue                                # ... so we have to skip known DHCP servers
+        for intf in n_data.interfaces:            
+          if intf.get(f'dhcp.server',None):       # ... as well as DHCP relays
+            continue
+          if intf.get(f'dhcp.client.{af}',None):  # Now check for the DHCP clients
+            host_af_list.remove(af)               # Found a DHCP client interface, remove the AF
+
+    if not host_af_list:                          # Is there anything left to do?
+      continue                                    # Nope, no need to muddy the waters
+
+    n_data.routing.static = []
+    sr_data = sr_default if features.initial.mgmt_vrf else sr_list
+    for af in host_af_list:
+      n_data.routing.static += [ data.get_box(sr_entry) for sr_entry in sr_data if af in sr_entry ]
+
+    data.append_to_list(n_data,'module','routing')
+    data.append_to_list(topology,'module','routing')
+
+def post_link_transform(topology: Box) -> None:
+  add_host_static_routes(topology)

--- a/netsim/roles/router.py
+++ b/netsim/roles/router.py
@@ -1,9 +1,7 @@
 '''
-Create detailed node-level data structures from topology
+Router-specific data transformation
 
-* Discover desired imagex (boxes)
-* Add default module list to nodes without specific modules
-* Set loopback and management interface data
+* Add loopback interface data
 '''
 import typing
 

--- a/netsim/roles/router.py
+++ b/netsim/roles/router.py
@@ -1,0 +1,57 @@
+'''
+Create detailed node-level data structures from topology
+
+* Discover desired imagex (boxes)
+* Add default module list to nodes without specific modules
+* Set loopback and management interface data
+'''
+import typing
+
+from box import Box, BoxList
+
+from ..utils import log
+from ..augment import devices,addressing,links
+
+from . import select_nodes_by_role
+
+'''
+Set addresses of the main loopback interface
+'''
+def loopback_interface(n: Box, pools: Box, topology: Box) -> None:
+  n.loopback.type = 'loopback'
+  n.loopback.neighbors = []
+  n.loopback.virtual_interface = True
+  n.loopback.ifindex = 0
+  n.loopback.ifname = devices.get_loopback_name(n,topology) or 'Loopback'
+
+  pool = n.get('loopback.pool','loopback')
+  prefix_list = addressing.get(pools,[ pool ],n.id)
+
+  for af in prefix_list:
+    if prefix_list[af] is True:
+      log.error(
+        f"Address pool {pool} cannot contain unnumbered/LLA addresses",
+        category=log.IncorrectType,
+        module='nodes')
+    elif not n.loopback[af] and not (prefix_list[af] is False):
+      if af == 'ipv6':
+        if prefix_list[af].prefixlen == 128:
+          n.loopback[af] = str(prefix_list[af])
+        else:
+          n.loopback[af] = addressing.get_nth_ip_from_prefix(prefix_list[af],1)
+      else:
+        n.loopback[af] = str(prefix_list[af])
+      n.af[af] = True
+
+  for af in log.AF_LIST:
+    if af in n.loopback and not isinstance(n.loopback[af],str):
+      log.error(
+        f'{af} address on the main loopback interface of node {n.name} must be a CIDR prefix',
+        category=log.IncorrectType,
+        module='nodes')
+  
+  links.check_interface_host_bits(n.loopback,n)
+
+def post_node_transform(topology: Box) -> None:
+  for ndata in select_nodes_by_role(topology,'router'):
+    loopback_interface(ndata,topology.pools,topology)


### PR DESCRIPTION
* Create 'roles' subsystem
* Initialize the subsystem as a set of role-specific plugins appended to the topology plugins
* Move loopback creation/addressing into 'router' role plugin
* Move default static route processing into 'host' role plugin