### PR TITLE
SR-OS: Implement BGP 'allowas-in'

### DIFF
--- a/netsim/extra/bgp.session/sros.j2
+++ b/netsim/extra/bgp.session/sros.j2
@@ -17,8 +17,8 @@
       ipv4: {{ activate.ipv4|default(False) }}
       ipv6: {{ activate.ipv6|default(False) }}
 {% endif %}
-{%   if n.allowas_in is defined %}
-     # allow-own-as: {{ n.allowas_in|int }}
+{%   if n.allowas_in|default(False) %}
+     loop-detect-threshold: {{ n.allowas_in|int }}
 {%   endif %}
 {%   if n.as_override|default(False) %}
      as-override: True


### PR DESCRIPTION
Fixing another 'I set the feature flag but never bothered to implement it on SR-OS' SNAFU.

FWIW, the parameter is called 'loop-detect-threshold' on SROS.