### PR TITLE
Add 'pool' attribute to VRF loopbacks

### DIFF
--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -109,17 +109,19 @@ You can also set these parameters to influence routing protocols within a VRF.
 (vrf-loopback)=
 ### Creating VRF Loopback Interfaces
 
-A loopback interface is created for a VRF whenever you set the **vrfs.*name*.loopback** or **vrf.loopback** global or node parameter.
+A loopback interface is created for a VRF whenever you set the **vrfs.*name*.loopback** or **vrf.loopback** global or node parameter. The global or node parameter is a boolean value that triggers (or turns off) the creation of loopbacks for all VRFs that do not have more specific loopback definitions.
 
-**loopback** parameter in a VRF definition could be:
+**loopback** parameter in a global- or node VRF definition could be:
 
 * A boolean value -- the address of the loopback interface will be allocated from the **vrf_loopback** address pool
-* A string specifying the IPv4 prefix of the loopback interface
+* A dictionary with the **pool** attribute to specify an alternate address pool
+
+**loopback** parameter in a node VRF definition can also be:
+
+* A string specifying the IPv4- or IPv6 prefix of the loopback interface (host bits are set to 1 for IPv4 prefixes larger than /32 or IPv6 prefixes larger than /128).
 * A dictionary of address families specifying IPv4 and/or IPv6 prefixes to be used on the loopback interface
 
-```{warning}
-The explicit IPv4/IPv6 loopback addresses can be used only in the node VRF definition, not in the global VRF definition.
-```
+To disable a VRF loopback, set the **loopback** parameter to *False* or *None* (no value).
 
 ### RD and RT Values
 

--- a/netsim/modules/vrf.yml
+++ b/netsim/modules/vrf.yml
@@ -10,7 +10,7 @@ attributes:
     loopback: bool
   node:
     as:
-    loopback:
+    loopback: bool
   link: id
   interface: id
   # Reserved VRF names
@@ -27,7 +27,11 @@ _top:                               # Modification of global defaults
       export: list
       id: { type: int, min_value: 1 }
       links: list
-      loopback:                     # Loopback is a mix of multiple formats, let the VRF module handle it
+      loopback:
+        ipv4: { type: ipv4, use: host_prefix }
+        ipv6: { type: ipv6, use: host_prefix }
+        pool: addr_pool
+        _alt_types: [ bool, prefix_str, NoneType ]
       _namespace: [ link ]          # VRFs can include link attributes
     global:
       vrfs:                         # vrfs is a valid global parameter

--- a/tests/errors/vrf-invalid-attr.log
+++ b/tests/errors/vrf-invalid-attr.log
@@ -3,6 +3,8 @@ IncorrectAttr in bgp: Invalid bgp vrf attribute 'as' found in topology.vrfs.red.
 IncorrectAttr in topology: Invalid vrf attribute 'wrong' found in topology.vrfs.red
 ... use 'netlab show attributes vrf' to display valid attributes
 IncorrectAttr in topology: topology.vrfs.red uses an attribute from module ospf which is not enabled in topology
+IncorrectAttr in topology: Incorrect vrf attribute 'x' in topology.vrfs.green.loopback
+IncorrectType in topology: attribute 'vrfs.yellow.loopback' must be a dictionary or any of a boolean, IPv4, IPv6, or named prefix, found str
 IncorrectAttr in bgp: Invalid bgp vrf attribute 'wrong' found in nodes.r1.vrfs.blue.bgp
 IncorrectAttr in nodes: nodes.r1.vrfs.blue uses an attribute from module ospf which is not enabled in nodes.r1
 IncorrectAttr in nodes: Invalid vrf attribute 'also_wrong' found in nodes.r1.vrfs.blue

--- a/tests/errors/vrf-invalid-attr.yml
+++ b/tests/errors/vrf-invalid-attr.yml
@@ -13,6 +13,10 @@ vrfs:
     bgp.as: 123
     wrong: True
     ospf.area: 17
+  green:
+    loopback.x: True
+  yellow:
+    loopback: 192.168.100.1/24
 
 nodes:
   r1:

--- a/tests/errors/vrf-loopback-global.log
+++ b/tests/errors/vrf-loopback-global.log
@@ -1,3 +1,3 @@
-IncorrectType in vrf: The "loopback" attribute in the global VRF "blue" must be a bool
-... You can specify specific IP address for a VRF loopback interface in the node VRF data
+IncorrectType in vrf: The "loopback" attribute in the global VRF "blue" cannot specify IPv4/IPv6 prefixes
+... Use pool attribute or specify specific IP address for a VRF loopback interface in the node VRF data
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting


### PR DESCRIPTION
Also:
* Deal with non-/32 IPv4 prefixes and /128 IPv6 prefixes
* Perform type validation on vrf.loopback attribute

Fixes #2382, fixes #2383, closes #2384, replaces #2387