### PR TITLE
Fix: Move VRF loopback creation to post_link_transform hook

### DIFF
--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -140,7 +140,9 @@ nodes:
       role: stub
       type: stub
       vrf: red
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.1/32
       name: VRF Loopback red
@@ -269,7 +271,9 @@ nodes:
       role: stub
       type: stub
       vrf: red
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.2/32
       name: VRF Loopback red

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -191,6 +191,7 @@ nodes:
       vrf: red
     - _parent_intf: Loopback1
       _parent_ipv4: 10.2.0.1/32
+      _parent_vrf: blue
       ifindex: 3
       ifname: eth3
       ipv4: true
@@ -203,7 +204,9 @@ nodes:
         vrf: blue
       type: p2p
       vrf: blue
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.1/32
       name: VRF Loopback blue
@@ -272,6 +275,7 @@ nodes:
           interfaces:
           - _parent_intf: Loopback1
             _parent_ipv4: 10.2.0.1/32
+            _parent_vrf: blue
             ifindex: 3
             ifname: eth3
             ipv4: true
@@ -287,7 +291,9 @@ nodes:
               vrf: blue
             type: p2p
             vrf: blue
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.1/32
             isis:
@@ -316,6 +322,7 @@ nodes:
           interfaces:
           - _parent_intf: Loopback1
             _parent_ipv4: 10.2.0.1/32
+            _parent_vrf: blue
             ifindex: 3
             ifname: eth3
             ipv4: true
@@ -332,7 +339,9 @@ nodes:
               passive: false
             type: p2p
             vrf: blue
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.1/32
             name: VRF Loopback blue
@@ -422,6 +431,7 @@ nodes:
       type: p2p
     - _parent_intf: Loopback1
       _parent_ipv4: 10.2.0.2/32
+      _parent_vrf: blue
       ifindex: 2
       ifname: eth2
       ipv4: true
@@ -445,7 +455,9 @@ nodes:
         node: r3
       type: p2p
       vrf: blue
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.2/32
       name: VRF Loopback blue
@@ -515,6 +527,7 @@ nodes:
           interfaces:
           - _parent_intf: Loopback1
             _parent_ipv4: 10.2.0.2/32
+            _parent_vrf: blue
             ifindex: 2
             ifname: eth2
             ipv4: true
@@ -544,7 +557,9 @@ nodes:
               node: r3
             type: p2p
             vrf: blue
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.2/32
             isis:
@@ -573,6 +588,7 @@ nodes:
           interfaces:
           - _parent_intf: Loopback1
             _parent_ipv4: 10.2.0.2/32
+            _parent_vrf: blue
             ifindex: 2
             ifname: eth2
             ipv4: true
@@ -604,7 +620,9 @@ nodes:
               passive: false
             type: p2p
             vrf: blue
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.2/32
             name: VRF Loopback blue

--- a/tests/topology/expected/vrf-loopback.yml
+++ b/tests/topology/expected/vrf-loopback.yml
@@ -8,6 +8,7 @@ nodes:
   r1:
     af:
       ipv4: true
+      vpnv4: true
     box: arista/veos
     device: eos
     id: 1

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -348,7 +348,9 @@ nodes:
       role: external
       type: p2p
       vrf: b_2
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.1/32
       name: VRF Loopback o_1
@@ -487,7 +489,9 @@ nodes:
               vrf: o_1
             type: p2p
             vrf: o_1
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.1/32
             isis:
@@ -530,7 +534,9 @@ nodes:
               passive: false
             type: p2p
             vrf: o_1
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.1/32
             name: VRF Loopback o_1
@@ -743,7 +749,9 @@ nodes:
         vrf: o_2
       type: p2p
       vrf: o_2
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.2/32
       name: VRF Loopback o_1
@@ -846,7 +854,9 @@ nodes:
               vrf: o_1
             type: p2p
             vrf: o_1
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.2/32
             isis:
@@ -889,7 +899,9 @@ nodes:
               passive: false
             type: p2p
             vrf: o_1
-          - ifindex: 10001
+          - bgp:
+              advertise: true
+            ifindex: 10001
             ifname: Loopback1
             ipv4: 10.2.0.2/32
             name: VRF Loopback o_1

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -141,7 +141,9 @@ nodes:
         node: r3
       type: p2p
       vrf: blue
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.2.0.1/32
       name: VRF Loopback red
@@ -149,7 +151,9 @@ nodes:
       type: loopback
       virtual_interface: true
       vrf: red
-    - ifindex: 10002
+    - bgp:
+        advertise: true
+      ifindex: 10002
       ifname: Loopback2
       ipv4: 10.2.0.2/32
       name: VRF Loopback blue
@@ -224,7 +228,9 @@ nodes:
               passive: false
             type: p2p
             vrf: blue
-          - ifindex: 10002
+          - bgp:
+              advertise: true
+            ifindex: 10002
             ifname: Loopback2
             ipv4: 10.2.0.2/32
             name: VRF Loopback blue
@@ -329,7 +335,9 @@ nodes:
       role: stub
       type: stub
       vrf: black
-    - ifindex: 10001
+    - bgp:
+        advertise: true
+      ifindex: 10001
       ifname: Loopback1
       ipv4: 10.0.0.1/32
       name: VRF Loopback black


### PR DESCRIPTION
This change exposes the VRF loopback interfaces to all post-transform hooks. The only visible side effect is the addition of 'bgp.advertise' flag as the BGP post-transform hook sees a new interface. That would cause a new 'network' statement in the device configurations, but no extra routes as most devices already do 'redistribute connected' into VRF BGP.