### PR TITLE
Dell OS10 ebgp.multihop

### DIFF
--- a/docs/plugins/ebgp.multihop.md
+++ b/docs/plugins/ebgp.multihop.md
@@ -16,6 +16,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Cisco IOSv/IOS-XE[^18v] | ✅ | ✅ |
 | Cumulus Linux 4.x   |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ✅  |
+| Dell OS10           |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |
 | JunOS               |  ✅  |  ✅  |
 | Nokia SR Linux      |  ✅  |  ❌   |

--- a/docs/plugins/ebgp.multihop.md
+++ b/docs/plugins/ebgp.multihop.md
@@ -16,7 +16,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Cisco IOSv/IOS-XE[^18v] | ✅ | ✅ |
 | Cumulus Linux 4.x   |  ✅  |  ✅  |
 | Cumulus 5.x (NVUE)  |  ✅  |  ✅  |
-| Dell OS10           |  ✅  |  ✅  |
+| Dell OS10            |  ✅  |  ✅  |
 | FRR                 |  ✅  |  ✅  |
 | JunOS               |  ✅  |  ✅  |
 | Nokia SR Linux      |  ✅  |  ❌   |

--- a/netsim/extra/ebgp.multihop/defaults.yml
+++ b/netsim/extra/ebgp.multihop/defaults.yml
@@ -10,6 +10,8 @@ devices:
     copy: frr
   cumulus_nvue.features.bgp:
     multihop: True
+  dellos10.features.bgp:
+    multihop: True
   junos.features.bgp:
     multihop.vrf: True
   ios.features.bgp:

--- a/netsim/extra/ebgp.multihop/dellos10.j2
+++ b/netsim/extra/ebgp.multihop/dellos10.j2
@@ -26,3 +26,5 @@ router bgp {{ bgp.as }}
 {%     endfor %}
 {%   endfor %}
 {% endif %}
+
+do clear ip bgp *

--- a/netsim/extra/ebgp.multihop/dellos10.j2
+++ b/netsim/extra/ebgp.multihop/dellos10.j2
@@ -1,0 +1,28 @@
+{% macro ebgp_session(n,af) -%}
+  neighbor {{ n[af] }}
+{%   if n.multihop is defined %}
+    ebgp-multihop {{ n.multihop }}
+{%   endif %}
+{%   if n._source_intf is defined %}
+    update-source {{ n._source_intf.ifname }}
+{%   endif %}
+  exit
+{% endmacro %}
+!
+router bgp {{ bgp.as }}
+{% for af in ['ipv4','ipv6'] %}
+{%   for n in bgp.neighbors if n[af] is defined %}
+{{     ebgp_session(n,af) -}}
+{%   endfor %}
+{% endfor %}
+!
+{% if vrfs is defined %}
+{%   for vname,vdata in vrfs.items() %}
+  vrf {{ vname }}
+{%     for af in ('ipv4','ipv6') if af in vdata.af|default({}) %}
+{%       for n in vdata.bgp.neighbors if n[af] is defined %}
+{{         ebgp_session(n,af) -}}
+{%       endfor %}
+{%     endfor %}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
* Passes first ebgp.multihop test (second one uses OSPFv3 in VRF which Dell OS10 does not support)
* Enables evpn/14-vxlan-ebgp-ebgp