### PR TITLE
Fix: Configuration reload in Cisco IOS-XE devices fails when copying

### DIFF
--- a/netsim/ansible/tasks/reload-config/_copy_config.yml
+++ b/netsim/ansible/tasks/reload-config/_copy_config.yml
@@ -11,5 +11,5 @@
     module: command
     cmd: >-
       sshpass -p '{{ ansible_ssh_pass }}'
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ netlab_ssh_args|default('') }}
+      scp -O -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{ netlab_ssh_args|default('') }}
       {{ config_template }} {{ ansible_user }}@{{ ansible_host }}:{{ netlab_device_disk }}replace-config


### PR DESCRIPTION
Updating _copy_config.yml for SCP to use the "-O" option, to avoid using SFTP in transferring files to a Cisco IOS-XE router and prefer SCP instead.