### PR TITLE
Bird: Filter BGP communities per neighbor type

### DIFF
--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -22,6 +22,11 @@ features:
     activate_af: true
     local_as: true
     local_as_ibgp: true
+    community:
+      standard: [ standard, large ]
+      large: [ large ]
+      extended: [ extended ]
+      2octet: [ standard ]
   ospf:
     unnumbered: true
   dhcp: false

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -13,7 +13,7 @@ protocol static bgp_ipv4 {
 {%   endif %}
 {% endfor %}
 
-filter bgp_prefixes {
+function bgp_prefixes() {
   if source ~ [ RTS_STATIC, RTS_BGP ]
     then accept;
 
@@ -27,6 +27,26 @@ filter bgp_prefixes {
 {% endfor %}
   reject;
 }
+
+{#
+ Build a BGP export filter per neighbor type, to filter communities
+#}
+{% for ntype in [ 'ebgp', 'ibgp', 'localas_ibgp' ] %}
+filter bgp_export_{{ ntype }} {
+{%   set list = bgp.community[ntype]|default([]) %}
+{%   if 'standard' not in list %}
+  bgp_community.empty;
+{%   endif %}
+{%   if 'large' not in list %}
+  bgp_large_community.empty;
+{%   endif %}
+{%   if 'extended' not in list %}
+  bgp_ext_community.empty;
+{%   endif %}
+
+  bgp_prefixes();
+}
+{% endfor %}
 
 {% for n in bgp.neighbors %}
 {%   for af in [ 'ipv4','ipv6' ] if af in n %}
@@ -53,7 +73,7 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%     if af in n.activate and n.activate[af] %}
   {{ af }} {
     import all;
-    export filter bgp_prefixes;
+    export filter bgp_export_{{ n.type }};
 {%       if 'next_hop_self' in bgp and bgp.next_hop_self and 'ibgp' in n.type %}
     next hop self {{ 'on' if n.type == 'localas_ibgp' else 'ebgp' }};
 {%       endif %}

--- a/tests/integration/bgp/05-community.yml
+++ b/tests/integration/bgp/05-community.yml
@@ -2,7 +2,7 @@
 message: |
   Use this topology to test the BGP community propagation. The device under test
   is a BGP route reflector that should propagate standard and extended
-  communities to IBGP neighbors but only extended communities to EBGP neighbors
+  communities to IBGP neighbors but only standard communities to EBGP neighbors
   (the default setting).
 
   Three BGP communities are attached to the prefix advertised by RC: a standard


### PR DESCRIPTION
Fixes https://tests.netlab.tools/bird/clab/bgp/05-community.yml-validate.log