### PR TITLE
VyOS: routing policy shall consider only ipv4 and ipv6 af

### DIFF
--- a/netsim/ansible/templates/routing/_route_policy_vyos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_vyos.j2
@@ -83,7 +83,7 @@ top
 #}
 {% macro create_route_maps(rp_dict) -%}
 {%   for rp_name,rp_list in rp_dict.items() %}
-{%     for rm_af in af %}
+{%     for rm_af in ['ipv4', 'ipv6'] if rm_af in af %}
 {{       build_route_map('%s-%s'|format(rp_name,rm_af),rp_list,rm_af) }}
 {%     endfor %}
 {%   endfor %}


### PR DESCRIPTION
Fix #2143