### PR TITLE
ArubaOS-CX: support for unnumbered interfaces (and ospf unnumbered)

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -113,7 +113,7 @@ The following table documents the common interface-level OSPF features:
 | Operating system         | Cost  | Network<br />type | Unnumbered<br />IPv4 interfaces | Passive<br />interfaces |
 | ------------------------ |:--:|:--:|:--:|:--:|
 | Arista EOS               | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX             | ✅ | ✅ | ❌  | ✅ |
+| Aruba AOS-CX             | ✅ | ✅ | ✅  | ✅ |
 | Cisco IOS                | ✅ | ✅ | ❌  | ✅ |
 | Cisco IOS XE[^18v]       | ✅ | ✅ | ✅ | ✅ |
 | Cisco IOS XRv            | ✅ | ✅ | ✅ | ✅ |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -236,7 +236,7 @@ The following interface addresses are supported on various platforms:
 | Operating system      | IPv4<br />addresses | IPv6<br />addresses | Unnumbered<br />IPv4 interfaces |
 | --------------------- | :-: | :-: | :-: |
 | Arista EOS            | ✅  | ✅  | ✅  |
-| Aruba AOS-CX          | ✅  | ✅  |  ❌  |
+| Aruba AOS-CX          | ✅  | ✅  |  ✅  |
 | Cisco ASAv            | ✅  | ✅  |  ❌  |
 | Cisco IOSv/IOSvL2     | ✅  | ✅  |  ❌  |
 | Cisco IOS XE[^18v]    | ✅  | ✅  | ✅  |

--- a/netsim/ansible/templates/initial/arubacx.j2
+++ b/netsim/ansible/templates/initial/arubacx.j2
@@ -54,13 +54,25 @@ interface {{ l.ifname }}{{ mclag_intf }}{{ mclag_intf_static }}
     Set interface IPv4 addresses
 #}
 {% if 'ipv4' in l %}
+{%   if l.ipv4 is sameas True %}
+    ip unnumbered interface {{ l._parent_intf }}
+{%   elif l.ipv4 is string and l.ipv4|ipv4 %}
     ip address {{ l.ipv4 }}
+{%   else %}
+! Invalid IPv4 address {{ l.ipv4 }}
+{%   endif %}
 {% endif %}
 {#
     Set interface IPv6 addresses
 #}
 {% if 'ipv6' in l %}
+{%   if l.ipv6 is sameas True %}
+    ipv6 address link-local
+{%   elif l.ipv6 is string and l.ipv6|ipv6 %}
     ipv6 address {{ l.ipv6 }}
+{%   else %}
+! Invalid IPv6 address {{ l.ipv6 }}
+{%   endif %}
 {# need to explicitly set nd ra config #}
     no ipv6 nd suppress-ra
     ipv6 nd ra min-interval 3

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -32,6 +32,11 @@ group_vars:
   ansible_ssh_pass: admin
   netlab_device_type: arubacx
 features:
+  initial:
+    ipv4:
+      unnumbered: true
+    ipv6:
+      lla: true
   bfd: true
   bgp:
     activate_af: true
@@ -59,6 +64,7 @@ features:
     password: true
     priority: true
     timers: true
+    unnumbered: true
   routing:
     policy:
       set:


### PR DESCRIPTION
Passing tests:

* ospf/ospfv2/05-unnumbered.yml
* ospf/ospfv3/05-unnumbered.yml