### PR TITLE
Bird bgp features

### DIFF
--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -9,6 +9,7 @@ BFD is supported on these platforms:
 | --------------------- | :-: | :-: | :-: |
 | Arista EOS            | ✅  | ✅  | ✅  |
 | Aruba AOS-CX          | ✅  | ✅  |  ❌  |
+| BIRD                  | ✅  | ❌  |  ❌  |
 | Cisco IOS             | ✅  | ✅  | ✅  |
 | Cisco IOS XE[^18v]    | ✅  | ✅  | ✅  |
 | Cisco Nexus OS        | ✅  | ✅  | ✅  |

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -77,6 +77,12 @@ The plugin implements generic BGP session features for the following platforms:
 * Arista EOS supports TCP-AO only when running as a virtual machine
 * _netlab_ always configures HMAC-SHA1-96 as the cryptographic algorithm on IOS XE
 
+BGP session features are also available on these daemons:
+
+| Operating system    | default<br>originate | BGP<br>timers |  BFD | Passive<br>peer |
+| ------------------- | :--: | :--: | :--: | :--: |
+| BIRD                |  ✅  |  ✅  |   ✅  |  ✅  |
+
 (bgp-session-security)=
 BGP session security features are available on these platforms:
 

--- a/netsim/ansible/templates/bfd/bird.j2
+++ b/netsim/ansible/templates/bfd/bird.j2
@@ -1,0 +1,1 @@
+# Bird BFD configuration is in daemon/bird/protocols.j2

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -21,6 +21,7 @@ libvirt:                        # Not yet available on libvirt or virtualbox
 virtualbox:
   image:
 features:
+  bfd: true
   bgp:
     activate_af: true
     ipv6_lla: false             # Bird supports dynamic neighbors using 'range', but not active discovery based on RAs

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -66,6 +66,7 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
   local {{ local_ip.split('/')[0] if n.type == 'ibgp' else '' }} as {{ n.local_as|default(bgp.as) }};
   neighbor {{ n[af] }} as {{ n['as'] }};
   connect retry time 10;
+  startup hold time 30;
 {% if n.local_if is defined %}
   interface "{{ n.local_if }}";
 {% endif %}

--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -13,7 +13,17 @@ protocol static bgp_ipv4 {
 {%   endif %}
 {% endfor %}
 
-function bgp_prefixes() {
+{% for _af in ['ipv4','ipv6'] if _af in af %}
+protocol static static_default_{{ _af }} {
+  {{ _af }};
+  route {{ '0.0.0.0/0' if _af=='ipv4' else '::/0' }} reject;
+}
+{% endfor %}
+
+function bgp_prefixes( bool originate_default ) {
+  if net.len = 0 && !originate_default
+    then reject "Don't originate default route";
+
   if source ~ [ RTS_STATIC, RTS_BGP ]
     then accept "Static or BGP route:", net;
 
@@ -25,14 +35,14 @@ function bgp_prefixes() {
   if source ~ [ RTS_DEVICE ] && ifname = "{{ intf.ifname }}"
     then accept "bgp.advertise:", net;
 {% endfor %}
-  reject "not accepted:", net, " source=", source, " preference=", preference;
+  reject "not accepted:", net, " source=", source, " preference=", preference, " proto=", proto;
 }
 
 {#
  Build a BGP export filter per neighbor type, to filter communities
 #}
 {% for ntype in [ 'ebgp', 'ibgp', 'localas_ibgp' ] %}
-filter bgp_export_{{ ntype }} {
+function bgp_export_{{ ntype }}( bool originate_default ) {
 {%   set list = bgp.community[ntype]|default([]) %}
 {%   if 'standard' not in list %}
   bgp_community.empty;
@@ -44,7 +54,7 @@ filter bgp_export_{{ ntype }} {
   bgp_ext_community.empty;
 {%   endif %}
 
-  bgp_prefixes();
+  bgp_prefixes(originate_default);
 }
 {% endfor %}
 
@@ -59,6 +69,16 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {% if n.local_if is defined %}
   interface "{{ n.local_if }}";
 {% endif %}
+{%     if n.bfd is defined %}
+  bfd yes;
+{%     endif %}
+{%     if n.passive is defined %}
+  passive yes;
+{%     endif %}
+{%   if n.timers is defined %}
+  hold time {{ n.timers.hold|default(180) }};
+  keepalive time {{ n.timers.keepalive|default(60) }};
+{%   endif %}
 {%     if n.password is defined %}
   password "{{ n.password }}";
 {%     endif %}
@@ -84,7 +104,7 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%      if _af in n.activate and n.activate[_af] %}
   {{ _af }} {
     import all;
-    export filter bgp_export_{{ n.type }};
+    export filter { bgp_export_{{ n.type }}( {{ 'true' if n.get('default_originate') else 'false' }} ); };
 {%       if 'next_hop_self' in bgp and bgp.next_hop_self and 'ibgp' in n.type %}
     next hop self {{ 'on' if n.type == 'localas_ibgp' else 'ebgp' }};
 {%       endif %}

--- a/netsim/daemons/bird/protocols.j2
+++ b/netsim/daemons/bird/protocols.j2
@@ -16,3 +16,14 @@ protocol kernel {
   };
 }
 {% endfor %}
+
+{% if bfd is defined %}
+protocol bfd {
+{%   set bfd_ifs = interfaces | selectattr('bgp.bfd','defined') | map(attribute='ifname') | list %}
+    interface "{{ '","'.join(bfd_ifs) }}" {
+      min rx interval {{ bfd.min_rx|default(500) }}ms;
+      min tx interval {{ bfd.min_tx|default(500) }}ms;
+      multiplier {{ bfd.multiplier|default(3) }};
+    };
+}
+{% endif %}

--- a/netsim/extra/bgp.session/defaults.yml
+++ b/netsim/extra/bgp.session/defaults.yml
@@ -6,10 +6,14 @@ devices:
     daemon_config:
       bgp@session: /etc/bird/bgp.session.conf
     features.bgp:
+      bfd: True
+      default_originate: True
       gtsm: True
+      passive: True
       password: True
       rs: True
       rs_client: True
+      timers: True
   dellos10.features.bgp:
     allowas_in: True
     bfd: True

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -23,6 +23,7 @@ links:
 - dut:
     bgp.bfd: True
   x1:
+  pool: p2p  # Force addressing to come from the p2p pool, else with host devices like bird it becomes a lan
 
 validate:
   session_v4:


### PR DESCRIPTION
* timers
* BFD for bgp
* originate_default
* passive peering

Note that Bird could support per-interface BFD timers, but the current template only supports global timers to start with

I had to tweak the startup hold time to pass the 05-gtsm test more consistently (default = 240 seconds)