### PR TITLE
Initial implementation of firewall.zonebased plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -19,6 +19,7 @@
    plugins/multilab.md
    plugins/node.clone.md
    plugins/vrrp.version.md
+   plugins/firewall.zonebased.md
 ```
 
 Plugins needed by a topology file are listed in the **plugin** top-level element, for example:

--- a/docs/plugins/firewall.zonebased.md
+++ b/docs/plugins/firewall.zonebased.md
@@ -1,0 +1,59 @@
+# Zone-Based Firewall plugin
+
+This plugin creates simple Zone-Based Firewall configuration for specific nodes.
+
+For now, the plugin supports only default *zone to zone* rules, with `permit` or `deny` actions.
+
+## Supported Platforms
+
+The plugin includes Jinja2 templates for the following platforms:
+
+| Operating system    | Default Policies |
+| ------------------- | :--: |
+| Juniper vSRX        |  ✅  |
+| VyOS                |  ✅  |
+
+## Using the Plugin
+
+* Add `plugin: [ firewall.zonebased ]` to the lab topology.
+* Include the **firewall.zonebased.default_rules** attribute in the firewall node
+* Include the **firewall.zone** attribute in the firewall links/interfaces
+
+### Supported attributes
+
+The plugin adds the following attributes defined at node level:
+* **firewall.zonebased.default_rules** (list) -- List of defaults *zone to zone* policies. Each item is a *dict* with the following attributes:
+    * **from_zone** (string, mandatory) -- Policy Source Zone
+    * **to_zone** (string, mandatory) -- Policy Destination Zone
+    * **action** (string, mandatory, one of `permit`, `deny`) -- Policy Action
+
+Additional interface level attributes:
+* **firewall.zone** (string) -- the firewall zone for this firewall interface
+
+## Example
+
+```
+
+plugin: [ firewall.zonebased ]
+
+nodes:
+  fw:
+    firewall.zonebased:
+      default_rules:
+      - from_zone: trusted
+        to_zone: trusted
+        action: permit
+      - from_zone: trusted
+        to_zone: untrusted
+        action: permit
+  h1:
+  h2:
+
+links:
+- fw:
+    firewall.zone: trusted
+  h1:
+- fw:
+    firewall.zone: untrusted
+  h2:
+```

--- a/docs/plugins/firewall.zonebased.md
+++ b/docs/plugins/firewall.zonebased.md
@@ -23,12 +23,12 @@ The plugin includes Jinja2 templates for the following platforms:
 
 The plugin adds the following attributes defined at node level:
 * **firewall.zonebased.default_rules** (list) -- List of defaults *zone to zone* policies. Each item is a *dict* with the following attributes:
-    * **from_zone** (string, mandatory) -- Policy Source Zone
-    * **to_zone** (string, mandatory) -- Policy Destination Zone
+    * **from_zone** (id, mandatory) -- Policy Source Zone
+    * **to_zone** (id, mandatory) -- Policy Destination Zone
     * **action** (string, mandatory, one of `permit`, `deny`) -- Policy Action
 
 Additional interface level attributes:
-* **firewall.zone** (string) -- the firewall zone for this firewall interface
+* **firewall.zone** (id) -- the firewall zone for this firewall interface
 
 ## Example
 

--- a/netsim/extra/firewall.zonebased/defaults.yml
+++ b/netsim/extra/firewall.zonebased/defaults.yml
@@ -6,6 +6,8 @@ devices:
     features.firewall.zonebased: True
   vyos:
     features.firewall.zonebased: True
+  none:
+    features.firewall.zonebased: True
 
 attributes:
   node:

--- a/netsim/extra/firewall.zonebased/defaults.yml
+++ b/netsim/extra/firewall.zonebased/defaults.yml
@@ -1,0 +1,28 @@
+# firewall.zonebased
+#
+---
+devices:
+  vsrx:
+    features.firewall.zonebased: True
+  vyos:
+    features.firewall.zonebased: True
+
+attributes:
+  node:
+    firewall.zonebased:
+      default_rules: { type: list, _subtype: _fw_rule_entry }
+  interface:
+    firewall.zone: { type: str }
+
+  # specific attributes
+  _fw_rule_entry:
+    action:
+      type: str
+      _required: true
+      valid_values: [ permit, deny ]
+    from_zone:
+      type: str
+      _required: true
+    to_zone:
+      type: str
+      _required: true

--- a/netsim/extra/firewall.zonebased/defaults.yml
+++ b/netsim/extra/firewall.zonebased/defaults.yml
@@ -12,7 +12,7 @@ attributes:
     firewall.zonebased:
       default_rules: { type: list, _subtype: _fw_rule_entry }
   interface:
-    firewall.zone: { type: str }
+    firewall.zone: { type: id }
 
   # specific attributes
   _fw_rule_entry:
@@ -21,8 +21,8 @@ attributes:
       _required: true
       valid_values: [ permit, deny ]
     from_zone:
-      type: str
+      type: id
       _required: true
     to_zone:
-      type: str
+      type: id
       _required: true

--- a/netsim/extra/firewall.zonebased/plugin.py
+++ b/netsim/extra/firewall.zonebased/plugin.py
@@ -14,24 +14,29 @@ def post_transform(topology: Box) -> None:
     for node in topology.nodes.values():
         features = devices.get_device_features(node,topology.defaults)
         zbf_supported = 'firewall.zonebased' in features
+        OK = True
+
         for intf in node.get('interfaces',[]):
-            # if link has a firewall zone, apply extra config to this node
             fw_zone = intf.get('firewall.zone', '')
-            if not zbf_supported and fw_zone:
+            if not fw_zone:                                     # No zone defined on the interface, move on
+                continue
+            if not zbf_supported:                               # Not supported, print error and move on
                 log.error( f"Node {node.name}({node.device}) does not support 'firewall.zone' used on {intf.name}",
                         category=log.IncorrectAttr,module=_config_name)
-            elif fw_zone:
-                # add zone to list of zones
-                node.firewall.zonebased._zones[fw_zone] = {}
-                # add config template
-                api.node_config(node,_config_name)
+                OK = False
+                continue
+
+            node.firewall.zonebased._zones[fw_zone] = {}        # Add zone to the list of zones
+            api.node_config(node,_config_name)                  # ... and remember we have to do extra config
+
+        if not OK:                                              # Errors? Move on
+            continue
+
         # now check that zones defined in rules are defined
-        rule_idx = 0
-        for def_rule in node.get('firewall.zonebased.default_rules', []):
+        for rule_idx,def_rule in enumerate(node.get('firewall.zonebased.default_rules', [])):
             for z_direction in [ 'from_zone', 'to_zone' ]:
                 z = def_rule[z_direction]
                 if z not in node.firewall.zonebased._zones:
-                    log.error( f"Node {node.name} does not have zone '{z}' defined in default zone rule '{rule_idx}' direction '{z_direction}'",
+                    log.error( f"Node {node.name} does not have zone '{z}' used in firewall.zonebased.default_rules[{rule_idx}].{z_direction}",
                             category=log.IncorrectAttr,module=_config_name)
-            rule_idx = rule_idx + 1
     return

--- a/netsim/extra/firewall.zonebased/plugin.py
+++ b/netsim/extra/firewall.zonebased/plugin.py
@@ -14,12 +14,6 @@ def post_transform(topology: Box) -> None:
     for node in topology.nodes.values():
         features = devices.get_device_features(node,topology.defaults)
         zbf_supported = 'firewall.zonebased' in features
-        if zbf_supported:
-            # Create basic structures if not exists
-            if 'firewall' not in node:
-                node.firewall = {}
-            if 'firewall.zonebased' not in node:
-                node.firewall.zonebased = { '_zones': {} }
         for intf in node.get('interfaces',[]):
             # if link has a firewall zone, apply extra config to this node
             fw_zone = intf.get('firewall.zone', '')

--- a/netsim/extra/firewall.zonebased/plugin.py
+++ b/netsim/extra/firewall.zonebased/plugin.py
@@ -1,0 +1,43 @@
+# Firewall Zone-Based Plugin
+## Simple rules for now, only default policy supported initially
+
+from netsim.utils import log
+from netsim.augment import addressing, devices
+from netsim import api,data
+from box import Box
+import netaddr
+
+_config_name = 'firewall.zonebased'
+
+def post_transform(topology: Box) -> None:
+    global _config_name
+    for node in topology.nodes.values():
+        features = devices.get_device_features(node,topology.defaults)
+        zbf_supported = 'firewall.zonebased' in features
+        if zbf_supported:
+            # Create basic structures if not exists
+            if 'firewall' not in node:
+                node.firewall = {}
+            if 'firewall.zonebased' not in node:
+                node.firewall.zonebased = { '_zones': {} }
+        for intf in node.get('interfaces',[]):
+            # if link has a firewall zone, apply extra config to this node
+            fw_zone = intf.get('firewall.zone', '')
+            if fw_zone:
+                if not zbf_supported:
+                    log.error( f"Node {node.name}({node.device}) does not support 'firewall.zone' used on {intf.name}",
+                            category=log.IncorrectAttr,module=_config_name)
+                else:
+                    # add zone to list of zones
+                    node.firewall.zonebased._zones[fw_zone] = {}
+                    # add config template
+                    api.node_config(node,_config_name)
+        # now check that zones defined in rules are defined
+        rule_idx = 0
+        for def_rule in node.get('firewall.zonebased.default_rules', []):
+            for z in [ def_rule.from_zone, def_rule.to_zone ]:
+                if z not in node.firewall.zonebased._zones:
+                    log.error( f"Node {node.name} does not have zone '{z}' defined in default zone rule '{rule_idx}'",
+                            category=log.IncorrectAttr,module=_config_name)
+            rule_idx = rule_idx + 1
+    return

--- a/netsim/extra/firewall.zonebased/vsrx.j2
+++ b/netsim/extra/firewall.zonebased/vsrx.j2
@@ -1,0 +1,47 @@
+{# basic zone-based firewall plugin template for vSRX #}
+
+{# create zones and allow all local services and fw host inbound traffic #}
+
+security {
+  zones {
+{% for zonename,zonedata in (firewall.zonebased._zones|default({})).items() %}
+    security-zone {{zonename}} {
+      host-inbound-traffic {
+        system-services all;
+        protocols all;
+      }
+    }
+{% endfor %}
+  }
+}
+
+{# assign interfaces to zones #}
+
+{% for intf in interfaces|default([]) if intf.firewall.zone is defined %}
+security zones security-zone {{ intf.firewall.zone }} interfaces {{ intf.ifname }};
+{% endfor %}
+
+security {
+  delete: policies;
+}
+security policies default-policy deny-all;
+
+{# TODO: specific zone-to-zone rules here #}
+
+{# default zone-to-zone rules #}
+security {
+  policies {
+{% for def_rule in firewall.zonebased.default_rules|default([]) %}
+    from-zone {{def_rule.from_zone}} to-zone {{def_rule.to_zone}} {
+      policy default {
+        match {
+          source-address any;
+          destination-address any;
+          application any;
+        }
+        then {{def_rule.action}};
+      }
+    }
+{% endfor %}
+  }
+}

--- a/netsim/extra/firewall.zonebased/vyos.j2
+++ b/netsim/extra/firewall.zonebased/vyos.j2
@@ -1,0 +1,57 @@
+#!/bin/vbash
+
+{# basic zone-based firewall plugin template for VyOS #}
+
+source /opt/vyatta/etc/functions/script-template
+
+if [ "$(id -g -n)" != 'vyattacfg' ] ; then
+    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
+fi
+
+# Configuration items start here
+
+configure
+
+{% set rule_action_map = { 'permit':'accept', 'deny':'drop' } %}
+
+{# make it stateful... #}
+set firewall global-options state-policy established action 'accept'
+set firewall global-options state-policy related action 'accept'
+
+{# create local zone to allow all local services and fw host inbound traffic #}
+
+set firewall ipv4 name def_LOCAL default-action accept
+set firewall ipv6 name def_LOCAL default-action accept
+set firewall zone LOCAL local-zone
+{% for zonename,zonedata in (firewall.zonebased._zones|default({})).items() %}
+set firewall zone LOCAL from {{zonename}} firewall name def_LOCAL
+set firewall zone LOCAL from {{zonename}} firewall ipv6-name def_LOCAL
+{% endfor %}
+
+{# add interfaces to zones #}
+
+{% for intf in interfaces|default([]) if intf.firewall.zone is defined %}
+set firewall zone {{ intf.firewall.zone }} member interface {{ intf.ifname }}
+{% endfor %}
+
+{# create required zone-to-zone named policies #}
+
+{% for def_rule in firewall.zonebased.default_rules|default([]) %}
+
+set firewall ipv4 name def_{{def_rule.from_zone}}_{{def_rule.to_zone}} default-action {{rule_action_map[def_rule.action]}}
+set firewall ipv6 name def_{{def_rule.from_zone}}_{{def_rule.to_zone}} default-action {{rule_action_map[def_rule.action]}}
+
+set firewall zone {{def_rule.to_zone}} from {{def_rule.from_zone}} firewall name def_{{def_rule.from_zone}}_{{def_rule.to_zone}}
+set firewall zone {{def_rule.to_zone}} from {{def_rule.from_zone}} firewall ipv6-name def_{{def_rule.from_zone}}_{{def_rule.to_zone}}
+
+{% endfor %}
+
+
+
+
+# Commit, save and exit from subshell
+
+commit
+save
+exit
+

--- a/tests/integration/firewall.zonebased/01-default-zone-policy.yml
+++ b/tests/integration/firewall.zonebased/01-default-zone-policy.yml
@@ -1,0 +1,52 @@
+---
+message: |
+  Use this topology to test the zone-to-zone default policy for firewall.zonebased plugin.
+
+plugin: [ firewall.zonebased ]
+
+defaults.devices.vsrx.clab.image: vrnetlab/juniper_vsrx:21.3R1.9
+
+nodes:
+  fw:
+    firewall.zonebased:
+      default_rules:
+      - from_zone: trusted
+        to_zone: trusted
+        action: permit
+      - from_zone: trusted
+        to_zone: untrusted
+        action: permit
+  h1:
+    device: linux
+    provider: clab
+  h2:
+    device: linux
+    provider: clab
+  h3:
+    device: linux
+    provider: clab
+
+links:
+- fw:
+    firewall.zone: trusted
+  h1:
+- fw:
+    firewall.zone: untrusted
+  h2:
+- fw:
+    firewall.zone: trusted
+  h3:
+
+validate:
+  ping_permit:
+    description: Ping from zone trusted to zone untrusted
+    nodes: [ h1 ]
+    plugin: ping('h2')
+  ping_drop:
+    description: Ping from zone untrusted to zone trusted (shall fail)
+    nodes: [ h2 ]
+    plugin: ping('h1',expect='fail')
+  ping_intrazone:
+    description: Ping from zone trusted to zone trusted (intra-zone)
+    nodes: [ h1 ]
+    plugin: ping('h3')


### PR DESCRIPTION
Starting point for zone-based firewall, for now supporting default zone-to-zone policies (with `permit`/`deny` actions)

The plugin has been put with `firewall.` as prefix, as in the future we may want to add additional "subplugins" (i.e., `firewall.nat`).

Created basic integration test as well.

Supported on:
* vSRX
* VyOS
