### PR TITLE
Add support for building multiple different versions of daemons, starting with Bird v3

### DIFF
--- a/docs/netlab/clab.md
+++ b/docs/netlab/clab.md
@@ -68,12 +68,18 @@ $ netlab clab build -l
 
 The 'netlab build' command can be used to build the following container images
 
-┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ daemon  ┃ default tag           ┃ description                                    ┃
-┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ bird    │ netlab/bird:latest    │ BIRD Internet Routing Daemon (bird.network.cz) │
-│ dnsmasq │ netlab/dnsmasq:latest │ dnsmasq DHCP server                            │
-└─────────┴───────────────────────┴────────────────────────────────────────────────┘
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ daemon  ┃ default tag           ┃ description                                       ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ bird    │ netlab/bird:latest    │ BIRD Internet Routing Daemon (bird.network.cz)    │
+│ bird.v3 │ netlab/bird.v3:latest │ BIRD Internet Routing Daemon (bird.network.cz) v3 │
+│ dnsmasq │ netlab/dnsmasq:latest │ dnsmasq DHCP server                               │
+└─────────┴───────────────────────┴───────────────────────────────────────────────────┘
+```
+
+Note how some daemons have multiple versions available. To use Bird version 3 as the default image:
+```
+$ netlab clab build bird.v3 --tag netlab/bird:latest
 ```
 
 (netlab-clab-cleanup)=

--- a/docs/netlab/clab.md
+++ b/docs/netlab/clab.md
@@ -17,7 +17,7 @@ The **netlab clab tarball** command:
 
 You can use this command only after starting a *containerlab*-only lab topology with devices that support the `startup-config` containerlab parameter.
 
-You can use the tar archive created by **netlab clab tarball** to recreate the lab in a *containerlab* environment without installing *netlab*.
+You can use the tar archive created by the **netlab clab tarball** to recreate the lab in a *containerlab* environment without installing *netlab*.
 
 ```
 $ netlab clab tarball -h
@@ -66,7 +66,7 @@ To list the available *Dockerfiles*, use the **netlab clab build --list** comman
 ```
 $ netlab clab build -l
 
-The 'netlab build' command can be used to build the following container images
+The 'netlab clab build' command can be used to build the following container images
 
 ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ daemon  ┃ default tag           ┃ description                                       ┃
@@ -77,17 +77,22 @@ The 'netlab build' command can be used to build the following container images
 └─────────┴───────────────────────┴───────────────────────────────────────────────────┘
 ```
 
-Note how some daemons have multiple versions available. To use Bird version 3 as the default image:
+For some daemons, you can build containers using different versions of that daemon. To use a non-default version of the daemon, you can:
+
+* Specify the default container tag with the `--tag` parameter, for example:
+
 ```
 $ netlab clab build bird.v3 --tag netlab/bird:latest
 ```
 
+* Change the container image with the **image** node parameter or the **defaults.daemons._daemon_.clab.image** [default setting](topo-defaults).
+
 (netlab-clab-cleanup)=
 ## Docker Cleanup
 
-Containerlab might refuse to bring down a lab when it encounters containers in an unexpected state, preventing **netlab down** to bring down a container-based lab. Alternatively, forcing a lab shutdown with **netlab down --force** might result in dangling containers or Docker networks.
+Containerlab might refuse to bring down a lab when it encounters containers in an unexpected state, preventing **netlab down** from bringing down a container-based lab. Alternatively, forcing a lab shutdown with **netlab down --force** might result in dangling containers or Docker networks.
 
-The easiest way to recover from these situations is to manually clean up the Docker containers and related objects. The **netlab clab cleanup** provides a convenient wrapper around the **docker kill** and **docker system prune** command.
+The easiest way to recover from these situations is to clean up the Docker containers and related objects manually. The **netlab clab cleanup** provides a convenient wrapper around the **docker kill** and **docker system prune** commands.
 
 ```text
 $ netlab clab cleanup -h

--- a/netsim/cli/clab_actions/build.py
+++ b/netsim/cli/clab_actions/build.py
@@ -37,13 +37,14 @@ def build_parser(parser: argparse.ArgumentParser) -> None:
 
 def get_dockerfiles() -> dict:
   d_path = _files.get_traversable_path('package:daemons')
-  d_list = _files.get_globbed_files(d_path,'*/Dockerfile')
+  d_list = _files.get_globbed_files(d_path,'*/Dockerfile*')
 
   df_dict: dict = {}
 
   for d_file in d_list:
     daemon = os.path.basename(os.path.dirname(d_file))
-    df_dict[daemon] = d_file
+    root, ext = os.path.splitext(d_file)
+    df_dict[daemon+ext] = d_file
 
   return df_dict
 

--- a/netsim/cli/clab_actions/build.py
+++ b/netsim/cli/clab_actions/build.py
@@ -115,7 +115,7 @@ def list_dockerfiles() -> None:
     rows.append([daemon, f'netlab/{daemon}:latest', get_description(df_dict[daemon])])
 
   print("""
-The 'netlab build' command can be used to build the following container images
+The 'netlab clab build' command can be used to build the following container images
 """)
   strings.print_table(['daemon','default tag','description'],rows,inter_row_line=False)
 

--- a/netsim/daemons/bird/Dockerfile.v3
+++ b/netsim/daemons/bird/Dockerfile.v3
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+LABEL maintainer="Netlab project <netlab.tools>"
+LABEL description="BIRD Internet Routing Daemon (bird.network.cz) v3"
+
+RUN mkdir /etc/bird && mkdir /run/bird && apt-get update && \
+    apt-get install -y iputils-ping net-tools iproute2 apt-transport-https ca-certificates wget
+
+RUN wget -O /usr/share/keyrings/cznic-labs-pkg.gpg https://pkg.labs.nic.cz/gpg
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cznic-labs-pkg.gpg] https://pkg.labs.nic.cz/bird3 trixie main" \
+    | tee /etc/apt/sources.list.d/cznic-labs-bird3.list
+
+RUN apt-get update && apt-get install -y bird3
+
+WORKDIR /root
+
+CMD [ "bird", "-c", "/etc/bird/bird.conf", "-d" ]


### PR DESCRIPTION
At some point we might decide to make v3 the default, and rename current ```Dockerfile``` to ```Dockerfile.v2```