### PR TITLE
Sort 'netlab install' scripts in dependency order

### DIFF
--- a/netsim/install/install.yml
+++ b/netsim/install/install.yml
@@ -1,0 +1,18 @@
+scripts:
+  ubuntu:
+    description: Mandatory and nice-to have Debian/Ubuntu packages
+    uses: [ apt ]
+    distro: [ ubuntu, debian ]
+  libvirt:
+    description: QEMU, KVM, libvirt, and Vagrant
+    uses: [ apt ]
+    distro: [ ubuntu, debian ]
+  containerlab:
+    description: Docker and containerlab
+    distro: [ ubuntu, debian ]
+    uses: [ apt ]
+  ansible:
+    description: Ansible and prerequisite Python libraries
+    uses: [ pip ]
+  grpc:
+    description: GRPC libraries and Nokia GRPC Ansible collection

--- a/netsim/install/libvirt.sh
+++ b/netsim/install/libvirt.sh
@@ -78,17 +78,3 @@ if [[ -z "$G" ]]; then
   echo ".. You might need to log out and log in to start using netlab with libvirt"
   echo
 fi
-#echo "Create vagrant-libvirt virtual network"
-#set +e
-#NET_LIST=$($SUDO virsh net-list --all|grep vagrant-libvirt)
-#if [[ -n "$NET_LIST" ]]; then
-#  echo ".. removing existing vagrant-libvirt network"
-#  $SUDO virsh net-destroy vagrant-libvirt
-#  $SUDO virsh net-undefine vagrant-libvirt
-#fi
-#SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-#set -e
-#$SUDO virsh net-define "$SCRIPT_DIR/../templates/provider/libvirt/vagrant-libvirt.xml"
-#echo ".. vagrant-libvirt network created"
-#$SUDO virsh net-start vagrant-libvirt
-#$SUDO virsh net-autostart vagrant-libvirt


### PR DESCRIPTION
* Add a 'script configuration' file
* Use the 'scripts' keys from the configuration file to execute scripts in correct order
* Now that we have that file, display nice usage summary

Cleanup:
* Move the inline PIP/APT flag settings to a function
* Remove the ancient comments from libvirt.sh