### PR TITLE
SR Linux: Mark ebgp.multihop inside VRFs as supported

### DIFF
--- a/netsim/extra/ebgp.multihop/defaults.yml
+++ b/netsim/extra/ebgp.multihop/defaults.yml
@@ -17,7 +17,7 @@ devices:
   arubacx.features.bgp:
     multihop.vrf: True
   srlinux.features.bgp:
-    multihop: True
+    multihop.vrf: True
   sros.features.bgp:
     multihop.vrf: True
 


### PR DESCRIPTION
Integration test passes