### PR TITLE
Bird: Prefer BGP routes over OSPF routes

### DIFF
--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -15,17 +15,17 @@ protocol static bgp_ipv4 {
 
 filter bgp_prefixes {
   if source ~ [ RTS_STATIC, RTS_BGP ]
-    then accept;
+    then accept "Static or BGP route:", net;
 
 {% if bgp.advertise_loopback|default(False) %}
   if source ~ [ RTS_DEVICE ] && ifname = "lo"
-    then accept;
+    then accept "advertise loopback:", net;
 {% endif %}
 {% for intf in interfaces if 'bgp' in intf and intf.bgp.advertise|default(False) %}
   if source ~ [ RTS_DEVICE ] && ifname = "{{ intf.ifname }}"
-    then accept;
+    then accept "bgp.advertise:", net;
 {% endfor %}
-  reject;
+  reject "not accepted:", net, " source=", source, " preference=", preference;
 }
 
 {% for n in bgp.neighbors %}
@@ -54,6 +54,7 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
   {{ af }} {
     import all;
     export filter bgp_prefixes;
+    preference 160; # Higher than OSPF 150, default is 100
 {%       if 'next_hop_self' in bgp and bgp.next_hop_self and 'ibgp' in n.type %}
     next hop self {{ 'on' if n.type == 'localas_ibgp' else 'ebgp' }};
 {%       endif %}


### PR DESCRIPTION
Passes all ```bgp/03-ibgp-rr tests```

Source that put me on the right track: https://bird.network.cz/pipermail/bird-users/2018-April/012175.html

Bird has no 'administrative distance', but *preference* can be used to the same effect. By default, OSPF has preference 150 and BGP has 100; by setting BGP to 160, BGP routes are preferred

PR also adds route policy debugging printouts that can be useful: 
```
birdcl
debug bgp_r2_ipv4 all
echo all
restart bgp_r2_ipv4
```
This prints out the routes exported to r2, evaluated against the policy