### PR TITLE
VXLAN test: Test DUT against reference implementation (FRR) instead of against itself

### DIFF
--- a/tests/integration/vxlan/01-vxlan-bridging.yml
+++ b/tests/integration/vxlan/01-vxlan-bridging.yml
@@ -54,8 +54,8 @@ validate:
 
   ping_red:
     description: Ping-based reachability test in VLAN red
-    wait_msg: Waiting for STP to converge
-    wait: 20
+    wait_msg: Waiting for STP to start forwarding
+    wait: stp_forwarding
     nodes: [ h1 ]
     plugin: ping('h2')
   ping_blue:

--- a/tests/integration/vxlan/01-vxlan-bridging.yml
+++ b/tests/integration/vxlan/01-vxlan-bridging.yml
@@ -11,6 +11,8 @@ message: |
   Please note it might take a while for the lab to work due to
   STP learning phase
 
+defaults.sources.extra: [ ../wait_times.yml ]
+
 groups:
   _auto_create: True
   hosts:
@@ -18,31 +20,42 @@ groups:
     device: linux
     provider: clab
   switches:
-    members: [ s1, s2 ]
+    members: [ dut, s2 ]
     module: [ vlan, vxlan, ospf ]
+  probes:
+    device: frr
+    provider: clab
+    members: [ s2 ]
 
 vlans:
   red:
     mode: bridge
     prefix:
       ipv4: 172.31.1.0/24
-    links: [ s1-h1, s2-h2 ]
+    links: [ dut-h1, s2-h2 ]
   blue:
     mode: bridge
     prefix:
       ipv4: 172.31.1.0/24
-    links: [ s1-h3, s2-h4 ]
+    links: [ dut-h3, s2-h4 ]
 
 links:
-- s1:
+- dut:
   s2:
   mtu: 1600
 
 validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: ospfv2_adj_lan
+    nodes: [ s2 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+
   ping_red:
     description: Ping-based reachability test in VLAN red
-    wait_msg: Waiting for OSFP and STP to wake up
-    wait: 50
+    wait_msg: Waiting for STP to converge
+    wait: 20
     nodes: [ h1 ]
     plugin: ping('h2')
   ping_blue:

--- a/tests/integration/wait_times.yml
+++ b/tests/integration/wait_times.yml
@@ -15,3 +15,5 @@ const.validate:
   ospf_import: 20
 
   ebgp_session: 30
+
+  stp_forwarding: 35


### PR DESCRIPTION
This allows for the introduction of an OSPF check, clarifying delays a bit. It also guards against a theoretical possibility of devices that only interop with themselves

Proposal in the context of #2254 