### PR TITLE
Split group sanity checks from in-depth data validation

### DIFF
--- a/docs/dev/transform.md
+++ b/docs/dev/transform.md
@@ -24,6 +24,7 @@ The data transformation has three major steps:
 * Adjust the nodes data structure: transform [list of strings](nodes-list-of-strings) into a dictionary with empty values (`netsim.augment.nodes.create_node_dict`)
 * Check basic group data structures and auto-create nodes from group members (`augment.groups.precheck_groups`)
 * Initialize [plugin system](../plugins.md): load all plugins listed in the **plugin** top-level element (`netsim.augment.plugin.init`)
+* Initialize [node roles](node-router-host) subsystem
 * Execute plugin **topology_expand** hook (`netsim.augment.plugin.execute`) for plugins that augment lab topology structures (example: [](../plugins/fabric.md))
 
 * Initialize the link list (`netsim.augment.links.links_init`)
@@ -33,8 +34,8 @@ The data transformation has three major steps:
   * Set **linkindex** attributes (`netsim.augment.links.set_linkindex`)
 
 * Expand topology components (`netsim.augment.components.expand_components`)
+* Initialize **groups** structure and perform basic sanity checks (`netsim.augment.groups.init_groups`)
 * Execute plugin **init** hook (`netsim.augment.plugin.execute`)
-* Process external **tools** (`augment.tools.process_tools`)
 * Check for the presence of required top-level topology elements (`netsim.augment.topology.check_required_elements`)
 
 * Initialize attribute validation (`netsim.data.validate.init_validation`)
@@ -43,20 +44,25 @@ The data transformation has three major steps:
 	* Check the attributes in the group data structures
 	* Add group members based on nodes' **group** attribute
 	* Check recursive groups
-	* Copy group **device** and **module** attribute into nodes
-	* Copy group **node_data** into nodes
-	* Process **bgp.as_list** to get **bgp.as** node attributes
-	* Create BGP autogroups (groups based on BGP AS numbers)
-	* Copy **node_data** from BGP autogroups into nodes
 
 * Adjust global parameters (`netsim.augment.topology.adjust_global_parameters`):
 
   * Set `provider` top-level element
   * Merge provider-specific device and addressing defaults with global defaults
 
-* Load provider plugin (`netsim.providers._Provider.load`)
+* Validate group parameters (`netsim.augment.groups.validate_groups`)
+* Copy group data into nodes (`netsim. augment.groups.copy_group_data`)
+
+	* Copy group **device** and **module** attribute into nodes
+	* Copy group **node_data** into nodes
+	* Process **bgp.as_list** to get **bgp.as** node attributes
+	* Create BGP autogroups (groups based on BGP AS numbers)
+	* Copy **node_data** from BGP autogroups into nodes
+
+* Select primary provider and load provider plugin(s) (`netsim.providers.select_primary_provider`)
 * Augment node provider data: set node device type, select VM/container image, copy provider-specific node data into node dictionary (`netsim.augment.nodes.augment_node_provider_data`)
 * Augment node data with global defaults that are not part of configuration modules (example: MTU) (`augment.nodes.augment_node_system_data`)
+* Process external **tools** (`augment.tools.process_tools`)
 * Setup [addressing pools](../addressing.md) (`netsim.addressing.setup`)
 
 ## Global Data Transformation

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -38,7 +38,6 @@ def transform_setup(topology: Box) -> None:
 
   augment.components.expand_components(topology)
   augment.groups.init_groups(topology)
-  log.exit_on_error()
 
   augment.plugin.execute('init',topology)
   augment.topology.check_required_elements(topology)

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -34,17 +34,23 @@ def transform_setup(topology: Box) -> None:
   if 'links' in topology:
     augment.links.links_init(topology)
 
+  log.exit_on_error()
+
   augment.components.expand_components(topology)
+  augment.groups.init_groups(topology)
+  log.exit_on_error()
 
   augment.plugin.execute('init',topology)
   augment.topology.check_required_elements(topology)
   log.exit_on_error()
 
   validate.init_validation(topology)
-  augment.groups.init_groups(topology)
   log.exit_on_error()
 
   augment.topology.adjust_global_parameters(topology)
+  augment.groups.validate_groups(topology)
+  augment.groups.copy_group_data(topology)
+
   providers.select_primary_provider(topology)
   log.exit_on_error()
 

--- a/tests/errors/group-invalid-attr-type.log
+++ b/tests/errors/group-invalid-attr-type.log
@@ -1,7 +1,11 @@
+IncorrectType in groups: attribute 'groups.g1.config' must be a scalar or a list, found dictionary
+... use 'netlab show attributes node_group' to display valid attributes
 IncorrectAttr in groups: topology.groups.g1 uses an attribute from module bgp which is not enabled in topology
 IncorrectAttr in groups: Invalid node_group attribute 'foo' found in topology.groups.g1
-... use 'netlab show attributes node_group' to display valid attributes
-IncorrectType in groups: attribute 'groups.g1.config' must be a scalar or a list, found dictionary
+IncorrectType in groups: attribute 'groups.g2.config' must be a scalar or a list, found dictionary
+IncorrectAttr in groups: topology.groups.g2 uses an attribute from module bgp which is not enabled in group
+IncorrectType in groups: attribute 'groups.g2.node_data' must be a dictionary, found str
+IncorrectType in validate: Cannot validate attributes in topology.groups.g2.node_data -- that should have been a dictionary, found str
 IncorrectType in groups: attribute 'defaults.groups.g2.config' must be a scalar or a list, found dictionary
 IncorrectAttr in groups: defaults.groups.g2 uses an attribute from module bgp which is not enabled in topology
 IncorrectType in groups: attribute 'defaults.groups.g2.node_data' must be a dictionary, found str

--- a/tests/errors/groups-recursive.log
+++ b/tests/errors/groups-recursive.log
@@ -1,3 +1,2 @@
-IncorrectAttr in groups: Invalid node attribute 'foo' found in topology.groups.g2.node_data
-... use 'netlab show attributes node' to display valid attributes
+IncorrectValue in groups: Recursive group definition chain ['g1', 'g2', 'g1']
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/invalid-group-element.log
+++ b/tests/errors/invalid-group-element.log
@@ -1,2 +1,2 @@
-IncorrectType in groups: attribute 'groups' must be a dictionary, found str
+IncorrectType in topology: attribute 'groups' must be a dictionary, found str
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/validate-list.log
+++ b/tests/errors/validate-list.log
@@ -1,6 +1,4 @@
 IncorrectValue in groups: attribute groups.g1.module has invalid value(s): a
 ... valid values are: bfd, bgp, dhcp, eigrp, evpn, gateway, isis, lag, mpls, ospf, ripv2, routing, sr, srv6, stp, vlan, vrf, vxlan
 IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
-... use 'netlab show attributes node_group' to display valid attributes
-IncorrectType in groups: attribute 'groups.g2.module' must be a scalar or a list, found dictionary
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting


### PR DESCRIPTION
The group data cannot be validated before the 'init' hooks are executed, forcing the 'init' hooks that deal with groups to do redundant checks to ensure the data they're working with is sane.

This change splits the sanity checks performed at the same time as node- and link sanity checks from the in-depth data validation which is performed after 'init' hooks