### PR TITLE
Implement static (defaults-driven) module hooks

### DIFF
--- a/docs/dev/transform.md
+++ b/docs/dev/transform.md
@@ -35,16 +35,16 @@ The data transformation has three major steps:
 
 * Expand topology components (`netsim.augment.components.expand_components`)
 * Initialize **groups** structure and perform basic sanity checks (`netsim.augment.groups.init_groups`)
+
+	* Check the mandatory attributes in the group data structures
+	* Add group members based on nodes' **group** attribute
+	* Check recursive groups
+
 * Execute plugin **init** hook (`netsim.augment.plugin.execute`)
 * Check for the presence of required top-level topology elements (`netsim.augment.topology.check_required_elements`)
 
 * Initialize attribute validation (`netsim.data.validate.init_validation`)
-* Complete node group initialization (`netsim.augment.groups.init_groups`):
-
-	* Check the attributes in the group data structures
-	* Add group members based on nodes' **group** attribute
-	* Check recursive groups
-
+* Execute data normalization static module hook (`netsim.modules.execute_module_hooks`):
 * Adjust global parameters (`netsim.augment.topology.adjust_global_parameters`):
 
   * Set `provider` top-level element

--- a/netsim/augment/main.py
+++ b/netsim/augment/main.py
@@ -44,6 +44,7 @@ def transform_setup(topology: Box) -> None:
   log.exit_on_error()
 
   validate.init_validation(topology)
+  modules.execute_module_hooks('normalize',topology)
   log.exit_on_error()
 
   augment.topology.adjust_global_parameters(topology)


### PR DESCRIPTION
This PR adds another way of calling module hooks: the "hooks" list in the module definition. The primary use case are hooks that have to be called before the topology data is validated and the "modules" list is finalized.

The "normalize" execute_module_hooks function is called before the data validation starts, giving the modules using it (planned: routing) the ability to do pre-validation data transformation.

See the discussion in #2154 for more details (hint: this implements the 'insane' option described in that discussion)

While implementing that functionality, I also refactored the whole module hook calling subsystem and removed duplicate code.