### PR TITLE
Fix: always set 'disable_ipv6' flag on Linux interfaces

### DIFF
--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -89,10 +89,8 @@ net.ipv6.conf.all.forwarding={{ pkt_fwd }}
 {%   if loopback.ipv6 is defined %}
 net.ipv6.conf.lo.disable_ipv6=0
 {%   endif %}
-{% for l in interfaces|default([]) %}
-{%   if l.ipv6 is defined %}
-net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
-{%   endif %}
+{% for intf in interfaces|default([]) %}
+net.ipv6.conf.{{ intf.ifname }}.disable_ipv6={{ '0' if intf.ipv6 is defined else '1' }}
 {% endfor %}
 
 SCRIPT

--- a/netsim/ansible/templates/initial/linux/vanilla-ifconfig.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla-ifconfig.j2
@@ -9,8 +9,8 @@ ip addr add {{ intf.ipv4 }} dev {{ intf.ifname }}
 ip addr add {{ intf._parent_ipv4 }} peer {{ intf._unnumbered_peer }} dev {{ intf.ifname }}
 {%   endif %}
 {% endif %}
-{% if intf.ipv6 is defined and intf.ipv6 is string %}
-sysctl -w net.ipv6.conf.{{ intf.ifname }}.disable_ipv6=0
+sysctl -w net.ipv6.conf.{{ intf.ifname }}.disable_ipv6={{ '0' if intf.ipv6 is defined else '1' }}
+{% if intf.ipv6|default(false) is string %}
 set +e
 ip -6 addr del {{ intf.ipv6 }} dev {{ intf.ifname }} 2>/dev/null
 set -e


### PR DESCRIPTION
Fixes #2152