### PR TITLE
Allow interface name to be set on a per-interface basis

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -63,6 +63,7 @@ updates:
 {% set if_desc = l.name|default( l.ifname )|replace('->','~')|regex_replace('[\\[\\]]','') %}
 - path: /interface[name={{ if_name }}]
   value:
+   description: "{{ if_desc }}"
 {% if l.mtu is defined and l.type!='loopback' %} # min 1500; max 9412 for 7220, 9500 for 7250 platforms
    mtu: {{ [l.mtu + 14,1500]|max }}
 {% endif %}

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -805,7 +805,12 @@ def set_interface_name(ifdata: Box, link: Box, ifcnt: int) -> None:
     ifdata.name = link.name
     return
 
-  node_name = link.interfaces[ifcnt].node
+  link_iface = link.interfaces[ifcnt]
+  if 'name' in link_iface:
+    ifdata.name = link_iface.name
+    return
+
+  node_name = link_iface.node
   n_list = [ link.interfaces[i].node for i in range(0,len(link.interfaces)) if i != ifcnt ]
   ifdata.name = create_ifname(node_name,n_list)
 

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -10,6 +10,7 @@ from box import Box
 # Related modules
 from ..utils import log,strings
 from .. import data
+from ..modules import get_effective_module_attribute
 from ..data.validate import validate_attributes,get_object_attributes
 from ..data.types import must_be_string,must_be_list,must_be_dict,must_be_id
 from ..data.global_vars import get_const
@@ -801,13 +802,9 @@ def create_ifname(node_name: str, ngb_list: typing.List[str],p2p_OK: bool = True
   return ifname
 
 def set_interface_name(ifdata: Box, link: Box, ifcnt: int) -> None:
-  if 'name' in link:
-    ifdata.name = link.name
-    return
-
   link_iface = link.interfaces[ifcnt]
-  if 'name' in link_iface:
-    ifdata.name = link_iface.name
+  ifdata.name = get_effective_module_attribute('name',intf=link_iface,link=link)
+  if ifdata.name:
     return
 
   node_name = link_iface.node

--- a/tests/topology/expected/vrf-leaking-loop.yml
+++ b/tests/topology/expected/vrf-leaking-loop.yml
@@ -53,7 +53,7 @@ nodes:
     - ifindex: 1
       ifname: eth1
       linkindex: 1
-      name: leaf1 -> leaf1
+      name: Global side
       neighbors:
       - ifname: eth2
         node: leaf1
@@ -62,7 +62,7 @@ nodes:
     - ifindex: 2
       ifname: eth2
       linkindex: 1
-      name: leaf1 -> leaf1
+      name: Customer side
       neighbors:
       - ifname: eth1
         node: leaf1


### PR DESCRIPTION
For example:
```
links:
  - router01:
    router02:
      name: 'My Description'
```

Also set interface descriptions on parent interfaces on SR Linux.
For example:
```
--{ + running }--[  ]--
A:router01# info interface ethernet-1/1
    interface ethernet-1/1 {
        description "My Description"
        admin-state enable
        subinterface 0 {
            description "My Description"
            ipv4 {
                admin-state enable
                address 172.17.0.33/30 {
                    primary
                }
            }
        }
    }
```

I'm happy to break up this PR if you'd prefer.