### PR TITLE
JunOS: remove MPLS bgp-igp-both-ribs

### DIFF
--- a/netsim/ansible/templates/mpls/junos.ldp.j2
+++ b/netsim/ansible/templates/mpls/junos.ldp.j2
@@ -10,7 +10,6 @@ interfaces {
 
 protocols {
   mpls {
-    traffic-engineering bgp-igp-both-ribs;
 {% for l in interfaces if ('ldp' in l) and not l.ldp.passive %}
     interface {{ l.ifname }};
 {% endfor %}


### PR DESCRIPTION
Following @nmodena's advice, removing `bgp-igp-both-ribs` from default MPLS config.