### PR TITLE
LAG: Accept user specified lag.ifindex, also when listed in descending order

### DIFF
--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -123,16 +123,12 @@ def set_lag_ifindex(bond: Box, intf: Box, topology: Box) -> bool:
       if is_mside:                                             # For M: side we need matching lag.ifindex
         if next_ifindex is None:                               # Do we have a local preference?
           next_ifindex = _dataplane.get_next_id(ID_SET)        # No -> allocate globally
-        bond.lag.ifindex = link_lag_ifindex = next_ifindex  # Put on the link for the other M side to match
+        bond.lag.ifindex = link_lag_ifindex = next_ifindex     # Put on the link for the other M side to match
       else:
         if next_ifindex is None:
           next_ifindex = topology.defaults.lag.start_lag_id    # Start at start_lag_id (default 1)
         link_lag_ifindex = next_ifindex
         intf.lag.ifindex = link_lag_ifindex                    # Put it on the interface for bond naming
-    elif next_ifindex and next_ifindex>link_lag_ifindex:
-      link_lag_ifindex = next_ifindex                          # Cannot accept link level lag.ifindex
-      if is_mside:
-        bond.lag.ifindex = next_ifindex                        # Override the unacceptable link value
     _n._lag_ifindex = link_lag_ifindex + 1                     # Track next ifindex to assign, per node
     intf.lag.ifindex = intf_lag_ifindex = link_lag_ifindex
   elif link_lag_ifindex is None or is_mside:

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -61,7 +61,7 @@ links:
     node: b1
   lag:
     _parentindex: 3
-  linkindex: 4
+  linkindex: 6
   node_count: 2
   prefix: false
   type: p2p
@@ -75,16 +75,72 @@ links:
     node: b2
   lag:
     _parentindex: 3
-  linkindex: 5
+  linkindex: 7
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[1]
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    node: a1
+  - ifindex: 3
+    ifname: Ethernet3
+    node: b1
+  lag:
+    _parentindex: 4
+  linkindex: 8
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[4].lag[2]
+  interfaces:
+  - ifindex: 3
+    ifname: Ethernet3
+    node: a2
+  - ifindex: 3
+    ifname: Ethernet3
+    node: b2
+  lag:
+    _parentindex: 4
+  linkindex: 9
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[5].lag[1]
+  interfaces:
+  - ifindex: 4
+    ifname: Ethernet4
+    node: a1
+  - ifindex: 4
+    ifname: Ethernet4
+    node: b1
+  lag:
+    _parentindex: 5
+  linkindex: 10
+  node_count: 2
+  prefix: false
+  type: p2p
+- _linkname: links[5].lag[2]
+  interfaces:
+  - ifindex: 4
+    ifname: Ethernet4
+    node: a2
+  - ifindex: 4
+    ifname: Ethernet4
+    node: b2
+  lag:
+    _parentindex: 5
+  linkindex: 11
   node_count: 2
   prefix: false
   type: p2p
 - _linkname: vlans.red.links[1]
-  bridge: input_6
+  bridge: input_12
   interfaces:
   - _vlan_mode: irb
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 5
+    ifname: Ethernet5
     ipv4: 172.16.0.1/24
     node: a1
     vlan:
@@ -93,7 +149,7 @@ links:
     ifname: eth1
     ipv4: 172.16.0.5/24
     node: h1
-  linkindex: 6
+  linkindex: 12
   node_count: 2
   prefix:
     allocation: id_based
@@ -102,11 +158,11 @@ links:
   vlan:
     access: red
 - _linkname: vlans.red.links[2]
-  bridge: input_7
+  bridge: input_13
   interfaces:
   - _vlan_mode: irb
-    ifindex: 3
-    ifname: Ethernet3
+    ifindex: 5
+    ifname: Ethernet5
     ipv4: 172.16.0.4/24
     node: b2
     vlan:
@@ -115,7 +171,7 @@ links:
     ifname: eth1
     ipv4: 172.16.0.6/24
     node: h2
-  linkindex: 7
+  linkindex: 13
   node_count: 2
   prefix:
     allocation: id_based
@@ -152,6 +208,50 @@ nodes:
         node: a2
       type: p2p
     - ifindex: 30000
+      ifname: port-channel25
+      lag:
+        _mlag: true
+        ifindex: 25
+        lacp: fast
+        lacp_mode: active
+      name: a1 -> [a2,b1,b2]
+      neighbors:
+      - ifname: port-channel25
+        node: a2
+      - ifname: port-channel25
+        node: b1
+      - ifname: port-channel25
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30001
+      ifname: port-channel15
+      lag:
+        _mlag: true
+        ifindex: 15
+        lacp: fast
+        lacp_mode: active
+      name: a1 -> [a2,b1,b2]
+      neighbors:
+      - ifname: port-channel15
+        node: a2
+      - ifname: port-channel15
+        node: b1
+      - ifname: port-channel15
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30002
       ifname: port-channel10
       lag:
         _mlag: true
@@ -176,17 +276,37 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       lag:
-        _parentindex: 10
-      linkindex: 4
+        _parentindex: 25
+      linkindex: 6
       name: a1 -> b1
       neighbors:
       - ifname: Ethernet2
         node: b1
       type: p2p
-    - bridge: input_6
-      ifindex: 3
+    - ifindex: 3
       ifname: Ethernet3
-      linkindex: 6
+      lag:
+        _parentindex: 15
+      linkindex: 8
+      name: a1 -> b1
+      neighbors:
+      - ifname: Ethernet3
+        node: b1
+      type: p2p
+    - ifindex: 4
+      ifname: Ethernet4
+      lag:
+        _parentindex: 10
+      linkindex: 10
+      name: a1 -> b1
+      neighbors:
+      - ifname: Ethernet4
+        node: b1
+      type: p2p
+    - bridge: input_12
+      ifindex: 5
+      ifname: Ethernet5
+      linkindex: 12
       name: '[Access VLAN red] a1 -> h1'
       neighbors:
       - ifname: eth1
@@ -274,6 +394,50 @@ nodes:
         node: a1
       type: p2p
     - ifindex: 30000
+      ifname: port-channel25
+      lag:
+        _mlag: true
+        ifindex: 25
+        lacp: fast
+        lacp_mode: active
+      name: a2 -> [a1,b1,b2]
+      neighbors:
+      - ifname: port-channel25
+        node: a1
+      - ifname: port-channel25
+        node: b1
+      - ifname: port-channel25
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30001
+      ifname: port-channel15
+      lag:
+        _mlag: true
+        ifindex: 15
+        lacp: fast
+        lacp_mode: active
+      name: a2 -> [a1,b1,b2]
+      neighbors:
+      - ifname: port-channel15
+        node: a1
+      - ifname: port-channel15
+        node: b1
+      - ifname: port-channel15
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30002
       ifname: port-channel10
       lag:
         _mlag: true
@@ -298,11 +462,31 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       lag:
-        _parentindex: 10
-      linkindex: 5
+        _parentindex: 25
+      linkindex: 7
       name: a2 -> b2
       neighbors:
       - ifname: Ethernet2
+        node: b2
+      type: p2p
+    - ifindex: 3
+      ifname: Ethernet3
+      lag:
+        _parentindex: 15
+      linkindex: 9
+      name: a2 -> b2
+      neighbors:
+      - ifname: Ethernet3
+        node: b2
+      type: p2p
+    - ifindex: 4
+      ifname: Ethernet4
+      lag:
+        _parentindex: 10
+      linkindex: 11
+      name: a2 -> b2
+      neighbors:
+      - ifname: Ethernet4
         node: b2
       type: p2p
     - bridge_group: 1
@@ -383,6 +567,50 @@ nodes:
         node: b2
       type: p2p
     - ifindex: 30000
+      ifname: port-channel25
+      lag:
+        _mlag: true
+        ifindex: 25
+        lacp: fast
+        lacp_mode: active
+      name: b1 -> [a1,a2,b2]
+      neighbors:
+      - ifname: port-channel25
+        node: a1
+      - ifname: port-channel25
+        node: a2
+      - ifname: port-channel25
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30001
+      ifname: port-channel15
+      lag:
+        _mlag: true
+        ifindex: 15
+        lacp: fast
+        lacp_mode: active
+      name: b1 -> [a1,a2,b2]
+      neighbors:
+      - ifname: port-channel15
+        node: a1
+      - ifname: port-channel15
+        node: a2
+      - ifname: port-channel15
+        node: b2
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30002
       ifname: port-channel20
       lag:
         _mlag: true
@@ -407,11 +635,31 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       lag:
-        _parentindex: 20
-      linkindex: 4
+        _parentindex: 25
+      linkindex: 6
       name: b1 -> a1
       neighbors:
       - ifname: Ethernet2
+        node: a1
+      type: p2p
+    - ifindex: 3
+      ifname: Ethernet3
+      lag:
+        _parentindex: 15
+      linkindex: 8
+      name: b1 -> a1
+      neighbors:
+      - ifname: Ethernet3
+        node: a1
+      type: p2p
+    - ifindex: 4
+      ifname: Ethernet4
+      lag:
+        _parentindex: 20
+      linkindex: 10
+      name: b1 -> a1
+      neighbors:
+      - ifname: Ethernet4
         node: a1
       type: p2p
     - bridge_group: 1
@@ -492,6 +740,50 @@ nodes:
         node: b1
       type: p2p
     - ifindex: 30000
+      ifname: port-channel25
+      lag:
+        _mlag: true
+        ifindex: 25
+        lacp: fast
+        lacp_mode: active
+      name: b2 -> [a1,a2,b1]
+      neighbors:
+      - ifname: port-channel25
+        node: a1
+      - ifname: port-channel25
+        node: a2
+      - ifname: port-channel25
+        node: b1
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30001
+      ifname: port-channel15
+      lag:
+        _mlag: true
+        ifindex: 15
+        lacp: fast
+        lacp_mode: active
+      name: b2 -> [a1,a2,b1]
+      neighbors:
+      - ifname: port-channel15
+        node: a1
+      - ifname: port-channel15
+        node: a2
+      - ifname: port-channel15
+        node: b1
+      type: lag
+      virtual_interface: true
+      vlan:
+        trunk:
+          red: {}
+        trunk_id:
+        - 1000
+    - ifindex: 30002
       ifname: port-channel20
       lag:
         _mlag: true
@@ -516,17 +808,37 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       lag:
-        _parentindex: 20
-      linkindex: 5
+        _parentindex: 25
+      linkindex: 7
       name: b2 -> a2
       neighbors:
       - ifname: Ethernet2
         node: a2
       type: p2p
-    - bridge: input_7
-      ifindex: 3
+    - ifindex: 3
       ifname: Ethernet3
-      linkindex: 7
+      lag:
+        _parentindex: 15
+      linkindex: 9
+      name: b2 -> a2
+      neighbors:
+      - ifname: Ethernet3
+        node: a2
+      type: p2p
+    - ifindex: 4
+      ifname: Ethernet4
+      lag:
+        _parentindex: 20
+      linkindex: 11
+      name: b2 -> a2
+      neighbors:
+      - ifname: Ethernet4
+        node: a2
+      type: p2p
+    - bridge: input_13
+      ifindex: 5
+      ifname: Ethernet5
+      linkindex: 13
       name: '[Access VLAN red] b2 -> h2'
       neighbors:
       - ifname: eth1
@@ -598,13 +910,13 @@ nodes:
     device: linux
     id: 5
     interfaces:
-    - bridge: input_6
+    - bridge: input_12
       gateway:
         ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.5/24
-      linkindex: 6
+      linkindex: 12
       name: h1 -> [a1,a2,b1,b2,h2]
       neighbors:
       - ifname: Vlan1000
@@ -660,13 +972,13 @@ nodes:
     device: linux
     id: 6
     interfaces:
-    - bridge: input_7
+    - bridge: input_13
       gateway:
         ipv4: 172.16.0.1/24
       ifindex: 1
       ifname: eth1
       ipv4: 172.16.0.6/24
-      linkindex: 7
+      linkindex: 13
       name: h2 -> [h1,a1,a2,b1,b2]
       neighbors:
       - ifname: eth1

--- a/tests/topology/input/lag-mlag-m_to_m.yml
+++ b/tests/topology/input/lag-mlag-m_to_m.yml
@@ -24,6 +24,14 @@ links:
     members: [b1-b2]
     mlag.peergroup: true # Auto-assigned 2
 - lag:
+    ifindex: 25
+    members: [ a1-b1, a2-b2 ]
+  vlan.trunk: [red]
+- lag:
+    ifindex: 15         # Regression: #2246
+    members: [ a1-b1, a2-b2 ]
+  vlan.trunk: [red]
+- lag:
     members:
     - a1:
         lag.ifindex: 10 # Custom port-channel number


### PR DESCRIPTION
Fixes #2246

Tested: ```./device-module-test -d eos -p clab lag```