### PR TITLE
Fix: SR-OS does not support unnumbered EBGP sessions

### DIFF
--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -32,7 +32,7 @@ features:
     vrf_local_as: True
     local_as_ibgp: True
     activate_af: True
-    ipv6_lla: True
+    ipv6_lla: False
   evpn:
     irb: True
     asymmetrical_irb: True


### PR DESCRIPTION
One has to admire the incredible audacity of a developer who sets 'features.bgp.ipv6_lla' flag to True while leaving a "TODO BGP unnumbered" comment in the configuration template.

Alas, faced with either implementing the missing functionality or disabling the feature, I decided to take the easy way out.

A brave soul wanting to revert this decision is most welcome to submit a working PR.