### PR TITLE
Update MANIFEST.in to include netsim/daemons sub directories

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include netsim/ansible *
 recursive-include netsim/extra *
 recursive-include netsim/templates *
+recursive-include netsim/daemons *
 recursive-include netsim/install *
 recursive-include netsim *.yml
 include requirements.txt


### PR DESCRIPTION
Enable the inclusion of sub directories under netsim/daemons in the distribution artifacts. This includes the  Dockerfiles and jinja2 templates for bird and dnsmasq. 