### PR TITLE
Fix inital configuration template for ios family - tunnel interfaces

### DIFF
--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -79,7 +79,11 @@ interface {{ l.ifname }}
 #}
 {% if 'ipv4' in l %}
 {%   if l.ipv4 == True %}
+{%     if l.type is defined and l.type == "tunnel" %}
+ ip unnumbered {{ l._parent_intf }}
+{%     else %}
  ip unnumbered {{ l._parent_intf }} poll
+{%     endif %}
 {%   elif l.ipv4|ipv4 %}
  ip address {{ l.ipv4|ipaddr('address') }} {{ l.ipv4|ipaddr('netmask') }}
 {%   else %}


### PR DESCRIPTION
Fix inital configuration template for ios family.
tunnel interfaces use "ip unnumbered..." on IOS XE, not not "ip unnumbered poll..".
Correct configuration was generated in both 03_unnumbered integration test, as well as a custom test using tunnel type interfaces.