### PR TITLE
fortios - mtu and docs

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -279,6 +279,14 @@ diag debug application httpsd -1
 * We're not testing Fortinet implementation as part of the regular integration tests; the configuration scripts might be outdated. If you encounter a problem, please open an issue.
 ```
 
+## Fortinet FortiOS 7.4.x/7.6.x
+
+* Starting from FortiOS 7.2, FortiGate devices do not come with a license out of the box. Users can link *one* device with a permanent evaluation license to an account on the Fortinet support portal.
+* The license needs to be added before creating the Vagrant box.
+* There are restrictions associated with the evaluation license, including a maximum of three interfaces, firewall policies, and routes... For more detailed information, refer to the [evaluation license restrictions](https://docs.fortinet.com/document/fortigate/7.6.3/administration-guide/441460).
+* The license is linked to the serial number of the device and the UUID. To ensure that the serial number remains consistent each time you start the lab, set the `libvirt.uuid` node parameter to the appropriate value.
+* MTU can be defined on the interface level, default is forced to 1500 bytes due to a different behaviour between `7.4.8` and `7.6.3` releases.
+
 ### OSPF Caveats
 
 * Fortinet implementation of OSPF configuration module does not implement per-interface OSPF areas. All interfaces belong to the OSPF area defined in the node data.

--- a/docs/labs/fortios.md
+++ b/docs/labs/fortios.md
@@ -9,7 +9,10 @@ FortiOS (FortiGate) is supported by the **netlab libvirt package** command. To b
 * Execute **netlab libvirt package fortios _qcow-file-name_** and follow the instructions
 
 ```{warning}
-* _netlab_ supports FortiGate devices that use username/password to authenticate API calls. The last software releases known to work are 7.0.x and 7.2.0.
+* _netlab_ supports FortiGate devices that use username/password to authenticate API calls.
+* Before `7.2.0`, the FortiGate VM included a 15 day evaluation license. The vagrant box would need to be recreated 15 days after the initial build to continue using it.
+* Starting with `7.2.0`, you can use a permanent evaluation license, linked to your FortiGate Support Portal account.
+* Limitations of the evaluation license can be found in the [FortiGate documentation](https://docs.fortinet.com/document/fortigate/7.6.3/administration-guide/441460).
 * If you're using a *‌netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -84,7 +84,7 @@ These documents contain box-building recipes using the **netlab libvirt** utilit
 * [Cisco Nexus OS](nxos.md)
 * [Cumulus Linux 5.x](cumulus_nvue.md)
 * [Dell OS10](dellos10.md) by [Stefano Sasso](http://stefano.dscnet.org)
-* [Fortinet FortiOS](fortios.md) (based on the [work](https://blog.petecrocker.com/post/fortinet_vagrant_libvirt/) by [Pete Crocker](https://blog.petecrocker.com/about/))
+* [Fortinet FortiOS](fortios.md) - instructions based on the [work](https://blog.petecrocker.com/post/fortinet_vagrant_libvirt/) by [Pete Crocker](https://blog.petecrocker.com/about/) for 6.x/7.0 and updated for 7.4/7.6 in this [blog post](https://noodleops.space/2025-06/add-a-fortigate-in-your-virtual-lab-from-qcow-to-netlab-by-creating-a-vagrant-box/) by [Seb d'Argoeuves](https://noodlesops.space/about/).
 * [Juniper vPTX](vptx.md)
 * [Juniper vSRX 3.0](vsrx.md)
 * [Mikrotik RouterOS 7](routeros7.md) - based on the original [Mikrotik RouterOS](http://stefano.dscnet.org/a/mikrotik_vagrant/) by [Stefano Sasso](http://stefano.dscnet.org)

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -220,7 +220,7 @@ The following interface parameters are configured on supported network operating
 | Cumulus Linux         | ✅  | ✅  | ✅  | ✅  |
 | Cumulus Linux 5.x (NVUE) | ✅ | ❌ | ✅  | ✅  |
 | Dell OS10             | ✅  |  ❌  | ✅  | ✅  |
-| Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
+| Fortinet FortiOS      | ✅  | ✅  |  ✅[❗](caveats-fortios)  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
 | Generic Linux         |  ❌  |  ❌  | ✅  |  ❌  |
 | Junos[^Junos]         | ✅  | ✅  | ✅  |  ❌  |

--- a/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
+++ b/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
@@ -54,6 +54,8 @@
       lldp_reception: "enable"
       lldp_transmission: "enable"
       mode: "static"
+      mtu: "{{ interface.mtu | default(1500) }}"
+      mtu_override: "enable"
       name: "{{ interface.ifname }}"
       macaddr: "52:dc:ca:fe:{{ id }}:{{ interface.ifindex }}"
       type: "physical"

--- a/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
+++ b/netsim/ansible/tasks/fortinet.fortios.fortios/initial.yml
@@ -54,7 +54,7 @@
       lldp_reception: "enable"
       lldp_transmission: "enable"
       mode: "static"
-      mtu: "{{ interface.mtu | default(1500) }}"
+      mtu: "{{ interface.mtu | default(mtu) }}"
       mtu_override: "enable"
       name: "{{ interface.ifname }}"
       macaddr: "52:dc:ca:fe:{{ id }}:{{ interface.ifindex }}"

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -2,6 +2,7 @@ description: Fortinet FortiOS firewall
 interface_name: port{ifindex}
 loopback_interface_name: loopback{ifindex}
 mgmt_if: port1
+mtu: 1500
 ifindex_offset: 2
 libvirt:
   image: fortinet/fortios


### PR DESCRIPTION
After playing with the FortiGate, I've successfully reproduced the creation of the Vagrant box using the current latest versions (`7.4.8` and `7.6.3`)
I have noticed a weird thing, on `7.4.8`, the MTU on the link between the fw and the device in front, was set to 9500, but it is 1500 on the `7.6.3`. I've only noticed when realising OSPF was configured but not established.

I've added a small fix for this in the yml file, so the MTU will be defaulted to 1500 on `fortios`, unless set in the interface parameter (not in node).

This is the PR I've created, with some documentation updates (caveats and platforms). Please let me know if I haven't followed the PR process correctly, or anything else I may have done incorrectly, I'm still trying to figure out how to correctly work with fork...

I have also documented the whole process to add a fortigate to *netlab* [here](https://noodleops.space/2025-06/add-a-fortigate-in-your-virtual-lab-from-qcow-to-netlab-by-creating-a-vagrant-box/)