### PR TITLE
Better way to disable KARL and make more space

### DIFF
--- a/netsim/install/libvirt/openbsd/user-data
+++ b/netsim/install/libvirt/openbsd/user-data
@@ -10,6 +10,6 @@ bootcmd:
 - echo "library_aslr=NO" >> /etc/rc.conf.local
 runcmd:
 - echo "library_aslr=NO" > /etc/rc.conf.local
-- rm -f /usr/libexec/reorder_kernel
-- rm -f /usr/share/relink/kernel/GENERIC.MP/newbsd*
+- rm -f /var/db/kernel.SHA256
+- rm -rf /usr/share/relink/kernel/GENERIC.MP
 - shutdown -p -h now


### PR DESCRIPTION
Disable kernel relinking (KARL, Kernel Address Randomized Link) by removing the checksum file instead of the relinking script.
Since disk space is very scarce with the current available VM image delete all the object files that would be used for kernel relinking and additional kernels in the same directory.