### PR TITLE
Cumulus: Enable ipv6 on extra loopbacks too

### DIFF
--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -117,7 +117,7 @@ done
 #
 # For whatever crazy reason, I had to enable IPv6 in containers
 #
-{% for l in interfaces if l.type in ['lan','p2p','stub','lag'] and (l.ipv6 is defined or 'external' in l.role|default('')) %}
+{% for l in interfaces if l.type in ['lan','p2p','stub','lag','loopback'] and (l.ipv6 is defined or 'external' in l.role|default('')) %}
 sysctl -qw net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
 {% endfor %}
 #


### PR DESCRIPTION
Triggered by https://github.com/ipspace/netlab/pull/2114

May not be strictly needed, but just to be consistent