### PR TITLE
Do not apply "isis network point-to-point" on virtual interfaces

### DIFF
--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -13,7 +13,7 @@ interface {{ l.ifname }}
 {%   if ('ipv6' in l or 'ipv6' in l.dhcp.client|default({})) and 'ipv6' in isis.af  %}
   ipv6 router isis {{ isis.instance }}
 {%   endif %}
-{%   if l.isis.network_type is defined %}
+{%   if l.isis.network_type is defined and l.virtual_interface is not defined  %}
   isis network {{ l.isis.network_type }}
 {%   endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}


### PR DESCRIPTION
Do not apply "isis network point-to-point" on virtual interfaces for ios.  Fixes #2448. 

