### PR TITLE
More nuanced 'ipv4.unnumbered' feature test checks interface type

### DIFF
--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -36,7 +36,7 @@ features:
   eigrp: true
   initial:
     ipv4:
-      unnumbered: false
+      unnumbered: [ tunnel ]
     ipv6:
       lla: true
       use_ra: true

--- a/tests/errors/unnumbered-capability.log
+++ b/tests/errors/unnumbered-capability.log
@@ -1,10 +1,12 @@
-IncorrectValue in interfaces: Device none (node r1) does not support unnumbered IPv4 interfaces
-... Interface eth1 (link r1 -> [r2,r3,r4])
-IncorrectValue in interfaces: Device none (node r2) does not support unnumbered IPv4 interfaces
+IncorrectValue in interfaces: Invalid unnumbered IPv4 interface eth1 (r1 -> [r2,r3,r4]) on node r1 
+... Device none (node r1) does not support unnumbered IPv4 interfaces
+IncorrectValue in interfaces: Node r2 uses unsupported unnumbered IPv4 interface type lan
 ... Interface eth1 (link r2 -> [r1,r3,r4])
+... Device none supports only tunnel unnumbered IPv4 interfaces
 IncorrectValue in interfaces: Device none (node r2) does not support LLA-only IPv6 interfaces
+... Interface eth1 (link r2 -> [r1,r3,r4])
 IncorrectValue in interfaces: Device none (node r3) does not support LLA-only IPv6 interfaces
 ... Interface eth1 (link r3 -> [r1,r2,r4])
-MissingDependency in interfaces: Unnumbered interfaces on device none (node r4) require a single unnumbered IPv4 peer
-... Interface eth1 (link r4 -> [r1,r2,r3])
+IncorrectType in interfaces: The unnumbered IPv4 interface eth1 (r4 -> [r1,r2,r3]) on node r4 is not supported
+... Device none can have unnumbered IPv4 interfaces with a single unnumbered peer
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/unnumbered-capability.yml
+++ b/tests/errors/unnumbered-capability.yml
@@ -8,7 +8,7 @@ nodes:
   r1:
     _features.initial.ipv4.unnumbered: False
   r2:
-    _features.initial.ipv4.unnumbered: False
+    _features.initial.ipv4.unnumbered: [ tunnel ]
     _features.initial.ipv6.lla: False
   r3:
     _features.initial.ipv6.lla: False


### PR DESCRIPTION
Cisco IOSv supports unnumbered tunnel interfaces but not Ethernet interfaces. The 'unnumbered IPv4' feature check was modified to check the supported interface type(s) if the value of ipv4.unnumbered feature is a list.

Closes #2402