### PR TITLE
BGP: use neighbor attributes instead of per-template logic (FRR Proof-of-concept)

### DIFF
--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -56,26 +56,18 @@ router bgp {{ bgp.as }}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !
-{%   for n in bgp.neighbors
-       if n[af] is defined 
-         and (n.activate[af] is defined and n.activate[af]) %}
+{%   for n in bgp.neighbors if n[af] is defined and n.activate.get(af) %}
 {%     set peer = n[af] if n[af] is string 
                   else n.local_if if n.local_if is defined
                   else n.ipv6 if af == 'ipv4' and n.ipv4_rfc8950 
                   else False %}
 {%     if peer %}
   neighbor {{ peer }} activate
-{%       if n.type == 'ibgp' %}
-{%         if bgp.next_hop_self is defined and bgp.next_hop_self %}
-  neighbor {{ peer }} next-hop-self
-{%         endif %}
-{%         if bgp.rr|default('') and not n.rr|default('') %}
-  neighbor {{ peer }} route-reflector-client
-{%         endif %}
+{%       if n.next_hop_self is defined  %}
+  neighbor {{ peer }} next-hop-self {{ 'force' if n.next_hop_self=='all' else '' }}
 {%       endif %}
-{%       if n.type == 'localas_ibgp' %}
+{%       if n.rr_client is defined %}
   neighbor {{ peer }} route-reflector-client
-  neighbor {{ peer }} next-hop-self force
 {%       endif %}
 {%       if n.type in bgp.community|default({}) %}
   no neighbor {{ peer }} send-community all

--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -23,7 +23,7 @@ router bgp {{ bgp.as }}
 {%   set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }} activate
 #  neighbor {{ peer }} soft-reconfiguration inbound
-{%   if bgp.rr|default('') and not n.rr|default('') %}
+{%   if n.rr_client is defined %}
   neighbor {{ peer }} route-reflector-client
 {%   endif %}
 {%  endfor %}

--- a/netsim/ansible/templates/mpls/frr.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/frr.mplsvpn.j2
@@ -7,8 +7,8 @@ router bgp {{ bgp.as }}
 {%   for n in bgp.neighbors if n[vpnaf] is defined %}
   neighbor {{ n[vpnaf] }} activate
   neighbor {{ n[vpnaf] }} send-community both
-{%     if n.type == 'ibgp' %}
-  neighbor {{ n[vpnaf] }} next-hop-self
+{%     if n.next_hop_self is defined %}
+  neighbor {{ n[vpnaf] }} next-hop-self {{ 'force' if n.next_hop_self=='all' else '' }}
 {%     endif %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/ansible/templates/srv6/frr.bgp.j2
+++ b/netsim/ansible/templates/srv6/frr.bgp.j2
@@ -1,3 +1,5 @@
+ipv6 route {{ srv6.locator }} Null0
+
 router bgp {{ bgp.as }}
  segment-routing srv6
   locator {{ inventory_hostname }}
@@ -14,8 +16,8 @@ router bgp {{ bgp.as }}
 {%   if n.next_hop_unchanged is defined %}
   neighbor {{ peer }} attribute-unchanged next-hop
 {%   endif %}
-{%   if n.type=='ibgp' and bgp.next_hop_self|default(True) %}
-  neighbor {{ peer }} next-hop-self
+{%   if n.next_hop_self is defined %}
+  neighbor {{ peer }} next-hop-self {{ 'force' if n.next_hop_self=='all' else '' }}
 {%   endif %}
 {% endmacro -%}
 
@@ -41,10 +43,12 @@ router bgp {{ bgp.as }}
 {%     for vname,vdata in vrfs.items() %}
 router bgp {{ vdata.as|default(bgp.as) }} vrf {{ vname }}
  sid vpn per-vrf export auto
+ no bgp ebgp-requires-policy
  no bgp network import-check
 
 {%       for af in ['ipv4','ipv6'] if 'ebgp' in srv6.vpn.get(af,[]) %}
  address-family {{ af }} unicast
+  # sid vpn export auto
   nexthop vpn export {{ loopback.ipv6|ipaddr('address') }}
 {%       endfor %}
 !

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -156,10 +156,10 @@ def build_ibgp_sessions(node: Box, sessions: Box, topology: Box) -> None:
     
     if 'loopback' in node:
       neighbor_data._source_intf = node.loopback
-    if node.bgp.get('next_hop_self',True):
-      neighbor_data.next_hop_self = True
     if node.bgp.get('rr') and not n.get('rr'):
       neighbor_data.rr_client = True
+    elif node.bgp.get('next_hop_self',True):      # Route reflectors should not apply next-hop-self
+      neighbor_data.next_hop_self = True
     node.bgp.neighbors.append(neighbor_data)
     return True
 

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -356,6 +356,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: pe2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -469,6 +470,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: pe1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -136,6 +136,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -151,6 +152,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -166,6 +168,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.7
@@ -289,6 +292,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -304,6 +308,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -319,6 +324,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.21
@@ -439,6 +445,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -454,6 +461,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -469,6 +477,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.42
@@ -567,6 +576,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -582,6 +592,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -597,6 +608,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -112,6 +112,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -127,6 +128,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -142,6 +144,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.7
@@ -234,6 +237,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -249,6 +253,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -264,6 +269,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.21
@@ -369,6 +375,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -384,6 +391,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -399,6 +407,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.42
@@ -489,6 +498,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -502,6 +512,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -515,6 +526,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -69,6 +69,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -147,6 +148,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -171,6 +171,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: a2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -186,6 +187,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: a3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -259,6 +261,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.5
         name: a1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -274,6 +277,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: a3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -347,6 +351,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.5
         name: a1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -362,6 +367,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: a2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -436,6 +442,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -514,6 +521,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -628,6 +636,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -724,6 +733,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -740,6 +751,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -756,6 +769,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: l3
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -733,7 +733,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -751,7 +750,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -769,7 +767,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: l3
-        next_hop_self: true
         rr_client: true
         type: ibgp
       next_hop_self: true

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -84,6 +84,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -97,6 +98,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -169,6 +171,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -182,6 +185,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -257,6 +261,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -270,6 +275,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -338,7 +338,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -353,7 +352,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -368,7 +366,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp
@@ -466,7 +463,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -481,7 +477,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -496,7 +491,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -109,6 +109,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -123,6 +124,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -226,6 +228,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -240,6 +243,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -334,6 +338,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -347,6 +353,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -360,7 +368,9 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
@@ -456,6 +466,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -469,6 +481,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -482,7 +496,9 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -274,6 +274,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -288,6 +289,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -378,6 +380,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -392,6 +395,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -482,7 +486,9 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -496,6 +502,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -509,6 +517,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -582,7 +592,9 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -596,6 +608,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -609,6 +623,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -486,7 +486,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp
@@ -502,7 +501,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -517,7 +515,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       next_hop_self: true
@@ -592,7 +589,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp
@@ -608,7 +604,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -623,7 +618,6 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       next_hop_self: true

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -108,6 +108,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:3::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -225,6 +226,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2::1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -729,7 +729,6 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp
@@ -748,7 +747,6 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -766,7 +764,6 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       next_hop_self: true
@@ -869,7 +866,6 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
-        next_hop_self: true
         rr: true
         rr_client: true
         type: ibgp
@@ -888,7 +884,6 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
-        next_hop_self: true
         rr_client: true
         type: ibgp
       - _source_intf:
@@ -906,7 +901,6 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
-        next_hop_self: true
         rr_client: true
         type: ibgp
       next_hop_self: true

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -455,6 +455,7 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -472,6 +473,7 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -590,6 +592,7 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -607,6 +610,7 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -725,7 +729,9 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -742,6 +748,8 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -758,6 +766,8 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -859,7 +869,9 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -876,6 +888,8 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -892,6 +906,8 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -365,6 +365,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.2
         name: c2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -452,6 +453,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -542,6 +544,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -558,6 +561,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4
@@ -727,6 +731,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -743,6 +748,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.6
@@ -912,6 +918,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.4
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -928,6 +935,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -944,6 +952,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: s2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1053,6 +1062,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.4
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1069,6 +1079,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1085,6 +1096,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: s1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1194,6 +1206,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1210,6 +1223,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.10
@@ -1379,6 +1393,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1395,6 +1410,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.12
@@ -1564,6 +1580,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.10
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1580,6 +1597,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.12
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1596,6 +1614,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: s2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1705,6 +1724,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.10
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1721,6 +1741,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.12
         name: leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1737,6 +1758,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: s1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -613,7 +613,6 @@ nodes:
         as: 65001
         ipv4: 10.0.0.1
         name: r1
-        next_hop_self: true
         password: Secret
         rr_client: true
         timers:

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -171,6 +171,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: rr
+        next_hop_self: true
         password: Secret
         rr: true
         type: ibgp
@@ -612,7 +613,9 @@ nodes:
         as: 65001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         password: Secret
+        rr_client: true
         timers:
           hold: 10
           keepalive: 3

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -410,6 +410,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -736,6 +737,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -77,6 +77,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -170,6 +171,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -105,6 +105,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -230,6 +231,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -390,6 +390,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -407,6 +408,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.3
         name: s3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -601,6 +603,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -618,6 +621,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.3
         name: s3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -759,6 +763,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -776,6 +781,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -257,6 +257,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.6
         name: S2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -384,6 +385,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.5
         name: S1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -85,6 +85,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: b
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -98,6 +99,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: c
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -152,6 +154,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: a
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -165,6 +168,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: c
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -219,6 +223,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: a
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -232,6 +237,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: b
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
@@ -286,6 +292,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.5
         name: e
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -299,6 +306,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.6
         name: f
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4
@@ -353,6 +361,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: d
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -366,6 +375,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.6
         name: f
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.5
@@ -420,6 +430,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: d
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -433,6 +444,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.5
         name: e
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.6

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -116,6 +116,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: e1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -129,6 +130,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: e2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -276,6 +278,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -289,6 +292,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: e2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
@@ -388,6 +392,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -403,6 +408,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: e1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -104,6 +104,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
         vpnv4: 10.0.0.2
       next_hop_self: true
@@ -235,6 +236,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
         vpnv4: 10.0.0.1
       next_hop_self: true

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -406,6 +406,7 @@ nodes:
         ipv6: 2001:db8:0:2::1
         ipv6_label: true
         name: pe2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -424,6 +425,7 @@ nodes:
         ipv6: 2001:db8:0:4::1
         ipv6_label: true
         name: rr
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -546,6 +548,7 @@ nodes:
         ipv6: 2001:db8:0:1::1
         ipv6_label: true
         name: pe1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -564,6 +567,7 @@ nodes:
         ipv6: 2001:db8:0:4::1
         ipv6_label: true
         name: rr
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -683,6 +687,7 @@ nodes:
         ipv4_label: true
         ipv6: 2001:db8:0:1::1
         name: pe1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -700,6 +705,7 @@ nodes:
         ipv4_label: true
         ipv6: 2001:db8:0:2::1
         name: pe2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -73,6 +73,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: n2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -158,6 +159,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: n1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -156,6 +156,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: pe2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -408,6 +409,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: pe1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -134,6 +134,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -147,6 +148,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -366,6 +368,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -379,6 +382,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -545,6 +549,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -558,6 +563,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -222,6 +222,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -675,6 +676,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2


### PR DESCRIPTION
Addresses #2251

Thoughts:
* Is ```rr_client``` relevant to MPLS VPN neighbors? Could create a macro that sets both flags, and include that everywhere for consistency (I've confirmed it works for EOS, but there may be other platforms where it's configured per AF?)
* None of the topology/expected test cases has ```next_hop_self: all```