### PR TITLE
Bird: Add bgp gtsm support

### DIFF
--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -99,7 +99,7 @@ BGP session security features are also available on these daemons:
 
 | Operating system    | password | GTSM | TCP-AO |
 | ------------------- | :------: | :-: | :-: |
-| BIRD                |    ✅    | ❌   | ❌   |
+| BIRD                |    ✅    | ✅   | ❌   |
 
 (bgp-session-as-path)=
 The plugin implements AS-path-mangling nerd knobs for the following platforms:

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -76,6 +76,9 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%     endif %}
 {%     if n.gtsm is defined %}
   ttl security on;
+{%       if n.type=='ibgp' %}
+  multihop {{ n.gtsm }};
+{%       endif %}
 {%     endif %}
 {%     for _af in [ 'ipv4','ipv6' ] if _af==af or (_af=='ipv4' and n.ipv4_rfc8950|default(False)) %}
 {%      if _af in n.activate and n.activate[_af] %}

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -55,6 +55,7 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%     set local_ip = loopback[af]|default('') %}
   local {{ local_ip.split('/')[0] if n.type == 'ibgp' else '' }} as {{ n.local_as|default(bgp.as) }};
   neighbor {{ n[af] }} as {{ n['as'] }};
+  connect retry time 10;
 {% if n.local_if is defined %}
   interface "{{ n.local_if }}";
 {% endif %}
@@ -72,6 +73,9 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%       if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}
   rr cluster id {{ bgp.rr_cluster_id }};
 {%       endif %}
+{%     endif %}
+{%     if n.gtsm is defined %}
+  ttl security on;
 {%     endif %}
 {%     for _af in [ 'ipv4','ipv6' ] if _af==af or (_af=='ipv4' and n.ipv4_rfc8950|default(False)) %}
 {%      if _af in n.activate and n.activate[_af] %}

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -6,6 +6,7 @@ devices:
     daemon_config:
       bgp@session: /etc/bird/bgp.session.conf
     features.bgp:
+      gtsm: True
       password: True
       rs: True
       rs_client: True

--- a/tests/integration/bgp.session/05-gtsm.yml
+++ b/tests/integration/bgp.session/05-gtsm.yml
@@ -22,6 +22,7 @@ defaults.bgp.as: 65000
 nodes:
   dut:
     id: 17
+    role: router # Test assumes a loopback exists
   x1:
     bgp.as: 65100
     id: 1


### PR DESCRIPTION
* Configure retry timer as 10 seconds, default 120s takes too long
* Update test case to set role: router (test assumes a loopback interface)

Modified the test case to verify ibgp working too; bird takes an unreasonably long time to accept the peers, but eventually does. See #2198 for an issue I encountered