### PR TITLE
Implement 'delete communities matching a list' in routing policies

### DIFF
--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -72,6 +72,7 @@ The **set.community** dictionary has these parameters:
 * **extended**: Extended BGP communities to set. The value is passed to the network device as-is (the same value might not work on all devices).
 * **append**: Add communities to existing BGP communities
 * **delete**: Remove specified communities from the BGP route
+* **delete_list**: Remove communities matching the specified community list from the BGP route. Cannot be used with any other **set.community** parameters.
 
 Routing policies are specified in the global- or node-level **routing.policy** dictionary (see [](routing-object-import) and  [](routing-object-merge) for more details).
 
@@ -128,16 +129,32 @@ You can use these routing policy **set** parameters on devices supported by the 
 
 The **set.community** attribute can be used to set these BGP communities on supported devices:
 
-| Operating system    | Standard<br>community | Large<br>community | Extended<br>community | Append | Delete |
-|---------------------|:--:|:--:|:--:|:--:|:--:|
-| Arista EOS          | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ❌  | ❌  | ✅ | ✅ |
-| Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  | ✅ | ❌  |
-| Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ❌  |
-| Dell OS10           | ✅ | ❌ | ✅ | ✅ | ❌  |
-| Junos               | ✅ | ✅ | ✅ | ✅ | ✅ |
-| FRR                 | ✅ | ✅ | ✅ | ✅ | ❌  |
-| VyOS                | ✅ | ✅ | ✅ | ✅ | ❌  |
+| Operating system    | Standard<br>community | Large<br>community | Extended<br>community |
+|---------------------|:--:|:--:|:--:|
+| Arista EOS          | ✅ | ✅ | ✅ |
+| Aruba AOS-CX        | ✅ | ❌  | ❌  |
+| Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  |
+| Cumulus Linux       | ✅ | ✅ | ✅ |
+| Dell OS10           | ✅ | ❌ | ✅ |
+| Junos               | ✅ | ✅ | ✅ |
+| FRR                 | ✅ | ✅ | ✅ |
+| VyOS                | ✅ | ✅ | ✅ |
+
+Apart from setting BGP communities on BGP routes, these devices can execute additional operations on BGP communities:
+
+| Operating system    | Append | Delete | Delete list |
+|---------------------|:--:|:--:| :--:|
+| Arista EOS          | ✅ | ✅ | ❌  |
+| Aruba AOS-CX        | ✅ | ✅ | ❌  |
+| Cisco IOS/XE[^18v]  | ✅ | ❌  | ❌  |
+| Cumulus Linux       | ✅ | ❌  | ❌  |
+| Dell OS10           | ✅ | ❌  | ❌  |
+| Junos               | ✅ | ✅ | ❌  |
+| FRR                 | ✅ | ✅❗️ | ✅ |
+| VyOS                | ✅ | ❌  | ❌  |
+
+**Notes:**
+* FRR is creating an internal BGP community list to delete BGP communities specified together with the **set.community.delete** routing policy parameter. This approach is currently limited to standard BGP communities; FRR cannot delete extended or large communities from a BGP route.
 
 ### Shortcut Routing Policy Definitions
 

--- a/netsim/ansible/templates/routing/frr.j2
+++ b/netsim/ansible/templates/routing/frr.j2
@@ -6,6 +6,9 @@
 {%       if 'bandwidth' in p_entry.set %}
   set extcommunity bandwidth {{ p_entry.set.bandwidth }}
 {%       endif %}
+{%       if p_entry.set.community.delete_list|default(False) %}
+  set comm-list {{ p_entry.set.community.delete_list }} delete
+{%       endif %}
 {%     endif %}
 {{     routemap.common_route_map_entry(p_entry,af_list) }}
 {%-   endcall %}

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -114,6 +114,8 @@ features:
           large: True
           extended: True
           append: True
+          delete: clist
+          delete_list: True
       match: [ prefix, nexthop, aspath, community ]
     prefix: True
     aspath: True

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -114,8 +114,15 @@ _top:                               # Modification of global defaults
           standard: list
           extended: list
           large: list
-          append: bool
-          delete: bool
+          append:
+            type: bool
+            _valid_with: [ standard, extended, large ]
+          delete:
+            type: bool
+            _valid_with: [ standard, extended, large ]
+          delete_list:
+            type: str
+            _valid_with: [ ]
       match:
         prefix: str
         nexthop: str

--- a/tests/integration/routing/07c-community-delete-list.yml
+++ b/tests/integration/routing/07c-community-delete-list.yml
@@ -1,0 +1,64 @@
+---
+message: |
+  Use this topology to test 'set.community.delete' route-map option.
+
+plugin: [ bgp.policy ]
+module: [ bgp, routing ]
+
+groups:
+  probes:
+    device: frr
+    provider: clab
+    members: [ probe, x1 ]
+
+routing.community.c_42: '65101:42'
+
+nodes:
+  dut:
+    bgp.as: 65000
+    routing.policy.set_comm:
+      set.community:
+        delete_list: c_42
+    id: 1
+  probe:
+    bgp.as: 65100
+  x1:
+    bgp.as: 65101
+    routing.policy.set_comm:
+      set.community:
+        standard: '65101:17 65101:42'
+
+links:
+- dut:
+    bgp.policy.out: set_comm
+  probe:
+- dut:
+  x1:
+    bgp.policy.out: set_comm
+
+validate:
+  ebgp:
+    description: Check EBGP sessions with DUT (wait up to 10 seconds)
+    wait: 10
+    nodes: [ probe, x1 ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'dut')
+
+  pfx_lb:
+    description: Check for X1 loopback prefix on Probe
+    wait: 10
+    nodes: [ probe ]
+    plugin: bgp_prefix(nodes.x1.loopback.ipv4)
+
+  comm_present:
+    description: Check for AS65101 communities attached to X1 loopback prefix
+    wait: 10
+    nodes: [ probe ]
+    plugin: >
+      bgp_prefix(nodes.x1.loopback.ipv4,community={'community': '65101:17'})
+
+  comm_missing:
+    description: Check for AS65101 communities removed from X1 loopback prefix
+    wait: 10
+    nodes: [ probe ]
+    plugin: >
+      bgp_prefix(nodes.x1.loopback.ipv4,community={'community': '65101:42'},state='missing')


### PR DESCRIPTION
Also:
* Use this functionality to emulate 'set.community.delete'
* FRR proof-of-concept implementation

Replaces #2162