### PR TITLE
Cumulus NVUE mlag vtep nexthop fixes

### DIFF
--- a/docs/plugins/mlag.vtep.md
+++ b/docs/plugins/mlag.vtep.md
@@ -33,7 +33,7 @@ nodes:
     lag.mlag.vtep: False
 ```
 
-The MLAG VTEP works for both static VXLAN and EVPN signalled topologies. IGP configuration is automatically applied based on active modules.
+The MLAG VTEP works for both static VXLAN and EVPN signalled topologies, using either IPv4 or IPv6 VTEPs. IGP configuration is automatically applied based on active modules.
 
 ## Customizing the Address Allocation Pool
 
@@ -43,13 +43,18 @@ addressing.mlag_vtep.ipv4: 10.99.99.0/24
 ```
 The plugin will use the `loopback.pool` from the first node in the pair, if provided.
 
+## EVPN next hop addressing for single-attached hosts
+
+Some platforms (e.g. Cumulus NVUE with FRR, EOS) support announcing the shared VTEP address for RT2 prefixes while using a unique VTEP loopback for RT5. This enables more optimal
+routing in case of single-attached hosts
+
 ## Sample Topologies
 
 The _netlab_ integration tests include anycast VTEP on an MLAG pair using VXLAN ingress replication and EVPN control plane. 
 
 Both lab topologies use:
 
-* VXLAN transport of bridged VLANs
+* VXLAN IPv4 transport of bridged VLANs
 * Linux hosts dual-attached to the MLAG pair
 * Single-attached (orphan) Linux hosts
 * OSPFv2 as the core routing protocol and IBGP as the EVPN control-plane protocol

--- a/docs/plugins/mlag.vtep.md
+++ b/docs/plugins/mlag.vtep.md
@@ -43,10 +43,10 @@ addressing.mlag_vtep.ipv4: 10.99.99.0/24
 ```
 The plugin will use the `loopback.pool` from the first node in the pair, if provided.
 
-## EVPN next hop addressing for single-attached hosts
+## Differentiated next hop addressing for EVPN RT2 and RT5 routes
 
-Some platforms (e.g. Cumulus NVUE with FRR, EOS) support announcing the shared VTEP address for RT2 prefixes while using a unique VTEP loopback for RT5. This enables more optimal
-routing in case of single-attached hosts
+Some platforms (e.g. Cumulus NVUE with FRR, EOS) support announcing the shared VTEP address for RT2 prefixes while using a unique VTEP loopback for RT5. This enables better MAC scale (half the number of routes) with more optimal
+routing (e.g. in case of single attached hosts) and ECMP (potentially utilizing the full combined bandwidth of all uplinks in parallel, depending on flow hashing)
 
 ## Sample Topologies
 

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -47,13 +47,13 @@
       enable: on
       # dad                    Duplicate Address Detection (DAD) configuration parameters
       # mac-vrf-soo            EVPN MAC VRF Site-of-Origin VPN extended community in ASN:NN or IP-ADDRESS:NN format.
-{% if vxlan._shared_vtep is defined %}
+{% if vxlan.shared_vtep is defined %}
       mac-vrf-soo: {{ vxlan.vtep }}:{{ interfaces|json_query('[*].lag.mlag.peergroup')|first }}
 {% endif %}
       # multihoming            Multihoming global configuration parameters
       # route-advertise        Route advertising
       route-advertise:
-        nexthop-setting: {{ 'shared-ip-mac' if vxlan._shared_vtep is defined else 'system-ip-mac' }}
+        nexthop-setting: system-ip-mac
         svi-ip: on
       # vni                    VNI
 

--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -47,7 +47,7 @@
       enable: on
       # dad                    Duplicate Address Detection (DAD) configuration parameters
       # mac-vrf-soo            EVPN MAC VRF Site-of-Origin VPN extended community in ASN:NN or IP-ADDRESS:NN format.
-{% if vxlan.shared_vtep is defined %}
+{% if vxlan._shared_vtep is defined %}
       mac-vrf-soo: {{ vxlan.vtep }}:{{ interfaces|json_query('[*].lag.mlag.peergroup')|first }}
 {% endif %}
       # multihoming            Multihoming global configuration parameters

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -31,6 +31,11 @@
       enable: on
       mac-address: {{ lag.mlag.mac | hwaddr('linux') }}
       peer-ip: {{ lag.mlag.peer }}
+
+- set:
+    system:
+      global:
+        anycast-id: {{ interfaces|map(attribute='lag.mlag.peergroup',default=0)|max + 256 }}
 {% endif %}
 
 {% for i in interfaces if i.type == 'lag' %}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -3,9 +3,9 @@
       vxlan:
         enable: on
         mac-learning: {{ 'on' if vxlan.flooding|default("") != "evpn" else 'off' }}
-{% if vxlan.shared_vtep is defined %}
+{% if vxlan._shared_vtep is defined %}
         mlag:
-          shared-address: {{ vxlan.shared_vtep }}
+          shared-address: {{ vxlan._shared_vtep }}
 {% endif %}
         source:
           address: {{ vxlan.vtep }}

--- a/netsim/ansible/templates/vxlan/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vxlan/cumulus_nvue.j2
@@ -3,9 +3,9 @@
       vxlan:
         enable: on
         mac-learning: {{ 'on' if vxlan.flooding|default("") != "evpn" else 'off' }}
-{% if vxlan._shared_vtep is defined %}
+{% if vxlan.shared_vtep is defined %}
         mlag:
-          shared-address: {{ vxlan.vtep }}
+          shared-address: {{ vxlan.shared_vtep }}
 {% endif %}
         source:
           address: {{ vxlan.vtep }}

--- a/netsim/devices/cumulus_nvue.py
+++ b/netsim/devices/cumulus_nvue.py
@@ -160,18 +160,6 @@ def nvue_mlag_vxlan_require_plugin(node: Box, topology: Box) -> None:
       more_data="Without this plugin, VXLAN interfaces will remain DOWN due to missing anycast IP",
       node=node)
 
-"""
-In case of shared MLAG VTEP, marks the VTEP such that the correct configuration can be applied
-"""
-def mark_shared_mlag_vtep(node: Box, topology: Box) -> None:
-  local_vtep = node.get('vxlan.vtep',None)
-  if not local_vtep:
-    return
-  for n in topology.nodes.values():
-    if n!=node and n.get('vxlan.vtep',None)==local_vtep:
-      node.vxlan._shared_vtep = n.name
-      return
-
 def nvue_check_nssa_summarize(node: Box) -> None:
   for (odata,_,_) in _rp_utils.rp_data(node,'ospf'):
     if 'areas' not in odata:
@@ -207,7 +195,7 @@ class Cumulus_Nvue(_Quirks):
 
     if 'vxlan' in mods and 'lag' in mods:
       nvue_mlag_vxlan_require_plugin(node,topology)
-      mark_shared_mlag_vtep(node,topology)
+
     if 'vlan' in mods:
       nvue_check_native_routed_on_mixed_trunk(node,topology)
 

--- a/netsim/extra/mlag.vtep/defaults.yml
+++ b/netsim/extra/mlag.vtep/defaults.yml
@@ -10,3 +10,9 @@ lag:
   attributes:
     node:
       mlag.vtep: bool              # Provide a way to selectively disable the plugin on nodes
+
+devices:
+  cumulus_nvue:
+    features.mlag_vtep.evpn.vtep_source_loopback: True
+  eos:
+    features.mlag_vtep.evpn.vtep_source_loopback: True

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -46,6 +46,7 @@ def pre_link_transform(topology: Box) -> None:
               f'Loopback pool {pool} does not provide an address for {af} to use as shared VTEP',
               log.MissingValue,
               _config_name)
+            return
         vtep_loopback = data.get_empty_box()
         vtep_loopback.type = 'loopback'              # Assign same static IP to both nodes
         vtep_loopback.interfaces = [ { 'node': node_name, af: str(vtep_a) } ]

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -28,7 +28,7 @@ def pre_link_transform(topology: Box) -> None:
       continue                                       # Nope - carry on
 
     # Allocate a shared IP for both peers
-    vtep_a = None
+    vtep_a : str = ""
     peers = [ i.node for i in l.interfaces ]
     for node_name in peers:
       node = topology.nodes[ node_name ]

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -2,8 +2,8 @@
 # Plugin to add a shared VTEP loopback to MLAG pairs that use VXLAN
 #
 
-from netsim.utils import log
-from netsim.augment import addressing, links
+from netsim.utils import log, routing as _rp_utils
+from netsim.augment import addressing, links, devices
 from netsim import data
 from box import Box
 
@@ -24,8 +24,8 @@ def pre_link_transform(topology: Box) -> None:
 
   # Find nodes that participate in MLAG and have VXLAN enabled, and add an extra VTEP loopback
   for l in list(topology.get('links',[])):
-    if not l.get('lag.mlag.peergroup'):             # Is this an MLAG peerlink?
-      continue                                      # Nope - carry on
+    if not l.get('lag.mlag.peergroup'):              # Is this an MLAG peerlink?
+      continue                                       # Nope - carry on
 
     # Allocate a shared IP for both peers
     vtep_a = None
@@ -33,19 +33,37 @@ def pre_link_transform(topology: Box) -> None:
     for node_name in peers:
       node = topology.nodes[ node_name ]
       if node.get('lag.mlag.vtep',None) is False:
-        continue                                    # Skip nodes for which the plugin is disabled
+        continue                                     # Skip nodes for which the plugin is disabled
       if 'vxlan' in node.module:
+        af = 'ipv6' if topology.get('vxlan.use_v6_vtep',False) else 'ipv4'
         if not vtep_a:
           pool = node.get('loopback.pool',POOL_NAME)
-          vtep_a = addressing.get(topology.pools, [pool, 'vrf_loopback'])['ipv4']
+          vtep_a = addressing.get(topology.pools, [pool, 'vrf_loopback'])[af]
         vtep_loopback = data.get_empty_box()
-        vtep_loopback.type = 'loopback'             # Assign same static IP to both nodes
-        vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a) } ]
-        vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
+        vtep_loopback.type = 'loopback'              # Assign same static IP to both nodes
+        vtep_loopback.interfaces = [ { 'node': node_name, af: str(vtep_a) } ]
+        vtep_loopback.name = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
         vtep_loopback.vxlan.vtep = True
-        vtep_loopback.vxlan.shared_vtep = True
         vtep_loopback.linkindex = links.get_next_linkindex(topology)
         topology.links.append(vtep_loopback)
+        node.vxlan._shared_vtep = str(vtep_a)
 
-      if log.debug_active('links'):                 # pragma: no cover (debugging)
+      if log.debug_active('links'):                  # pragma: no cover (debugging)
         print(f'\nmlag.vtep Create VTEP loopback link for {node_name}: {vtep_loopback}')
+
+"""
+After the VXLAN module sets the VTEP IP to the shared loopback in module_post_transform, revert the source address back
+to the individual loopback address (in case of EVPN, for nodes that support it)
+"""
+def post_transform(topology: Box) -> None:
+  for node,ndata in topology.nodes.items():
+    _shared_vtep = ndata.get('vxlan._shared_vtep')
+    if not _shared_vtep:
+      continue
+    if ndata.get('vxlan.flooding','static')!='evpn': # For static VXLAN, keep the shared address
+      continue
+    features = devices.get_device_features(ndata,topology.defaults)
+    if features.get('mlag_vtep.evpn.vtep_source_loopback'):
+      af = 'ipv6' if topology.get('vxlan.use_v6_vtep',False) else 'ipv4'
+      ndata.vxlan.vtep = _rp_utils.get_intf_address(ndata.loopback[af])
+      ndata.vxlan.vtep_interface = ndata.loopback.ifname

--- a/netsim/extra/mlag.vtep/plugin.py
+++ b/netsim/extra/mlag.vtep/plugin.py
@@ -43,6 +43,7 @@ def pre_link_transform(topology: Box) -> None:
         vtep_loopback.interfaces = [ { 'node': node_name, 'ipv4': str(vtep_a) } ]
         vtep_loopback._linkname = f"MLAG VTEP VXLAN interface shared between {' - '.join(peers)}"
         vtep_loopback.vxlan.vtep = True
+        vtep_loopback.vxlan.shared_vtep = True
         vtep_loopback.linkindex = links.get_next_linkindex(topology)
         topology.links.append(vtep_loopback)
 

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -95,7 +95,6 @@ def assign_vni(toponode: Box, obj_path: str, topology: Box) -> None:
 def node_set_vtep(node: Box, topology: Box) -> bool:
   # default vtep interface & interface name
   vtep_interface = node.loopback
-  shared_vtep = None
   loopback_name = devices.get_loopback_name(node,topology)
   if not loopback_name:
     log.fatal("Can't find the loopback name of VXLAN-capable device {node.device}",module="vxlan",header=True)
@@ -103,10 +102,6 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
   # Search for additional loopback interfaces with vxlan.vtep' flag, and use the first one
   for intf in node.interfaces:
     if intf.get('type', '') == 'loopback' and 'vxlan' in intf and intf.vxlan.get('vtep', False):
-      if intf.vxlan.get('shared_vtep'):
-        shared_vtep = intf
-        if node.get('vxlan.flooding','static')!='static':           # For static VXLAN, shared VTEP replaces both single ones
-          break
       vtep_interface = intf
       loopback_name = intf.ifname
       break
@@ -134,8 +129,6 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
   #
   node.vxlan.vtep = _rp_utils.get_intf_address(vtep_interface[vtep_af])
   node.vxlan.vtep_interface = loopback_name
-  if shared_vtep:
-    node.vxlan.shared_vtep = _rp_utils.get_intf_address(shared_vtep[vtep_af])
   return True
 
 #

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -105,9 +105,10 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
     if intf.get('type', '') == 'loopback' and 'vxlan' in intf and intf.vxlan.get('vtep', False):
       if intf.vxlan.get('shared_vtep'):
         shared_vtep = intf
-      else:
-        vtep_interface = intf
-        loopback_name = intf.ifname
+        if node.get('vxlan.flooding','static')!='static':           # For static VXLAN, shared VTEP replaces both single ones
+          break
+      vtep_interface = intf
+      loopback_name = intf.ifname
       break
 
   if topology.defaults.vxlan.use_v6_vtep:

--- a/tests/integration/mlag.vtep/03-evpn-vxlan-symm-irb.yml
+++ b/tests/integration/mlag.vtep/03-evpn-vxlan-symm-irb.yml
@@ -1,12 +1,13 @@
 ---
 message: |
   The devices under test are an MLAG pair of VLAN-to-VXLAN bridges providing two
-  access VLANs and two VXLAN VNIs using EVPN signalled VXLAN tunnels. Both VLANs are
-  using the same IP prefix to identify potential inter-VLAN leaking.
+  access VLANs and two VXLAN VNIs using EVPN signalled VXLAN tunnels. The VLANs use different
+  IP prefix to test inter-vlan routing, with symmetric IRB using RT5
 
   The pair uses the mlag.vtep plugin to provision an anycast MLAG VTEP across
   both, such that both devices are equivalent from the perspective of the 3rd
-  VTEP (FRR).
+  VTEP (FRR). However, for RT5 the DUT should use the specific local VTEP IP as nexthop, not
+  the shared IP (which can be suboptimal)
 
   The network uses BGP EVPN as the control plane for VXLAN
 
@@ -17,7 +18,7 @@ message: |
   * x2 -- an orphan host attached to dut_b
   * xr -- a host attached to remote VTEP
 
-  All hosts within a single VLAN should be able to ping each other.
+  All hosts within both VLANs should be able to ping each other.
 
   Please note it might take a while for the lab to work due to STP learning
   phase and/or OSPF peering delays
@@ -25,6 +26,12 @@ message: |
 plugin: [ mlag.vtep ]
 
 bgp.as: 65000
+
+gateway.protocol: anycast
+
+vrfs:
+  customer:
+    evpn.transit_vni: 5042
 
 groups:
   _auto_create: True
@@ -41,7 +48,7 @@ groups:
 
   switches:
     members: [ dut_a, dut_b ]
-    module: [ vlan, vxlan, ospf, lag, bgp, evpn ]
+    module: [ vlan, vxlan, ospf, lag, bgp, evpn, gateway, vrf ]
 
   probes:
     members: [ xs ]
@@ -51,14 +58,18 @@ groups:
 
 vlans:
   red:
-    mode: bridge
-    prefix:
-      ipv4: 172.31.1.0/24
+    mode: irb
+    role: external
+    vrf: customer
+    gateway: True
+    vni: 1000
     links: [ xs-rr, dut_a-r1, dut_b-r2 ]      # Single-connected hosts
   blue:
-    mode: bridge
-    prefix:
-      ipv4: 172.31.1.0/24
+    mode: irb
+    role: external
+    vrf: customer
+    gateway: True
+    vni: 1001
     links: [ xs-br, dut_a-b1, dut_b-b2 ]      # Single-connected hosts
 
 vxlan.vlans: [ red, blue ]
@@ -112,8 +123,23 @@ validate:
     description: Ping-based reachability test in VLAN blue
     nodes: [ bl, b1, b2 ]
     plugin: ping('br')
-  inter_vlan:
-    description: Ping-based reachability test between blue and red VLANs
-    nodes: [ rl ]
+  inter_vlan_bl:
+    description: Ping-based reachability test between blue and red VLANs bl
+    nodes: [ rl, r1, r2, rr ]
     devices: [ linux ]
-    plugin: ping('br',expect='fail')
+    plugin: ping('bl')
+  inter_vlan_b1:
+    description: Ping-based reachability test between blue and red VLANs b1
+    nodes: [ rl, r1, r2, rr ]
+    devices: [ linux ]
+    plugin: ping('b1')
+  inter_vlan_b2:
+    description: Ping-based reachability test between blue and red VLANs b2
+    nodes: [ rl, r1, r2, rr ]
+    devices: [ linux ]
+    plugin: ping('b2')
+  inter_vlan_br:
+    description: Ping-based reachability test between blue and red VLANs br
+    nodes: [ rl, r1, r2, rr ]
+    devices: [ linux ]
+    plugin: ping('br')


### PR DESCRIPTION
This PR adds a symmetric IRB routing test case for the mlag.vtep plugin; it illustrates a few issues with the Cumulus NVUE templates (e.g. compared to Arista cEOS)

```
Cumulus NVUE:

xs# show bgp l2vpn evpn route type 5
BGP table version is 4, local router ID is 10.0.0.11
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
                    Extended Community
Route Distinguisher: 65000:1
 *>i [5]:[0]:[24]:[172.16.0.0]
                    10.101.101.1(dut-a)
                                             0    100      0 ?
                    RT:65000:1 ET:8 Rmac:08:4f:c2:a9:09:07
 *=i [5]:[0]:[24]:[172.16.0.0]
                    10.101.101.1(dut-b)
                                             0    100      0 ?
                    RT:65000:1 ET:8 Rmac:08:4f:c2:a9:0a:07
 *>i [5]:[0]:[24]:[172.16.1.0]
                    10.101.101.1(dut-a)
                                             0    100      0 ?
                    RT:65000:1 ET:8 Rmac:08:4f:c2:a9:09:07
 *=i [5]:[0]:[24]:[172.16.1.0]
                    10.101.101.1(dut-b)
                                             0    100      0 ?
                    RT:65000:1 ET:8 Rmac:08:4f:c2:a9:0a:07

Displayed 2 prefixes (4 paths) (of requested type)


Arista:

xs# show bgp l2vpn evpn route type 5
BGP table version is 2, local router ID is 10.0.0.11
Status codes: s suppressed, d damped, h history, * valid, > best, i - internal
Origin codes: i - IGP, e - EGP, ? - incomplete
EVPN type-1 prefix: [1]:[EthTag]:[ESI]:[IPlen]:[VTEP-IP]:[Frag-id]
EVPN type-2 prefix: [2]:[EthTag]:[MAClen]:[MAC]:[IPlen]:[IP]
EVPN type-3 prefix: [3]:[EthTag]:[IPlen]:[OrigIP]
EVPN type-4 prefix: [4]:[ESI]:[IPlen]:[OrigIP]
EVPN type-5 prefix: [5]:[EthTag]:[IPlen]:[IP]

   Network          Next Hop            Metric LocPrf Weight Path
                    Extended Community
Route Distinguisher: 65000:1
 *>i [5]:[0]:[24]:[172.16.0.0]
                    10.0.0.9                      100      0 i
                    RT:65000:1 ET:8 Rmac:00:1c:73:cb:da:cb
 *=i [5]:[0]:[24]:[172.16.0.0]
                    10.0.0.10                     100      0 i
                    RT:65000:1 ET:8 Rmac:00:1c:73:05:1c:3a
 *>i [5]:[0]:[24]:[172.16.1.0]
                    10.0.0.9                      100      0 i
                    RT:65000:1 ET:8 Rmac:00:1c:73:cb:da:cb
 *=i [5]:[0]:[24]:[172.16.1.0]
                    10.0.0.10                     100      0 i
                    RT:65000:1 ET:8 Rmac:00:1c:73:05:1c:3a
```

cEOS correctly uses unique system IPs for RT5, while Cumulus uses the anycast IP (unintentionally). In either case the tests pass (i.e. they're not selective enough yet)

The issues are:
* Cumulus NVUE templates don't set the global anycast MAC (= separate from the MLAG MAC, it is used as nexthop in EVPN routes - set on each VRF L3 VNI interface as 'virtual-address')
* The mlag.vtep plugin overwrites the individual system VTEP IP with the shared anycast VTEP IP, while it is preferable to keep both (in case of EVPN)

I tried adding a test using the bgp_prefix plugin with ```nh``` etc. but didn't quite manage

Perhaps we could opt to merge the mlag.vtep plugin with the vxlan module, there are quite a few references to attributes created by the plugin in the vxlan templates resulting in tight coupling