### PR TITLE
Enable iosvl2 under containerlab provider. 

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -104,7 +104,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | Cisco IOL          |  ❌ | ❌  |  ✅[❗](clab-vrnetlab) |
 | Cisco IOL L2       |  ❌ | ❌  |  ✅[❗](clab-vrnetlab) |
 | Cisco IOSv         | [✅](build-iosv)  | ✅  |  ✅[❗](clab-vrnetlab) |
-| Cisco IOSvL2       | [✅](build-iosvl2)|  ❌  |  ❌  |
+| Cisco IOSvL2       | [✅](build-iosvl2)|  ❌  | ✅[❗](clab-vrnetlab) |
 | Cisco IOS XRv      | [✅](build-iosxr) |  ❌  | ✅  |
 | Cisco Nexus 9300v  | [✅](build-nxos) | ✅  |  ✅[❗](clab-vrnetlab)  |
 | Cumulus Linux      | ✅  | ✅  | ✅[❗](caveats-cumulus) |

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -17,3 +17,14 @@ libvirt:
   image: cisco/iosvl2
   build: https://netlab.tools/labs/iosvl2/
   create_template: iosv.xml.j2
+clab:
+  group_vars:
+    ansible_ssh_pass: admin
+    ansible_user: admin
+    netlab_check_retries: 50
+  image: vrnetlab/cisco_viosl2:15.2.2020
+  node:
+    kind: linux
+  interface.name: eth{ifindex}
+  build: https://github.com/hellt/vrnetlab/tree/master/viosl2
+


### PR DESCRIPTION
Enable iosvl2 under containerlab provider. While at it, modify the provider by device matrix in documentation to reflect those changes. Default image is set to vrnetlab/iosvl2, tag 15.2.2020.

Hope this is not controversial ( didnt open an issue before to see if we want it,  but the deed is done)