### PR TITLE
Fix: Multi-protocol BFD whacked the IGP AF information

### DIFF
--- a/netsim/modules/bfd.py
+++ b/netsim/modules/bfd.py
@@ -66,10 +66,10 @@ def multiprotocol_bfd_link_state(node: Box,proto: str) -> None:
       node[proto].bfd = {}
 
   for l in node.interfaces:
-    if proto in l and l[proto] is False:   # Skip interfaces that have disabled routing protocol
+    if proto not in l:                     # IGP active on the interface?
+      continue                             # ... nope skip it.
+    if l[proto] is False:                  # Skip interfaces that have disabled routing protocol
       continue
-    if not proto in l:                     # No protocol-specific link parameters?
-      l[proto] = {}                        # ... start with an empty dictionary
 
     if not 'bfd' in l[proto]:              # No BFD protocol-specific parameters?
       l[proto].bfd = node[proto].bfd       # ... copy from node value and move on

--- a/netsim/modules/isis.py
+++ b/netsim/modules/isis.py
@@ -50,7 +50,6 @@ class ISIS(_Module):
     if 'sr' in node.module:
       _routing.router_id(node,'isis',topology.pools)
 
-    bfd.multiprotocol_bfd_link_state(node,'isis')
     for l in node.get('interfaces',[]):
       if _routing.external(l,'isis') or not (l.get('ipv4',False) or l.get('ipv6',False)):
         l.pop('isis',None) # Don't run IS-IS on external interfaces, or l2-only
@@ -63,6 +62,7 @@ class ISIS(_Module):
         l,'isis.type',f'nodes.{node.name}.interfaces.{l.ifname}',module='isis',valid_values=isis_type)
 
     _routing.igp_post_transform(node,topology,proto='isis',vrf_aware=True)
+    bfd.multiprotocol_bfd_link_state(node,'isis')
     _routing.check_vrf_protocol_support(node,'isis','ipv4','isis',topology)
     _routing.check_vrf_protocol_support(node,'isis','ipv6','isis',topology)
 

--- a/tests/topology/expected/isis-bfd-test.yml
+++ b/tests/topology/expected/isis-bfd-test.yml
@@ -606,6 +606,8 @@ nodes:
       ifname: eth1
       ipv4: 172.16.0.2/24
       isis:
+        bfd:
+          ipv4: true
         passive: false
       linkindex: 1
       name: Regular (IPv4-only) link, BFD enabled
@@ -622,6 +624,9 @@ nodes:
       ipv4: 10.1.0.2/30
       ipv6: 2001:db8:1::2/64
       isis:
+        bfd:
+          ipv4: true
+          ipv6: true
         network_type: point-to-point
         passive: false
       linkindex: 2
@@ -715,6 +720,8 @@ nodes:
       ifname: eth8
       ipv4: 10.42.42.2/24
       isis:
+        bfd:
+          ipv4: true
         network_type: point-to-point
         passive: false
       linkindex: 8
@@ -728,6 +735,8 @@ nodes:
       ifname: eth9
       ipv6: 2001:db8:42:1::2/64
       isis:
+        bfd:
+          ipv6: true
         network_type: point-to-point
         passive: false
       linkindex: 9
@@ -751,14 +760,21 @@ nodes:
         node: r1
       type: p2p
     isis:
-      af: {}
+      af:
+        ipv4: true
+        ipv6: true
       area: '49.0002'
+      bfd:
+        ipv4: true
+        ipv6: true
       instance: Gandalf
       type: level-2
     loopback:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -767,6 +783,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: 08:4f:a9:02:00:00
     module:
+    - isis
     - bfd
     name: r2
 provider: clab


### PR DESCRIPTION
The multi-protocol BFD code was referencing igp.af data structures before they were created, resulting in IGP data with no usable AF. Had to move the BFD call to a later step in the IS-IS post-transform.

Also, the multi-protocol BFD code created IGP data on interfaces that were already fully processed, so that bit of code needed further cleanup.