### PR TITLE
SR-OS: Fix EVPN-over-EBGP when SR-OS is a spine node

### DIFF
--- a/netsim/ansible/templates/bgp/sros.j2
+++ b/netsim/ansible/templates/bgp/sros.j2
@@ -4,8 +4,8 @@ updates:
 
 - path: configure/policy-options/policy-statement[name=accept_all]
   val:
-   default-action:
-    action-type: accept
+    default-action:
+      action-type: accept
 
 {% if bgp.next_hop_self|default(False) %}
 - path: configure/policy-options/policy-statement[name=next-hop-self-ebgp-routes-only]

--- a/netsim/ansible/templates/evpn/sros.j2
+++ b/netsim/ansible/templates/evpn/sros.j2
@@ -2,21 +2,22 @@
 updates:
 - path: configure/router[router-name=Base]
   val:
-   bgp:
-    group:
-{%  for type in evpn.session %}
-    - group-name: {{ 'ibgp-ipv4' if type=='ibgp' else 'ebgp' }}
-      family:
-       evpn: True
-{%  if bgp.rr|default(0) %}
-      next-hop-unchanged:
-       evpn: True
+    bgp:
+      rapid-withdrawal: True
+      rapid-update:
+        evpn: True
+{%  if 'ebgp' in evpn.session %}
+      inter-as-vpn: true
 {%  endif %}
-
-    rapid-withdrawal: True
-    rapid-update:
-     evpn: True
-
+      group:
+{%  for type in evpn.session %}
+      - group-name: {{ 'ibgp-ipv4' if type=='ibgp' else 'ebgp' }}
+        family:
+          evpn: True
+{%  if bgp.rr|default(0) or type == 'ebgp' %}
+        next-hop-unchanged:
+          evpn: True
+{%  endif %}
 {%  endfor %}
 
 {# Configure EVPN parameters for VLANs, TODO bundles #}


### PR DESCRIPTION
The "EVPN-over-EBGP" configuration template had no chance of working outside of the most basic SR-OS-as-leaf scenario:

* There were YAML errors in BGP configuration when EVPN was enabled on IBGP and EBGP sessions
* SR-OS could not be used as a spine node because it did not propagate EVPN routes (missing 'inter-as-vpn') or changed the next hop (missing 'next-hop-unchanged')