### PR TITLE
SR-OS multihop EBGP and EVPN EBGP-over-EBGP fixes

### DIFF
--- a/netsim/ansible/templates/evpn/sros.j2
+++ b/netsim/ansible/templates/evpn/sros.j2
@@ -6,10 +6,25 @@ updates:
       rapid-withdrawal: True
       rapid-update:
         evpn: True
-{% if 'ebgp' in evpn.session %}
+{#
+    OK, here's how the following Jinja2 line noise works:
+
+    * Take BGP neighbors, default to empty list just in case * Select all BGP
+      neighbors where 'evpn' attribute is defined indicating we want to run EVPN
+      AF with this neighbor (note: the only value we'll ever see is 'evpn: true')
+    * Select neighbor type (ibgp/ebgp) from neighbors with EVPN AF
+    * We might have multiple neighbors with the same type, so apply the 'unique'
+      filter to the results
+
+    And voila, we have the BGP session types on which we want to run EVPN
+
+    Note we can't use evpn.session -- it's not set for EBGP multihop neighbors
+#}
+{% set evpn_session_types = bgp.neighbors|default([])|selectattr('evpn','defined')|map(attribute='type')|unique %}
+{% if 'ebgp' in evpn_session_types %}
       inter-as-vpn: true
 {% endif %}
-{% for type in evpn.session %}
+{% for type in evpn_session_types %}
 {%   if loop.first %}
       group:
 {%   endif %}

--- a/netsim/extra/ebgp.multihop/defaults.yml
+++ b/netsim/extra/ebgp.multihop/defaults.yml
@@ -37,7 +37,7 @@ devices:
   srlinux.features.bgp:
     multihop: True
   sros.features.bgp:
-    multihop: True
+    multihop.vrf: True
 
 bgp:
   attributes:

--- a/netsim/extra/ebgp.multihop/sros.j2
+++ b/netsim/extra/ebgp.multihop/sros.j2
@@ -1,26 +1,25 @@
 {% macro ebgp_session(n,af,vrf) -%}
-{%   if n.multihop is defined %}
 {% set path = "router[router-name=Base]" if not vrf else "service/vprn[service-name="+vrf+"]" %}
 - path: configure/{{ path }}/bgp
   val:
-   neighbor:
-   - ip-address: {{ n[af]|ipaddr('address') }}
-     multihop: {{ n.multihop|int }}
-     local-address: "{{ loopback[af.replace('vpn','ip')]|ipaddr('address') }}"
-     description: "{{ n.name }} (multihop={{n.multihop|int}})"
-{%   endif %}
+    neighbor:
+    - ip-address: {{ n[af]|ipaddr('address') }}
+      multihop: {{ n.multihop|int }}
+      local-address: "{{ loopback[af.replace('vpn','ip')]|ipaddr('address') }}"
+      description: "{{ n.name }} (multihop={{n.multihop|int}})"
 {%- endmacro %}
 
-{% for af in ['ipv4','ipv6','vpnv4','vpnv6'] %}
-{%   for n in bgp.neighbors if n[af] is defined %}
-{{     ebgp_session(n,af,None) -}}
+updates:
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined and n.multihop is defined %}
+{{     ebgp_session(n,af,None) }}
 {%   endfor %}
 {% endfor %}
 
 {% if vrfs is defined %}
 {%   for vname,vdata in vrfs.items() if vdata.bgp is defined %}
-{%     for af in ['ipv4','ipv6','vpnv4','vpnv6'] %}
-{%       for n in bgp.neighbors if n[af] is defined %}
+{%     for af in ['ipv4','ipv6'] %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined %}
 {{         ebgp_session(n,af,vname) -}}
 {%       endfor %}
 {%     endfor %}


### PR DESCRIPTION
* Fix the EBGP multihop configuration template. Considering the necessary changes, it's sadly obvious that the previous template never encountered an actual device.
* Rewrite the EVPN BGP neighbor configuration template that used a suboptimal mechanism to identify BGP neighbor types using EVPN. BGP neighbor types with EVPN AF are now calculated from the bgp.neighbors data structure.