### PR TITLE
Popos install support

### DIFF
--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -4,7 +4,8 @@ Ubuntu Packages Installation Script
 =====================================================================
 This script updates your system, installs additional APT packages,
 and nice-to-have tools like git, jq... The script was tested on Debian
-12 (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
+12 (bookworm) and Ubuntu 20.04, 22.04, and 24.04,
+as well as Pop!_OS 22.04 LTS.
 
 NOTE: the script is set to abort on first error. If the installation
 completed you're probably OK even though you might have seen errors
@@ -39,12 +40,17 @@ echo "Install missing packages (also a pretty long operation)"
 # linux-modules-extra-$(uname -r) should exist, but it won't if we're running
 # on a kernel that has been purged from the package server; in that case the
 # user will likely need to reboot.
-EXTRA=""
-if apt-cache show linux-modules-extra-$(uname -r) > /dev/null; then
-  EXTRA="linux-modules-extra-$(uname -r)"
+# Note: not all Ubuntu-based distributives might have this package available
+# or need it to be installed (e.g. Pop!_OS).
+EXTRA="linux-modules-extra-$(uname -r)"
+if [[ $EXTRA == $(apt-cache show $EXTRA | awk -F': ' '/^Package: /{print $2; }') ]]
+then
+  $SUDO apt-get -y $FLAG_APT install $EXTRA
+else
+  echo "SKIPPING package $EXTRA: package not available"
 fi
 # Added curl, which is not installed by default on Debian - ghostinthenet - 20220417
-$SUDO apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip curl $EXTRA
+$SUDO apt-get -y $FLAG_APT install python3 python3-setuptools ifupdown python3-pip curl
 echo "Install nice-to-have packages"
 $SUDO apt-get -y $FLAG_APT install git ack-grep jq tree sshpass colordiff
 #

--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -40,7 +40,7 @@ echo "Install missing packages (also a pretty long operation)"
 # linux-modules-extra-$(uname -r) should exist, but it won't if we're running
 # on a kernel that has been purged from the package server; in that case the
 # user will likely need to reboot.
-# Note: not all Ubuntu-based distributives might have this package available
+# Note: not all Ubuntu-based distributions might have this package available
 # or need it to be installed (e.g. Pop!_OS).
 EXTRA="linux-modules-extra-$(uname -r)"
 if [[ $EXTRA == $(apt-cache show $EXTRA | awk -F': ' '/^Package: /{print $2; }') ]]


### PR DESCRIPTION
The install scripts **ubuntu.sh** and **containerlab.sh** were modified to also allow installation on Pop!_OS. The modifications are minimal and supposedly do not break the logic of installing the required and nice-to-have packages on a vanilla Ubuntu system. After the modification, the installation procedure was tested thoroughly (but in "manual" mode) on virtual machines running Pop!_OS 22.04 as well as Ubuntu Server 22.04 LTS and 24.04 LTS. One hint unrelated to the script modifications — in general, it is best to perform the entire **netlab** installation from within Python **venv** on Ubuntu 22.04 or 24.04, because of the "scared Python" configuration in these distros.