### PR TITLE
Fix SR-OS IS-IS configuration template

### DIFF
--- a/netsim/ansible/templates/isis/sros.j2
+++ b/netsim/ansible/templates/isis/sros.j2
@@ -1,47 +1,58 @@
 {% from "templates/initial/sros.j2" import if_name, declare_router with context %}
 
-{% macro isis_config(l) %}
-{{ declare_router(l) }}
+{% macro isis_router(vrf_data,isis,intf_list) %}
+{% set kw_level = {'level-1': '1', 'level-2': '2', 'level-1-2': '1/2'} %}
+{{ declare_router(vrf_data) }}
   val:
-   isis:
-   - isis-instance: 0
-     admin-state: enable
-     area-address: ["{{ isis.net | default( "%s.0000.0000.%04d.00" % (isis.area,id) ) }}"]
-     level-capability: "{{ '2' if isis.type=='level-2' else ('1' if isis.type=='level-1' else '1/2') }}"
-{%   if isis.af.ipv6 is defined %}
-     multi-topology:
-      ipv6-unicast: True
+    isis:
+    - isis-instance: 0
+      system-id: "{{ isis.system_id }}"
+      admin-state: enable
+      area-address: ["{{ isis.area }}"]
+      level:
+      - level-number: "1"
+        wide-metrics-only: True
+      - level-number: "2"
+        wide-metrics-only: True
+{%   if isis.type is defined %}
+      level-capability: "{{ kw_level[isis.type] }}"
 {%   endif %}
-     interface:
-     - interface-name: {{ if_name(l,l.ifname) }}
-       interface-type: {{ l.isis.network_type|default('broadcast') }}
-       passive: {{ l.isis.passive }}
+{%   if isis.af.ipv6 is defined %}
+      multi-topology:
+        ipv6-unicast: True
+{%   endif %}
+{%   for l in intf_list if 'isis' in l %}
+{%     if loop.first %}
+      interface:
+{%     endif %}
+      - interface-name: {{ if_name(l,l.ifname) }}
+        interface-type: {{ l.isis.network_type|default('broadcast') }}
+        passive: {{ l.isis.passive }}
 {%     if l.isis.bfd is defined %}
-       bfd-liveness:
+        bfd-liveness:
 {%     if l.isis.bfd.ipv4|default(False) %}
-        ipv4:
-         include-bfd-tlv: True
+          ipv4:
+            include-bfd-tlv: True
 {%     endif %}
 {%     if l.isis.bfd.ipv6|default(False) %}
-        ipv6:
-         include-bfd-tlv: True
+          ipv6:
+            include-bfd-tlv: True
 {%     endif %}
 {%     endif %}
 {%     if (l.isis.metric is defined or l.isis.cost is defined) %}
-       level:
-{%     for level in ['1','2'] %}
-       - level-number: "{{ level }}"
-         metric: {{ l.isis.metric|default(l.isis.cost) }}
-{%       if 'ipv6' in isis.af and 'ipv6' in l %}
-         ipv6-unicast-metric: {{ l.isis.metric|default(l.isis.cost) }}
-{%       endif %}
-{%     endfor %}
+        level:
+{%       for level in ['1','2'] %}
+        - level-number: "{{ level }}"
+          metric: {{ l.isis.metric|default(l.isis.cost) }}
+{%         if 'ipv6' in isis.af and 'ipv6' in l %}
+          ipv6-unicast-metric: {{ l.isis.metric|default(l.isis.cost) }}
+{%         endif %}
+{%       endfor %}
 {%     endif %}
+{%   endfor %}
 {% endmacro %}
 
 updates:
-{{ isis_config( { 'ifname': 'system', 'isis': { 'passive' : True } } ) }}
-
-{% for l in interfaces|default([]) if 'isis' in l %}
-{{ isis_config(l) }}
-{% endfor %}
+{% if isis is defined %}
+{{ isis_router({},isis,netlab_interfaces) }}
+{% endif %}


### PR DESCRIPTION
* Set area and system ID
* Configure wide metrics
* Use lookup table for IS-IS level keywords
* Configure the routing protocol only once
* Include interfaces in the routing protocol configuration