### PR TITLE
Bird: Add IP unnumbered support for OSPF using 'peer' construct

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -138,7 +138,7 @@ OSPF routing daemons support these interface-level features:
 
 | Operating system         | Cost  | Network<br />type | Unnumbered<br />IPv4 interfaces | Passive<br />interfaces |
 | ------------------------ |:--:|:--:|:--:|:--:|
-| BIRD                     | ✅ | ✅ | ❌  | ✅ |
+| BIRD                     | ✅ | ✅ | ✅  | ✅ |
 
 **Notes:**
 * Routing daemons usually have a single interface. Running OSPF on them seems frivolous unless you need OSPF to get paths toward remote endpoints of IBGP sessions.

--- a/netsim/ansible/templates/initial/bird-clab.j2
+++ b/netsim/ansible/templates/initial/bird-clab.j2
@@ -2,3 +2,8 @@
 #
 set -e
 ip addr add fe80::1/64 dev lo scope link
+
+# Configure ipv4 unnumbered interfaces, if any
+{% for intf in interfaces if intf._bird_unnumbered_peer is defined %}
+ip addr add {{ intf._parent_ipv4 }} peer {{ intf._bird_unnumbered_peer }} dev {{ intf.ifname }}
+{% endfor %}

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -23,7 +23,9 @@ features:
     local_as: true
     local_as_ibgp: true
   ospf:
-    unnumbered: false
+    unnumbered: true
   dhcp: false
   initial:
     roles: [ host, router ]
+    ipv4:
+      unnumbered: true

--- a/netsim/devices/bird.py
+++ b/netsim/devices/bird.py
@@ -3,11 +3,33 @@
 #
 from box import Box
 
-from . import _Quirks
+from . import _Quirks, report_quirk
 from ._common import check_indirect_static_routes
+
+"""
+set_unnumbered_peers - check for ipv4 unnumbered interfaces with a single direct peer
+"""
+def set_unnumbered_peers(node: Box, topology: Box) -> None:
+  err_data = []
+  for intf in node.get('interfaces',[]):
+    if intf.get('ipv4',None) is True and '_parent_intf' in intf:
+      if len(intf.neighbors)==1:
+        peer = topology.nodes[ intf.neighbors[0].node ]
+        if 'ipv4' in peer.loopback:
+          intf._bird_unnumbered_peer = peer.loopback.ipv4
+          continue
+      err_data.append(f'Unnumbered interface without direct IPv4 peer {intf.ifname}')
+  
+  if err_data:
+    report_quirk(
+      f'node {node.name} has unsupported unnumbered interface(s)',
+      quirk='no_unnumbered_peer',
+      more_data=err_data,
+      node=node)
 
 class Bird(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
+    set_unnumbered_peers(node,topology)
     check_indirect_static_routes(node)

--- a/tests/integration/ospf/ospfv2/05-unnumbered.yml
+++ b/tests/integration/ospf/ospfv2/05-unnumbered.yml
@@ -12,6 +12,7 @@ groups:
 
 nodes:
   dut:
+    role: router
   x1:
 
 links:


### PR DESCRIPTION
* Fix OSPFv2 test adding 'mode: router'

Based on https://bird.network.cz/pipermail/bird-users/2014-June/009118.html (note: could be applied to any Linux device)

Test: passes ```netlab up integration/ospf/ospfv2/05-unnumbered.yml -d bird -p clab -v```