### PR TITLE
Allow loopback interfaces on all node types when specified by the user

### DIFF
--- a/docs/node-roles.md
+++ b/docs/node-roles.md
@@ -14,7 +14,7 @@ Most _netlab_-supported devices act as *routers*; see the [platform support tabl
 
 The defining characteristics of devices with the **router** role   (the default device role) are:
 
-* At least one global [loopback interface](node-loopback) that can be used as the *router ID* and the control-plane endpoint
+* At least one global [loopback interface](node-loopback) that can be used as the *router ID* and the control-plane endpoint. If you don't want a router to have a loopback interface, [set the **loopback** node parameter to *False*](node-loopback).
 * Layer-3 packet forwarding for the configured address families (IPv4/IPv6)
 
 Routers usually run routing protocols but can also rely on static routing. When used with the **[vlan](module-vlan)** configuration module, they can also perform layer-2 packet forwarding and IRB.
@@ -22,7 +22,9 @@ Routers usually run routing protocols but can also rely on static routing. When 
 (node-role-host)=
 ## Hosts
 
-Hosts do not have loopback interfaces (it's easiest if they have a single interface) and use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab set up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
+Hosts do not have loopback interfaces (it's easiest if they have a single interface) unless you [specify **loopback** parameters in node data](node-loopback).
+
+Hosts use static routes toward an adjacent [default gateway](links-gateway). On devices that don't have the management VRF, Vagrant or containerlab sets up the default route, and _netlab_ adds static IPv4 routes for IPv4 prefixes defined in [address pools](address-pools).
 
 Hosts that have a management VRF (mostly network devices used as hosts) get two IPv4 default routes. Vagrant or containerlab sets up the IPv4 default route in the management VRF, and netlab adds a default route toward an adjacent router in the global routing table.
 
@@ -35,15 +37,17 @@ Most hosts listen to IPv6 RA messages to get the IPv6 default route. _netlab_ ca
 
 The **bridge** role is a thin abstraction layer on top of the [**vlan** configuration module](module-vlan), making deploying simple topologies with a single bridge connecting multiple routers or hosts easier. You can also use a **bridge** node to test failover scenarios using a familiar layer-2 device[^SD].
 
-[^SD]: It's easier to shut down an interface on a familiar device than trying to figure out how to do that on a Linux bridge.
+[^SD]: It's easier to shut down an interface on a familiar device than to try to figure out how to do that on a Linux bridge.
 
 Do not try to build complex topologies with bridges; use the VLAN configuration module.
 
-Bridges are simple layer-2 packet forwarding devices[^VM]. They do not have a loopback interface and might not even have a data-plane IP address. Without additional parameters, _netlab_ configures them the way non-VLAN bridges have been working for decades -- bridge interfaces do not use VLAN tagging and belong to a single layer-2 forwarding domain.
+Bridges are simple layer-2 packet forwarding devices[^VM]. They do not have a loopback interface[^BLB] and might not even have a data-plane IP address. Without additional parameters, _netlab_ configures them the way non-VLAN bridges have been working for decades -- bridge interfaces do not use VLAN tagging and belong to a single layer-2 forwarding domain.
+
+[^BLB]: Unless you [specified **loopback** data in node parameters](node-loopback). However, since the bridges usually don't have IP addresses assigned to VLAN interfaces, the loopback interface isn't particularly useful.
 
 [^VM]: The node **vlan.mode** parameter for a bridge node is set to **bridge** unless it's defined in the lab topology.
 
-You can use the **bridge** devices to implement simple small bridged segments, for example:
+You can use the **bridge** devices to implement simple, small bridged segments, for example:
 
 ```
 nodes:

--- a/netsim/ansible/templates/initial/arubacx.j2
+++ b/netsim/ansible/templates/initial/arubacx.j2
@@ -11,21 +11,12 @@ lldp
 {% include 'arubacx.vlan.j2' %}
 {% endif %}
 
-interface loopback 0
-{% if 'ipv4' in loopback %}
-    ip address {{ loopback.ipv4 }}
-{% endif %}
-{% if 'ipv6' in loopback %}
-    ipv6 address {{ loopback.ipv6 }}
-{% endif %}
-!
 interface {{ mgmt.ifname|default('mgmt') }}
     no lldp transmit
     no lldp receive
 !
 
-{% for l in interfaces|default([]) %}
-
+{% for l in netlab_interfaces %}
 {#
 # Unfortunately we have to mix domains here.
 # If a LAG interface is defined as a simple LAG here on the initial module, it cannot be set as multi-chassis later on.

--- a/netsim/ansible/templates/initial/dellos10.j2
+++ b/netsim/ansible/templates/initial/dellos10.j2
@@ -16,21 +16,11 @@ ip host {{ k|replace('_','') }} {{ v.loopback.ipv4.split('/')[0] }}
 default mtu {{ mtu + 32 }}
 {% endif %}
 !
-interface loopback0
-{% if 'ipv4' in loopback %}
- ip address {{ loopback.ipv4 }}
-{% endif %}
-{% if 'ipv6' in loopback %}
- ipv6 address {{ loopback.ipv6 }}
-{% else %}
- no ipv6 enable
-{% endif %}
-!
 interface {{ mgmt.ifname|default('mgmt1/1/1') }}
  no lldp transmit
  no lldp receive
 !
-{% for l in interfaces|default([]) %}
+{% for l in netlab_interfaces %}
 interface {{ l.ifname }}
  no shutdown
 {%   if l.virtual_interface is not defined or (l.type=='lag' and ('ipv4' in l or 'ipv6' in l)) %}

--- a/netsim/ansible/templates/initial/routeros.j2
+++ b/netsim/ansible/templates/initial/routeros.j2
@@ -3,10 +3,10 @@
 
 /interface bridge add name=loopback protocol-mode=none
 
-{% if 'ipv4' in loopback %}
+{% if loopback.ipv4 is defined %}
 /ip address add interface=loopback address={{ loopback.ipv4 }}
 {% endif %}
-{% if 'ipv6' in loopback %}
+{% if loopback.ipv6 is defined %}
 /ipv6 address add interface=loopback address={{ loopback.ipv6 }}
 {% endif %}
 

--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -10,10 +10,10 @@
 /interface bridge add name={{l.ifname}} protocol-mode=none
 {% endfor %}
 
-{% if 'ipv4' in loopback %}
+{% if loopback.ipv4 is defined %}
 /ip address add interface=loopback address={{ loopback.ipv4 }}
 {% endif %}
-{% if 'ipv6' in loopback %}
+{% if loopback.ipv6 is defined %}
 /ipv6 address add interface=loopback address={{ loopback.ipv6 }}
 {% endif %}
 

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -55,8 +55,9 @@ updates:
 {% endif %}
 {% endif %}
 
+{% if loopback is defined %}
 {{  ip_addresses('system0',0,loopback,False,True)  }}
-
+{% endif %}
 {% for l in interfaces|default([]) if l.vlan is not defined and l.subif_index is not defined %}
 {% set if_name_index = l.ifname.split('.') %}
 {% set if_name = if_name_index[0] %}

--- a/netsim/ansible/templates/initial/sros.j2
+++ b/netsim/ansible/templates/initial/sros.j2
@@ -152,7 +152,7 @@ updates:
   val:
    ecmp: {{ 1 if 'ixr' in clab.type else 64 }}
 
-{% if loopback.ipv4|default('')|ipv4 or 'ipv6' in loopback %}
+{% if loopback is defined %}
 {% set _v4 = loopback.ipv4|default(False) %}
 {% set _v6 = loopback.ipv6|default(False) %}
 {# The interface name 'system' is special, also used for IP unnumbered #}

--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -24,10 +24,10 @@ set system host-name 'vyos-{{ inventory_hostname | replace("_","-") }}'
 {% include 'vyos.vlan.j2' %}
 {% endif %}
 
-{% if 'ipv4' in loopback %}
+{% if loopback.ipv4 is defined %}
 set interfaces dummy dum0 address {{ loopback.ipv4 }}
 {% endif %}
-{% if 'ipv6' in loopback %}
+{% if loopback.ipv6 is defined %}
 set interfaces dummy dum0 address {{ loopback.ipv6 }}
 {% endif %}
 

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -1077,15 +1077,11 @@ def copy_link_gateway(link: Box, nodes: Box) -> None:
         intf.gateway[af] = link.gateway[af]
 
 """
-Set node.af flags to indicate that the node has IPv4 and/or IPv6 address family configured
+Set node.af flags to indicate that the node has IPv4 and/or IPv6 address family configured on its interfaces
 """
 def set_node_af(nodes: Box) -> None:
   for n in nodes.values():
     for af in ['ipv4','ipv6']:
-      if af in n.get('loopback',{}):
-        n.af[af] = True
-        continue
-
       for l in n.get('interfaces',[]):
         if af in l:
           n.af[af] = True

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -1082,6 +1082,8 @@ Set node.af flags to indicate that the node has IPv4 and/or IPv6 address family 
 def set_node_af(nodes: Box) -> None:
   for n in nodes.values():
     for af in ['ipv4','ipv6']:
+      if n.af.get(af) is True:
+        continue
       for l in n.get('interfaces',[]):
         if af in l:
           n.af[af] = True

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -100,9 +100,10 @@ node:
     ifname: str
   mtu: { type: int, min_value: 64, max_value: 9216 }
   loopback:
-    ipv4: { type: ipv4, use: host_prefix }
-    ipv6: { type: ipv6, use: host_prefix }
+    ipv4: { type: ipv4, use: host_prefix, _alt_types: [ bool ] }
+    ipv6: { type: ipv6, use: host_prefix, _alt_types: [ bool ] }
     pool: addr_pool
+    _alt_types: [ bool ]
   provider: id
   cpu:
   memory: int

--- a/netsim/roles/router.py
+++ b/netsim/roles/router.py
@@ -12,44 +12,5 @@ from ..augment import devices,addressing,links
 
 from . import select_nodes_by_role
 
-'''
-Set addresses of the main loopback interface
-'''
-def loopback_interface(n: Box, pools: Box, topology: Box) -> None:
-  n.loopback.type = 'loopback'
-  n.loopback.neighbors = []
-  n.loopback.virtual_interface = True
-  n.loopback.ifindex = 0
-  n.loopback.ifname = devices.get_loopback_name(n,topology) or 'Loopback'
-
-  pool = n.get('loopback.pool','loopback')
-  prefix_list = addressing.get(pools,[ pool ],n.id)
-
-  for af in prefix_list:
-    if prefix_list[af] is True:
-      log.error(
-        f"Address pool {pool} cannot contain unnumbered/LLA addresses",
-        category=log.IncorrectType,
-        module='nodes')
-    elif not n.loopback[af] and not (prefix_list[af] is False):
-      if af == 'ipv6':
-        if prefix_list[af].prefixlen == 128:
-          n.loopback[af] = str(prefix_list[af])
-        else:
-          n.loopback[af] = addressing.get_nth_ip_from_prefix(prefix_list[af],1)
-      else:
-        n.loopback[af] = str(prefix_list[af])
-      n.af[af] = True
-
-  for af in log.AF_LIST:
-    if af in n.loopback and not isinstance(n.loopback[af],str):
-      log.error(
-        f'{af} address on the main loopback interface of node {n.name} must be a CIDR prefix',
-        category=log.IncorrectType,
-        module='nodes')
-  
-  links.check_interface_host_bits(n.loopback,n)
-
 def post_node_transform(topology: Box) -> None:
-  for ndata in select_nodes_by_role(topology,'router'):
-    loopback_interface(ndata,topology.pools,topology)
+  pass

--- a/netsim/roles/router.py
+++ b/netsim/roles/router.py
@@ -1,16 +1,9 @@
 '''
-Router-specific data transformation
-
-* Add loopback interface data
+Router-specific data transformation: none
 '''
 import typing
 
-from box import Box, BoxList
-
-from ..utils import log
-from ..augment import devices,addressing,links
-
-from . import select_nodes_by_role
+from box import Box
 
 def post_node_transform(topology: Box) -> None:
   pass

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -345,6 +345,13 @@ nodes:
         node: h2
       role: stub
       type: lan
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.3/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
     mgmt:
       ifname: eth0
       ipv4: 192.168.121.103
@@ -380,6 +387,13 @@ nodes:
         node: s1
       role: stub
       type: lan
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.4/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
     mgmt:
       ifname: eth0
       ipv4: 192.168.121.104

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -238,7 +238,6 @@ nodes:
     loopback:
       ifindex: 0
       ifname: Loopback0
-      ipv4: 10.0.0.1/32
       ipv6: 2001:db8:0:1::1/64
       neighbors: []
       type: loopback
@@ -296,14 +295,6 @@ nodes:
         node: a_eos
       pool: lan
       type: lan
-    loopback:
-      ifindex: 0
-      ifname: loopback0
-      ipv4: 10.0.0.3/32
-      ipv6: 2001:db8:0:3::1/64
-      neighbors: []
-      type: loopback
-      virtual_interface: true
     mgmt:
       ifname: mgmt0
       ipv4: 192.168.121.103

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -36,12 +36,10 @@ links:
   - ifindex: 2
     ifname: Ethernet1/2
     ipv4: true
-    ipv6: true
     node: c_nxos
   - ifindex: 2
     ifname: Ethernet2
     ipv4: true
-    ipv6: true
     node: a_eos
   linkindex: 2
   node_count: 2
@@ -52,7 +50,6 @@ links:
   - ifindex: 3
     ifname: Ethernet3
     ipv4: true
-    ipv6: true
     node: a_eos
   - ifindex: 2
     ifname: swp2
@@ -68,7 +65,6 @@ links:
   - ifindex: 3
     ifname: Ethernet1/3
     ipv4: true
-    ipv6: true
     node: c_nxos
   - ifindex: 1
     ifname: ge-0/0/1
@@ -111,26 +107,23 @@ nodes:
         node: n_cumulus
       type: lan
     - _parent_intf: Loopback0
-      _parent_ipv4: 172.18.1.2/32
+      _parent_ipv4: 172.18.2.1/32
       ifindex: 2
       ifname: Ethernet2
       ipv4: true
-      ipv6: true
       linkindex: 2
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
         ipv4: true
-        ipv6: true
         node: c_nxos
       pool: core
       type: p2p
     - _parent_intf: Loopback0
-      _parent_ipv4: 172.18.1.2/32
+      _parent_ipv4: 172.18.2.1/32
       ifindex: 3
       ifname: Ethernet3
       ipv4: true
-      ipv6: true
       linkindex: 3
       name: a_eos -> n_cumulus
       neighbors:
@@ -143,8 +136,7 @@ nodes:
     loopback:
       ifindex: 0
       ifname: Loopback0
-      ipv4: 172.18.1.2/32
-      ipv6: 2001:db8:0:2::1/64
+      ipv4: 172.18.2.1/32
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -188,13 +180,11 @@ nodes:
       ifindex: 2
       ifname: Ethernet1/2
       ipv4: true
-      ipv6: true
       linkindex: 2
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2
         ipv4: true
-        ipv6: true
         node: a_eos
       pool: core
       type: p2p
@@ -203,7 +193,6 @@ nodes:
       ifindex: 3
       ifname: Ethernet1/3
       ipv4: true
-      ipv6: true
       linkindex: 4
       name: c_nxos -> j_vsrx
       neighbors:
@@ -217,7 +206,6 @@ nodes:
       ifindex: 0
       ifname: loopback0
       ipv4: 172.18.1.1/32
-      ipv6: 2001:db8:0:1::1/64
       neighbors: []
       type: loopback
       virtual_interface: true
@@ -270,7 +258,6 @@ nodes:
       neighbors:
       - ifname: Ethernet1/3
         ipv4: true
-        ipv6: true
         node: c_nxos
       role: core
       type: p2p
@@ -327,7 +314,6 @@ nodes:
       neighbors:
       - ifname: Ethernet3
         ipv4: true
-        ipv6: true
         node: a_eos
       pool: core
       type: p2p

--- a/tests/topology/input/dhcp-vlan.yml
+++ b/tests/topology/input/dhcp-vlan.yml
@@ -34,7 +34,9 @@ nodes:
       blue:
         dhcp.server: dhs
   h1:
+    loopback: True                      # Test for new #2267 feature
   h2:
+    loopback.ipv4: True                 # Test for new #2267 feature
   h3:
   r1:
     device: none

--- a/tests/topology/input/dual-stack.yml
+++ b/tests/topology/input/dual-stack.yml
@@ -10,10 +10,13 @@ addressing:
 nodes:
 - name: c_ios
   device: iosv
+  loopback.ipv4: False                  # Test for new #2267 feature
 - name: c_csr
   device: csr
+  loopback.ipv6: True                   # Test for new #2267 feature
 - name: c_nxos
   device: nxos
+  loopback: False                       # Test for new #2267 feature
 - name: a_eos
   device: eos
 - name: j_vsrx

--- a/tests/topology/input/unnumbered.yml
+++ b/tests/topology/input/unnumbered.yml
@@ -13,8 +13,12 @@ defaults.const.ifname.maxlength: 30     # Regression test for 1709
 nodes:
 - name: c_nxos
   device: nxos
+  loopback.ipv6: False
 - name: a_eos
   device: eos
+  loopback:
+    ipv4: 172.18.2.1/32
+    ipv6: False
 - name: j_vsrx
   device: vsrx
 - name: n_cumulus


### PR DESCRIPTION
This is the main logic for fixing #2261 and #2266. @jbemmel: would appreciate if you could double-check it.

Next, I have to create test cases to validate the edge conditions (**loopback.ipv4** on host, **loopback: True** and **loopback: False** work correctly), and finally run all known devices through these test cases to verify that the configuration templates don't break.