### PR TITLE
SR-OS: Fix L2 EVPN configuration

### DIFF
--- a/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
@@ -67,10 +67,6 @@
       ebgp-default-reject-policy:
         import: False
         export: False
-{% if vrf=="default" %}
-      vpn-apply-export: True
-      vpn-apply-import: True
-{% endif %}
 {% if vrf_bgp.rr|default(False) %}
       client-reflect: True
 {% endif %}

--- a/netsim/ansible/templates/evpn/sros.j2
+++ b/netsim/ansible/templates/evpn/sros.j2
@@ -31,6 +31,7 @@ updates:
       export: "target:{{ vdata.evpn.export[0] }}"
       import: "target:{{ vdata.evpn.import[0] }}"
 
+{%     if evpn.transport|default('vxlan') == 'mpls' %}
    bgp-evpn:
     evi: {{ vdata.evpn.evi }}
     # TODO if evpn.transport == 'mpls'
@@ -42,5 +43,6 @@ updates:
       auto-bind-tunnel:
        resolution: any
        ecmp: {{ 2 if 'ixr' in clab.type else 32 }}
+{%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
Yet again, the "let's leave untested TODO stuff in config templates" mentality caused the total configuration failure of all EVPN scenarios. It turns out that trying to configure VXLAN and MPLS EVPN under the same BGP instance doesn't work.

However, as they say, third time is a charm, I hope that's it.

The minimal fixes in this patch got L2 EVPN to work. More advanced scenarios are still failing with config or validation failures.

Also: applying decent global BGP policies to VPN routes turned out to be a bad idea.