### PR TITLE
Implement provider-specific module/role support

### DIFF
--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -382,8 +382,9 @@ def augment_node_device_data(n: Box, defaults: Box) -> None:
     features = devices.get_device_features(n,defaults)
     allowed_roles = features.initial.get('roles',['router'])
     if role not in allowed_roles:
+      d_provider = devices.get_provider(n,defaults)
       log.warning(
-        text=f"Node {n.name} (device {n.device}) cannot have role '{role}'",
+        text=f"Node {n.name} (device {n.device}/provider {d_provider}) cannot have role '{role}'",
         more_hints=[ f'Allowed roles for this device type are: {",".join(allowed_roles) }' ],
         flag='nodes.roles',
         category=log.IncorrectType,

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -20,13 +20,7 @@ features:
       unnumbered: peer
     ipv6:
       use_ra: true
-    roles: [ host, bridge ]
-  vlan:
-    mixed_trunk: true
-    model: router
-    native_routed: true
-    subif_name: '{ifname}.{vlan.access_id}'
-    svi_interface_name: vlan{vlan}
+    roles: [ host ]
 libvirt:
   image: bento/ubuntu-24.04
   group_vars:
@@ -45,6 +39,15 @@ group_vars:
   netlab_lldp_enable: False
   netlab_net_tools: False
 clab:
+  features:
+    initial:
+      roles: [ host, bridge ]
+    vlan:
+      mixed_trunk: true
+      model: router
+      native_routed: true
+      subif_name: '{ifname}.{vlan.access_id}'
+      svi_interface_name: vlan{vlan}
   image: python:3.13-alpine
   mtu: 1500
   kmods:

--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -176,14 +176,23 @@ def check_supported_node_devices(topology: Box) -> None:
           log.IncorrectValue,
           'modules')
         continue
-      mod_def = topology.defaults[m]                            # Get module defaults
-      if mod_def and "supported_on" in mod_def :                # Are they sane and do they include supported device list?
-        if not n.device in topology.defaults[m].supported_on:   # ... and is the device on the list?
-          log.error(
-            f"Device type {n.device} used by node {name} is not supported by module {m}",
-            log.IncorrectValue,
-            'modules')
-          continue
+      mod_def = topology.defaults[m]
+      if not n.device in mod_def.supported_on:                  # ... and is the device on the list?
+        log.error(
+          f"Device type {n.device} (node {name}) does not support module {m}",
+          log.IncorrectValue,
+          'modules')
+        continue
+      if not isinstance(mod_def.supported_on[n.device],Box):    # Provider-specific support?
+        continue
+
+      d_provider = devices.get_provider(n,topology.defaults)    # Check per-provider support status
+      if not mod_def.supported_on[n.device].get(d_provider,False):
+        log.error(
+          f"Device type {n.device} (node {name}) does not support module {m} with provider {d_provider}",
+          log.IncorrectValue,
+          'modules')
+        continue
 
 # Merge global module parameters with per-node module parameters
 #

--- a/tests/errors/module-device-provider.log
+++ b/tests/errors/module-device-provider.log
@@ -1,0 +1,2 @@
+IncorrectValue in modules: Device type linux (node sw1) does not support module vlan with provider libvirt
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/module-device-provider.yml
+++ b/tests/errors/module-device-provider.yml
@@ -1,0 +1,14 @@
+---
+defaults.devices.linux:
+  clab.image: constant
+  libvirt.image: constant
+
+defaults.device: linux
+
+nodes:
+  sw1:
+    module: [ vlan ]
+    provider: libvirt
+  sw2:
+    module: [ vlan ]
+    provider: clab


### PR DESCRIPTION
This change extends the "features" dictionary to device/provider data, allowing us to specify platform-specific
module support (for example, VLANs run only on Linux containers) or provider-specific functionality
(for example, Arista EOS cannot run DHCP clients in containers).