### PR TITLE
Bird: Fix inherited roles from Linux parent

### DIFF
--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -13,6 +13,11 @@ clab:
     docker_shell: bash -il
   image: netlab/bird:latest
   build: 'https://netlab.tools/netlab/clab/#netlab-clab-build'
+  features:
+    initial:
+      ipv4:
+        unnumbered: peer
+      roles: [ host, router ]   # Override inherited Linux parent settings
 libvirt:                        # Not yet available on libvirt or virtualbox
   image:
 virtualbox:

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -1,5 +1,5 @@
 ---
-description: BIRD Internet Routing Daemon
+description: DNSmasq - DNS, DHCP and TFTP server
 packages:
   dnsmasq: dnsmasq
 daemon_config:


### PR DESCRIPTION
A recent PR #2177 introduced support for per-provider features, updating the Linux device features for clab. This PR fixes the resulting inherited feature flags for bird, including 'router' (and omitting 'bridge')

DNSmasq seems fine, however its description should be updated

Fixes #2189 