### PR TITLE
Fix: Configure EIGRP on unnumbered interfaces

### DIFF
--- a/netsim/ansible/templates/eigrp/ios.j2
+++ b/netsim/ansible/templates/eigrp/ios.j2
@@ -8,7 +8,7 @@ router eigrp {{ eigrp.as }}
 {% if eigrp.router_id|ipv4 %}
  eigrp router-id {{ eigrp.router_id }}
 {% endif %}
-{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv4' in l  %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv4' in l  and l.ipv4 is string %}
  network {{ l.ipv4|ipaddr('address') }} 0.0.0.0
 {% endfor %}
 {% for l in interfaces|default([]) if 'eigrp' in l and l.eigrp.passive %}
@@ -34,7 +34,7 @@ ipv6 router eigrp {{ eigrp.as }}
  passive-interface {{ l.ifname }}
 {% endfor %}
 !
-{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv6' in l and 'ipv6' in eigrp.af %}
+{% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv6' in l %}
 interface {{ l.ifname }}
  ipv6 eigrp {{ eigrp.as }}
 !


### PR DESCRIPTION
This fix results in a valid EIGRP configuration for an IOS device that has unnumbered interfaces. However, it looks like EIGRP does not work over unnumbered Ethernets anyway (it might over tunnels).

Closes #2440