### PR TITLE
Bird: Add route filter debugging messages

### DIFF
--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -15,17 +15,17 @@ protocol static bgp_ipv4 {
 
 function bgp_prefixes() {
   if source ~ [ RTS_STATIC, RTS_BGP ]
-    then accept;
+    then accept "Static or BGP route:", net;
 
 {% if bgp.advertise_loopback|default(False) %}
   if source ~ [ RTS_DEVICE ] && ifname = "lo"
-    then accept;
+    then accept "advertise loopback:", net;
 {% endif %}
 {% for intf in interfaces if 'bgp' in intf and intf.bgp.advertise|default(False) %}
   if source ~ [ RTS_DEVICE ] && ifname = "{{ intf.ifname }}"
-    then accept;
+    then accept "bgp.advertise:", net;
 {% endfor %}
-  reject;
+  reject "not accepted:", net, " source=", source, " preference=", preference;
 }
 
 {#


### PR DESCRIPTION
PR adds route policy debugging printouts that can be useful:
```
birdcl
debug bgp_r2_ipv4 all
echo all
restart bgp_r2_ipv4
```
This prints out the routes exported to r2, evaluated against the policy

Replaces #2129 