### PR TITLE
JunOS: initial/foundation implementation for routing (and bgp) policies

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -304,31 +304,24 @@ diag debug application httpsd -1
 * Junos cannot have more than one loopback interface per routing instance. Using **loopback** links on Junos devices will result in configuration errors.
 * Junos configuration template configures BFD timers within routing protocol configuration, not on individual interfaces
 * Junos does not disable the default BGP address family on a BGP neighbor until another AF is configured.
-* Anycast Gateway is not working properly on vSRX and vPTX:
 
-    * On vPTX, the virtual MAC address is ignored. Hence, the integration test is failing. Removing the support for anycast gateway for now.
-    * Anycast Gateway cannot be tested on vSRX as it does not support the VLAN IRB configuration.
+Implementation limitations in import/export route filters (reported as errors that can be disabled with topology settings):
 
-* Routing import/export filters *currently* have the following caveats (reported as errors in device quirks):
-
-    * When prepending an AS number different than the local one, JunOS put the prepend as ath the beginning of the *AS_PATH*,
-      (while other vendors perform the prepending first, and then add its own AS at the beginning).
-      This leads other BGP peers to deny an update received from an eBGP peer that does not list its autonomous system number at the beginning of the *AS_PATH*.
-      For this reason, in case we detect a prepend which does not start with the *local-as*, we automatically add it at the beginning of the *AS_PATH*.
-    * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent) - as a *kind-of* workaround, if you disable this specific *quirk*, the prefix-list match will be done as `prefix-list-filter XXX orlonger`.
-    * *as-path* items cannot have deny items. Also, remember that *as-path* regex syntax for JunOS has different rules than other vendors. I.e., a *null as-path* is represented as `()`.
-    * *community* match cannot have deny items
+* When prepending an AS number different than the local one, JunOS puts the prepended AS at the beginning of the *AS_PATH* while other vendors perform the prepending and then add the device's own AS at the beginning. Most EBGP peers deny a BGP update that does not have the neighbor's AS number at the beginning of the *AS_PATH*. If needed, _netlab_ automatically adds the *local-as* to the prepend list to get it at the beginning of the *AS_PATH*.
+* *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent). As a workaround (if you disable this specific *quirk*), the prefix-list match will be done as `prefix-list-filter XXX orlonger`.
+* *as-path* items cannot have "deny" items. Also, remember that the *as-path* regex syntax for JunOS has different rules than other vendors. For example, a *null as-path* is represented as `()`.
+* *community* matches cannot have "deny" items
 
 (caveats-vmx)=
 ## Juniper vMX
 
 * vMX can run only as a [_vrnetlab_ container](clab-vrnetlab)
-* vMX requires a license file. By default, _netlab_ downloads the evaluation license for Junos 18.2 from Juniper web site.
+* vMX requires a license file. By default, _netlab_ downloads the evaluation license for Junos 18.2 from the Juniper website.
 
 You can change the location of the license file with two variables:
 
 * **netlab_license_file** -- the name of a local file containing the relevant vMX license.
-* **netlab_license_url** -- the URL of a license file. The license file will be downloaded and installed to the vMX device. This parameter is used only when the local license file is not specified.
+* **netlab_license_url** -- the URL of a license file. The license file will be downloaded and installed on the vMX device. This parameter is used only when the local license file is not specified.
 
 You can change the license file parameters within a node definition or with **defaults.devices.vmx.group_vars._parameter_name_** [system default](topo-defaults).
 
@@ -336,6 +329,7 @@ You can change the license file parameters within a node definition or with **de
 ## Juniper vPTX
 
 * *netlab* release 1.7.0 supports only vJunosEvolved releases that do not require external PFE- and RPIO links. The first vJunosEvolved release implementing internal PFE- and RPIO links is the release 23.2R1-S1.8.
+* The virtual MAC address of the anycast gateway is ignored. _netlab_, therefore, does not support the anycast gateway on vPTX.
 
 The rest of this section lists information you might find helpful if you're a long-time Junos user:
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -309,6 +309,12 @@ diag debug application httpsd -1
     * On vPTX, the virtual MAC address is ignored. Hence, the integration test is failing. Removing the support for anycast gateway for now.
     * Anycast Gateway cannot be tested on vSRX as it does not support the VLAN IRB configuration.
 
+* Routing import/export filters *currently* have the following caveats (reported as errors in device quirks):
+
+    * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent)
+    * *as-path* items cannot have deny items
+    * *community* match cannot have deny items
+
 (caveats-vmx)=
 ## Juniper vMX
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -315,7 +315,7 @@ diag debug application httpsd -1
       (while other vendors perform the prepending first, and then add its own AS at the beginning).
       This leads other BGP peers to deny an update received from an eBGP peer that does not list its autonomous system number at the beginning of the *AS_PATH*.
       For this reason, in case we detect a prepend which does not start with the *local-as*, we automatically add it at the beginning of the *AS_PATH*.
-    * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent)
+    * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent) - as a *kind-of* workaround, if you disable this specific *quirk*, the prefix-list match will be done as `prefix-list-filter XXX orlonger`.
     * *as-path* items cannot have deny items
     * *community* match cannot have deny items
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -316,7 +316,7 @@ diag debug application httpsd -1
       This leads other BGP peers to deny an update received from an eBGP peer that does not list its autonomous system number at the beginning of the *AS_PATH*.
       For this reason, in case we detect a prepend which does not start with the *local-as*, we automatically add it at the beginning of the *AS_PATH*.
     * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent) - as a *kind-of* workaround, if you disable this specific *quirk*, the prefix-list match will be done as `prefix-list-filter XXX orlonger`.
-    * *as-path* items cannot have deny items
+    * *as-path* items cannot have deny items. Also, remember that *as-path* regex syntax for JunOS has different rules than other vendors. I.e., a *null as-path* is represented as `()`.
     * *community* match cannot have deny items
 
 (caveats-vmx)=

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -311,6 +311,10 @@ diag debug application httpsd -1
 
 * Routing import/export filters *currently* have the following caveats (reported as errors in device quirks):
 
+    * When prepending an AS number different than the local one, JunOS put the prepend as ath the beginning of the *AS_PATH*,
+      (while other vendors perform the prepending first, and then add its own AS at the beginning).
+      This leads other BGP peers to deny an update received from an eBGP peer that does not list its autonomous system number at the beginning of the *AS_PATH*.
+      For this reason, in case we detect a prepend which does not start with the *local-as*, we automatically add it at the beginning of the *AS_PATH*.
     * *prefix-list* items cannot have *min*/*max* items (*ge*/*le*-equivalent)
     * *as-path* items cannot have deny items
     * *community* match cannot have deny items

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -30,7 +30,7 @@ The following table describes high-level per-platform support of generic routing
 | Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |
-| JunOS              | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Junos              | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux     |  ✅ |  ✅ [❗](caveats-srlinux) |
 | Nokia SR OS        |  ✅ |
 | VyOS               |  ✅ |  ✅ | ✅ |  ✅  |
@@ -106,7 +106,7 @@ You can use these routing policy **match** parameters on devices supported by th
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ |
 | Dell OS10           | ✅ | ❌  | ✅ | ✅ |
-| JunOS               | [✅](caveats-junos) | ❌  | [✅](caveats-junos) | [✅](caveats-junos) |
+| Junos               | [✅](caveats-junos) | ❌  | [✅](caveats-junos) | [✅](caveats-junos) |
 | FRR                 | ✅ | ❌  | ✅ | ✅ |
 | Nokia SR Linux      | ✅ |
 | VyOS                | ✅ | ❌  | ✅ | ✅ |
@@ -120,7 +120,7 @@ You can use these routing policy **set** parameters on devices supported by the 
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Dell OS10           | ✅ | ✅ | ✅ | ✅ | ✅ |
-| JunOS               | ✅ | ✅ | ✅ | ❌  | ✅ |
+| Junos               | ✅ | ✅ | ✅ | ❌  | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux      | ❌  | ✅ | ✅ | ❌  | ❌  |
 | Nokia SR OS         | ❌  | ✅ | ✅ | ❌  | ❌  |
@@ -135,7 +135,7 @@ The **set.community** attribute can be used to set these BGP communities on supp
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
 | Dell OS10           | ✅ | ❌ | ✅ | ✅ | ❌  |
-| JunOS               | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Junos               | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
 | VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
 
@@ -541,7 +541,7 @@ _netlab_ supports static routes on these platforms:
 | Aruba AOS-CX        | ✅ | ✅ | [❗](caveats-aruba) |
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x   | ✅ | ✅ | ✅ |
-| JunOS               | ✅ | ✅ | ❌ |
+| Junos               | ✅ | ✅ | ❌ |
 | FRR                 | ✅ | ✅ | ✅ |
 | Linux               | ✅ |  ❌ |  ❌ |
 

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -30,6 +30,7 @@ The following table describes high-level per-platform support of generic routing
 | Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |
+| JunOS              | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux     |  ✅ |  ✅ [❗](caveats-srlinux) |
 | Nokia SR OS        |  ✅ |
 | VyOS               |  ✅ |  ✅ | ✅ |  ✅  |
@@ -105,6 +106,7 @@ You can use these routing policy **match** parameters on devices supported by th
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ |
 | Dell OS10           | ✅ | ❌  | ✅ | ✅ |
+| JunOS               | ✅ | ❌  | ✅ | ✅ |
 | FRR                 | ✅ | ❌  | ✅ | ✅ |
 | Nokia SR Linux      | ✅ |
 | VyOS                | ✅ | ❌  | ✅ | ✅ |
@@ -118,6 +120,7 @@ You can use these routing policy **set** parameters on devices supported by the 
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Dell OS10           | ✅ | ✅ | ✅ | ✅ | ✅ |
+| JunOS               | ✅ | ✅ | ✅ | ❌  | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Nokia SR Linux      | ❌  | ✅ | ✅ | ❌  | ❌  |
 | Nokia SR OS         | ❌  | ✅ | ✅ | ❌  | ❌  |
@@ -132,6 +135,7 @@ The **set.community** attribute can be used to set these BGP communities on supp
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
 | Dell OS10           | ✅ | ❌ | ✅ | ✅ | ❌  |
+| JunOS               | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
 | VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
 
@@ -537,6 +541,7 @@ _netlab_ supports static routes on these platforms:
 | Aruba AOS-CX        | ✅ | ✅ | [❗](caveats-aruba) |
 | Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x   | ✅ | ✅ | ✅ |
+| JunOS               | ✅ | ✅ | ❌ |
 | FRR                 | ✅ | ✅ | ✅ |
 | Linux               | ✅ |  ❌ |  ❌ |
 

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -106,7 +106,7 @@ You can use these routing policy **match** parameters on devices supported by th
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ |
 | Dell OS10           | ✅ | ❌  | ✅ | ✅ |
-| JunOS               | ✅ | ❌  | ✅ | ✅ |
+| JunOS               | [✅](caveats-junos) | ❌  | [✅](caveats-junos) | [✅](caveats-junos) |
 | FRR                 | ✅ | ❌  | ✅ | ✅ |
 | Nokia SR Linux      | ✅ |
 | VyOS                | ✅ | ❌  | ✅ | ✅ |

--- a/docs/plugins/bgp.policy.md
+++ b/docs/plugins/bgp.policy.md
@@ -56,6 +56,7 @@ The plugin implements BGP routing policies and individual BGP policy attributes 
 | Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅[❗](caveats-iosv) |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
+| JunOS               |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |  ❌  |   ❌  |   ❌  |
 | Nokia SR OS         |  ✅  |  ✅  |  ✅  |  ❌  |   ❌  |  ✅  |
 | VyOS                |  ✅  |  ✅  |  ✅  |  ❌  |   ✅  |   ❌  |

--- a/docs/plugins/bgp.policy.md
+++ b/docs/plugins/bgp.policy.md
@@ -56,7 +56,7 @@ The plugin implements BGP routing policies and individual BGP policy attributes 
 | Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅[❗](caveats-iosv) |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| JunOS               |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |   ❌  |
+| Junos               |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |  ❌  |   ❌  |   ❌  |
 | Nokia SR OS         |  ✅  |  ✅  |  ✅  |  ❌  |   ❌  |  ✅  |
 | VyOS                |  ✅  |  ✅  |  ✅  |  ❌  |   ✅  |   ❌  |

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -62,7 +62,7 @@ The plugin implements generic BGP session features for the following platforms:
 | Cisco Nexus OS      |  ✅  |  ✅  |   ❌  |  ✅  |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |
-| Junos[^Junos]       |   ❌  |  ✅  |  ✅  |  ✅  |
+| Junos[^Junos]       |  ✅  |  ✅  |  ✅  |  ✅  |
 | Mikrotik RouterOS 7 |  ✅  |   ❌  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |  ✅  |
 | Nokia SR OS         |  ✅  |   ❌  |   ❌  |   ❌  |
@@ -113,7 +113,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Cumulus Linux 4.x   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
-| Junos[^Junos]       |   ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
+| Junos[^Junos]       |   ✅  |  ✅  |   ✅  |   ❌  |   ❌  |
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |   ❌  |  ✅  |
 | Nokia SR OS         |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |

--- a/netsim/ansible/templates/routing/_prefix_list_junos.j2
+++ b/netsim/ansible/templates/routing/_prefix_list_junos.j2
@@ -1,0 +1,19 @@
+{# WARNING: JunOS prefix-list does not support entries with ge/le - a quirk will warn the user #}
+
+policy-options {
+
+{% for pf_af in af if pf_af in routing._prefix|default({}) %}
+{%   for p_name,p_value in routing._prefix[pf_af].items() %}
+
+  prefix-list {{ p_name }}-{{ pf_af }} {
+
+{%     for p_entry in p_value %}
+    {{ p_entry[pf_af] }};
+{%     endfor %}
+
+  }
+
+{%   endfor %}
+{% endfor %}
+
+}

--- a/netsim/ansible/templates/routing/_route_policy_junos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_junos.j2
@@ -1,0 +1,105 @@
+{% macro prepend_set(s_param,asn) -%}
+{%   if s_param.path|default('') %}
+      then as-path-prepend "{{ s_param.path }}";
+{%   elif s_param.count|default(0) %}
+      then as-path-prepend "{{ (asn + " ") * s_param.count }}";
+{%   endif %}
+{%- endmacro %}
+
+{% macro community_set(cwt,comm,c_append,c_delete) -%}
+{% if c_append %}
+      then community add {{ comm }};
+{% elif c_delete %}
+      then community delete {{ comm }};
+{% endif %}
+{%- endmacro %}
+
+{#
+   This macro generates the elements of route-map entries
+#}
+{% macro common_route_map_entry(p_entry,match_af) -%}
+{# - SET entries #}
+{%   if 'set' in p_entry %}
+{%     if 'locpref' in p_entry.set %}
+      then local-preference {{ p_entry.set.locpref }};
+{%     endif %}
+{%     if 'med' in p_entry.set %}
+      then metric {{ p_entry.set.med }};
+{%     endif %}
+{%     if 'community' in p_entry.set %}
+{%       set cset = p_entry.set.community %}
+{%       set ckw = { 'standard': 'community', 'extended': 'extcommunity', 'large': 'large-community' } %}
+{%         for kw in ('standard','extended','large') if kw in cset %}
+{%           if cset[kw] is not string %}
+{%             for cur_com in cset[kw] %}
+{{               community_set(ckw[kw], cur_com, cset.append|default(False), cset.delete|default(False)) }}
+{%             endfor %}
+{%           else %}
+{{             community_set(ckw[kw], cur_com, cset.append|default(False), cset.delete|default(False)) }}
+{%           endif %}
+{%         endfor %}
+{%     endif %}
+{%     if 'prepend' in p_entry.set %}
+{{       prepend_set(p_entry.set.prepend,bgp.as|string) }}
+{%     endif %}
+{%   endif %}
+{# - MATCH entries #}
+{%   if 'match' in p_entry %}
+{%     set ipkwd = 'ip' if match_af == 'ipv4' else 'ipv6' %}
+{%     if 'prefix' in p_entry.match %}
+      from prefix-list {{ p_entry.match.prefix }}-{{ match_af }};
+{%     endif %}
+{%     if 'aspath' in p_entry.match %}
+      from as-path-group {{ p_entry.match.aspath }};
+{%     endif %}
+{%     if 'community' in p_entry.match %}
+      from community {{ p_entry.match.community }};
+{%     endif %}
+{%   endif %}
+{%- endmacro %}
+
+{#
+   This macro builds a single route map and uses the callback to define a route map entry.
+#}
+{% macro build_route_map(rp_name,rp_list,match_af) -%}
+
+{% set action_map = { 'permit':'accept', 'deny':'reject' } %}
+
+{# delete a previously defined route map with the same name #}
+policy-options {
+  delete: policy-statement {{ rp_name }};
+}
+
+{# policy entries #}
+policy-options {
+  policy-statement {{ rp_name }} {
+{%   for p_entry in rp_list %}
+{%     set seq = p_entry.sequence|default(loop.index * 10) %}
+{# define basic action #}
+    term seq{{seq}} {
+      then {
+        {{ action_map[p_entry.action|default('permit')] }};
+      }
+    }
+{# define real entry #}
+    term seq{{seq}} {
+{{     common_route_map_entry(p_entry,match_af) }}
+    }
+{%   endfor %}
+  }
+}
+
+{%- endmacro %}
+
+{#
+   This macro creates route maps from the routing.policy dictionary
+
+   The callback defines a route map entry.
+#}
+{% macro create_route_maps(rp_dict) -%}
+{%   for rp_name,rp_list in rp_dict.items() %}
+{%     for rm_af in af %}
+{{       build_route_map('%s-%s'|format(rp_name,rm_af),rp_list,rm_af) }}
+{%     endfor %}
+{%   endfor %}
+{%- endmacro %}

--- a/netsim/ansible/templates/routing/_route_policy_junos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_junos.j2
@@ -7,10 +7,10 @@
 {%- endmacro %}
 
 {% macro community_set(cwt,comm,c_append,c_delete) -%}
-{% if c_append %}
-      then community add {{ comm }};
-{% elif c_delete %}
-      then community delete {{ comm }};
+{% if c_delete %}
+      then community delete x_comm_set_{{ comm|replace(':', '_')|replace('.', '_') }};
+{% else %}
+      then community add x_comm_set_{{ comm|replace(':', '_')|replace('.', '_') }};
 {% endif %}
 {%- endmacro %}
 

--- a/netsim/ansible/templates/routing/_route_policy_junos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_junos.j2
@@ -47,7 +47,12 @@
 {%   if 'match' in p_entry %}
 {%     set ipkwd = 'ip' if match_af == 'ipv4' else 'ipv6' %}
 {%     if 'prefix' in p_entry.match %}
+{#       in case a prefix has min/max, at least set 'prefix-list-filter xxx orlonger' as a form of workaround #}
+{%       if p_entry.match.prefix in routing._junos_prefix_min_max %}
+      from prefix-list-filter {{ p_entry.match.prefix }}-{{ match_af }} orlonger;
+{%       else %}
       from prefix-list {{ p_entry.match.prefix }}-{{ match_af }};
+{%       endif %}
 {%     endif %}
 {%     if 'aspath' in p_entry.match %}
       from as-path-group {{ p_entry.match.aspath }};
@@ -86,6 +91,14 @@ policy-options {
 {{     common_route_map_entry(p_entry,match_af) }}
     }
 {%   endfor %}
+
+{# last-resort reject #}
+    term default-reject {
+      then {
+        reject;
+      }
+    }
+
   }
 }
 

--- a/netsim/ansible/templates/routing/_route_policy_junos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_junos.j2
@@ -2,7 +2,7 @@
 {%   if s_param.path|default('') %}
       then as-path-prepend "{{ s_param.path }}";
 {%   elif s_param.count|default(0) %}
-      then as-path-prepend "{{ (asn + " ") * s_param.count }}";
+      then as-path-prepend "{{ ([asn] * s_param.count)|join(" ") }}";
 {%   endif %}
 {%- endmacro %}
 

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -4,7 +4,6 @@
 
 {% if routing.aspath|default({}) %}
 policy-options {
-}
 {%   for asp_name,asp_list in routing.aspath.items() %}
   as-path-group {{ asp_name }} {
 {%     for asp_line in asp_list %}

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -32,3 +32,30 @@ policy-options community {{ c_name }} members [ "{{ c_line._value }}" ];
 {%   import '_route_policy_junos.j2' as routemap with context %}
 {{   routemap.create_route_maps(routing.policy) }}
 {% endif %}
+
+{# ### Static Routing ### #}
+
+{% for sr_data in routing.static|default([]) %}
+{#   if we have a vrf route, open the routing instance stanza #}
+{%   if 'vrf' in sr_data %}
+routing-instances {
+  {{sr_data.vrf}} {
+{%   endif %}
+
+{#   recursive lookup is triggered by a route without the intf parameter #}
+{%   set route_resolve = ' resolve' if not 'intf' in sr_data.nexthop else '' %}
+    routing-options {
+{%   if 'ipv4' in sr_data %}
+      static route {{sr_data.ipv4}} next-hop {{sr_data.nexthop.ipv4}}{{route_resolve}};
+{%   endif %}
+{%   if 'ipv6' in sr_data %}
+{%   set ipv6_vrf_rib = sr_data.vrf + '.' if 'vrf' in sr_data else '' %}
+        rib {{ ipv6_vrf_rib }}inet6.0 static route {{sr_data.ipv6}} next-hop {{sr_data.nexthop.ipv6}}{{route_resolve}};
+{%   endif %}
+    }
+
+{%   if 'vrf' in sr_data %}
+  }
+}
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -20,7 +20,11 @@ policy-options {
 {%   for c_name,c_value in routing.community.items() %}
 {%     for c_line in c_value.value %}
 {# WARNING: c_line.action not usable #}
+{%       if c_value.type|default('') == 'large' %}
+policy-options community {{ c_name }} members [ "large:{{ c_line._value }}" ];
+{%       else %}
 policy-options community {{ c_name }} members [ "{{ c_line._value }}" ];
+{%       endif %}
 {%     endfor %}
 {%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -1,0 +1,31 @@
+{% if routing.prefix|default({}) %}
+{%   include '_prefix_list_junos.j2' %}
+{% endif %}
+
+{% if routing.aspath|default({}) %}
+policy-options {
+}
+{%   for asp_name,asp_list in routing.aspath.items() %}
+  as-path-group {{ asp_name }} {
+{%     for asp_line in asp_list %}
+{# WARNING: asp_line.action not usable - a quirk will warn the user #}
+    as-path {{ asp_name }}-{{ asp_line.sequence }} "{{ asp_line.path }}";
+{%     endfor %}
+  }
+{%   endfor %}
+}
+{% endif %}
+
+{% if routing.community|default({}) %}
+{%   for c_name,c_value in routing.community.items() %}
+{%     for c_line in c_value.value %}
+{# WARNING: c_line.action not usable #}
+policy-options community {{ c_name }} members [ "{{ c_line._value }}" ];
+{%     endfor %}
+{%   endfor %}
+{% endif %}
+
+{% if routing.policy|default({}) %}
+{%   import '_route_policy_junos.j2' as routemap with context %}
+{{   routemap.create_route_maps(routing.policy) }}
+{% endif %}

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -140,6 +140,12 @@ def check_routing_policy_quirks(node: Box, topology: Box) -> None:
           quirk='routing_prefixlist_min_max',
           module='junos'
         )
+        # as a kind-of workaround, add the prefix list name to a dedicated list;
+        #  then, on the policy evaluation, use 'prefix-list-filter XXX orlonger' if the prefix-list is in the list
+        if not '_junos_prefix_min_max' in node.routing:
+          node.routing['_junos_prefix_min_max'] = []
+        node.routing['_junos_prefix_min_max'].append(pl_name)
+
   # AS-PATH cannot directly have action "deny"
   for asp_name,asp_list in node.routing.get('aspath', {}).items():
     for asp_item in asp_list:

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -35,6 +35,25 @@ features:
     vpn: true
   ospf:
     unnumbered: true
+  routing:
+    policy:
+      match: [ prefix, aspath, community ]
+      set:
+        locpref: True
+        med: True
+        prepend: True
+        community:
+          standard: True
+          large: True
+          extended: True
+          append: True
+          delete: True
+    static:
+      vrf: True
+    prefix: True
+    aspath: True
+    community:
+      expanded: True
   sr: true
   vrf:
     ospfv2: True

--- a/netsim/extra/bgp.policy/defaults.yml
+++ b/netsim/extra/bgp.policy/defaults.yml
@@ -32,7 +32,7 @@ devices:
   ioll2:
     copy: iosv
   junos.features.bgp:
-    _default_locpref: True
+    _default_locpref: False
   vptx:
     copy: junos
   vsrx:

--- a/netsim/extra/bgp.policy/defaults.yml
+++ b/netsim/extra/bgp.policy/defaults.yml
@@ -31,6 +31,18 @@ devices:
     copy: iosv
   ioll2:
     copy: iosv
+  junos.features.bgp:
+    _default_locpref: True
+  vptx:
+    copy: junos
+  vsrx:
+    copy: junos
+  vmx:
+    copy: junos
+  vjunos-switch:
+    copy: junos
+  vjunos-router:
+    copy: junos
   sros.features.bgp:
     bandwidth:
       in: auto

--- a/netsim/extra/bgp.policy/junos.j2
+++ b/netsim/extra/bgp.policy/junos.j2
@@ -17,9 +17,6 @@
 {# Main BGP Instance #}
 protocols {
   bgp {
-{% if 'locpref' in bgp %}
-    local-preference {{ bgp.locpref }};
-{% endif %}
 {% for af in ['ipv4','ipv6'] if bgp[af] is defined and loopback[af] is defined %}
 {%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
 {%     if loop.first %}
@@ -58,9 +55,6 @@ routing-instances {
   {{vname}} {
     protocols {
       bgp {
-{% if 'locpref' in bgp %}
-        local-preference {{ bgp.locpref }};
-{% endif %}
 {%   for af in ['ipv4','ipv6'] if vdata.af[af] is defined and vdata.loopback_address[af] is defined %}
 {%     for n in vdata.bgp.neighbors|default([]) if n[af] is defined and n.type == 'ibgp' %}
 {%       if loop.first %}

--- a/netsim/extra/bgp.policy/junos.j2
+++ b/netsim/extra/bgp.policy/junos.j2
@@ -1,0 +1,98 @@
+{% set directions_map = { 'in':'import', 'out':'export' } %}
+
+{#
+   Macro for neighbor attributes (for bgp.policy)
+#}
+{% macro bgp_neighbor(n,bfd,af,k) %}
+{%   if 'policy' in n %}
+{# export policy needs to consider also ibgp-export/ebgp-export ----- TODO how to handle that?? #}
+{%     for direction in [ 'in','out' ] if direction in n.policy %}
+  {{ directions_map[direction] }} {{ n.policy[direction] }}-{{ af }};
+{%     endfor %}
+
+{%   endif %}
+{%- endmacro %}
+
+
+{# Main BGP Instance #}
+protocols {
+  bgp {
+{% if 'locpref' in bgp %}
+    local-preference {{ bgp.locpref }};
+{% endif %}
+{% for af in ['ipv4','ipv6'] if bgp[af] is defined and loopback[af] is defined %}
+{%   for n in bgp.neighbors if n[af] is defined and n.type == 'ibgp' %}
+{%     if loop.first %}
+    group ibgp-peers-{{ af }} {
+{%     endif %}
+      neighbor {{ n[af] }} {
+        {# IBGP neighbor within an address family #}
+        {{ bgp_neighbor(n,bfd,af,'ibgp') }}
+      }
+{%     if loop.last %}
+    }
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+{% for n in bgp.neighbors if n.type == 'ebgp' %}
+{%   if loop.first %}
+    group ebgp-peers {
+{%   endif %}
+{%   for af in ['ipv4','ipv6'] if n[af] is defined %}
+      neighbor {{ n[af] }} {
+        {# EBGP neighbor #}
+        {{ bgp_neighbor(n,bfd,af,'ebgp') }}
+      }
+{%   endfor %}
+{%     if loop.last %}
+    }
+{%     endif %}
+{% endfor %}
+  }
+}
+
+{# VRF -> BGP Instances #}
+routing-instances {
+{% for vname,vdata in (vrfs|default({})).items() %}
+
+  {{vname}} {
+    protocols {
+      bgp {
+{% if 'locpref' in bgp %}
+        local-preference {{ bgp.locpref }};
+{% endif %}
+{%   for af in ['ipv4','ipv6'] if vdata.af[af] is defined and vdata.loopback_address[af] is defined %}
+{%     for n in vdata.bgp.neighbors|default([]) if n[af] is defined and n.type == 'ibgp' %}
+{%       if loop.first %}
+        group ibgp-peers-{{ af }} {
+{%       endif %}
+          neighbor {{ n[af] }} {
+            {# THIS HERE IS THE NEIGHBOR (VRF->iBGP) #}
+            {{ bgp_neighbor(n,bfd,af,'ibgp') }}
+          }
+{%       if loop.last %}
+        }
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+
+{%   for n in vdata.bgp.neighbors|default([]) if n.type == 'ebgp' %}
+{%     if loop.first %}
+        group ebgp-peers {
+{%     endif %}
+{%     for af in ['ipv4','ipv6'] if n[af] is defined %}
+          neighbor {{ n[af] }} {
+            {# THIS HERE IS THE NEIGHBOR (VRF->eBGP) #}
+            {{ bgp_neighbor(n,bfd,af,'ebgp') }}
+          }
+{%     endfor %}
+{%     if loop.last %}
+        }
+{%     endif %}
+{%   endfor %}
+      }
+    }
+  }
+
+{% endfor %}
+}

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -69,9 +69,11 @@ devices:
   junos.features.bgp:
     allowas_in: True
     as_override: True
+    default_originate: True
     bfd: True
     password: True
     passive: True
+    remove_private_as: True
     timers: True
   vptx:
     copy: junos

--- a/netsim/extra/bgp.session/junos.j2
+++ b/netsim/extra/bgp.session/junos.j2
@@ -1,9 +1,61 @@
 {# Make sure BFD variable exists ;) #}
 {% set bfd = bfd|default({}) %}
+
+{#
+   Policy for default route originate, and insert discard route
+#}
+policy-options {
+  policy-statement default-route {
+    term default-route-v4 {
+      from {
+        route-filter 0.0.0.0/0 exact;
+      }
+      then accept;
+    }
+    term default-route-v6 {
+      from {
+        route-filter ::/0 exact;
+      }
+      then accept;
+    }
+  }
+}
+
+{% if bgp._junos_default_originate|default(false) %}
+routing-options {
+  static {
+    route 0.0.0.0/0 discard no-install;
+  }
+  rib inet6.0 {
+    static {
+      route ::/0 discard no-install;
+    }
+  }
+}
+{% endif %}
+{% for vname,vdata in (vrfs|default({})).items() %}
+{%   if vdata.bgp._junos_default_originate|default(false) %}
+routing-instances {
+  {{vname}} {
+    routing-options {
+      static {
+        route 0.0.0.0/0 discard no-install;
+      }
+      rib {{vname}}.inet6.0 {
+        static {
+          route ::/0 discard no-install;
+        }
+      }
+    }
+  }
+}
+{%   endif %}
+{% endfor %}
+
 {#
    Macro for neighbor attributes
 #}
-{% macro bgp_neighbor(n,bfd,af) %}
+{% macro bgp_neighbor(n,bfd,af,k) %}
 {%   if n.as_override|default(false) %}
   as-override;
 {%   endif %}
@@ -23,6 +75,12 @@
 {%   endif %}
 {%   if n.passive|default(false) %}
   passive;
+{%   endif %}
+{%   if n.remove_private_as|default(false) %}
+  remove-private;
+{%   endif %}
+{%   if n.default_originate|default(false) %}
+  export [ default-route {{k}}-export ];
 {%   endif %}
 {%   if n.password is defined %}
   authentication-key "{{ n.password }}";
@@ -46,7 +104,7 @@ protocols {
 {%     endif %}
       neighbor {{ n[af] }} {
         {# IBGP neighbor within an address family #}
-        {{ bgp_neighbor(n,bfd,af) }}
+        {{ bgp_neighbor(n,bfd,af,'ibgp') }}
       }
 {%     if loop.last %}
     }
@@ -60,7 +118,7 @@ protocols {
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
       neighbor {{ n[af] }} {
         {# EBGP neighbor #}
-        {{ bgp_neighbor(n,bfd,af) }}
+        {{ bgp_neighbor(n,bfd,af,'ebgp') }}
       }
 {%   endfor %}
 {%     if loop.last %}
@@ -84,7 +142,7 @@ routing-instances {
 {%       endif %}
           neighbor {{ n[af] }} {
             {# THIS HERE IS THE NEIGHBOR (VRF->iBGP) #}
-            {{ bgp_neighbor(n,bfd,af) }}
+            {{ bgp_neighbor(n,bfd,af,'ibgp') }}
           }
 {%       if loop.last %}
         }
@@ -99,7 +157,7 @@ routing-instances {
 {%     for af in ['ipv4','ipv6'] if n[af] is defined %}
           neighbor {{ n[af] }} {
             {# THIS HERE IS THE NEIGHBOR (VRF->eBGP) #}
-            {{ bgp_neighbor(n,bfd,af) }}
+            {{ bgp_neighbor(n,bfd,af,'ebgp') }}
           }
 {%     endfor %}
 {%     if loop.last %}

--- a/tests/integration/routing/21-static-vrf.yml
+++ b/tests/integration/routing/21-static-vrf.yml
@@ -45,6 +45,10 @@ validate:
     wait: 20
     nodes: [ x1 ]
     plugin: ospf6_neighbor(nodes.x2.ospf.router_id)
+  ping_x1_local:
+    description: Ping DUT interface from X1 local address
+    nodes: [ x1 ]
+    plugin: ping(nodes.dut.interfaces[1].ipv4)
   ping_x1_v4:
     description: Ping DUT from loopback IPv4 address of X1
     nodes: [ x1 ]


### PR DESCRIPTION
This PR introduces **foundations and basic working support** for routing policies (and static routing) in JunOS.

Despite it has a lot of quirks (and caveats), it works for basic use cases.

Sooner or later the quirks/caveats will be solved by changing the policy logic (again as a quirk), but for now we have something which works, at least with basic features, in a short time :)

Tested with routing integration test cases; 

test cases which trigger quirks have been validated in terms of "applied config", but of course test validation fails.

NOTES:

* *10-match-prefix.yml* passes as well with the workaround set by the quirk (and disabling the quirk in the topology), but the workaround does not cover all the test cases - see documented caveats.

* *21-static-vrf.yml* and *23-static-indirect.yml* require some seconds of wait time before succeeding.
