### PR TITLE
Draft proposal: Postpone loading of override _top attributes, and do it only for modules actually used

### DIFF
--- a/netsim/modules/vlan.yml
+++ b/netsim/modules/vlan.yml
@@ -77,7 +77,7 @@ _top:                               # Modification of global defaults
     vlan:                           # Define the VLAN object type
       _description: Global VLAN definition
       id: { type: int, min_value: 1, max_value: 4095 }
-      vni: { type: int, min_value: 1, max_value: 16777215 }
+      # vni: { type: int, min_value: 1, max_value: 16777215 }
       mode: { type: str, valid_values: [ bridge, irb, route ] }
       links: list
       prefix:
@@ -85,7 +85,7 @@ _top:                               # Modification of global defaults
     node_vlan:
       _description: Node VLAN definition
       id: { type: int, min_value: 1, max_value: 4095 }
-      vni: { type: int, min_value: 1, max_value: 16777215 }
+      # vni: { type: int, min_value: 1, max_value: 16777215 }
       mode: { type: str, valid_values: [ bridge, irb, route ] }
       links: list
       prefix:

--- a/netsim/modules/vxlan.yml
+++ b/netsim/modules/vxlan.yml
@@ -22,3 +22,9 @@ no_propagate: [ use_v6_vtep, start_vni ]
 use_v6_vtep: false
 features:
   vtep6: VXLAN over IPv6
+_top:                               # Modification of global defaults
+  attributes:
+    vlan:                           # Define the VLAN object type
+      vni: { type: int, min_value: 1, max_value: 16777215 }
+    node_vlan:
+      vni: { type: int, min_value: 1, max_value: 16777215 }

--- a/netsim/utils/read.py
+++ b/netsim/utils/read.py
@@ -63,14 +63,14 @@ def include_yaml(data: Box, source_file: str) -> None:
         log.fatal(f'Cannot read {file_name} that should be included into {source_file}','topology',header=True)
         return
 
-      if '_top' in yaml_data:                                   # Do we have to modify parent defaults outside of include scope?
-        for k,v in yaml_data._top.items():                      # Iterate over top-level modifications
-          if not k in data:                                     # New item, add it
-            data[k] = v
-          elif isinstance(v,Box) and isinstance(data[k],Box):   # Otherwise, we can only merge boxes
-            data[k] = data[k] + v
+      #if '_top' in yaml_data:                                   # Do we have to modify parent defaults outside of include scope?
+      #  for k,v in yaml_data._top.items():                      # Iterate over top-level modifications
+      #    if not k in data:                                     # New item, add it
+      #      data[k] = v
+      #    elif isinstance(v,Box) and isinstance(data[k],Box):   # Otherwise, we can only merge boxes
+      #      data[k] = data[k] + v
 
-        yaml_data.pop('_top',None)                              # And remove the out-of-scope modifications
+      #  yaml_data.pop('_top',None)                              # And remove the out-of-scope modifications
 
       # Finally, insert the included file in its proper place
       data[os.path.splitext(os.path.basename(file_name))[0]] = yaml_data


### PR DESCRIPTION
Case in point: the vlan.vni attribute really belongs in the VXLAN module, and should not be included when swapping vxlan for MPLS

This is incomplete; for example, an exception would have to be made for 'netlab show attributes vlan' to list all attributes from all modules