### PR TITLE
BGP Confederation plugin (updated)

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -50,6 +50,7 @@ Even more BGP features are implemented in the following plugins:
 * [bgp.originate](../plugins/bgp.originate.md): creates loopback interfaces instead of static routes to originate additional IPv4 or IPv6 prefixes
 * [ebgp.multihop](../plugins/ebgp.multihop.md): implements multihop EBGP sessions.
 * [bgp.domain](../plugins/bgp.domain.md): allows you to build topologies that reuse the same BGP ASN in different network parts.
+* [bgp.confederation](../plugins/bgp.confederation.md): allows you to configure BGP confederations.
 
 (bgp-platform)=
 ## Platform Support

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,6 +13,7 @@
    plugins/bonding.md
    plugins/ebgp.multihop.md
    plugins/bgp.originate.md
+   plugins/bgp.confederation.md
    plugins/check.config.md
    plugins/fabric.md
    plugins/mlag.vtep.md

--- a/docs/plugins/bgp.confederation.md
+++ b/docs/plugins/bgp.confederation.md
@@ -1,0 +1,44 @@
+(plugin-bgp-confederation)=
+# BGP Confederation Plugin
+
+## Overview
+
+This plugin adds support for **BGP Confederations**, as defined in [RFC 5065](https://datatracker.ietf.org/doc/html/rfc5065), to the Netlab topology definition. BGP Confederations are a scalability hack—not a magic bullet. They split a single autonomous system (AS) into smaller internal sub-ASes, pretending to the outside world that it's still one single AS.
+
+Confederations are mainly useful in very large networks to:
+- Reduce IBGP full-mesh requirements
+- Limit BGP path visibility and state propagation
+- Maintain policy granularity inside large ASes
+
+They do *not* magically fix route convergence issues, nor are they a replacement for BGP route reflectors. Use with caution and only if you know exactly why you're deploying them.
+
+## Syntax
+
+Add the `bgp.confederation` plugin and definition in the topology file:
+
+```yaml
+---
+plugin: [ bgp.confederation ]       # Enable BGP Confederation plugin
+module: [ bgp ]                     # Load BGP module (required)
+
+# Define BGP Confederation
+bgp.confederation:
+  65000:                            # External-facing AS number
+    members: [ 65001, 65002 ]       # Internal confederation AS numbers
+```
+## Platform Support
+
+The plugin implements BGP confederation for these devices:
+
+| Operating system    | BGP Confederation |
+|---------------------|:-----------------:|
+| Arista EOS          |        ✅         |
+| Cumulus NVUE 5.x    |        ✅         |
+| Dell OS10           |        ✅         |
+| FRR                 |        ✅         |
+
+## New Attributes
+
+The plugin defines a new global attribute: 
+
+* **bgp.confederation** (dict) -- a mapping of external-facing AS numbers to internal members

--- a/docs/plugins/bgp.confederation.md
+++ b/docs/plugins/bgp.confederation.md
@@ -42,3 +42,6 @@ The plugin implements BGP confederation for these devices:
 The plugin defines a new global attribute: 
 
 * **bgp.confederation** (dict) -- a mapping of external-facing AS numbers to internal members
+
+Internally, the plugin adds a new type of BGP session **confed_ebgp** to account for the fact that federated AS peers are more like iBGP peers than eBGP (e.g., they typically exchange extended communities).
+**bgp.sessions** settings for such peers are inherited from **ibgp** (and currently cannot be controlled separately)

--- a/netsim/extra/bgp.confederation/cumulus_nvue.j2
+++ b/netsim/extra/bgp.confederation/cumulus_nvue.j2
@@ -6,4 +6,6 @@
            !
            router bgp {{ bgp.as }}
              bgp confederation identifier {{ bgp.confederation.as }}
+{% if bgp.confederation.peers %}
              bgp confederation peers {{ bgp.confederation.peers|join(' ') }}
+{% endif %}

--- a/netsim/extra/bgp.confederation/cumulus_nvue.j2
+++ b/netsim/extra/bgp.confederation/cumulus_nvue.j2
@@ -1,0 +1,9 @@
+- set:
+    system:
+      config:
+        snippet:
+          frr.conf: |
+           !
+           router bgp {{ bgp.as }}
+             bgp confederation identifier {{ bgp.confederation.as }}
+             bgp confederation peers {{ bgp.confederation.peers|join(' ') }}

--- a/netsim/extra/bgp.confederation/defaults.yml
+++ b/netsim/extra/bgp.confederation/defaults.yml
@@ -17,5 +17,6 @@ bgp:
         _subtype: _confed_members
 
 devices:
+  cumulus_nvue.features.bgp.confederation: True
   eos.features.bgp.confederation: True
   frr.features.bgp.confederation: True

--- a/netsim/extra/bgp.confederation/defaults.yml
+++ b/netsim/extra/bgp.confederation/defaults.yml
@@ -17,4 +17,5 @@ bgp:
         _subtype: _confed_members
 
 devices:
+  eos.features.bgp.confederation: True
   frr.features.bgp.confederation: True

--- a/netsim/extra/bgp.confederation/defaults.yml
+++ b/netsim/extra/bgp.confederation/defaults.yml
@@ -1,0 +1,20 @@
+---
+bgp:
+  no_propagate:
+    confederation:
+  attributes:
+    _confed_members:
+      members:
+        type: list
+        _required: True
+        _subtype: asn
+        # Future: potential route maps, policies, settings etc. associated with the confederation
+
+    global:
+      confederation:
+        type: dict
+        _keytype: asn
+        _subtype: _confed_members
+
+devices:
+  frr.features.bgp.confederation: True

--- a/netsim/extra/bgp.confederation/defaults.yml
+++ b/netsim/extra/bgp.confederation/defaults.yml
@@ -18,5 +18,7 @@ bgp:
 
 devices:
   cumulus_nvue.features.bgp.confederation: True
+  dellos10.features.bgp.confederation: True
   eos.features.bgp.confederation: True
   frr.features.bgp.confederation: True
+  none.features.bgp.confederation: True

--- a/netsim/extra/bgp.confederation/dellos10.j2
+++ b/netsim/extra/bgp.confederation/dellos10.j2
@@ -1,4 +1,6 @@
 !
 router bgp {{ bgp.as }}
   confederation identifier {{ bgp.confederation.as }}
+{% if bgp.confederation.peers %}
   confederation peers {{ bgp.confederation.peers|join(' ') }}
+{% endif %}

--- a/netsim/extra/bgp.confederation/dellos10.j2
+++ b/netsim/extra/bgp.confederation/dellos10.j2
@@ -1,0 +1,4 @@
+!
+router bgp {{ bgp.as }}
+  confederation identifier {{ bgp.confederation.as }}
+  confederation peers {{ bgp.confederation.peers|join(' ') }}

--- a/netsim/extra/bgp.confederation/eos.j2
+++ b/netsim/extra/bgp.confederation/eos.j2
@@ -1,4 +1,6 @@
 !
 router bgp {{ bgp.as }}
   bgp confederation identifier {{ bgp.confederation.as }}
+{% if bgp.confederation.peers %}
   bgp confederation peers {{ bgp.confederation.peers|join(' ') }}
+{% endif %}

--- a/netsim/extra/bgp.confederation/eos.j2
+++ b/netsim/extra/bgp.confederation/eos.j2
@@ -1,0 +1,4 @@
+!
+router bgp {{ bgp.as }}
+  bgp confederation identifier {{ bgp.confederation.as }}
+  bgp confederation peers {{ bgp.confederation.peers|join(' ') }}

--- a/netsim/extra/bgp.confederation/frr.j2
+++ b/netsim/extra/bgp.confederation/frr.j2
@@ -1,4 +1,6 @@
 !
 router bgp {{ bgp.as }}
   bgp confederation identifier {{ bgp.confederation.as }}
+{% if bgp.confederation.peers %}
   bgp confederation peers {{ bgp.confederation.peers|join(' ') }}
+{% endif %}

--- a/netsim/extra/bgp.confederation/frr.j2
+++ b/netsim/extra/bgp.confederation/frr.j2
@@ -1,0 +1,4 @@
+!
+router bgp {{ bgp.as }}
+  bgp confederation identifier {{ bgp.confederation.as }}
+  bgp confederation peers {{ bgp.confederation.peers|join(' ') }}

--- a/netsim/extra/bgp.confederation/plugin.py
+++ b/netsim/extra/bgp.confederation/plugin.py
@@ -1,0 +1,35 @@
+import typing
+from box import Box
+from netsim import api
+from netsim.utils import log
+
+_config_name = 'bgp.confederation'
+_requires    = [ 'bgp' ]
+
+def post_transform(topology: Box) -> None:
+  global _config_name
+  confed = topology.get('bgp.confederation')
+  if not confed:
+    return
+  
+  for n, ndata in topology.nodes.items():
+    if 'bgp' not in ndata.module:                           # Skip nodes not running BGP
+      continue
+
+    bgp_as = ndata.get('bgp.as')
+    for casn,cdata in confed.items():
+      members = cdata.get('members',[])
+      if bgp_as in members:
+        ndata.bgp.confederation['as'] = casn
+        ndata.bgp.confederation.peers = [ m for m in members if m!=bgp_as ]
+        api.node_config(ndata,_config_name)                 # Remember that we have to do extra configuration
+
+        for nb in ndata.get('bgp.neighbors',[]):            # Update remote AS used by ebgp peers
+          neighbor = topology.nodes[ nb.name ]
+          for nb2 in neighbor.get('bgp.neighbors',[]):
+            if nb2.name == n and nb2.type=='ebgp':
+              nb2['as'] = casn
+
+        # TODO: Apply ibgp type community exchange, confed is really a new type of ebgp peer
+
+        break

--- a/netsim/extra/bgp.confederation/plugin.py
+++ b/netsim/extra/bgp.confederation/plugin.py
@@ -26,6 +26,8 @@ def post_transform(topology: Box) -> None:
 
         for nb in ndata.get('bgp.neighbors',[]):            # Update remote AS used by ebgp peers
           neighbor = topology.nodes[ nb.name ]
+          if neighbor.get('bgp.as') in members:             # Skip members of the same confederation
+            continue
           for nb2 in neighbor.get('bgp.neighbors',[]):
             if nb2.name == n and nb2.type=='ebgp':
               nb2['as'] = casn

--- a/netsim/extra/bgp.confederation/plugin.py
+++ b/netsim/extra/bgp.confederation/plugin.py
@@ -7,6 +7,18 @@ from netsim.augment import devices
 _config_name = 'bgp.confederation'
 _requires    = [ 'bgp' ]
 
+CONFED_EBGP = 'confed_ebgp'
+
+def init(topology: Box) -> None:
+  topology.defaults.attributes.bgp_session_type.valid_values[ CONFED_EBGP ] = None
+  topology.defaults.bgp.attributes._inherit_community[ CONFED_EBGP ] = 'ibgp'
+
+  for af in log.AF_LIST:
+    if CONFED_EBGP in topology.get(f'bgp.sessions.{af}',{}):
+      log.error( f"Cannot use {CONFED_EBGP} in bgp.sessions", category=Warning )
+    if CONFED_EBGP in topology.get(f'bgp.activate.{af}',{}):
+      log.error( f"Cannot use {CONFED_EBGP} in bgp.activate", category=Warning )
+
 def post_transform(topology: Box) -> None:
   global _config_name
   confed = topology.get('bgp.confederation')
@@ -33,13 +45,15 @@ def post_transform(topology: Box) -> None:
         api.node_config(ndata,_config_name)                 # Remember that we have to do extra configuration
 
         for nb in ndata.get('bgp.neighbors',[]):            # Update remote AS used by ebgp peers
+          if nb.type != 'ebgp':                             # Only applies to EBGP peers
+            continue
           neighbor = topology.nodes[ nb.name ]
           if neighbor.get('bgp.as') in members:             # Skip members of the same confederation
             continue
+          nb.type = CONFED_EBGP
           for nb2 in neighbor.get('bgp.neighbors',[]):
             if nb2.name == n and nb2.type=='ebgp':
               nb2['as'] = casn                              # Update peer to use the confederation AS instead
-
-        # TODO: Apply ibgp type community exchange, confed is really a new type of ebgp peer
+              # nb2.type = CONFED_EBGP                      # DO NOT update BGP session type - peer device may not support this plugin
 
         break

--- a/netsim/extra/bgp.confederation/plugin.py
+++ b/netsim/extra/bgp.confederation/plugin.py
@@ -15,9 +15,11 @@ def init(topology: Box) -> None:
 
   for af in log.AF_LIST:
     if CONFED_EBGP in topology.get(f'bgp.sessions.{af}',{}):
-      log.error( f"Cannot use {CONFED_EBGP} in bgp.sessions", category=Warning )
+      log.error( f"Cannot use {CONFED_EBGP} in bgp.sessions", category=Warning,
+                 more_hints=["Settings are inherited from the 'ibgp' key"] )
     if CONFED_EBGP in topology.get(f'bgp.activate.{af}',{}):
-      log.error( f"Cannot use {CONFED_EBGP} in bgp.activate", category=Warning )
+      log.error( f"Cannot use {CONFED_EBGP} in bgp.activate", category=Warning,
+                 more_hints=["Settings are inherited from the 'ibgp' key"] )
 
 def post_transform(topology: Box) -> None:
   global _config_name

--- a/tests/integration/bgp.confederation/01-baseline.yml
+++ b/tests/integration/bgp.confederation/01-baseline.yml
@@ -6,6 +6,9 @@ bgp.confederation:
   65000:
     members: [ 65001, 65002 ]
 
+bgp.sessions:
+  ipv4: [ ibgp, confed_ebgp, ebgp ]  # To test that the new session type is available
+
 groups:
   _auto_create: True
 

--- a/tests/integration/bgp.confederation/01-baseline.yml
+++ b/tests/integration/bgp.confederation/01-baseline.yml
@@ -1,0 +1,33 @@
+---
+plugin: [ bgp.confederation ]
+module: [ bgp ]
+
+bgp.confederation:
+  65000:
+    members: [ 65001, 65002 ]
+
+groups:
+  _auto_create: True
+
+  confed:
+    members: [ c1, c2 ]
+
+  ext:
+    members: [ e1 ]
+    device: frr
+    provider: clab
+
+nodes:
+  c1:
+    bgp.as: 65001
+  c2:
+    bgp.as: 65002
+    device: frr
+    provider: clab
+  e1:
+    bgp.as: 65003
+
+links:
+- c1-c2
+- c1-e1
+- c2-e1

--- a/tests/integration/bgp.confederation/01-baseline.yml
+++ b/tests/integration/bgp.confederation/01-baseline.yml
@@ -10,7 +10,7 @@ groups:
   _auto_create: True
 
   confed:
-    members: [ c1, c2 ]
+    members: [ c1, c2, c3 ]
 
   ext:
     members: [ e1 ]
@@ -24,6 +24,10 @@ nodes:
     bgp.as: 65002
     device: frr
     provider: clab
+  c3:
+    bgp.as: 65002 # Same as C2
+    device: frr
+    provider: clab
   e1:
     bgp.as: 65003
 
@@ -31,3 +35,4 @@ links:
 - c1-c2
 - c1-e1
 - c2-e1
+- c2-c3 # iBGP within same confederation

--- a/tests/integration/bgp.confederation/01-baseline.yml
+++ b/tests/integration/bgp.confederation/01-baseline.yml
@@ -10,7 +10,7 @@ groups:
   _auto_create: True
 
   confed:
-    members: [ c1, c2, c3 ]
+    members: [ dut, c2, c3 ]
 
   ext:
     members: [ e1 ]
@@ -18,21 +18,23 @@ groups:
     provider: clab
 
 nodes:
-  c1:
+  dut:
     bgp.as: 65001
+    module: [ bgp, ospf ]
   c2:
     bgp.as: 65002
     device: frr
     provider: clab
   c3:
-    bgp.as: 65002 # Same as C2
+    bgp.as: 65001 # Same as DUT
     device: frr
     provider: clab
+    module: [ bgp, ospf ]
   e1:
     bgp.as: 65003
 
 links:
-- c1-c2
-- c1-e1
+- dut-c2
+- dut-e1
 - c2-e1
-- c2-c3 # iBGP within same confederation
+- dut-c3 # iBGP within same confederation


### PR DESCRIPTION
Updated after #2462 

Currently issues a warning if the user tries to use ```confed_ebgp``` in bgp.sessions, as this does not achieve the expected result - instead, **ibgp** settings are inherited (note added to documentation)