### PR TITLE
Add eye candy to 'netlab install' command

### DIFF
--- a/docs/netlab/install.md
+++ b/docs/netlab/install.md
@@ -3,38 +3,56 @@
 
 **netlab install** uses internal installation scripts to install nice-to-have Ubuntu software, Ansible and related networking libraries, or libvirt+vagrant.
 
-The *ubuntu* and *libvirt* installation scripts run only on Ubuntu[^U20] and Debian[^D10]; the *ansible* installation script should run in any environment with **bash** and **pip3**.
+The *ubuntu*, *libvirt*, and *containerlab* installation scripts run only on Ubuntu[^U20] and Debian[^D10]; the *ansible* and *grpc* installation scripts should run in any environment with **bash** and **pip3**.
 
 ## Usage
 
 ```text
-usage: netlab install [-h] [-v] [-q] [-y] [-u][{ubuntu,containerlab,ansible,grpc,libvirt} ...]
+netlab install -h
+usage: netlab install [-h] [-v] [-q] [-y] [-u] [--all] [script ...]
 
 Install additional software
 
 positional arguments:
-  {ubuntu,containerlab,ansible,grpc,libvirt}
-                        Run the specified installation script
+  script         Run the specified installation script
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --verbose         Verbose logging
-  -q, --quiet           Be as quiet as possible
-  -y, --yes             Run the script without prompting for a confirmation
-  -u, --user            Install Python libraries into user .local directory
+options:
+  -h, --help     show this help message and exit
+  -v, --verbose  Verbose logging
+  -q, --quiet    Be as quiet as possible
+  -y, --yes      Run the script without prompting for a confirmation
+  -u, --user     Install Python libraries into user .local directory
+  --all          Run all installation scripts
+
+Run "netlab install" with no arguments to get install script descriptions
 ```
 
 ## Installation Scripts
 
 * The *ubuntu* script installs Python3 development components that might be needed for Ansible installation, common tools like **git** and **sshpass**, and XML libraries.
-* The *ansible* script uses **pip3** to install the latest version of Ansible, networking libraries (*netaddr, paramiko, netmiko*), text parsing libraries (*testfsm, ttp, ntc-templates*), and a few other utility libraries (*jmespath, yamllint, yq*)
 * The *libvirt* script installs *libvirt* and supporting libraries/packages, *vagrant*, *vagrant-libvirt* plugin, and creates the *vagrant-libvirt* virtual network.
 * The *containerlab* script installs Docker Engine and *containerlab*.
+* The *ansible* script uses **pip3** to install the latest version of Ansible, networking libraries (*netaddr, paramiko, netmiko*), text parsing libraries (*testfsm, ttp, ntc-templates*), and a few other utility libraries (*jmespath, yamllint, yq*)
 * The *grpc* installs gRPC Python libraries needed to configure Nokia SR Linux and Nokia SR OS.
 
-[^U20]: Tested on Ubuntu 20.04
+[^U20]: Tested on Ubuntu 20.04, 22.04, and 24.04
 
-[^D10]: Tested on Debian 10 and 11
+[^D10]: Tested on Debian 12 (bookworm)
+
+You can display an up-to-date list of installation scripts with **netlab install** command:
+
+```text
+$ netlab install
+┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Script       ┃ Installs                                          ┃
+┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ ubuntu       │ Mandatory and nice-to have Debian/Ubuntu packages │
+│ libvirt      │ QEMU, KVM, libvirt, and Vagrant                   │
+│ containerlab │ Docker and containerlab                           │
+│ ansible      │ Ansible and prerequisite Python libraries         │
+│ grpc         │ GRPC libraries and Nokia GRPC Ansible collection  │
+└──────────────┴───────────────────────────────────────────────────┘
+```
 
 (netlab-install-python)=
 ## Python Package Installation

--- a/netsim/install/ansible.sh
+++ b/netsim/install/ansible.sh
@@ -1,32 +1,4 @@
 #!/bin/bash
-cat <<EOM
-Ansible installation script
-=====================================================================
-This script installs Ansible and related Python3 packages required
-to run netlab Ansible playbooks. The script was tested on Ubuntu
-20.04, 22.04, and 24.04, and Debian 12 (bookworm), and should work
-on other Linux distributions as well.
-
-The script assumes that you already set up Python3 environment. If
-that's not the case, please run "netlab install ubuntu" first.
-
-NOTE: the script is set to abort on first error. If the installation
-completed you're probably OK even though you might have seen errors
-during the installation process.
-=====================================================================
-
-EOM
-
-if [[ -z "$FLAG_YES" ]]; then
-  # Remove implied default of Y - ghostinthenet 20220418
-  read -p "Are you sure you want to proceed [y/n] " -n 1 -r
-  echo
-  if ! [[ $REPLY =~ [Yy] ]]; then
-    echo "Aborting..."
-    exit 1
-  fi
-  FLAG_YES="Y"
-fi
 #
 set -e
 REPLACE="--upgrade"

--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -1,32 +1,7 @@
 #!/bin/bash
-
+#
 # Install a specific version of Containerlab
 CONTAINERLAB_VERSION="0.62.2"
-
-cat <<EOM
-Docker/Containerlab Installation Script
-=====================================================================
-This script installs Docker and containerlab on a Debian or Ubuntu
-system. The script was tested on Debian 12 (bookworm) and Ubuntu 20.04,
-22.04, and 24.04.
-
-NOTE: the script is set to abort on first error. If the installation
-completed you're probably OK even though you might have seen errors
-during the installation process.
-=====================================================================
-
-EOM
-
-if [[ -z "$FLAG_YES" ]]; then
-  # Remove implied default of Y - ghostinthenet 20220418
-  read -p "Are you sure you want to proceed [y/n]: " -n 1 -r
-  echo
-  if ! [[ $REPLY =~ [Yy] ]]; then
-   echo "Aborting..."
-   exit 1
-  fi
-  FLAG_YES="Y"
-fi
 #
 set -e
 REPLACE="--upgrade"
@@ -80,18 +55,4 @@ set -e
 if [[ -z "$G" ]]; then
   echo "Add user $USER to docker group"
   $SUDO usermod -a -G docker $USER
-  echo ".. You might need to log out and log in if you want to use Docker commands"
-  echo
 fi
-cat <<EOM
-
-=====================================================================
-Docker and Containerlab were successfully installed.
-
-To test the installation:
-
-* Log out
-* Log back in
-* Run 'netlab test clab'
-=====================================================================
-EOM

--- a/netsim/install/grpc.sh
+++ b/netsim/install/grpc.sh
@@ -1,35 +1,10 @@
 #!/bin/bash
-cat <<EOM
-Nokia GRPC installation script
-=====================================================================
-This script installs Nokia Ansible Galaxy GRPC plug-in and related
-Python3 packages. The script was tested on Ubuntu 22.04.
-
-The script assumes that you already set up Python3 environment. If
-that's not the case, please run "netlab install ubuntu" first.
-
-NOTE: the script is set to abort on first error. If the installation
-completed you're probably OK even though you might have seen errors
-during the installation process.
-=====================================================================
-
-EOM
+#
 set -e
 # Check dependencies
 if [[ ! `which ansible-galaxy` ]]; then
   echo "GRPC packages depend on Ansible (ansible-galaxy), aborting..."
   exit 1
-fi
-
-if [[ -z "$FLAG_YES" ]]; then
-  # Remove implied default of Y - ghostinthenet 20220418
-  read -p "Are you sure you want to proceed [y/n]: " -n 1 -r
-  echo
-  if ! [[ $REPLY =~ [Yy] ]]; then
-    echo "Aborting..."
-    exit 1
-  fi
-  FLAG_YES="Y"
 fi
 
 # Install Ansible grpc plug-in and its dependencies from github repo
@@ -43,13 +18,4 @@ $SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP 'ansible>=9.5.1'
 
 # grpc sources contain generated pb2 file which is not compatible with newer versions of protobuf
 $SUDO pip3 install $REPLACE $IGNORE $FLAG_PIP grpcio protobuf==3.20.1
-
-cat <<EOM
-=====================================================================
-GRPC plug-in and related Python libraries were installed.
-
-To test the installation, run 'netlab test grpc'
-=====================================================================
-EOM
-
 exit $?

--- a/netsim/install/install.yml
+++ b/netsim/install/install.yml
@@ -3,16 +3,63 @@ scripts:
     description: Mandatory and nice-to have Debian/Ubuntu packages
     uses: [ apt ]
     distro: [ ubuntu, debian ]
+    intro: |
+      This script updates your Ubuntu/Debian system, installs additional APT
+      packages, and nice-to-have tools like git, jq... The script was tested on
+      Debian 12 (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
+
   libvirt:
     description: QEMU, KVM, libvirt, and Vagrant
     uses: [ apt ]
     distro: [ ubuntu, debian ]
+    intro: |
+      This script installs QEMU, KVM, Libvirt, Vagrant, and vagrant-libvirt
+      plugin on a Ubuntu/Debian system. The script was tested on Debian 12
+      (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
+    epilog: |
+      * You might need to log out and log in to start using netlab with libvirt.
+      * Use 'netlab test libvirt' command to test your installation
+
   containerlab:
     description: Docker and containerlab
     distro: [ ubuntu, debian ]
     uses: [ apt ]
+    intro: |
+      This script installs Docker and containerlab on a Debian or Ubuntu
+      system. The script was tested on Debian 12 (bookworm) and Ubuntu 20.04,
+      22.04, and 24.04.
+    epilog: |
+      * Log out and back in to start using netlab with containerlab/Docker
+      * Use 'netlab test clab' command to test your installation
+
   ansible:
     description: Ansible and prerequisite Python libraries
     uses: [ pip ]
+    intro: |
+      This script installs Ansible and related Python3 packages required to run
+      netlab Ansible playbooks. The script was tested on Ubuntu 20.04, 22.04,
+      and 24.04, and Debian 12 (bookworm), and should work on other Linux
+      distributions as well.
+
+      The script assumes that you already set up Python3 environment. If that's
+      not the case, please run "netlab install ubuntu" first.
+
   grpc:
     description: GRPC libraries and Nokia GRPC Ansible collection
+    uses: [ pip ]
+    intro: |
+      This script installs Nokia Ansible Galaxy GRPC plug-in and related Python3
+      packages. The script was tested on Ubuntu 22.04 but should work on any
+      Linux system with Ansible and pip3.
+
+      The script assumes that you already set up Python3 environment and
+      installed Ansible. If that's not the case, please run "netlab install
+      ubuntu" or "netlab install ansible" first.
+    epilog:
+      To test the installation, run 'netlab test grpc'
+
+shared:
+  intro: |
+    The script is set to abort on first error. If the installation completes
+    you're probably OK even though you might have seen errors during the
+    installation process.

--- a/netsim/install/libvirt.sh
+++ b/netsim/install/libvirt.sh
@@ -1,28 +1,4 @@
 #!/bin/bash
-cat <<EOM
-Libvirt/Ubuntu Installation Script
-=====================================================================
-This script installs Libvirt, Vagrant, and vagrant-libvirt plugin
-on a Ubuntu system. The script was tested on Debian 12 (bookworm) and
-Ubuntu 20.04, 22.04, and 24.04.
-
-NOTE: the script is set to abort on first error. If the installation
-completed you're probably OK even though you might have seen errors
-during the installation process.
-=====================================================================
-
-EOM
-
-if [[ -z "$FLAG_YES" ]]; then
-  # Remove implied default of Y - ghostinthenet 20220418
-  read -p "Are you sure you want to proceed [y/n]: " -n 1 -r
-  echo
-  if ! [[ $REPLY =~ [Yy] ]]; then
-   echo "Aborting..."
-   exit 1
-  fi
-  FLAG_YES="Y"
-fi
 #
 set -e
 #
@@ -75,6 +51,4 @@ set -e
 if [[ -z "$G" ]]; then
   echo "Add user $USER to libvirt group"
   $SUDO usermod -a -G libvirt $USER
-  echo ".. You might need to log out and log in to start using netlab with libvirt"
-  echo
 fi

--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -1,28 +1,4 @@
 #!/bin/bash
-cat <<EOM
-Ubuntu Packages Installation Script
-=====================================================================
-This script updates your system, installs additional APT packages,
-and nice-to-have tools like git, jq... The script was tested on Debian
-12 (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
-
-NOTE: the script is set to abort on first error. If the installation
-completed you're probably OK even though you might have seen errors
-during the installation process.
-=====================================================================
-
-EOM
-
-if [[ -z "$FLAG_YES" ]]; then
-  # Remove implied default of Y - ghostinthenet 20220418
-  read -p "Are you sure you want to proceed [y/n]: " -n 1 -r
-  echo
-  if ! [[ $REPLY =~ [Yy] ]]; then
-   echo "Aborting..."
-   exit 1
-  fi
-  FLAG_YES="Y"
-fi
 #
 set -e
 #
@@ -54,6 +30,3 @@ echo "Install Python development and build modules"
 $SUDO apt-get -y $FLAG_APT install build-essential python3-dev libffi-dev libssh-dev
 echo "Installing XML libraries"
 $SUDO apt-get -y $FLAG_APT install libxslt1-dev libssl-dev
-echo
-echo "Installation complete."
-echo

--- a/netsim/utils/log.py
+++ b/netsim/utils/log.py
@@ -362,7 +362,7 @@ def info(
   else:
     mod_txt += ' [INFO] '
 
-  print(f'{mod_txt}{text}')
+  print(strings.wrap_error_message(f'{mod_txt}{text}',indent))
   if more_hints is not None:                                        # Caller supplied hints, print them with HINT label
     print_more_hints(more_hints,h_warning=True,indent=indent)
 

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -56,6 +56,7 @@ def wrap_text_into_lines(
       initial_indent=first_line,
       subsequent_indent=next_line,
       width=width).fill(line)
+    first_line = next_line
     lines.extend(wrap_line.split('\n'))
   
   return lines


### PR DESCRIPTION
* Move dialogs and confirmations from installation scripts to Python code
* Add colorful headers and sidebars
* Make intro/script/epilog behavior consistent across all scripts

However, even more important:

* Display what the script will do and ask for the confirmation first
* After the user confirms he wants to run the script ask about Python installation options
* Run the script after everything has been agreed upon

But wait, there's more:

* '--all' option installs everything
* '-q' option implies '--yes' and removes most of the eye candy (apt-get is still noisy as an F-16 taking off)