### PR TITLE
Fix EOS config reload

### DIFF
--- a/netsim/ansible/tasks/reload-config/eos.yml
+++ b/netsim/ansible/tasks/reload-config/eos.yml
@@ -1,3 +1,7 @@
+- name: Enable SCP
+  arista.eos.eos_config:
+    lines: aaa authorization exec default local
+
 - name: Copy replacement configuration to Arista EOS device
   include_tasks: _copy_config.yml
   vars:


### PR DESCRIPTION
Somehow the ability to do scp is no longer enabled by default

Fixes #2407