### PR TITLE
Implement 'reload config' for SR Linux

### DIFF
--- a/netsim/ansible/tasks/reload-config/srlinux.yml
+++ b/netsim/ansible/tasks/reload-config/srlinux.yml
@@ -1,0 +1,13 @@
+- name: Copy replacement configuration to SR Linux container
+  shell: docker cp {{ config_template }} {{ ansible_host }}:/tmp/replace-config
+  delegate_to: localhost
+
+- name: Load SR Linux configuration file
+  vars:
+    ansible_network_os: nokia.srlinux.srlinux
+    ansible_connection: ansible.netcommon.httpapi
+  nokia.srlinux.cli:
+    commands:
+    - enter candidate
+    - load file /tmp/replace-config
+    - commit now save


### PR DESCRIPTION
The 'reload-config' task list uses Docker to copy target configuration into SR Linux container, then loads the file into candidate config and commits/saves it.

Closes #2173