### PR TITLE
Fix double transformation for routing.community objects

### DIFF
--- a/tests/topology/expected/rp-clist-expansion.yml
+++ b/tests/topology/expected/rp-clist-expansion.yml
@@ -57,12 +57,15 @@ nodes:
           regexp: ''
           type: standard
           value:
-          - _value: 65000:100 65001:100
+          - _value: 65000:104
             action: permit
             sequence: 10
-          - _value: 65000:103 65001:103
+          - _value: 65000:100 65001:100
             action: permit
             sequence: 20
+          - _value: 65000:103 65001:103
+            action: permit
+            sequence: 30
         cl5:
           regexp: regexp
           type: expanded
@@ -74,6 +77,9 @@ nodes:
             action: permit
             regexp: _6510.:307_
             sequence: 20
+          - _value: 65000:100
+            action: permit
+            sequence: 100
         cl6:
           regexp: regexp
           type: expanded
@@ -85,8 +91,40 @@ nodes:
             action: permit
             regexp: .*
             sequence: 20
+        cl7:
+          regexp: ''
+          type: standard
+          value:
+          - _value: 65000:106
+            action: permit
+            sequence: 10
+      policy:
+        m_clist:
+        - action: permit
+          match:
+            community: cl5
+          sequence: 10
+        - action: permit
+          match:
+            community: cl7
+          sequence: 20
 prefix:
   any:
     ipv4: 0.0.0.0/0
     ipv6: ::/0
 provider: libvirt
+routing:
+  community:
+    cl4:
+    - action: permit
+      path:
+      - 65000:104
+      sequence: 10
+    cl5:
+    - action: permit
+      path: 65000:100
+      sequence: 100
+    cl7:
+    - _value: 65000:106
+      action: permit
+      sequence: 10

--- a/tests/topology/input/rp-clist-expansion.yml
+++ b/tests/topology/input/rp-clist-expansion.yml
@@ -5,9 +5,25 @@ defaults.device: none
 
 module: [routing]
 
+routing:
+  community:                                      # Merge of global clist with a node clisst
+    cl4: 65000:104                                # ... regression test for #2155
+    cl5:
+    - sequence: 100
+      action: permit
+      path: 65000:100
+    cl7: 65000:106
+
 nodes:
   r1:
     routing:
+      policy:
+        m_clist:
+        - match.community: cl5
+          action: permit
+        - match.community: cl7                    # Import a clist due to a routing policy reference
+          action: permit                          # ... another regression test for #2155
+
       community:
         cl1: 65000:100                            # Single-entry ACL
         cl2: [65000:100, 65000:101]               # Single-entry multivalue ACL
@@ -15,8 +31,10 @@ nodes:
         cl4:                                      # More complex standard ACL
         - action: permit                          # Used to implement or-of-ands condition
           path: [65000:100, 65001:100]
+          sequence: 20
         - action: permit
           path: [65000:103, 65001:103]
+          sequence: 30
         cl5:                                      # A mix standard and extended conditions ==> extended
         - action: deny
           path: [65000:100, 65001:100]            # first entry is a list of communities


### PR DESCRIPTION
The routing.community objects start as a list of rules but get transformed into a dictionary late in the transformation process to simplify the config templates.

However, the transformation process was also triggered by a routing policy reference, and later executed again when we processed the node clists, resulting in unexpected data structure.

This fix checks whether a clist was already transformed before doing the transformation. It also fixes the common code used in as-path and clist import to recognize 'regexp' attribute (which can never appear in as-path object, so we're OK there ;)

Fixes #2155