### PR TITLE
SR-OS: Set correct port mode for all VLAN combinations

### DIFF
--- a/netsim/ansible/templates/initial/sros.j2
+++ b/netsim/ansible/templates/initial/sros.j2
@@ -152,12 +152,8 @@
 {%   if l.mtu is defined and '_use_ip_mtu' not in l %}
     mtu: {{ l.mtu + eth_header }} # max 9800
 {%   endif %}
-{%   if l.vlan.trunk_id is defined or (l.parent_ifindex is defined and interfaces[l.parent_ifindex-1].vlan.trunk_id is defined) %}
-    mode: hybrid # Support mixed trunks by using hybrid ports
-{%   elif not in_base %}
-    mode: access
-{%   else %}
-    mode: network
+{%   if l._port_mode is defined %}
+    mode: {{ l._port_mode }}
 {%   endif %}
 {%   if tagged %}
 {%    set portname = portname + ':' + vlan|string %}


### PR DESCRIPTION
A combination of SVI VLAN and routed VLAN on the same interface requires "hybrid" port mode due to the way routed VLAN interfaces are configured on SR-OS (they are in "router Base", not in IES service).

This commit moves the calculation of port mode into SR-OS device module, making it much easier to understand and debug than the attempts to reverse-engineer it in the Jinja2 template.