### PR TITLE
Bugfix: Set 'linkindex' for VTEP loopback link

### DIFF
--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -40,6 +40,7 @@ def pre_link_transform(topology: Box) -> None:
           vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network_address)+"/32" } ]
           vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
           vtep_loopback.vxlan.vtep = True
+          vtep_loopback.linkindex = len(topology.links)+1
           topology.links.append(vtep_loopback)
 
       if log.debug_active('links'):                 # pragma: no cover (debugging)


### PR DESCRIPTION
Else a call to ```get_next_linkindex``` from ```vlan.create_loopback_vlan_links``` results in an error