### PR TITLE
Cumulus Linux: Change STP parameters on bridge and VXLAN interface

### DIFF
--- a/netsim/ansible/templates/vlan/cumulus.j2
+++ b/netsim/ansible/templates/vlan/cumulus.j2
@@ -22,9 +22,14 @@ CONFIG
 cat >/etc/network/interfaces.d/51-bridge-interfaces.intf <<CONFIG
 {% for ifdata in interfaces if ifdata.vlan is defined %}
 {%   if ifdata.type == "svi" %}
+
 auto {{ ifdata.ifname }}
 {%   endif %}
+
 iface {{ ifdata.ifname }}
+{%   if ifdata.mtu is defined %}
+    mtu {{ ifdata.mtu }}
+{%   endif %}
 {%   if ifdata.vlan.trunk_id is defined %}
     bridge-vids {{ ifdata.vlan.trunk_id|sort|join(",") }}
 {%     if ifdata.vlan.native is defined %}

--- a/netsim/ansible/templates/vxlan/cumulus.j2
+++ b/netsim/ansible/templates/vxlan/cumulus.j2
@@ -14,6 +14,8 @@ iface vni-{{ vlan.vni }}
 {% else %}
     vxlan-learning yes
 {% endif %}
+    mstpctl-bpduguard yes
+    mstpctl-portbpdufilter yes
 {% endmacro -%}
 #
 # Create VXLAN interfaces with static flood lists
@@ -34,7 +36,6 @@ iface lo inet loopback
 {%   endfor %}
 #
 iface bridge
-    bridge-stp no
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
     bridge-ports vni-{{ vlans[vname].vni }}
 {%   endfor %}


### PR DESCRIPTION
This seems to be the fix for #2254 -- I have no idea why things worked in the past, stopped working after changes mentioned in #2254, and behaved randomly afterwards. The root cause seems to be access ports stuck in **learning** phase forever (so clearly a bug somewhere in Linux networking code, but who's counting).

The only other significant thing that changed is b02bc24, but that should not have impacted interface configuration.

Anyway, let's wait until I can run the full suite of integration tests.