### PR TITLE
Expand routing object shortcut definitions with the 'normalize' hook

### DIFF
--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -10,6 +10,7 @@ no_propagate:
 
 transform_after: [ vlan ]
 config_after: [ vlan ]
+hooks: [ normalize ]
 
 attributes:
   global:

--- a/tests/errors/rp-invalid-data-types-1.log
+++ b/tests/errors/rp-invalid-data-types-1.log
@@ -6,4 +6,7 @@ IncorrectType in routing: attribute 'topology.routing.policy.p1[1]' must be a di
 IncorrectType in routing: attribute 'topology.routing.policy.p2[1]' must be a dictionary, found str
 IncorrectType in routing: attribute 'routing.policy.p3[1].set.locpref' must be an integer, found BoxList
 IncorrectType in routing: attribute 'topology.routing.policy.p4[1]' must be a dictionary, found int
+IncorrectType in validate: Cannot validate attributes in nodes.r1.routing -- that should have been a dictionary, found bool
+IncorrectType in routing: attribute 'nodes.r2.routing.policy' must be a dictionary, found int
+... use 'netlab show attributes --module routing node' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/rp-invalid-data-types-1.yml
+++ b/tests/errors/rp-invalid-data-types-1.yml
@@ -10,5 +10,8 @@ routing.policy:
   p5%1:
     locpref: 100
 
-nodes:
+nodes:                              # Added to test extra features needed to solve #2154
   r1:
+    routing: false
+  r2:
+    routing.policy: 12

--- a/tests/topology/expected/rp-clist-expansion.yml
+++ b/tests/topology/expected/rp-clist-expansion.yml
@@ -1,3 +1,15 @@
+groups:
+  rtr:
+    members:
+    - r1
+    node_data:
+      routing:
+        community:
+          cg1:
+          - action: permit
+            path:
+            - 65000:100
+            sequence: 10
 input:
 - topology/input/rp-clist-expansion.yml
 - package:topology-defaults.yml
@@ -28,7 +40,7 @@ nodes:
     name: r1
     routing:
       community:
-        cl1:
+        cg1:
           regexp: ''
           type: standard
           value:

--- a/tests/topology/input/rp-clist-expansion.yml
+++ b/tests/topology/input/rp-clist-expansion.yml
@@ -1,9 +1,15 @@
-# Test the "import and number aspaths"
+# Test the parsing of community lists
 #
 
 defaults.device: none
 
-module: [routing]
+module: [ routing ]
+
+groups:
+  rtr:                                            # Added a group as a regression test for 2154
+    members: [ r1 ]
+    routing.community:
+      cg1: 65000:100                              # Single-entry ACL
 
 routing:
   community:                                      # Merge of global clist with a node clisst
@@ -25,7 +31,6 @@ nodes:
           action: permit                          # ... another regression test for #2155
 
       community:
-        cl1: 65000:100                            # Single-entry ACL
         cl2: [65000:100, 65000:101]               # Single-entry multivalue ACL
         cl3: _65000:10[1-2]_                      # Regular expression
         cl4:                                      # More complex standard ACL


### PR DESCRIPTION
The 'normalize' hook is the only hook that can be called before the group data is validated, so it has to be used if we want to support shortcut routing object definitions in group data.

Closes #2154 (see that issue for more details)