### PR TITLE
Mlag vtep plugin enhancements

### DIFF
--- a/docs/plugins/mlag.vtep.md
+++ b/docs/plugins/mlag.vtep.md
@@ -33,7 +33,7 @@ nodes:
     lag.mlag.vtep: False
 ```
 
-The MLAG VTEP works for both static VXLAN and EVPN signalled topologies. IGP configuration is copied from the primary loopback interface.
+The MLAG VTEP works for both static VXLAN and EVPN signalled topologies. IGP configuration is automatically applied based on active modules.
 
 ## Customizing the Address Allocation Pool
 
@@ -41,7 +41,7 @@ By default, the plugin configures a "mlag_vtep" pool for `10.101.101.0/24` to al
 ```
 addressing.mlag_vtep.ipv4: 10.99.99.0/24
 ```
-The plugin will use the `loopback.pool` for the first node in the pair, if provided.
+The plugin will use the `loopback.pool` from the first node in the pair, if provided.
 
 ## Sample Topologies
 

--- a/docs/plugins/mlag.vtep.md
+++ b/docs/plugins/mlag.vtep.md
@@ -33,7 +33,7 @@ nodes:
     lag.mlag.vtep: False
 ```
 
-The MLAG VTEP works for both static VXLAN and EVPN signalled topologies.
+The MLAG VTEP works for both static VXLAN and EVPN signalled topologies. IGP configuration is copied from the primary loopback interface.
 
 ## Customizing the Address Allocation Pool
 
@@ -41,6 +41,7 @@ By default, the plugin configures a "mlag_vtep" pool for `10.101.101.0/24` to al
 ```
 addressing.mlag_vtep.ipv4: 10.99.99.0/24
 ```
+The plugin will use the `loopback.pool` for the first node in the pair, if provided.
 
 ## Sample Topologies
 

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -28,19 +28,38 @@ def pre_link_transform(topology: Box) -> None:
       continue                                      # Nope - carry on
 
     # Allocate a shared IP for both peers
-    vtep_a = addressing.get(topology.pools, [POOL_NAME, 'vrf_loopback'])['ipv4']
+    vtep_a = None
     peers = [ i.node for i in l.interfaces ]
     for node_name in peers:
       node = topology.nodes[ node_name ]
       if node.get('lag.mlag.vtep',None) is False:
         continue                                    # Skip nodes for which the plugin is disabled
       if 'vxlan' in node.module:
-          vtep_loopback = data.get_empty_box()
-          vtep_loopback.type = 'loopback'           # Assign same static IP to both nodes
-          vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network_address)+"/32" } ]
-          vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
-          vtep_loopback.vxlan.vtep = True
-          topology.links.append(vtep_loopback)
+        if not vtep_a:
+          pool = node.get('loopback.pool',POOL_NAME)
+          vtep_a = addressing.get(topology.pools, [pool, 'vrf_loopback'])['ipv4']
+        vtep_loopback = data.get_empty_box()
+        vtep_loopback.type = 'loopback'             # Assign same static IP to both nodes
+        vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network_address)+"/32" } ]
+        vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
+        vtep_loopback.vxlan.vtep = True
+        vtep_loopback.linkindex = len(topology.links)+1
+        topology.links.append(vtep_loopback)
 
       if log.debug_active('links'):                 # pragma: no cover (debugging)
         print(f'\nmlag.vtep Create VTEP loopback link for {node_name}: {vtep_loopback}')
+
+#
+# post_transform: Copy IGP configuration from primary loopbacks to VTEP loopbacks
+#
+def post_transform(topology: Box) -> None:
+  for node in topology.nodes.values():              # For each node
+    if not node.get('vxlan.vtep'):
+      continue
+    lb = node.get('loopback',{})
+    for intf in node.interfaces:
+      if intf.type != 'loopback' or not intf.get('vxlan.vtep'):
+        continue
+      for igp in ['isis','ospf','eigrp','ripv2']:   # Copy IGP from primary loopback
+        if igp in lb:
+          intf[igp] = lb[igp]

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -3,7 +3,7 @@
 #
 
 from netsim.utils import log
-from netsim.augment import addressing
+from netsim.augment import addressing, links
 from netsim import data
 from box import Box
 
@@ -40,10 +40,10 @@ def pre_link_transform(topology: Box) -> None:
           vtep_a = addressing.get(topology.pools, [pool, 'vrf_loopback'])['ipv4']
         vtep_loopback = data.get_empty_box()
         vtep_loopback.type = 'loopback'             # Assign same static IP to both nodes
-        vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a.network_address)+"/32" } ]
+        vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a) } ]
         vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
         vtep_loopback.vxlan.vtep = True
-        vtep_loopback.linkindex = len(topology.links)+1
+        vtep_loopback.linkindex = links.get_next_linkindex(topology)
         topology.links.append(vtep_loopback)
 
       if log.debug_active('links'):                 # pragma: no cover (debugging)

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -48,18 +48,3 @@ def pre_link_transform(topology: Box) -> None:
 
       if log.debug_active('links'):                 # pragma: no cover (debugging)
         print(f'\nmlag.vtep Create VTEP loopback link for {node_name}: {vtep_loopback}')
-
-#
-# post_transform: Copy IGP configuration from primary loopbacks to VTEP loopbacks
-#
-def post_transform(topology: Box) -> None:
-  for node in topology.nodes.values():              # For each node
-    if not node.get('vxlan.vtep'):
-      continue
-    lb = node.get('loopback',{})
-    for intf in node.interfaces:
-      if intf.type != 'loopback' or not intf.get('vxlan.vtep'):
-        continue
-      for igp in ['isis','ospf','eigrp','ripv2']:   # Copy IGP from primary loopback
-        if igp in lb:
-          intf[igp] = lb[igp]

--- a/tests/integration/mlag.vtep/01-vxlan-bridging.yml
+++ b/tests/integration/mlag.vtep/01-vxlan-bridging.yml
@@ -23,6 +23,12 @@ message: |
 defaults.sources.extra: [ ../wait_times.yml ]
 plugin: [ mlag.vtep ]
 
+addressing:
+  vtep_lb:
+    ipv4: 10.12.34.0/29  # Small to test for potential duplicate IPs
+    prefix: 32
+    allocation: sequential
+
 groups:
   _auto_create: True
   lag_hosts:
@@ -39,12 +45,19 @@ groups:
   switches:
     members: [ dut_a, dut_b ]
     module: [ vlan, vxlan, ospf, lag ]
+    loopback.pool: vtep_lb
 
   probes:
     members: [ xs ]
     module: [ vlan, vxlan, ospf ]
     device: frr
     provider: clab
+
+nodes:
+  dut_a:
+    id: 10
+  dut_b:
+    id: 20
 
 vlans:
   red:

--- a/tests/integration/mlag.vtep/01-vxlan-bridging.yml
+++ b/tests/integration/mlag.vtep/01-vxlan-bridging.yml
@@ -25,9 +25,8 @@ plugin: [ mlag.vtep ]
 
 addressing:
   vtep_lb:
-    ipv4: 10.12.34.0/29  # Small to test for potential duplicate IPs
+    ipv4: 10.12.34.0/24
     prefix: 32
-    allocation: sequential
 
 groups:
   _auto_create: True

--- a/tests/integration/mlag.vtep/01-vxlan-bridging.yml
+++ b/tests/integration/mlag.vtep/01-vxlan-bridging.yml
@@ -20,6 +20,7 @@ message: |
   Please note it might take a while for the lab to work due to STP learning
   phase and/or OSPF peering delays
 
+defaults.sources.extra: [ ../wait_times.yml ]
 plugin: [ mlag.vtep ]
 
 groups:
@@ -79,15 +80,21 @@ validate:
   adj_a:
     description: Check OSPF adjacency with DUT_A
     wait_msg: Waiting for OSPF adjacency process to complete
-    wait: 30
+    wait: ospfv2_adj_lan
     nodes: [ xs ]
     plugin: ospf_neighbor(nodes.dut_a.ospf.router_id)
   adj_b:
     description: Check OSPF adjacency with DUT_B
     wait_msg: Waiting for OSPF adjacency process to complete
-    wait: 30
+    wait: ospfv2_adj_lan
     nodes: [ xs ]
     plugin: ospf_neighbor(nodes.dut_b.ospf.router_id)
+  vtep_in_ospf:
+    description: Check that the MLAG VTEP IP is announced in OSPF
+    wait: ospfv2_spf
+    wait_msg: Waiting for DUT and SPF to do their magic
+    nodes: [ xs ]
+    plugin: ospf_prefix(nodes.dut_a.vxlan.vtep)
   ping_red:
     description: Ping-based reachability test in VLAN red
     nodes: [ rl, r1, r2 ]


### PR DESCRIPTION
* Set 'linkindex' on created stub link
* Adjust test to check that VTEP loopback gets advertised in OSPF
* Use `loopback.pool` if specified, to enable per-site loopback ranges