### PR TITLE
JunOS: support for LAG module

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -15,6 +15,9 @@ LAG is currently supported on these platforms:
 | Dell OS10             | ✅ | ✅ | ✅  | ✅ |
 | FRR                   | ✅ | ✅ | ❌  | ❌ |
 | Generic Linux hosts   | ✅ | ✅ | ❌  | ❌ |
+| JunOS[^Junos]         | ✅ | ✅ | ✅  | ❌ |
+
+[^Junos]: Includes vSRX, vPTX and vJunos-switch. vJunos-router (and vMX) do not support LAG.
 
 ## Parameters
 

--- a/netsim/ansible/templates/lag/junos.j2
+++ b/netsim/ansible/templates/lag/junos.j2
@@ -1,0 +1,48 @@
+{# first of all, need to count all lag interfaces and create specific config #}
+
+chassis {
+  aggregated-devices {
+    ethernet {
+      device-count {{interfaces|selectattr("type", "equalto", "lag")|length}};
+    }
+  }
+}
+
+
+interfaces {
+
+{% for intf in interfaces if intf.type == 'lag' %}
+  {{ intf.junos_interface }} {
+    description "{{ intf.name }} (LAG)";
+    aggregated-ether-options {
+
+{%   if intf.lag.lacp|default('') == 'off' %}
+{%   elif intf.lag.lacp|default('') %}
+      lacp {
+{%     if intf.lag.lacp_mode|default('') == 'active' %}
+        active;
+{%     elif intf.lag.lacp_mode|default('') == 'passive' %}
+        passive;
+{%     endif %}
+        periodic {{intf.lag.lacp}};
+      }
+{%   endif %}
+
+    }
+  }
+
+{%   for ch in interfaces if ch.lag._parentindex|default(None) == intf.lag.ifindex %}
+  {{ ch.junos_interface }} {
+    description "{{ ch.name }} in LAG {{ intf.lag.ifindex }}";
+    ether-options {
+      802.3ad ae{{ intf.lag.ifindex }};
+    }
+{# must delete mtu and unit 0 #}
+    delete: mtu;
+    delete: unit 0;
+  }
+{%   endfor %}
+
+{% endfor %}
+
+}

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -4,6 +4,7 @@ template: true
 loopback_interface_name: "lo0.{ifindex}"
 ifindex_offset: 0
 interface_name: ge-0/0/{ifindex}
+lag_interface_name: "ae{lag.ifindex}"
 mgmt_if: fxp0
 group_vars:
   ansible_user: vagrant

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -10,6 +10,8 @@ features:
     asymmetrical_irb: true
     irb: true
     multi_rt: true
+  lag:
+    passive: True
   vlan:
     model: l3-switch
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vptx.yml
+++ b/netsim/devices/vptx.yml
@@ -9,6 +9,8 @@ group_vars:
 features:
   gateway:
     protocol: [ vrrp ]
+  lag:
+    passive: True
   vlan:
     model: l3-switch
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -7,6 +7,8 @@ group_vars:
 features:
   gateway:
     protocol: [ vrrp ]
+  lag:
+    passive: True
   vlan:
     model: router
     subif_name: "{ifname}.{vlan.access_id}"


### PR DESCRIPTION
Tested:

* 01-l3-lag.yml
* 02-lag-vlan-trunk.yml
* 03-l3-lag-passive.yml
* 04-lag-vlan-routed-trunk.yml

With:

* vjunos-switch
* vptx
* vsrx in *packet mode* (except for 02-lag-vlan-trunk and 03-l3-lag-passive.yml which use vlans - is not supported)

**NOTE**: vjunos-router does not support LAG:

```
 ##
 ## Warning: configuration block ignored: unsupported platform (vmx)
 ##
```
