### PR TITLE
Force isis three-way-handshake to "ietf" mode for p2p links and tunnels

### DIFF
--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -16,6 +16,9 @@ interface {{ l.ifname }}
 {%   if l.isis.network_type is defined and l.type not in ['tunnel','loopback']  %}
   isis network {{ l.isis.network_type }}
 {%   endif %}
+{%   if l.type in ['tunnel','p2p']  %}
+  isis three-way-handshake ietf
+{%   endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
   isis metric {{ l.isis.metric|default(l.isis.cost) }}
 {%     if ('ipv6' in l or 'ipv6' in l.dhcp.client|default({})) and 'ipv6' in isis.af  %}


### PR DESCRIPTION
Force isis three-way-handshake to "ietf" mode for p2p links and tunnels across Cisco ios family (iosv is the only one which still defaults to "cisco" mode ).

Closes #2457 