### PR TITLE
Fix: calculate BGP default values from valid values of BGP attributes

### DIFF
--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -31,7 +31,7 @@ def setup_bgp_constants(topology: Box) -> None:
 
   # Valid session types are reconstructed from the valid values of the bgp.sessions.ipv4 global attribute
   # We're assuming there's no difference between IPv4 and IPv6
-  BGP_VALID_SESSION_TYPE = [ v for v in topology.defaults.bgp.attributes['global'].sessions.ipv4 ]
+  BGP_VALID_SESSION_TYPE = [ v for v in topology.defaults.attributes.bgp_session_type.valid_values ]
 
   # We're assuming all address families are active on all session types
   for af in log.AF_LIST:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -37,6 +37,9 @@ attributes:
       _alt_types: [ str, BoxList ]
     replace_global_as: bool
 
+  _inherit_community:                 # This is a lookup table for rare session types so you don't
+    localas_ibgp: ibgp                # have to specify them in bgp.community attribute
+
   node:
     as:
       type: asn

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -15,6 +15,17 @@ no_propagate:
 transform_after: [ vlan ]
 config_after: [ routing, ospf, isis, eigrp, ripv2 ]
 next_hop_self: true
+
+_top:                         # Define custom data types used by the BGP module
+  attributes:
+    bgp_session_type:
+      _description: BGP session types
+      type: str
+      valid_values:           # Valid values are structured like a dict to allow plugins to add values
+        ibgp:
+        ebgp:
+        localas_ibgp:
+
 attributes:
   global:
     as: asn
@@ -24,11 +35,11 @@ attributes:
     ebgp_role: str
     as_list: dict
     sessions:
-      ipv4: [ ibgp, ebgp, localas_ibgp ]
-      ipv6: [ ibgp, ebgp, localas_ibgp ]
+      ipv4: { type: list, _subtype: bgp_session_type }
+      ipv6: { type: list, _subtype: bgp_session_type }
     activate:
-      ipv4: [ ibgp, ebgp, localas_ibgp ]
-      ipv6: [ ibgp, ebgp, localas_ibgp ]
+      ipv4: { type: list, _subtype: bgp_session_type }
+      ipv6: { type: list, _subtype: bgp_session_type }
     advertise_loopback: bool
     advertise_roles: list
     community:


### PR DESCRIPTION
Instead of having a hard-coded list of default session types (and similar), this change copies them from the valid values of global BGP attributes, making it possible for plugins to add new session types.