### PR TITLE
Set loopback IGP passive based on global default, if defined

### DIFF
--- a/netsim/modules/_routing.py
+++ b/netsim/modules/_routing.py
@@ -206,7 +206,8 @@ def add_loopback_igp(node: Box, proto: str, topology: Box) -> None:
   node.loopback[proto] = lb_data + node.loopback[proto]     # Merge device LB info with whatever is already on LB
                                                             # Note that an empty box is created on first reference
   if 'passive' not in node.loopback[proto]:                 # Finally, many templates expect 'passive' to be present
-    node.loopback[proto].passive = False                    # ... so add a bogus 'not passive' flag if needed
+    _passive = topology.get(f"{proto}.passive",False)       # Check the global default
+    node.loopback[proto].passive = _passive                 # ... and add a 'passive' flag if needed
 
 # Get a router ID prefix from the router_id pool
 #


### PR DESCRIPTION
Apply #1612 to loopback interfaces too

Plays a role in #2406 - the Cumulus quirk complains about inconsistent IGP settings on the different loopback interfaces