### PR TITLE
Check reserved ranges during IPv4/IPv6 address/prefix validation

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -379,10 +379,10 @@ def set_fhrp_gateway(link: Box, pfx_list: Box, nodes: Box, link_path: str) -> No
     except Exception as ex:
       log.error(
         f'Cannot generate gateway IP address on {link_path}' + \
-        f' from [af] prefix {link.prefix[af]} and gateway ID {link.gateway.id}\n' + \
-        strings.extra_data_printout(str(ex)),
-        log.IncorrectValue,
-        'links')
+        f' from [af] prefix {link.prefix[af]} and gateway ID {link.gateway.id}\n',
+        more_hints=str(ex),
+        category=log.IncorrectValue,
+        module='links')
       return
 
   if not fhrp_assigned:
@@ -583,10 +583,10 @@ def set_interface_address(intf: Box, af: str, pfx: ipaddress._BaseNetwork, node_
     return True
   except Exception as ex:
     log.error(
-      f'Cannot assign host index {node_id} in {af} from prefix {str(pfx)} to node {intf.node}\n' + \
-          strings.extra_data_printout(str(ex)),
-      log.IncorrectValue,
-      'links')
+      f'Cannot assign host index {node_id} in {af} from prefix {str(pfx)} to node {intf.node}',
+      more_hints=str(ex),
+      category=log.IncorrectValue,
+      module='links')
 
   return False
 
@@ -755,18 +755,18 @@ def cleanup_link_interface_AF_entries(link: Box) -> None:
 
       if data.is_true_int(intf[af]):            # Unprocessed int. Must be node index on an unnumbered link ==> error
         log.error(
-          f'Interface ID for node {intf.node} did not result in a usable address on {link._linkname}\n' + \
-            strings.extra_data_printout(f'{link}'),
-          log.IncorrectType,
-          'links')
+          f'Interface ID for node {intf.node} did not result in a usable address on {link._linkname}',
+          more_data=str(link),
+          category=log.IncorrectType,
+          module='links')
         continue
 
       if not '/' in intf[af]:                   # Subnet mask is unknown
         log.error(
-          f'Unknown subnet mask for {af} address {intf[af]} used by node {intf.node} on {link._linkname}\n' + \
-            strings.extra_data_printout(f'{link}'),
-          log.IncorrectType,
-          'links')
+          f'Unknown subnet mask for {af} address {intf[af]} used by node {intf.node} on {link._linkname}',
+          more_data=str(link),
+          category=log.IncorrectType,
+          module='links')
         continue
 
 """

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -650,7 +650,7 @@ id            |          |    OK     |      | OK  |
 Furthermore, we can use 'named' prefixes in some scenarios.
 """
 
-RESERVED_PREFIX: typing.Dict[str,dict] = {
+RESERVED_PREFIXES: typing.Dict[str,dict] = {
   'IPv4': {
     'local':     ipaddress.IPv4Network('0.0.0.0/8'),
     'loopback':  ipaddress.IPv4Network('127.0.0.0/8'),
@@ -672,7 +672,7 @@ def common_addr_parse(
       xform_int: typing.Optional[typing.Callable] = None,
       xform_pfx: typing.Optional[typing.Callable] = None) -> dict:
 
-  global RESERVED_PREFIX
+  global RESERVED_PREFIXES
 
   def check_int_value(value: int, xform_int: typing.Optional[typing.Callable]) -> dict:
     if value < 0 or value > 2**32-1:
@@ -732,7 +732,7 @@ def common_addr_parse(
       return { '_value': f'{af} prefix ({Ex})' }
 
   if use not in ['prefix','id']:
-    r_hit = check_reserved_range(RESERVED_PREFIX[af],p_addr)
+    r_hit = check_reserved_range(RESERVED_PREFIXES[af],p_addr)
     if r_hit:
       return {'_value': f'{af} {"prefix" if "prefix" in use else "address"}'+
                         f' outside of reserved ranges ({value} is in {r_hit} range)'}

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -650,6 +650,18 @@ id            |          |    OK     |      | OK  |
 Furthermore, we can use 'named' prefixes in some scenarios.
 """
 
+RESERVED_PREFIX: typing.Dict[str,dict] = {
+  'IPv4': {
+    'local':     ipaddress.IPv4Network('0.0.0.0/8'),
+    'loopback':  ipaddress.IPv4Network('127.0.0.0/8'),
+    'multicast': ipaddress.IPv4Network('224.0.0.0/4')
+  },
+  'IPv6': {
+    'loopback':  ipaddress.IPv6Network('::1/128'),
+    'multicast': ipaddress.IPv6Network('ff00::/8')
+  }
+}
+
 def common_addr_parse(
       value: typing.Any,
       use: str,
@@ -660,6 +672,8 @@ def common_addr_parse(
       xform_int: typing.Optional[typing.Callable] = None,
       xform_pfx: typing.Optional[typing.Callable] = None) -> dict:
 
+  global RESERVED_PREFIX
+
   def check_int_value(value: int, xform_int: typing.Optional[typing.Callable]) -> dict:
     if value < 0 or value > 2**32-1:
       return { '_value': f'an {af} address or an integer between 0 and 2**32' }
@@ -668,6 +682,15 @@ def common_addr_parse(
         return { '_valid': True, '_transform': xform_int }
       else:
         return { '_valid': True }
+
+  def check_reserved_range(
+        ranges: dict,
+        p_addr: typing.Any) -> typing.Optional[str]:
+    for k,v in ranges.items():
+      if v.overlaps(p_addr):
+        return k
+
+    return None
 
   if isinstance(value,bool):                      # bool values are valid only on interfaces and subnets
     if use not in ('interface','subnet_prefix'):
@@ -697,16 +720,22 @@ def common_addr_parse(
 
   if use in ['id','address'] or (use in ['interface'] and '/' not in value):
     try:
-      addr_parse(value)
+      p_addr = addr_parse(value)
     except Exception as Ex:
       return { '_value': f'{af} address ({Ex})' }
 
     return { '_valid': True }
+  else:
+    try:
+      p_addr = net_parse(value,strict=use not in ['interface','host_prefix'])
+    except Exception as Ex:
+      return { '_value': f'{af} prefix ({Ex})' }
 
-  try:
-    net_parse(value,strict=use not in ['interface','host_prefix'])
-  except Exception as Ex:
-    return { '_value': f'{af} prefix ({Ex})' }
+  if use not in ['prefix','id']:
+    r_hit = check_reserved_range(RESERVED_PREFIX[af],p_addr)
+    if r_hit:
+      return {'_value': f'{af} {"prefix" if "prefix" in use else "address"}'+
+                        f' outside of reserved ranges ({value} is in {r_hit} range)'}
 
   return { '_valid': True }
 

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -179,8 +179,8 @@ _top:                               # Modification of global defaults
         _valid_with: [ action, sequence ]
 
     static_entry:
-      ipv4: { type: ipv4, use: subnet_prefix }
-      ipv6: { type: ipv6, use: subnet_prefix }
+      ipv4: { type: ipv4, use: prefix }
+      ipv6: { type: ipv6, use: prefix }
       prefix:
         type: named_pfx
         _valid_with: [ nexthop, vrf ]

--- a/tests/errors/addr-errors-intf.log
+++ b/tests/errors/addr-errors-intf.log
@@ -1,0 +1,38 @@
+IncorrectValue in links: Node r1 is using host index 1 for ipv4 on an unnumbered link
+IncorrectType in links: Interface ID for node r1 did not result in a usable address on links[1]
+... {'_linkname': 'links[1]', 'name': 'Host ID on unnumbered link + Host ID without
+... prefix AF', 'interfaces': [{'ipv4': 1, 'node': 'r1', 'ifindex': 1, 'ifname':
+... 'swp1'}, {'ipv6': 1, 'node': 'r2', 'ipv4': True, 'ifindex': 1, 'ifname':
+... 'swp1'}], 'linkindex': 1, 'node_count': 2, 'type': 'p2p', 'prefix': {'ipv4':
+... True}}
+IncorrectType in links: Interface ID for node r2 did not result in a usable address on links[1]
+... {'_linkname': 'links[1]', 'name': 'Host ID on unnumbered link + Host ID without
+... prefix AF', 'interfaces': [{'ipv4': 1, 'node': 'r1', 'ifindex': 1, 'ifname':
+... 'swp1'}, {'ipv6': 1, 'node': 'r2', 'ipv4': True, 'ifindex': 1, 'ifname':
+... 'swp1'}], 'linkindex': 1, 'node_count': 2, 'type': 'p2p', 'prefix': {'ipv4':
+... True}}
+IncorrectValue in links: Cannot assign host index 77 in ipv4 from prefix 172.17.0.0/29 to node r1
+... address out of range
+IncorrectType in links: Interface ID for node r1 did not result in a usable address on links[2]
+... {'_linkname': 'links[2]', 'name': 'Host ID too large', 'role': 'dualstack',
+... 'interfaces': [{'ipv4': 77, 'node': 'r1', 'ipv6': '2001:db8:3::1/64', 'ifindex':
+... 2, 'ifname': 'swp2'}, {'node': 'r2', 'ipv4': '172.17.0.2/29', 'ipv6':
+... '2001:db8:3::2/64', 'ifindex': 2, 'ifname': 'swp2'}], 'linkindex': 2,
+... 'node_count': 2, 'type': 'p2p', 'prefix': {'ipv4': '172.17.0.0/29', 'ipv6':
+... '2001:db8:3::/64'}}
+IncorrectValue in links: Node r1 is using host index 2 for ipv4 on an unnumbered link
+IncorrectType in links: Interface ID for node r1 did not result in a usable address on links[3]
+... {'_linkname': 'links[3]', 'name': 'Host ID specified on a fully-unnumbered
+... link', 'role': 'unnumbered', 'interfaces': [{'ipv4': 2, 'node': 'r1', 'ipv6':
+... False, 'ifindex': 3, 'ifname': 'swp3'}, {'node': 'r2', 'ipv4': True, 'ipv6':
+... False, 'ifindex': 3, 'ifname': 'swp3'}], 'linkindex': 3, 'node_count': 2,
+... 'type': 'p2p'}
+IncorrectValue in links: Node r1 is using host index 2 for ipv4 on an unnumbered link
+IncorrectType in links: Interface ID for node r1 did not result in a usable address on links[4]
+... {'_linkname': 'links[4]', 'name': 'Host ID specified on unnumbered link',
+... 'prefix': {'ipv4': True}, 'interfaces': [{'ipv4': 2, 'node': 'r1', 'ifindex': 4,
+... 'ifname': 'swp4'}, {'node': 'r2', 'ipv4': True, 'ifindex': 4, 'ifname':
+... 'swp4'}], 'linkindex': 4, 'node_count': 2, 'type': 'p2p'}
+IncorrectValue in links: Address 10.17.17.4/30 on node r1/links[5] does not contain host bits
+IncorrectValue in links: Address 2001:db8:2::/64 on node r2/links[5] does not contain host bits
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/addr-errors-intf.yml
+++ b/tests/errors/addr-errors-intf.yml
@@ -34,34 +34,33 @@ nodes:
 
 # And now the real work starts
 links:
-- name: IPv6 prefix has host bits
+- name: Host ID on unnumbered link + Host ID without prefix AF
   r1:
+    ipv4: 1
   r2:
-  r3:
+    ipv6: 1
+
+- name: Host ID too large
+  r1:
+    ipv4: 77
+  r2:
+  role: dualstack
+
+- name: Host ID specified on a fully-unnumbered link
+  r1:
+    ipv4: 2
+  r2:
+  role: unnumbered
+
+- name: Host ID specified on unnumbered link
   prefix:
-    ipv4: 172.42.42.16/29
-    ipv6: 2001:db8:42:42::1/64
-
-- name: Prefix contains host portion
+    ipv4: True
   r1:
+    ipv4: 2
   r2:
-  r3:
-  prefix:
-    ipv4: 172.42.42.16/22
 
-- name: Invalid prefix
+- name: Static IP address does not include a host portion
   r1:
+    ipv4: 10.17.17.4/30
   r2:
-  r3:
-  prefix:
-    ipv4: 172.42.a.16/22
-
-- name: Prefix in reserved range
-  r1:
-  r2:
-  prefix.ipv4: 127.0.1.0/24
-
-- name: IP addresses in reserved ranges
-  r1:
-    ipv4: 0.0.0.1/24
-    ipv6: ff00::1/64
+    ipv6: 2001:db8:2::/64

--- a/tests/errors/addr-errors.log
+++ b/tests/errors/addr-errors.log
@@ -1,3 +1,9 @@
-IncorrectAttr in addressing: Invalid address pool attribute 'type' found in addressing.dualstack
-... use 'netlab show attributes pool' to display valid attributes
+IncorrectValue in links: attribute 'links[1].prefix.ipv6' must be IPv6 prefix (2001:db8:42:42::1/64 has host bits set)
+... use 'netlab show attributes link' to display valid attributes
+IncorrectValue in links: attribute 'links[2].prefix.ipv4' must be IPv4 prefix (172.42.42.16/22 has host bits set)
+IncorrectValue in links: attribute 'links[3].prefix.ipv4' must be IPv4 prefix (Only decimal digits permitted in 'a' in '172.42.a.16')
+IncorrectValue in links: attribute 'links[4].prefix.ipv4' must be IPv4 prefix outside of reserved ranges (127.0.1.0/24 is in loopback range)
+IncorrectValue in links: attribute 'links[5].r1.ipv4' must be IPv4 address outside of reserved ranges (0.0.0.1/24 is in local range)
+... use 'netlab show attributes interface' to display valid attributes
+IncorrectValue in links: attribute 'links[5].r1.ipv6' must be IPv6 address outside of reserved ranges (ff00::1/64 is in multicast range)
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/addr-pool-errors.log
+++ b/tests/errors/addr-pool-errors.log
@@ -3,6 +3,7 @@ IncorrectValue in addressing: Cannot parse address prefix: '2001:none:2::/48' do
 IncorrectType in addressing: attribute 'addressing.pfx_string.prefix' must be an integer, found str
 ... use 'netlab show attributes pool' to display valid attributes
 IncorrectValue in addressing: attribute 'addressing.pfx_long.prefix' must be an integer between 1 and 32
+IncorrectValue in addressing: attribute 'addressing.reserved.ipv4' must be IPv4 prefix outside of reserved ranges (224.0.0.0/24 is in multicast range)
 IncorrectValue in addressing: IPv4 prefix length in 'pfx_string' addressing pool is not an integer
 IncorrectValue in addressing: IPv4 subnet prefix length in 'pfx_long' addressing pool is not between 1 and 32
 IncorrectValue in addressing: IPv4 subnet prefix length in 'pfx_short' addressing pool is not longer than pool prefix

--- a/tests/errors/addr-pool-errors.yml
+++ b/tests/errors/addr-pool-errors.yml
@@ -27,6 +27,8 @@ addressing:
     prefix: 21
   pfx_v6:
     ipv6: 2001:db8:0:1::/64
+  reserved:
+    ipv4: 224.0.0.0/24
   ipv4_pool: 10.4.0.0/16
 
 nodes:

--- a/tests/run-xerr.sh
+++ b/tests/run-xerr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+DIRNAME=`dirname "$0"`
+echo "Executing CI/CD tests in $DIRNAME"
+cd "$DIRNAME"
+PYTHONPATH="../" python3 -m pytest -vvv -k error_cases


### PR DESCRIPTION
Also:
* Split the address validation error test in prefix- and link/addr tests
* Fix the error messages in augment/links to use more_* arguments
* Change the static route prefix attribute type from 'subnet_prefix' to 'prefix'

Fixes #2229