### PR TITLE
Dnsmasq: Use same Ubuntu base image 24.04 as other daemons (bird)

### DIFF
--- a/netsim/daemons/dnsmasq/Dockerfile
+++ b/netsim/daemons/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Netlab project <netlab.tools>"


### PR DESCRIPTION
Still builds the same dnsmasq version 2.90