### PR TITLE
Cumulus NVUE: Implement static routing

### DIFF
--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -27,6 +27,7 @@ The following table describes high-level per-platform support of generic routing
 | Aruba AOS-CX       | ✅ | ✅ | ✅ | ✅ |
 | Cisco IOS/XE[^18v] | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux      | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Cumulus NVUE 5.x   | ❌  | ❌  | ❌  | ❌  | ✅ |
 | Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |

--- a/netsim/ansible/templates/routing/cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/cumulus_nvue.j2
@@ -1,0 +1,28 @@
+---
+{% if routing.static|default([]) %}
+{%   for sr_data in routing.static %}
+{%     for sr_af in ['ipv4','ipv6'] if sr_af in sr_data %}
+- set:
+    vrf:
+      {{ sr_data.vrf | default('default') }}:
+        router:
+          static:
+            {{ sr_data[sr_af] }}:
+              address-family: {{ sr_af }}-unicast
+              via:
+{%       if sr_data.nexthop.discard is defined %}
+                blackhole:
+                  type: blackhole
+{%       elif sr_data.nexthop.intf is defined %}
+                {{ sr_data.nexthop.intf }}:
+                  type: interface
+{%       else %}
+                {{ sr_data.nexthop[ sr_af ] }}:
+                  type: {{ sr_af }}-address
+{%         if sr_data.nexthop.vrf is defined %}
+                  vrf: {{ sr_data.nexthop.vrf }}
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}

--- a/netsim/ansible/templates/routing/cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/cumulus_nvue.j2
@@ -20,8 +20,13 @@
 {%           if sr_data.nexthop.vrf is defined %}
                   vrf: {{ sr_data.nexthop.vrf or 'default' }}
 {%           elif sr_data.nexthop.intf is defined %}
-                  interface:
+{%             set version = box.split(':')[1] %}
+{%             if version=='latest' or version > '5.10.0' %}
+                  interface: 
                     {{ sr_data.nexthop.intf }}: {}
+{%             else %}
+                  interface: {{ sr_data.nexthop.intf }}
+{%             endif %}
 {%           endif %}
 {%         elif sr_data.nexthop.intf is defined %}
                 {{ sr_data.nexthop.intf }}:

--- a/netsim/ansible/templates/routing/cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/cumulus_nvue.j2
@@ -13,14 +13,17 @@
 {%       if sr_data.nexthop.discard is defined %}
                 blackhole:
                   type: blackhole
-{%       elif sr_data.nexthop.intf is defined %}
+{%       else %}
+{%         if sr_data.nexthop.intf is defined %}
                 {{ sr_data.nexthop.intf }}:
                   type: interface
-{%       else %}
+{%         endif %}
+{%         if sr_af in sr_data.nexthop %}
                 {{ sr_data.nexthop[ sr_af ] }}:
                   type: {{ sr_af }}-address
-{%         if sr_data.nexthop.vrf is defined %}
+{%           if sr_data.nexthop.vrf is defined %}
                   vrf: {{ sr_data.nexthop.vrf }}
+{%           endif %}
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/netsim/ansible/templates/routing/cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/cumulus_nvue.j2
@@ -14,16 +14,19 @@
                 blackhole:
                   type: blackhole
 {%       else %}
-{%         if sr_data.nexthop.intf is defined %}
-                {{ sr_data.nexthop.intf }}:
-                  type: interface
-{%         endif %}
 {%         if sr_af in sr_data.nexthop %}
                 {{ sr_data.nexthop[ sr_af ] }}:
                   type: {{ sr_af }}-address
+{%           if sr_data.nexthop.intf is defined %}
+                  interface:
+                    {{ sr_data.nexthop.intf }}: {}
+{%           endif %}
 {%           if sr_data.nexthop.vrf is defined %}
                   vrf: {{ sr_data.nexthop.vrf }}
 {%           endif %}
+{%         elif sr_data.nexthop.intf is defined %}
+                {{ sr_data.nexthop.intf }}:
+                  type: interface
 {%         endif %}
 {%       endif %}
 {%     endfor %}

--- a/netsim/ansible/templates/routing/cumulus_nvue.j2
+++ b/netsim/ansible/templates/routing/cumulus_nvue.j2
@@ -17,12 +17,11 @@
 {%         if sr_af in sr_data.nexthop %}
                 {{ sr_data.nexthop[ sr_af ] }}:
                   type: {{ sr_af }}-address
-{%           if sr_data.nexthop.intf is defined %}
+{%           if sr_data.nexthop.vrf is defined %}
+                  vrf: {{ sr_data.nexthop.vrf or 'default' }}
+{%           elif sr_data.nexthop.intf is defined %}
                   interface:
                     {{ sr_data.nexthop.intf }}: {}
-{%           endif %}
-{%           if sr_data.nexthop.vrf is defined %}
-                  vrf: {{ sr_data.nexthop.vrf }}
 {%           endif %}
 {%         elif sr_data.nexthop.intf is defined %}
                 {{ sr_data.nexthop.intf }}:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -29,7 +29,7 @@ features:
       lla: True
   bgp:
     activate_af: True
-    import: [ connected, ospf, vrf ]
+    import: [ connected, ospf, static, vrf ]
     ipv6_lla: True
     rfc8950: true
     local_as: True
@@ -51,10 +51,15 @@ features:
         backup_ip: loopback.ipv4  # Use loopback.ipv4 as a backup IP address for peerlink
   ospf:
     default: True
-    import: [ bgp, connected, vrf ]
+    import: [ bgp, connected, static, vrf ]
     unnumbered: True
     timers: True
     priority: True
+  routing:
+    static:
+      vrf: True
+      inter_vrf: True
+      discard: True
   stp:
     supported_protocols: [ stp, rstp, pvrst ]  # PVRST requires release 5.6.0 or higher
     enable_per_port: True


### PR DESCRIPTION
Testing:
```
jeroen@j:~/Projects/netlab/tests/integration$ ./device-module-test -d cumulus_nvue -p libvirt --limit=*static routing
Pre-test cleanup: 
13:09:37 routing/20-static.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
13:11:43 routing/21-static-vrf.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
13:13:57 routing/22-static-inter-vrf.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
13:15:59 routing/23-static-indirect.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
13:18:13 routing/24-static-indirect-inter-vrf.yml: create(FAIL) 
13:18:14 routing/25-static-discard.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
```

24 fails due to lack of OSPFv3 support.

Also tested ```ospf/ospfv2/10-import.yml```, ```bgp/30-import-ds-ospf.yml``` fails due to OSPFv3