### PR TITLE
ArubaOS-CX: clear all bgp session (soft) after policy config

### DIFF
--- a/netsim/extra/bgp.policy/arubacx.j2
+++ b/netsim/extra/bgp.policy/arubacx.j2
@@ -47,6 +47,9 @@ router bgp {{ bgp.as }}
 {% endfor %}
 {% endif %}
 !
-{% for ngb in bgp._session_clear|default([]) %}
-do clear bgp {{ ngb }}
+do clear bgp all * soft out
+do clear bgp all * soft in
+{% for vname,vdata in (vrfs|default({})).items() if vdata.bgp is defined %}
+do clear bgp vrf {{vname}} all * soft in
+do clear bgp vrf {{vname}} all * soft out
 {% endfor %}


### PR DESCRIPTION
Fix #2139