### PR TITLE
SR-OS: Control prefix origination for IBGP neighbors

### DIFF
--- a/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
@@ -86,26 +86,28 @@
     import:
       policy: ["accept_all"]
     export:
-      policy: [ "{{ (vrf + "_export") if type in ['localas_ibgp','ebgp'] else 
-                  'next-hop-self-ebgp-routes-only' if 'ibgp' in type and bgp.next_hop_self|default(False) else 'accept_all' }}" ]
-
-{% if bgp.community[ type ]|default([])|length < 2 %}
-    send-communities:
-{%  for c,vals in {'standard': ['standard','large'],'extended':['extended'] }.items() %}
-{%   if c not in bgp.community[ type ] %}
-{%    for knob in vals %}
-      {{ knob }}: False  # True value not allowed, on by default
-{%    endfor %}
+      policy:
+{%   if 'ibgp' in type and bgp.next_hop_self|default(False) %}
+      - next-hop-self-ebgp-routes-only
 {%   endif %}
-{%  endfor %}
-{% endif %}
-{% if transport_ip %}
+      - {{ vrf }}_export
+{%   if bgp.community[ type ]|default([])|length < 2 %}
+    send-communities:
+{%     for c,vals in {'standard': ['standard','large'],'extended':['extended'] }.items() %}
+{%       if c not in bgp.community[ type ] %}
+{%         for knob in vals %}
+      {{ knob }}: False  # True value not allowed, on by default
+{%         endfor %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{%   if transport_ip %}
     local-address: "{{ transport_ip }}"
-{%  if bgp.rr|default(False) and 'ibgp' in name %}
+{%   endif %}
+{%   if bgp.rr|default(False) and 'ibgp' in name %}
     cluster:
       cluster-id: "{{ bgp.rr_cluster_id|default(vrf_bgp.router_id|default(bgp.router_id)) }}"
-{%  endif %}
-{% endif %}
+{%   endif %}
 {% endmacro %}
 
 {% for n in vrf_bgp.neighbors %}

--- a/netsim/ansible/templates/bgp/sros.j2
+++ b/netsim/ansible/templates/bgp/sros.j2
@@ -18,7 +18,7 @@ updates:
       action-type: accept
       next-hop: self
    default-action:
-    action-type: accept
+    action-type: next-policy
 {% endif %}
 
 {{ bgp_config("default",bgp,{ 'af' : af }) }}


### PR DESCRIPTION
SR-OS implementation advertised all known prefixes to IBGP neighbors. This fix uses two policies for IBGP session: next-hop-self (for EBGP routes) and default_export (to match prefixes)