### PR TITLE
Dell OS10 bgp features

### DIFF
--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -14,7 +14,7 @@ BFD is supported on these platforms:
 | Cisco Nexus OS        | ✅  | ✅  | ✅  |
 | Cumulus Linux         | ✅[❗](caveats-frr) | ✅  |  ❌  |
 | FRR                   | ✅[❗](caveats-frr) | ✅  |  ❌  |
-| Dell OS10             |  ❌  | ✅  |  ❌  |
+| Dell OS10             | ✅  | ✅  |  ❌  |
 | Junos[^Junos]         | ✅[❗](caveats-junos) | ✅  | ✅  |
 | Mikrotik RouterOS 6   |  ❌  | ✅  | ✅  |
 | Mikrotik RouterOS 7   |  ❌  |  ❌  |  ❌  |

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -183,6 +183,7 @@ The implementations of the **neighbor remove-private-as** command vary widely ac
 | Cisco IOSv/IOSvL2   |  ✅  |  ❗  |  ❗  |   ❌  |   ❌  |
 | Cisco IOS-XE        |  ✅  |  ❗  |  ❗  |   ❌  |   ❌  |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
+| Dell OS10           |  ✅  |  ❌  |  ❌  |   ❌  |   ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
 

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -61,6 +61,7 @@ The plugin implements generic BGP session features for the following platforms:
 | Cisco IOS-XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco Nexus OS      |  ✅  |  ✅  |   ❌  |  ✅  |
 | Cumulus Linux       |  ✅  |  ✅  |  ✅  |  ✅  |
+| Dell OS10           |  ✅  |  ✅  |  ✅  |  ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |
 | Junos[^Junos]       |  ✅  |  ✅  |  ✅  |  ✅  |
 | Mikrotik RouterOS 7 |  ✅  |   ❌  |   ❌  |   ❌  |
@@ -80,18 +81,19 @@ The plugin implements generic BGP session features for the following platforms:
 BGP session security features are available on these platforms:
 
 | Operating system    | password | GTSM | TCP-AO |
-| ------------------- | :------: | :-: | :-: |
-| Arista EOS          |    ✅    | ✅  | ✅  |
+| ------------------- | :------: | :-: | :-:  |
+| Arista EOS          |    ✅    | ✅  |  ✅  |
 | Aruba AOS-CX        |    ✅    | ✅  |  ❌  |
 | Cisco IOSv/IOSvL2   |    ✅    | ✅  |  ❌  |
-| Cisco IOS-XE[^18v]  |    ✅    |  ✅ |  ✅ |
+| Cisco IOS-XE[^18v]  |    ✅    | ✅  |  ✅  |
 | Cisco Nexus OS      |    ✅    | ✅  |  ❌  |
 | Cumulus Linux       |    ✅    | ✅  |  ❌  |
+| Dell OS10           |    ✅    | ❌  |  ❌  |
 | FRR                 |    ✅    | ✅  |  ❌  |
-| Junos[^Junos]       |    ✅    |  ❌  |  ❌  |
-| Mikrotik RouterOS 7 |    ✅    |  ❌  |  ❌  |
-| Nokia SR Linux      |    ✅    |  ❌  |  ❌  |
-| Nokia SR OS         |    ✅    |  ❌  | ✅  |
+| Junos[^Junos]       |    ✅    | ❌  |  ❌  |
+| Mikrotik RouterOS 7 |    ✅    | ❌  |  ❌  |
+| Nokia SR Linux      |    ✅    | ❌  |  ❌  |
+| Nokia SR OS         |    ✅    | ❌  |  ✅  |
 
 BGP session security features are also available on these daemons:
 
@@ -112,6 +114,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Cisco Nexus OS      |  ✅  |  ✅  |  ✅  |   ❌  |   ❌  |
 | Cumulus Linux 4.x   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
+| Dell OS10           |  ✅  |  ❌  |  ✅  |  ❌  |  ❌  |
 | FRR                 |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Junos[^Junos]       |   ✅  |  ✅  |   ✅  |   ❌  |   ❌  |
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |

--- a/netsim/ansible/templates/bfd/dellos10.j2
+++ b/netsim/ansible/templates/bfd/dellos10.j2
@@ -1,0 +1,5 @@
+!
+! Dell OS10 only supports a single global configuration, not different timer intervals per interface
+!
+bfd interval {{ bfd.min_tx|default(500) }} min_rx {{ bfd.min_rx|default(500) }} multiplier {{ bfd.multiplier|default(3) }} role active
+bfd enable

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -12,6 +12,7 @@ features:
     ipv6:
       lla: true
     delay: 30
+  bfd: true
   bgp:
     activate_af: true
     ipv6_lla: true

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -11,7 +11,7 @@ devices:
       rs_client: True
   dellos10.features.bgp:
     allowas_in: True
-    bfd: True 
+    bfd: True
     default_originate: True
     passive: False # Suggested trick with listen templates does not work
     password: True

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -9,6 +9,14 @@ devices:
       password: True
       rs: True
       rs_client: True
+  dellos10.features.bgp:
+    allowas_in: True
+    bfd: True 
+    default_originate: True
+    passive: False # Suggested trick with listen templates does not work
+    password: True
+    remove_private_as: True
+    timers: True
   eos.features.bgp:
     allowas_in: True
     as_override: True

--- a/netsim/extra/bgp.session/dellos10.j2
+++ b/netsim/extra/bgp.session/dellos10.j2
@@ -1,0 +1,47 @@
+{% macro ebgp_neighbor(n,af) -%}
+{%   set peer = n[af] if n[af] is string else 'interface ' + n.local_if|default('?') %}
+  neighbor {{ peer }}
+{%   if n.bfd|default(False) %}
+   bfd
+{% endif %}
+{%   if n.remove_private_as|default([]) %}
+   remove-private-as
+{%   endif %}
+{%   if n.timers is defined %}
+   timers {{ n.timers.keepalive|default(60) }} {{ n.timers.hold|default(180) }}
+{%   endif %}
+{%   if n.password is defined %}
+   password {{ n.password }}
+{%   endif %}
+{% for _af in ['ipv4','ipv6'] if n.activate[_af]|default(False) %}
+   address-family {{ _af }} unicast
+{%   if n.allowas_in is defined %}
+    allowas-in {{ n.allowas_in }}
+{%   endif %}
+{%   if n.default_originate|default(False) %}
+    default-originate
+{%   endif %}
+   exit
+{% endfor %}
+  !
+{% endmacro %}
+
+router bgp {{ bgp.as }}
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined %}
+{{     ebgp_neighbor(n,af) -}}
+{%   endfor %}
+{% endfor %}
+!
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
+ vrf {{ vname }}
+{%     for af in ['ipv4','ipv6'] %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined %}
+{{       ebgp_neighbor(n,af) -}}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}
+!
+do clear ip bgp *


### PR DESCRIPTION
* BFD timers and BFD on BGP sessions
* BGP passwords, timers, allow AS in, remove private AS, default originate

Tested: ```device-module-test bgp.session -d dellos10 -p libvirt -v```