### PR TITLE
Bird: Remove check on af.ipv6 for enabling Router Advertisements

### DIFF
--- a/netsim/daemons/bird/bird.j2
+++ b/netsim/daemons/bird/bird.j2
@@ -1,7 +1,8 @@
 {% set module = module|default([]) %}
 {% include 'protocols.j2' %}
 
-{% if role != 'host' and 'ipv6' in af %}
+{% if role != 'host' %}
+{# Enables Router Advertisements if any interface uses ipv6 #}
 {%   include 'radv.j2' %}
 {% endif %}
 


### PR DESCRIPTION
af.ipv6 may be false even when some interfaces use ipv6 (#2193)