### PR TITLE
FRR: Support deleting of communities

### DIFF
--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -136,7 +136,7 @@ The **set.community** attribute can be used to set these BGP communities on supp
 | Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
 | Dell OS10           | ✅ | ❌ | ✅ | ✅ | ❌  |
 | Junos               | ✅ | ✅ | ✅ | ✅ | ✅ |
-| FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
+| FRR                 | ✅ | ✅ | ✅ | ✅ | ✅  |
 | VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
 
 ### Shortcut Routing Policy Definitions

--- a/netsim/ansible/templates/routing/frr.j2
+++ b/netsim/ansible/templates/routing/frr.j2
@@ -64,7 +64,9 @@ vrf {{ r_vrf }}
 {%   endfor %}
 {% endif %}
 
+{% if bgp is defined %}
 router bgp {{ bgp.as }}
   ! Allow outbound policies for reflected iBGP routes, if any
   bgp route-reflector allow-outbound-policy
 !
+{% endif %}

--- a/netsim/ansible/templates/routing/frr.j2
+++ b/netsim/ansible/templates/routing/frr.j2
@@ -7,7 +7,11 @@
   set extcommunity bandwidth {{ p_entry.set.bandwidth }}
 {%       endif %}
 {%     endif %}
-{{     routemap.common_route_map_entry(p_entry,af_list) }}
+{%     if p_entry.set.community.delete is defined %}
+  set comm-list {{ p_entry.set.community._frr_list }} delete
+{%     else %}
+{{       routemap.common_route_map_entry(p_entry,af_list) }}
+{%     endif %}
 {%-   endcall %}
 {% endif %}
 {% if routing.prefix|default({}) %}
@@ -59,3 +63,8 @@ vrf {{ r_vrf }}
 {%     endfor %}
 {%   endfor %}
 {% endif %}
+
+router bgp {{ bgp.as }}
+  ! Allow outbound policies for reflected iBGP routes, if any
+  bgp route-reflector allow-outbound-policy
+!

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -114,6 +114,7 @@ features:
           large: True
           extended: True
           append: True
+          delete: True
       match: [ prefix, nexthop, aspath, community ]
     prefix: True
     aspath: True


### PR DESCRIPTION
FRR supports community deletion, but only using a list. This PR adds a quirk to configure such lists

Source: https://github.com/FRRouting/frr/issues/4692

Notes:
* Post suggests to enable ```bgp route-reflector allow-outbound-policy``` to fix deletion on reflected routes, PR adds this flag since I see no downside to having it enabled

Tested: ```NETLAB_DEVICE=frr NETLAB_PROVIDER=clab ./device-module-test routing```