### PR TITLE
SR-OS: Fix routing policies

### DIFF
--- a/netsim/ansible/templates/routing/sros.j2
+++ b/netsim/ansible/templates/routing/sros.j2
@@ -1,19 +1,18 @@
 updates:
 {% for rp_name,rp_list in routing.policy|default({})|items %}
-- path: routing-policy/policy[name={{ rp_name }}]
+- path: /configure/policy-options/policy-statement[name={{ rp_name }}]
   val:
-   statement:
+    entry:
 {%  for entry in rp_list %}
-   - name: rpe_{{ entry.sequence }}
-     action:
-      bgp:
+    - entry-id: {{ entry.sequence }}
+      action:
+        action-type: accept
 {%    if 'locpref' in entry.set %}
-       local-preference:
-        set: {{ entry.set.locpref }}
+        local-preference: "{{ entry.set.locpref }}"
 {%    endif %}
 {%    if 'med' in entry.set %}
-       med:
-        set: {{ entry.set.med }}
+        bgp-med:
+          set: "{{ entry.set.med }}"
 {%    endif %}
 {%  endfor %}
 {% endfor %}


### PR DESCRIPTION
The previous author committed code that had no chance of ever working anywhere close to SR-OS (unless Nokia completely rewamped its data model which I doubt). It looks way too much like SR-Linux template for my comfort level, and it's pretty obvious it was never tested.

This commit replaces that "contribution" with working code that sets local preference and MED.