### PR TITLE
VyOS: lldp intf disable inconsistency between 1.4 and 1.5

### DIFF
--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -89,7 +89,9 @@ set interfaces {{ ns.iface_level }} {{ ns.ifname }} vrf {{ l.vrf }}
 {% endfor %}
 
 set service lldp interface all
-set service lldp interface {{ mgmt.ifname|default('eth0') }} mode disable
+{# LLDP FUBAR: different syntax for version 1.4 (used by vagrant box vyos/current) and 1.5 - See: https://github.com/ipspace/netlab/issues/2160 #}
+>/dev/null 2>/dev/null set service lldp interface {{ mgmt.ifname|default('eth0') }} disable
+>/dev/null 2>/dev/null set service lldp interface {{ mgmt.ifname|default('eth0') }} mode disable
 
 {# IPv6 RA config #}
 {% for l in netlab_interfaces if 'ipv6' in l and l.type != 'loopback' %}


### PR DESCRIPTION
LLDP FUBAR: different syntax for version 1.4 (used by vagrant box vyos/current) and 1.5

Fix #2160