### PR TITLE
Use /128 IPv6 loopback in BGP integration tests

### DIFF
--- a/tests/integration/bgp.policy/31-med.yml
+++ b/tests/integration/bgp.policy/31-med.yml
@@ -19,6 +19,9 @@ nodes:
     bgp.as: 65000
     id: 1
     bgp.locpref: 17
+    loopback:
+      ipv4: 10.0.0.42/32
+      ipv6: 2001:db8:42:1::1/128
   probe:
     bgp.as: 65100
 

--- a/tests/integration/bgp.policy/32-med-unnumbered.yml
+++ b/tests/integration/bgp.policy/32-med-unnumbered.yml
@@ -19,6 +19,9 @@ nodes:
     bgp.as: 65000
     id: 1
     bgp.locpref: 17
+    loopback:
+      ipv4: 10.0.0.42/32
+      ipv6: 2001:db8:42:1::1/128
   probe:
     bgp.as: 65100
 

--- a/tests/integration/bgp/13-ipv6-ibgp-rr.yml
+++ b/tests/integration/bgp/13-ipv6-ibgp-rr.yml
@@ -62,8 +62,7 @@ validate:
     wait: 5
     plugin: >
       bgp_prefix(
-        '2001:db8:cafe:e::1/64',af='ipv6',
-        nh=nodes.dut.loopback.ipv6 if 'loopback' in nodes.dut else nodes.dut.interfaces[0].ipv6)
+        '2001:db8:cafe:e::1/64',af='ipv6',nh=nodes.dut.loopback.ipv6)
   reflect:
     description: Check route reflection on DUT
     wait_msg: Wait for BGP convergence
@@ -77,7 +76,7 @@ validate:
   nhu:
     description: Check next-hop handling of reflected routes
     nodes: [ r2 ]
-    plugin: bgp_prefix('2001:db8:cafe:1::/64',af='ipv6',nh='2001:db8:1:a::1',peer=nodes.dut.bgp.router_id)
+    plugin: bgp_prefix('2001:db8:cafe:1::/64',af='ipv6',nh=nodes.r1.loopback.ipv6,peer=nodes.dut.bgp.router_id)
   cluster:
     description: Check cluster-id attribute in the BGP update from RR
     nodes: [ r2 ]

--- a/tests/integration/bgp/14-ipv6-originate.yml
+++ b/tests/integration/bgp/14-ipv6-originate.yml
@@ -55,11 +55,11 @@ validate:
     wait: 15
     wait_msg: Waiting for the loopback prefix to be originated and propagated
     nodes: [ x1, x2 ]
-    plugin: bgp_prefix('2001:db8:1:2::/64',af='ipv6')
+    plugin: bgp_prefix(nodes.dut2.loopback.ipv6,af='ipv6')
   suppress_lb:
     description: Check whether DUT suppresses the loopback prefix
     nodes: [ x1, x2 ]
-    plugin: bgp_prefix('2001:db8:1:1::/64',state='missing',af='ipv6')
+    plugin: bgp_prefix(nodes.dut.loopback.ipv6,state='missing',af='ipv6')
   suppress_p2p:
     description: Check whether DUT originates an unwanted prefix on a P2P link
     nodes: [ x1, x2 ]

--- a/tests/integration/bgp/defaults-ipv6.yml
+++ b/tests/integration/bgp/defaults-ipv6.yml
@@ -2,6 +2,7 @@ addressing:
   loopback:
     ipv4: False
     ipv6: 2001:db8:1::/48
+    prefix6: 128
   lan:
     ipv4: False
     ipv6: 2001:db8:2::/48

--- a/tests/integration/routing/03-med-out.yml
+++ b/tests/integration/routing/03-med-out.yml
@@ -29,6 +29,9 @@ nodes:
     module: [ bgp, routing, vrf ]
     bgp.as: 65000
     id: 1
+    loopback:
+      ipv4: 10.0.0.42/32
+      ipv6: 2001:db8:42:1::1/128
   p_global:
     bgp.as: 65100
   p_vrf:


### PR DESCRIPTION
Nokia SR-OS does not accept anything but /128 as the IPv6 on the system loopback interface (probably a smart choice). Instead of fighting that behavior, several integration tests were modified to use the /128 loopback IPv6 prefix on the device under test.