### PR TITLE
SR Linux: OSPF areas support

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -436,6 +436,7 @@ See [](generic-linux-devices)
 * The SR Linux configuration templates do not support additional routing policies on routing protocol route imports
 * SR Linux needs a static default route (with low route preference) to implement OSPF **default-originate always** functionality.
 * SR Linux does not set metrics on routes imported into OSPF. While you can specify the metric and metric type of the OSPF default route, those settings have no impact.
+* SR Linux does not support setting a default metric for NSSA areas
 
 (caveats-sros)=
 ## Nokia SR OS

--- a/docs/plugins/ospf.areas.md
+++ b/docs/plugins/ospf.areas.md
@@ -15,6 +15,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Dell OS10    |✅|✅|✅ [❗](caveats-os10) |
 | FRR          |✅|✅|✅ [❗](caveats-frr) |
 | JunOS        |✅|✅|✅|
+| SR Linux     |✅|✅|✅ [❗](caveats-srlinux) |
 
 ## Specifying OSPF Area Parameters
 

--- a/netsim/extra/ospf.areas/defaults.yml
+++ b/netsim/extra/ospf.areas/defaults.yml
@@ -7,6 +7,7 @@ devices:
   frr.features.ospf.areas: True
   eos.features.ospf.areas: True
   junos.features.ospf.areas: True
+  srlinux.features.ospf.areas: True
   vjunos-switch:
     copy: junos
   vjunos-router:

--- a/netsim/extra/ospf.areas/srlinux.j2
+++ b/netsim/extra/ospf.areas/srlinux.j2
@@ -44,7 +44,7 @@ updates:
     protocols:
       ospf:
         instance:
-        - name: "{{ ospf.process|default(0) + (1 if af=='ipv6' else 0) }}"
+        - name: "{{ ospf.process|default(0) + (1 if af=='ipv6' and vrf=='default' else 0) }}"
 {%     for adata in odata.areas %}
 {%       if loop.first %}
           area:

--- a/netsim/extra/ospf.areas/srlinux.j2
+++ b/netsim/extra/ospf.areas/srlinux.j2
@@ -4,15 +4,17 @@ updates:
           - area-id: {{ adata.area }}
 {%   if adata.kind == 'stub' %}
             stub:
-              summaries: {{ not adata.inter_area }}
+              summaries: {{ adata.inter_area }}
 {%     if adata.default.cost is defined %}
               default-metric: {{ adata.default.cost }}
 {%     endif %}
 {%   elif adata.kind == 'nssa' %}
             nssa:
-              summaries: {{ not adata.inter_area }}
+              summaries: {{ adata.inter_area }}
+{# Note: 'default-metric' missing here, cannot set cost for NSSA area #}
 {%     if abr %}
-{%       if adata.default|default(false) %}
+{# Note: SR Linux won't automatically insert a default route when 'summaries' is False #}
+{%       if adata.default|default(not adata.inter_area) %}
               originate-default-route: { }
 {%       endif %}
 {%       for range in adata.external_range|default([])+adata.external_filter|default([]) if range[af] is defined %}

--- a/netsim/extra/ospf.areas/srlinux.j2
+++ b/netsim/extra/ospf.areas/srlinux.j2
@@ -1,0 +1,62 @@
+---
+updates:
+{% macro area_config(adata,af,abr) %}
+          - area-id: {{ adata.area }}
+{%   if adata.kind == 'stub' %}
+            stub:
+              summaries: {{ not adata.inter_area }}
+{%     if adata.default.cost is defined %}
+              default-metric: {{ adata.default.cost }}
+{%     endif %}
+{%   elif adata.kind == 'nssa' %}
+            nssa:
+              summaries: {{ not adata.inter_area }}
+{%     if abr %}
+{%       if adata.default|default(false) %}
+              originate-default-route: { }
+{%       endif %}
+{%       for range in adata.external_range|default([])+adata.external_filter|default([]) if range[af] is defined %}
+{%         if loop.first %}
+              area-range:
+{%         endif %}
+              - ip-prefix-mask: {{ range[af] }}
+                advertise: {{ range in adata.external_range|default([]) }}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{%   if abr %}
+{%     for range in adata.range|default([])+adata.filter|default([]) if range[af] is defined %}
+{%       if loop.first %}
+            area-range:
+{%       endif %}
+            - ip-prefix-mask: {{ range[af] }}
+              advertise: {{ range in adata.range|default([]) }}
+{%     endfor %}
+{%   endif %}
+{% endmacro %}
+
+{% macro ospf_area_config(odata,vrf='default') %}
+{%   for af in ['ipv4','ipv6'] if odata.af[af] is defined %}
+- path: /network-instance[name={{ vrf }}]
+  value:
+    protocols:
+      ospf:
+        instance:
+        - name: "{{ ospf.process|default(0) + (1 if af=='ipv6' else 0) }}"
+{%     for adata in odata.areas %}
+{%       if loop.first %}
+          area:
+{%       endif %}
+{{        area_config(adata,af,odata._abr|default(false)) -}}
+{%     endfor %}
+{%   endfor %}
+{% endmacro %}
+
+{% if ospf.areas is defined %}
+{{   ospf_area_config(ospf) }}
+{% endif %}
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() if vdata.ospf.areas is defined %}
+{{     ospf_area_config(vdata.ospf,vname) }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
Turns out SR Linux cannot configure a default metric for NSSA areas

Template mimics current OSPF instance naming, may need adjusting if #2370 is implemented