### PR TITLE
bird: Configure static routes using 'protocol static'

### DIFF
--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -6,6 +6,7 @@ daemon_config:
   bird: /etc/bird/bird.conf
   bgp: /etc/bird/bgp.mod.conf
   ospf: /etc/bird/ospf.mod.conf
+  routing: /etc/bird/routing.mod.conf
 clab:
   group_vars:
     netlab_show_command: [ birdc, 'show $@' ]
@@ -38,6 +39,8 @@ features:
     priority: true
     timers: true
     unnumbered: true
+  routing:
+    static.discard: true
   dhcp: false
   initial:
     ipv4:

--- a/netsim/daemons/bird/routing.j2
+++ b/netsim/daemons/bird/routing.j2
@@ -1,0 +1,25 @@
+{# Static routes #}
+{% macro config_sr(sr_data,af) %}
+{%   set sr_intf = ' dev "'+sr_data.nexthop.intf+'"' if 'intf' in sr_data.nexthop else '' %}
+{%   set sr_intf = '' %}
+{%   set sr_nh = 'unreachable' if 'discard' in sr_data.nexthop else 'via ' + sr_data.nexthop[af] %}
+route {{ sr_data[af] }} {{ sr_nh }}{{ sr_intf }};
+{% endmacro -%}
+{% if routing.static|default([]) %}
+#
+# Global static routes
+#
+{% for sr_af in ['ipv4','ipv6'] %}
+{%   for sr_data in routing.static if sr_af in sr_data and 'vrf' not in sr_data %}
+{%     if loop.first %}
+protocol static {
+  {{ sr_af }};
+  check link;
+{%     endif %}
+  {{ config_sr(sr_data,sr_af) }}
+{%     if loop.last %}
+}
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+{% endif %}{# static routes #}

--- a/netsim/devices/_common.py
+++ b/netsim/devices/_common.py
@@ -7,6 +7,8 @@ from . import report_quirk
 
 def check_indirect_static_routes(node: Box) -> None:
   for sr_entry in node.get('routing.static',[]):
+    if 'discard' in sr_entry.nexthop:
+      continue
     if 'intf' not in sr_entry.nexthop:
       report_quirk(
         f'static routes with indirect next hops cannot be used (node {node.name})',


### PR DESCRIPTION
Bird used Linux static route configuration. That resulted in a working data plane, but those static routes were not redistributed into other routing protocols.

This fix uses 'protocol static' to configure static routes, resulting in correct static route redistribution.