### PR TITLE
Fix: implement stricter checks on node names on links

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -99,9 +99,12 @@ def adjust_link_object(l: typing.Any, linkname: str, nodes: Box) -> typing.Optio
     for n in l.split('-'):                # ... split it into a list of nodes
       n = n.strip()                       # ... strip leading and trailing spaces (fixing #816)
       valid_node = n in nodes
-      if not valid_node:
-        valid_node = len([ x for x in nodes if n.startswith(x) ]) > 0
-
+      if not valid_node:                  # ... maybe its a link to a node within a component
+        valid_node = len([ 
+          x for x in nodes                # ... so check the node names with a '_' suffix
+            if n.startswith(x+"_")        # ... but only for components
+              and 'include' in nodes[x]]) > 0
+                                          # ... note this is not a final check, it's only a viability check
       if valid_node:                      # If the node name is valid
         link_intf.append({ 'node': n })   # ... append it to the list of interfaces
       else:

--- a/tests/errors/component-links.log
+++ b/tests/errors/component-links.log
@@ -1,0 +1,2 @@
+IncorrectValue in links: links[1] refers to an unknown node s2_px
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/component-links.yml
+++ b/tests/errors/component-links.yml
@@ -1,0 +1,14 @@
+defaults.device: frr
+
+components:
+  site:
+    nodes:
+      p:
+
+nodes:
+  s1:
+    include: site
+  s2:
+    include: site
+
+links: [ s1_p-s2_px ]

--- a/tests/errors/link-invalid-format.log
+++ b/tests/errors/link-invalid-format.log
@@ -10,4 +10,6 @@ IncorrectValue in links: Interface data links[5].interfaces[3] refers to an unkn
 IncorrectValue in links: Link string a-b in links[6] refers to an unknown node a
 IncorrectValue in links: Link string a-b in links[6] refers to an unknown node b
 IncorrectType in links: Invalid type int for links[7]
+IncorrectValue in links: Link string r1-r3_a in links[8] refers to an unknown node r3_a
+IncorrectValue in links: Link string r1-r3a in links[9] refers to an unknown node r3a
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/link-invalid-format.yml
+++ b/tests/errors/link-invalid-format.yml
@@ -24,3 +24,5 @@ links:
   - node: wtf
 - a-b
 - 42
+- r1-r3_a                           # Regression test for 2273
+- r1-r3a                            # Regression test for 2273


### PR DESCRIPTION
The code introduced with netlab components accepted any name in the link string definition as long as a valid node name was its prefix. That check was upgraded to 'node name + _ but only for components'

Furthermore, the content of 'links' list is rechecked after the component expansion to ensure the node names are correct (it's impossible to do the final check before components are expanded).

Fixes #2273