### PR TITLE
Accept 'int' and 'bool' values for management IP addresses

### DIFF
--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -94,8 +94,8 @@ node:
   group: list
   role: { type: str, valid_values: [ router, host, bridge, gateway ] }
   mgmt:
-    ipv4: { type: ipv4, use: address }
-    ipv6: { type: ipv6, use: address }
+    ipv4: { type: ipv4, use: interface }
+    ipv6: { type: ipv6, use: interface }
     mac: str
     ifname: str
   mtu: { type: int, min_value: 64, max_value: 9216 }

--- a/tests/errors/dup-mgmt-addr.log
+++ b/tests/errors/dup-mgmt-addr.log
@@ -1,6 +1,8 @@
 IncorrectValue in nodes: Incorrect management MAC address wtf on node r5
 ... failed to detect EUI version: 'wtf'
+MissingValue in nodes: Node r6 does not have a usable management IP addresss
 IncorrectValue in nodes: Duplicate management ipv4 address 192.168.121.101 on r2 and r1
+IncorrectValue in nodes: Duplicate management ipv4 address 192.168.121.105 on r7 and r5
 IncorrectValue in nodes: Duplicate management ipv6 address 2001:db8:cafe::1 on r4 and r3
 IncorrectValue in nodes: Duplicate management mac address 08:4f:a9:02:00:00 on r3 and r2
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/dup-mgmt-addr.yml
+++ b/tests/errors/dup-mgmt-addr.yml
@@ -26,3 +26,9 @@ nodes:
 
   r5:
     mgmt.mac: wtf
+
+  r6:
+    mgmt.ipv4: False
+
+  r7:
+    mgmt.ipv4: 105


### PR DESCRIPTION
Closes #1959

Note: it was too cumbersome to tweak the management IP logic (and all its exceptions) into something that could be used with regular interface-on-link IP assignment. Adding logic to handle bools and ints was easier ;)