### PR TITLE
SR-OS: Import BGP-VPN routes into VRF BGP and OSPF processes

### DIFF
--- a/netsim/ansible/templates/mpls/sros.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/sros.mplsvpn.j2
@@ -10,15 +10,37 @@
 {% for af in ['ipv4','ipv6'] if mpls.vpn[af] is defined %}
 {%   set vpnaf = 'vpn' + af.replace('ip','') %}
 {%   for n in bgp.neighbors if n[vpnaf] is defined and n.type in mpls.vpn[af] %}
-
-{# Assuming no need to (re)create peer group #}
-{%   set peer_group = 'ebgp' if n.type=='ebgp' else 'ibgp-local-as' if n.type=='localas_ibgp' else ('ibgp-'+af) %}
+{#
+   The neighbor should have been configured by the BGP module, we just need to
+   enable the VPN address family
+#}
 - path: configure/router[router-name=Base]/bgp/neighbor[ip-address={{ n[vpnaf] }}]
   val:
-   description: "{{ n.name }}"
-   group: "{{ peer_group }}" 
-   peer-as: {{ n.as }}
-   family:
-    vpn-{{ af }}: True
+    family:
+      vpn-{{ af }}: True
 {%   endfor %}
+{% endfor %}
+{% for vname,vdata in (vrfs|default({})).items() %}
+{%   if vdata.bgp.neighbors|default([]) %}
+- path: configure/policy-options/policy-statement[name={{ vname }}_export]
+  val:
+    entry:
+    - entry-id: 1000
+      from:
+        protocol:
+          name: [ bgp-vpn ]
+      action:
+        action-type: accept
+{%   endif %}
+{%   if vdata.ospf is defined %}
+- path: configure/policy-options/policy-statement[name=ospf_{{ vname }}_export]
+  val:
+    entry:
+    - entry-id: 1000
+      from:
+        protocol:
+          name: [ bgp-vpn ]
+      action:
+        action-type: accept
+{%   endif %}
 {% endfor %}


### PR DESCRIPTION
It turns out that if you don't export 'bgp-vpn' (= MPLS/VPN) routes into VRF BGP and OSPF processes, you don't get end-to-end connectivity. Who would have thought.

Also, the activation of VPNv6 AF was broken (and there's no need to recreate the BGP neighbor that has already been defined)

Another pair of sad examples of insufficient testing :(