### PR TITLE
Update default iosv username/password for vrnetlab clab image

### DIFF
--- a/netsim/devices/iosv.yml
+++ b/netsim/devices/iosv.yml
@@ -19,8 +19,8 @@ features:
     max_mtu: 9600
 clab:
   group_vars:
-    ansible_ssh_pass: VR-netlab9
-    ansible_user: vrnetlab
+    ansible_ssh_pass: admin
+    ansible_user: admin
     netlab_check_retries: 50
   image: vrnetlab/cisco_vios:15.9.3
   node:


### PR DESCRIPTION
Defaults changed from 2024, now admin/admin

Fixes #2376