### PR TITLE
FRR: Replace obsolete 'brctl' commands with modern equivalents

### DIFF
--- a/netsim/ansible/templates/stp/frr.j2
+++ b/netsim/ansible/templates/stp/frr.j2
@@ -15,7 +15,7 @@ bridge link set dev {{ i.ifname }} priority {{ i.stp.port_priority * 4 }}
 {%  elif i.type=='svi' %} 
 {%    set vlan = vlans[ i.vlan.name ] %}
 {%    if vlan.stp.priority is defined or 'priority' in stp %}
-brctl setbridgeprio {{ i.ifname }} {{ vlan.stp.priority|default(stp.priority) }}
+ip link set dev {{ i.ifname }} type bridge priority {{ vlan.stp.priority|default(stp.priority) }}
 {%    endif %}
 {%  endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -11,11 +11,11 @@ fi
 {% endfor %}
 {% for i in interfaces if i.type == 'svi' %}
 if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
-  brctl addbr {{ i.ifname }}
+  ip link add {{ i.ifname }} type bridge
   ip link set dev {{ i.ifname }} address {{ '52:dc:ca:fd:%02x:%02x' % ( id,i.ifindex % 100 ) }}
 {# If STP is required, enable it before bringing up the bridge device to avoid any forwarding loops #}
 {%  if 'stp' in module|default([]) and (i.stp|default(stp)).enable|default(True) %}
-  brctl stp {{ i.ifname }} on
+  ip link set {{ i.ifname }} type bridge stp_state 1
 {%  endif %}
 
 {%   if i.mtu is defined %}
@@ -38,7 +38,7 @@ fi
 
 {# Add interfaces to VLAN bridges #}
 {% for i in interfaces if i.vlan.access_id is defined and i.vlan.mode|default('') != 'route' %}
-brctl addif vlan{{ i.vlan.access_id }} {{ i.ifname }}
+ip link set dev {{ i.ifname }} master vlan{{ i.vlan.access_id }}
 {% endfor %}
 
 {% for i in interfaces if i.type == 'svi' %}

--- a/netsim/ansible/templates/vxlan/frr.j2
+++ b/netsim/ansible/templates/vxlan/frr.j2
@@ -17,7 +17,7 @@ ip link add {{ br_name }} type bridge
 ip link set up dev {{ br_name }}
 fi
 ip link set dev vxlan{{ vni }} master {{ br_name }}
-ip link set {{ br_name }} type bridge stp_state 1
+ip link set {{ br_name }} type bridge stp_state 0
 
 # Do not generate ipv6 link-local address for VXLAN devices
 ip link set mtu {{ mtu }} addrgenmode none dev vxlan{{ vni }}

--- a/netsim/ansible/templates/vxlan/frr.j2
+++ b/netsim/ansible/templates/vxlan/frr.j2
@@ -13,11 +13,12 @@ ip link add vxlan{{ vni }} type vxlan \
 #
 # Add it to the VLAN bridge (create if needed for l3 vnis); disable STP
 if [ ! -e /sys/devices/virtual/net/{{ br_name}} ]; then
-brctl addbr {{ br_name }}
+ip link add {{ br_name }} type bridge
 ip link set up dev {{ br_name }}
 fi
-brctl addif {{ br_name }} vxlan{{ vni }}
-brctl stp {{ br_name }} off
+ip link set dev vxlan{{ vni }} master {{ br_name }}
+ip link set {{ br_name }} type bridge stp_state 1
+
 # Do not generate ipv6 link-local address for VXLAN devices
 ip link set mtu {{ mtu }} addrgenmode none dev vxlan{{ vni }}
 {% if use_evpn %}


### PR DESCRIPTION
Newer FRR images no longer have [long deprecated 'brctl' support](https://lwn.net/Articles/703776/)