### PR TITLE
Import (redistribute) static routes into OSPF on EOS/FRR/IOS

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -72,6 +72,7 @@ The following table describes per-platform support of individual router-level OS
 
 **Notes:**
 * Dell OS10 does not support OSPF on the so-called *Virtual Network* interface, the VLAN implementation model currently used in our templates.
+* Use the `netlab show modules -m ospf` command to display the route types that can be imported into OSPFv2/OSPFv3.
 
 [^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
 

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -70,7 +70,7 @@ features:
     vpn: true
   ospf:
     unnumbered: true
-    import: [ bgp, isis, ripv2, connected, vrf ]
+    import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true
     password: true
     priority: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -92,7 +92,7 @@ features:
       ipv4: true
   ospf:
     unnumbered: true
-    import: [ bgp, ripv2, isis, connected, vrf ]
+    import: [ bgp, ripv2, isis, connected, static, vrf ]
     default: true
     password: true
     priority: true

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -55,7 +55,7 @@ features:
     6pe: true
   ospf:
     unnumbered: true
-    import: [ bgp, isis, ripv2, connected, vrf ]
+    import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true
     password: true
     priority: true

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -83,7 +83,7 @@ features:
     6pe: True
   ospf:
     unnumbered: True
-    import: [ bgp, isis, ripv2, connected, vrf ]
+    import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true
     password: true
     priority: true

--- a/tests/integration/ospf/ospfv2/10-import.yml
+++ b/tests/integration/ospf/ospfv2/10-import.yml
@@ -1,8 +1,12 @@
 ---
 message: |
-  This lab tests the simple import of BGP routes into OSPF.
+  This lab tests the simple import of BGP and (optionally) static routes into
+  OSPF.
 
 defaults.sources.extra: [ ../../wait_times.yml ]
+defaults.paths.prepend.plugin: [ "topology:../../plugin" ]
+plugin: [ static_import ]
+
 groups:
   probes:
     device: frr
@@ -11,9 +15,12 @@ groups:
 
 nodes:
   dut:
-    module: [ ospf, bgp ]
+    module: [ ospf, bgp, routing ]
+    routing.static:
+    - ipv4: 10.0.0.42/32
+      nexthop.node: x1
     bgp.as: 65000
-    ospf.import: [ bgp ]
+    ospf.import: [ bgp, static ]
   r2:
     module: [ ospf ]
   x1:
@@ -35,9 +42,13 @@ validate:
     wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
-  redist:
-    description: Check for redistributed X1 loopback on R2
+  p_bgp:
+    description: Check for redistributed BGP route (X1 loopback) on R2
     wait: ospf_import
     wait_msg: Waiting for routing protocols to do their magic
     nodes: [ r2 ]
     plugin: ospf_prefix(nodes.x1.loopback.ipv4)
+  p_static:
+    description: Check for redistributed static route on R2
+    nodes: [ r2 ]
+    plugin: ospf_prefix(nodes.dut.routing.static[0].ipv4)

--- a/tests/integration/ospf/ospfv3/10-import.yml
+++ b/tests/integration/ospf/ospfv3/10-import.yml
@@ -1,8 +1,11 @@
 ---
 message: |
-  This lab tests the simple import of IPv6 BGP routes into OSPFv3.
+  This lab tests the simple import of IPv6 BGP and (optionally) static routes
+  into OSPFv3.
 
 defaults.sources.extra: [ ../../wait_times.yml ]
+defaults.paths.prepend.plugin: [ "topology:../../plugin" ]
+plugin: [ static_import ]
 
 groups:
   probes:
@@ -12,9 +15,12 @@ groups:
 
 nodes:
   dut:
-    module: [ ospf, bgp ]
+    module: [ ospf, bgp, routing ]
+    routing.static:
+    - ipv6: 2001:db8::42/128
+      nexthop.node: x1
     bgp.as: 65000
-    ospf.import: [ bgp ]
+    ospf.import: [ bgp, static ]
   r2:
     module: [ ospf ]
   x1:
@@ -36,9 +42,13 @@ validate:
     wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
-  redist:
-    description: Check for redistributed X1 loopback on R2
+  p_bgp:
+    description: Check for redistributed BGP route (X1 loopback) on R2
     wait: ospf_import
     wait_msg: Waiting for routing protocols to do their magic
     nodes: [ r2 ]
     plugin: ospf6_prefix(nodes.x1.loopback.ipv6)
+  p_static:
+    description: Check for redistributed static route on R2
+    nodes: [ r2 ]
+    plugin: ospf6_prefix(nodes.dut.routing.static[0].ipv6)

--- a/tests/integration/plugin/static_import/plugin.py
+++ b/tests/integration/plugin/static_import/plugin.py
@@ -1,0 +1,74 @@
+#
+# Check whether the device under test supports VRFs and removes
+# VRF links and related tests if needed
+#
+
+import typing
+from box import Box
+from netsim.augment.devices import get_device_features
+from netsim.utils import log
+from netsim.data import get_box
+
+def remove_validation(topology: Box, warning: str) -> None:
+  for tname,tdata in get_box(topology.validate).items():
+    if 'static' in tname:
+      log.info(f'Removing validation test {tname}')
+      topology.validate.pop(tname,None)
+
+  topology.validate.r_warning = {
+    'wait': 0,
+    'level': 'warning',
+    'fail': warning }
+
+def is_static_import(attr: typing.Any) -> bool:
+  if not isinstance(attr,Box):                        # Current node attribute is not a box, move on
+    return False
+  if 'import' not in attr:                            # ... or it does not have 'import' key
+    return False
+  if not isinstance(attr['import'],Box):              # ... or the 'import' key is not a dictionary
+    return False
+  
+  return 'static' in attr['import']                   # ... We have imports, check whether we're importing static
+
+def remove_routing(ndata: Box, topology: Box, warning: str) -> None:
+  if 'routing' in ndata:
+    log.info(f'Removing routing from node {ndata.name} modules')
+    ndata.module.remove('routing')
+    ndata.pop('routing',None)
+
+  for n_attr,n_data in ndata.items():                 # Now remove all mentions of static route imports
+    if not is_static_import(n_data):
+      continue
+    n_data['import'].pop('static',None)
+    log.info(f'Removing import of static routes from {n_attr}')
+
+  remove_validation(topology,warning)
+
+def check_static_import(ndata: Box, features: Box, topology: Box) -> None:
+  for n_attr,n_data in ndata.items():                 # Check for static route imports
+    if not is_static_import(n_data):
+      continue
+    if 'static' in features[n_attr]['import']:
+      continue
+    msg = f'Device {ndata.device}/{ndata.name} does not support import of static routes into {n_attr}'
+    n_data['import'].pop('static',None)
+    log.warning(
+      text=msg,
+      module='routing_check')
+
+    remove_validation(topology,msg)
+
+def pre_transform(topology: Box) -> None:
+  for node,ndata in topology.nodes.items():
+    if 'routing' not in ndata.get('module',[]):
+      continue
+
+    features = get_device_features(ndata,topology.defaults)
+    if not features.get('routing.static',None):
+      msg = f'Device {ndata.device}/{node} does not support static routes'
+      log.warning(
+        text=msg,
+        module='routing_check')
+      remove_routing(ndata,topology,msg)
+    else:
+      check_static_import(ndata,features,topology)

--- a/tests/integration/plugin/static_import/plugin.py
+++ b/tests/integration/plugin/static_import/plugin.py
@@ -1,7 +1,14 @@
-#
-# Check whether the device under test supports VRFs and removes
-# VRF links and related tests if needed
-#
+"""
+Check whether the device under test supports static routing and import of static
+routes into the routing protocol(s) configured on the device.
+
+If the device under test (the node using 'routing' module) does not support
+these features:
+
+* Removes 'routing' module and 'routing' attribute from the node
+* Removes 'static' from routing protocol imports
+* Adds a warning to the validation tests
+"""
 
 import typing
 from box import Box


### PR DESCRIPTION
The existing configuration templates work, the only change is the extra keyword in the 'ospf.import' feature flag.

The main modifications of this PR are the changes to the integration tests that use a new 'static_import' plugin to adjust the test based on whether the DUT supports static routes and redistribution of static routes into OSPF.