### PR TITLE
'bridge' node role: a simple layer-2 bridge

### DIFF
--- a/docs/node-roles.md
+++ b/docs/node-roles.md
@@ -5,14 +5,14 @@ _netlab_ supports three types of nodes:
 
 * **[router](node-role-router)** -- a device performing a combination of layer-3 and (optional) layer-2 forwarding.
 * **[host](node-role-host)** -- an IP host, usually using static (default) routes instead of a routing protocol
-* **[bridge](node-role-bridge)** -- simple layer-3 bridges
+* **[bridge](node-role-bridge)** -- simple layer-2 switches (devices formerly known as *bridges*)
 
 Most _netlab_-supported devices act as *routers*; see the [platform support tables](platform-host) for a list of devices that can act as hosts or bridges.
 
 (node-role-router)=
 ## Routers and Layer-3 Switches
 
-The defining characteristics of routers are:
+The defining characteristics of devices with the **router** role   (the default device role) are:
 
 * At least one global [loopback interface](node-loopback) that can be used as the *router ID* and the control-plane endpoint
 * Layer-3 packet forwarding for the configured address families (IPv4/IPv6)
@@ -24,7 +24,7 @@ Routers usually run routing protocols but can also rely on static routing. When 
 
 Hosts do not have loopback interfaces (it's easiest if they have a single interface) and use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab set up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
 
-Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route in the global VRF.
+Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route toward an adjacent router in the global routing table.
 
 Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ can add an IPv6 default route[^SRv6] on devices that do not listen to RA messages.
 
@@ -33,68 +33,64 @@ Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ ca
 (node-role-bridge)=
 ## Bridges
 
-Bridges are simple layer-2 packet forwarding devices[^VM]. They do not have a loopback interface and might not even have a data-plane IP address.
+The **bridge** role is a thin abstraction layer on top of the [**vlan** configuration module](module-vlan), making deploying simple topologies with a single bridge connecting multiple routers or hosts easier. Do not try to build complex topologies with bridges; use the VLAN configuration module.
+
+Bridges are simple layer-2 packet forwarding devices[^VM]. They do not have a loopback interface and might not even have a data-plane IP address. Without additional parameters, _netlab_ configures them the way non-VLAN bridges have been working for decades -- bridge interfaces do not use VLAN tagging and belong to a single layer-2 forwarding domain.
 
 [^VM]: The node **vlan.mode** parameter for a bridge node is set to **bridge** unless it's defined in the lab topology.
 
-Bridges can use **vlan** parameters on interfaces to define VLAN access links or VLAN trunks. All bridge interfaces without a **vlan** parameter are configured as access VLANs for the default bridge VLAN (**br_default**[^BRD]/VLAN 1[^BRID]) (`vlan.access: br_default`)
-
-[^BRD]: You can change the name of the default bridge VLAN with the **topology.defaults.const.default_vlan.name** parameter
-
-[^BRID]: You can change the VLAN tag of the default bridge VLAN with the **topology.defaults.const.default_vlan.id** parameter
-
-You can use the **bridge** devices to implement simple bridged networks, for example:
+You can use the **bridge** devices to implement simple small bridged segments, for example:
 
 ```
 nodes:
-	rtr:
-		device: eos
-	h1:
-		device: linux
-	h2:
-		device: linux
-	br:
-		device: ioll2
-		role: bridge
+  rtr:
+    device: eos
+  h1:
+    device: linux
+  h2:
+    device: linux
+  br:
+    device: ioll2
+    role: bridge
 
 links: [ rtr-br, h1-br, h2-br ]
 ```
 
-In the above topology, *netlab* assigns an IP prefix from the **lan** pool to the VLAN segment connecting the four devices. You can change the **br.vlans.br_default** VLAN definition to change the parameters of the default bridge VLAN on node **br**.
+In the above topology, *netlab* assigns an IP prefix from the **lan** pool to the VLAN segment connecting the four devices ([you can change that](node-bridge-details)).
 
-You can use a multi-access link with a single bridge attached to it instead of a series of point-to-point links. The following topology is equivalent to the one above; the multi-access link is expanded into a series of point-to-point links with the **br** device.
+In the lab topology, you can use a multi-access link with a single bridge attached instead of a series of point-to-point links. The following topology is equivalent to the one above; the multi-access link is expanded into a series of point-to-point links with the **br** device.
 
 ```
 nodes:
-	rtr:
-		device: eos
-	h1:
-		device: linux
-	h2:
-		device: linux
-	br:
-		device: ioll2
-		role: bridge
+  rtr:
+    device: eos
+  h1:
+    device: linux
+  h2:
+    device: linux
+  br:
+    device: ioll2
+    role: bridge
 
 links: [ rtr-h1-h2-br ]
 ```
 
-You can also connect multiple bridges into a larger bridged network. In this scenario, you SHOULD use a global **br_default** VLAN (defined as **vlans.br_default** topology attribute) to share the same IP subnet across all bridges.
+You can also connect multiple bridges into a larger bridged network. This scenario stretches the limitations of the **bridge** nodes (using the [**vlan** configuration module](module-vlan) would be better). If you decide to use it in your topology, you SHOULD define a global **br_default** VLAN (defined as **vlans.br_default** topology attribute) to share the same IP subnet across all bridges.
 
 ```
 nodes:
-	rtr:
-		device: eos
-	h1:
-		device: linux
-	h2:
-		device: linux
+  rtr:
+    device: eos
+  h1:
+    device: linux
+  h2:
+    device: linux
 	br1:
-		device: ioll2
-		role: bridge
-	br2:
-		device: ioll2
-		role: bridge
+    device: ioll2
+    role: bridge
+  br2:
+    device: ioll2
+    role: bridge
 
 links: [ rtr-br1, br1-br2, h1-br2, h2-br2 ]
 ```
@@ -102,5 +98,18 @@ links: [ rtr-br1, br1-br2, h1-br2, h2-br2 ]
 ```{warning}
 _netlab_ does not implement multiple independent bridge domains for the same VLAN.
 ```
+
+(node-bridge-details)=
+### Implementation Details
+
+_netlab_ uses the **vlan** configuration module to implement the *simple bridging* functionality -- it places all bridge interfaces without an explicit **vlan** parameter into the same access VLAN.
+
+The VLAN configuration module needs the *default access VLAN* name and VLAN ID (tag). The default name of that VLAN is **br_default**[^BRD], and it uses VLAN tag 1[^BRID] to make the final device configuration similar to the out-of-the-box configuration of simple layer-2 switches.
+
+You can use the node- or global VLAN definition of the **br_default** VLAN to change the parameters (for example, the IP prefix or address pool) of the LAN segment created around a **bridge** node.
+ 
+[^BRD]: You can change the name of the default bridge VLAN with the `topology.defaults.const.bridge.default_vlan.name` parameter
+
+[^BRID]: You can change the VLAN tag of the default bridge VLAN with the `topology.defaults.const.bridge.default_vlan.id` parameter
 
 For more VLAN configuration- and implementation details, read the [**vlan** configuration module documentation](module-vlan).

--- a/docs/node-roles.md
+++ b/docs/node-roles.md
@@ -1,0 +1,106 @@
+(node-router-host)=
+# Routers, Host, and Bridges
+
+_netlab_ supports three types of nodes:
+
+* **[router](node-role-router)** -- a device performing a combination of layer-3 and (optional) layer-2 forwarding.
+* **[host](node-role-host)** -- an IP host, usually using static (default) routes instead of a routing protocol
+* **[bridge](node-role-bridge)** -- simple layer-3 bridges
+
+Most _netlab_-supported devices act as *routers*; see the [platform support tables](platform-host) for a list of devices that can act as hosts or bridges.
+
+(node-role-router)=
+## Routers and Layer-3 Switches
+
+The defining characteristics of routers are:
+
+* At least one global [loopback interface](node-loopback) that can be used as the *router ID* and the control-plane endpoint
+* Layer-3 packet forwarding for the configured address families (IPv4/IPv6)
+
+Routers usually run routing protocols but can also rely on static routing. When used with the **[vlan](module-vlan)** configuration module, they can also perform layer-2 packet forwarding and IRB.
+
+(node-role-host)=
+## Hosts
+
+Hosts do not have loopback interfaces (it's easiest if they have a single interface) and use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab set up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
+
+Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route in the global VRF.
+
+Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ can add an IPv6 default route[^SRv6] on devices that do not listen to RA messages.
+
+[^SRv6]: Or a set of static IPv6 routes for address pool prefixes on devices without a management VRF
+
+(node-role-bridge)=
+## Bridges
+
+Bridges are simple layer-2 packet forwarding devices[^VM]. They do not have a loopback interface and might not even have a data-plane IP address.
+
+[^VM]: The node **vlan.mode** parameter for a bridge node is set to **bridge** unless it's defined in the lab topology.
+
+Bridges can use **vlan** parameters on interfaces to define VLAN access links or VLAN trunks. All bridge interfaces without a **vlan** parameter are configured as access VLANs for the default bridge VLAN (**br_default**[^BRD]/VLAN 1[^BRID]) (`vlan.access: br_default`)
+
+[^BRD]: You can change the name of the default bridge VLAN with the **topology.defaults.const.default_vlan.name** parameter
+
+[^BRID]: You can change the VLAN tag of the default bridge VLAN with the **topology.defaults.const.default_vlan.id** parameter
+
+You can use the **bridge** devices to implement simple bridged networks, for example:
+
+```
+nodes:
+	rtr:
+		device: eos
+	h1:
+		device: linux
+	h2:
+		device: linux
+	br:
+		device: ioll2
+		role: bridge
+
+links: [ rtr-br, h1-br, h2-br ]
+```
+
+In the above topology, *netlab* assigns an IP prefix from the **lan** pool to the VLAN segment connecting the four devices. You can change the **br.vlans.br_default** VLAN definition to change the parameters of the default bridge VLAN on node **br**.
+
+You can use a multi-access link with a single bridge attached to it instead of a series of point-to-point links. The following topology is equivalent to the one above; the multi-access link is expanded into a series of point-to-point links with the **br** device.
+
+```
+nodes:
+	rtr:
+		device: eos
+	h1:
+		device: linux
+	h2:
+		device: linux
+	br:
+		device: ioll2
+		role: bridge
+
+links: [ rtr-h1-h2-br ]
+```
+
+You can also connect multiple bridges into a larger bridged network. In this scenario, you SHOULD use a global **br_default** VLAN (defined as **vlans.br_default** topology attribute) to share the same IP subnet across all bridges.
+
+```
+nodes:
+	rtr:
+		device: eos
+	h1:
+		device: linux
+	h2:
+		device: linux
+	br1:
+		device: ioll2
+		role: bridge
+	br2:
+		device: ioll2
+		role: bridge
+
+links: [ rtr-br1, br1-br2, h1-br2, h2-br2 ]
+```
+
+```{warning}
+_netlab_ does not implement multiple independent bridge domains for the same VLAN.
+```
+
+For more VLAN configuration- and implementation details, read the [**vlan** configuration module documentation](module-vlan).

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -84,19 +84,6 @@ nodes:
 * You still have to specify the device type (either in the node or as the [default device type](default-device-type)) for unmanaged nodes. _netlab_ uses the device type to determine which features a node supports. If you want to use an unsupported unmanaged device, set **‌device** to **‌none**.
 ```
 
-(node-router-host)=
-## Hosts and Routers
-
-Most _netlab_-supported devices act as *routers*: they have at least one [loopback interface](node-loopback) and run routing protocols to find the best path(s) toward remote destinations.
-
-Hosts do not have loopback interfaces (it's easiest if they have a single interface) and use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab set up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
-
-Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route in the global VRF.
-
-Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ can add an IPv6 default route[^SRv6] on devices that do not listen to RA messages.
-
-[^SRv6]: Or a set of static IPv6 routes for address pool prefixes on devices without a management VRF
-
 (node-loopback)=
 ## Loopbacks
 
@@ -337,4 +324,13 @@ nodes:
     ipv4: 192.168.121.101
     mac: 08-4F-A9-00-00-01
   name: r3
+```
+
+## Advanced Topics
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+
+   node-roles.md
 ```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -53,14 +53,14 @@
 (platform-host)=
 Most devices behave as routers (or layer-3 switches); the following devices can take multiple roles or behave as [IP hosts](node-router-host):
 
-| Device | router | host |
-|-----------------------|:--:|:--:|
-| Arista EOS            | ✅ | ✅ |
-| Bird                  | ✅ | ✅ |
-| Cisco IOS/IOS XE[^18v]| ✅ | ✅ |
-| dnsmasq               | ❌  | ✅ |
-| FRRouting             | ✅ | ✅ |
-| Generic Linux         | ❌  | ✅ |
+| Device | router | host | bridge |
+|-----------------------|:--:|:--:| :--:|
+| Arista EOS            | ✅ | ✅ | ✅ |
+| Bird                  | ✅ | ✅ | ❌  |
+| Cisco IOS/IOS XE[^18v]| ✅ | ✅ | ✅ |
+| dnsmasq               | ❌  | ✅ | ❌  |
+| FRRouting             | ✅ | ✅ | ❌  |
+| Generic Linux         | ❌  | ✅ | ❌  |
 
 **Notes:**
 

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -23,7 +23,7 @@ features:
       use_ra: true
     max_mtu: 9194
     min_mtu: 68
-    roles: [ host, router ]
+    roles: [ host, router, bridge ]
     mgmt_vrf: true
   bfd: true
   bgp:

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -40,7 +40,7 @@ features:
     ipv6:
       lla: true
       use_ra: true
-    roles: [ host, router ]
+    roles: [ host, router, bridge ]
     mgmt_vrf: true
   isis:
     import: [ bgp, ospf, ripv2, connected ]

--- a/netsim/modules/routing.py
+++ b/netsim/modules/routing.py
@@ -806,10 +806,13 @@ def create_gateway_last_resort(intf: Box, missing_af: Box, topology: Box) -> typ
   gw_data = data.get_empty_box()
   unnum_ngb = False
 
+  # Get roles that can be default gateways
+  gw_roles = global_vars.get_const('gateway.roles',['router','gateway'])
+
   for af in list(missing_af.keys()):                        # Iterate over all missing AFs
     for ngb in intf.neighbors:                              # Iterate over all interface neighbors
       n_node = topology.nodes[ngb.node]
-      if n_node.get('role') == 'host':                      # Host neighbors are useless
+      if n_node.get('role','router') not in gw_roles:       # Host/bridge neighbors are useless
         continue
       if af not in ngb:                                     # Does the neighbor have an address in desired AF?
         continue

--- a/netsim/roles/__init__.py
+++ b/netsim/roles/__init__.py
@@ -20,7 +20,7 @@ def select_nodes_by_role(topology: Box, select: typing.Union[str,list]) -> typin
 Initialize the node role subsystem: append all node-handling modules to topology plugins
 """
 def init(topology: Box) -> None:
-  from . import host,router
+  from . import host,router,bridge
 
-  for role in [ host, router ]:
+  for role in [ host, router, bridge ]:
     append_to_list(topology,'Plugin',role)

--- a/netsim/roles/bridge.py
+++ b/netsim/roles/bridge.py
@@ -1,0 +1,110 @@
+'''
+Bridge-specific data transformation:
+
+* Define 'br_default' VLAN 1 if it's not defined
+* Set vlan.mode to 'bridge' on bridge devices
+* Set vlan.access on bridge interfaces without the 'vlan' parameter
+'''
+import typing
+
+from box import Box, BoxList
+
+from ..utils import log
+from ..data import global_vars,append_to_list,get_box
+from ..augment import links
+from . import select_nodes_by_role
+
+"""
+Set the default VLAN mode on bridges to 'bridge' in the pre-transform hook
+to prevent VLAN module from setting it to some other value.
+
+Also, define 'br_default' node VLAN if it's not defined
+
+Return 'True' if we found at least one bridge (so we need further processing)
+"""
+def create_default_VLAN(topology: Box) -> bool:
+  BR_DEFAULT = global_vars.get_const('bridge.default_vlan.name','br_default')
+  BR_DEF_ID  = global_vars.get_const('bridge.default_vlan.id',1)
+  br_found = False
+
+  for ndata in select_nodes_by_role(topology,'bridge'):
+    br_found = True
+    if not ndata.get('vlan.mode',None):                     # Do we have vlan.mode set on the node?
+      ndata.vlan.mode = 'bridge'                            # ... nope, default is bridge
+    if not isinstance(ndata.vlans,Box):                     # Check the 'vlans' data type just to be on the safe side
+      continue
+    if 'id' not in ndata.vlans[BR_DEFAULT]:                 # Create default VLAN box on the fly and check for id
+      ndata.vlans[BR_DEFAULT].id = BR_DEF_ID
+
+  return br_found
+
+"""
+Go through the links and add 'vlan.access: br_default' to every interface of
+a bridge node that does not have a VLAN parameter
+
+Return 'True' if we found at least one "default" link attached to a bridge
+"""
+def add_default_access_vlan(topology: Box) -> bool:
+  BR_DEFAULT = global_vars.get_const('bridge.default_vlan.name','br_default')
+  link_found = False
+
+  for link in topology.get('links',[]):
+    if 'vlan' in link:                                      # A link already has VLAN parameters, skip it
+      continue
+    for intf in link.get('interfaces',[]):
+      if 'vlan' in intf:                                    # The interface has VLAN parameters, skip it
+        continue
+      n_role = topology.nodes[intf.node].get('role','router')
+      if n_role != 'bridge':                                # Not a bridge interface, skip it
+        continue
+      intf.vlan.access = BR_DEFAULT
+      link_found = True
+      append_to_list(link,'_br_list',intf)                  # Remember the bridges we found
+
+  return link_found
+
+"""
+When exactly one of the nodes on link with more than two nodes is a bridge,
+expand the link into multiple P2P links with the bridge node. Print a warning
+(and do nothing) if there are more than two bridges attached to the link
+"""
+def expand_multiaccess_links(topology: Box) -> None:
+  for link in list(topology.get('links',[])):
+    if '_br_list' not in link:                              # Is this one of the relevant links?
+      continue                                              # No, move on
+
+    br_list = link._br_list                                 # Get the list of bridges
+    link.pop('_br_list',None)                               # ... and remove it from the link
+
+    if not br_list:                                         # Empty list?
+      continue                                              # Weird, but we've seen weirder things
+
+    if len(br_list) > 1:                                    # Multiple bridges on multi-access links confuse us
+      br_names = [ intf.node for intf in br_list ]
+      log.warning(
+        text=f'Multiple bridges ({",".join(br_names)}) attached to multi-access link {link._linkname}',
+        more_hints='netlab can expand only multi-access links attached to a single bridge',
+        module='bridge')
+      continue
+
+    br_intf = br_list[0]                                    # Remember the bridge interface
+    link_cnt = 0
+    for intf in link.interfaces:
+      if intf != br_intf:                                   # Did we find an interesting interface?
+        l_data = get_box(link)                              # Copy the link data
+        link_cnt += 1
+        l_data._linkname = f'{link._linkname}.{link_cnt}'   # Create unique link and and linkindex
+        l_data.linkindex = links.get_next_linkindex(topology)
+        l_data.interfaces = [ get_box(br_intf), intf ]      # ... recreate P2P interfaces
+        topology.links.append(l_data)                       # ... and append the new P2P link to the links
+
+    topology.links.remove(link)                             # Finally, remove original link
+
+def pre_transform(topology: Box) -> None:
+  if not create_default_VLAN(topology):                     # Add default bridge VLAN
+    return                                                  # ... exit if we found no bridges
+
+  if not add_default_access_vlan(topology):                 # Add 'vlan.access' to non-VLAN bridge ports
+    return                                                  # ... exit if we found no relevant links
+  
+  expand_multiaccess_links(topology)                        # Expand multi-access links 

--- a/netsim/roles/bridge.py
+++ b/netsim/roles/bridge.py
@@ -36,6 +36,9 @@ def create_default_VLAN(topology: Box) -> bool:
     if 'id' not in ndata.vlans[BR_DEFAULT]:                 # Create default VLAN box on the fly and check for id
       ndata.vlans[BR_DEFAULT].id = BR_DEF_ID
 
+    append_to_list(ndata,'module','vlan')                   # Activate VLAN module in bridge node and topology
+    append_to_list(topology,'module','vlan')
+
   return br_found
 
 """


### PR DESCRIPTION
This is the initial implementation of the 'bridge' node role:

* Bridge interfaces without a VLAN parameter are assigned to the default VLAN (name/id defined as a topology const)
* The default value of 'vlan.mode' for a bridge device is 'bridge' (not IRB)
* Multi-access link with a single attached bridge are expanded into a series of point-to-point links

Note: any device implementing the VLAN configuration module could potentially be a bridge. Whether that makes sense is a totally different question.

Future plans after this PR:

* Per-node default VLAN name/ID (can be used to implement multiple independent bridging domains)
* Integration test (at least on the platform level, it might not make sense to have it for individual devices)