### PR TITLE
SR Linux: Need to explicitly specify type as link-local for ipv6 addresses that are... link-local (duh)

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -23,6 +23,7 @@
 {%   if intf.ipv6 is string %}
     address:
     - ip-prefix: "{{ intf.ipv6 }}"
+      type: "{{ 'link-local' if intf.ipv6|ipaddr('link-local') else 'global' }}-unicast"
 {%   endif %}
 {% if ipv6_ra %}
     neighbor-discovery:


### PR DESCRIPTION
One would think that the NOS could derive the correct intended type...but no, not this one

Considered adding a test case to ```integration/initial/01-interfaces``` but I don't think any other platform suffers from this particular stupidity