### PR TITLE
The 'prefix6' attribute should be treated just like the 'prefix' attribute

### DIFF
--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -117,7 +117,7 @@ pool:                       # Address pool definition
   allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
   mac: mac
   unnumbered: bool
-pool_no_copy: [ start, prefix, mac ]
+pool_no_copy: [ start, prefix, prefix6, mac ]
 
 prefix:                     # Link prefix (called by link module directly)
   ipv4: { type: ipv4, use: subnet_prefix }

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -59,7 +59,6 @@ links:
   node_count: 2
   prefix:
     ipv6: 2001:db8:2::2/127
-    prefix6: 127
   type: p2p
 - _linkname: links[3]
   interfaces:
@@ -76,7 +75,6 @@ links:
   node_count: 2
   prefix:
     ipv6: 2001:db8:2::4/127
-    prefix6: 127
   type: p2p
 module:
 - bgp
@@ -86,7 +84,6 @@ nodes:
   r1:
     af:
       ipv6: true
-      prefix6: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -108,7 +105,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -124,7 +120,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -140,7 +135,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -197,7 +191,6 @@ nodes:
       isis:
         passive: false
       neighbors: []
-      prefix6: '128'
       type: loopback
       virtual_interface: true
     mgmt:
@@ -213,7 +206,6 @@ nodes:
   r2:
     af:
       ipv6: true
-      prefix6: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -235,7 +227,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -251,7 +242,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -267,7 +257,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -337,7 +326,6 @@ nodes:
       isis:
         passive: false
       neighbors: []
-      prefix6: '128'
       type: loopback
       virtual_interface: true
     mgmt:
@@ -353,7 +341,6 @@ nodes:
   r3:
     af:
       ipv6: true
-      prefix6: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -375,7 +362,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -391,7 +377,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -407,7 +392,6 @@ nodes:
           isis:
             passive: false
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -464,7 +448,6 @@ nodes:
       isis:
         passive: false
       neighbors: []
-      prefix6: '128'
       type: loopback
       virtual_interface: true
     mgmt:
@@ -480,7 +463,6 @@ nodes:
   r4:
     af:
       ipv6: true
-      prefix6: true
     bgp:
       advertise_loopback: true
       as: 65000
@@ -500,7 +482,6 @@ nodes:
           ifname: Loopback0
           ipv6: 2001:db8::1/128
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -514,7 +495,6 @@ nodes:
           ifname: Loopback0
           ipv6: 2001:db8::1/128
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -528,7 +508,6 @@ nodes:
           ifname: Loopback0
           ipv6: 2001:db8::1/128
           neighbors: []
-          prefix6: '128'
           type: loopback
           virtual_interface: true
         activate:
@@ -548,7 +527,6 @@ nodes:
       ifname: Loopback0
       ipv6: 2001:db8::1/128
       neighbors: []
-      prefix6: '128'
       type: loopback
       virtual_interface: true
     mgmt:


### PR DESCRIPTION
This removes nonsensical values such as 'True' and string-type '127'