### PR TITLE
Improve OpenBSD interface configuration and enable handling of RAs.

### DIFF
--- a/netsim/ansible/templates/initial/openbsd.j2
+++ b/netsim/ansible/templates/initial/openbsd.j2
@@ -27,15 +27,14 @@ ifconfig {{ intf.ifname }} -inet6
 ifconfig {{ intf.ifname }} inet {{ intf.ipv4 }} {{ alias }}
 {% endif %}
 {% if intf.ipv6 is defined %}
+{%   set is_host = role == 'host' %}
 {%   if role == 'router' %}
-{%     if intf.ipv6 is string %}
-ifconfig {{ intf.ifname }} inet6 {{ intf.ipv6 }}
-{%     else %}
-ifconfig {{ intf.ifname }} inet6 eui64
-{%     endif %}
 echo interface {{ intf.ifname }} >> /etc/rad.conf
-{%   elif role == 'host' %}
-ifconfig {{ intf.ifname }} inet6 autoconf
+{%   endif %}
+{%   if intf.ipv6 is string %}
+ifconfig {{ intf.ifname }} inet6 {{ intf.ipv6 }}{% if is_host %} autoconf{% endif +%}
+{%   else %}
+ifconfig {{ intf.ifname }} inet6 eui64{% if is_host %} autoconf{% endif +%}
 {%   endif %}
 {% endif %}
 {% if intf.mtu is defined %}

--- a/netsim/ansible/templates/initial/openbsd.j2
+++ b/netsim/ansible/templates/initial/openbsd.j2
@@ -1,53 +1,65 @@
 {#
   This script configures an OpenBSD host
 #}
-#!/bin/bash
+#!/bin/sh
 #
 set -e
 set -x
-#
-# Create bash profile script
-#
-cat <<SCRIPT >/root/.bash_profile
-#!/bin/bash
-#
-export PS1="\h(bash)$ "
-SCRIPT
+
 hostname {{ inventory_hostname.replace("_","-") }}
 {% include 'linux/hosts.j2' +%}
+
 {% if role == 'router' %}
+#
+# Enable forwarding
+#
 sysctl net.inet.ip.forwarding=1
 sysctl net.inet6.ip6.forwarding=1
+echo -n > /etc/rad.conf
 {% endif %}
 
 {% macro ifconfig(intf,alias='') %}
 {%   if not alias %}
-set +e
-ifconfig {{ intf.ifname }} inet delete
-ifconfig {{ intf.ifname }} inet6 delete
-set -e
+ifconfig {{ intf.ifname }} -inet
+ifconfig {{ intf.ifname }} -inet6
 {%   endif %}
 {% if intf.ipv4 is string %}
 ifconfig {{ intf.ifname }} inet {{ intf.ipv4 }} {{ alias }}
 {% endif %}
 {% if intf.ipv6 is defined %}
-{%   if intf.ipv6 is string %}
-ifconfig {{ intf.ifname }} inet6 {{ intf.ipv6 }} {{ alias }}
-{%   else %}
-ifconfig {{ intf.ifname }} inet6
+{%   if role == 'router' %}
+{%     if intf.ipv6 is string %}
+ifconfig {{ intf.ifname }} inet6 {{ intf.ipv6 }}
+{%     else %}
+ifconfig {{ intf.ifname }} inet6 eui64
+{%     endif %}
+echo interface {{ intf.ifname }} >> /etc/rad.conf
+{%   elif role == 'host' %}
+ifconfig {{ intf.ifname }} inet6 autoconf
 {%   endif %}
-{% else %}
-ifconfig {{ intf.ifname }} -inet6
 {% endif %}
 {% if intf.mtu is defined %}
 ifconfig {{ intf.ifname }} mtu {{ intf.mtu }}
 {% endif %}
+{% if intf.name is defined %}
+ifconfig {{ intf.ifname }} description "{{ intf.name }}"
+{% endif %}
 {% endmacro %}
 #
 # Interface configuration
+#
 {% if loopback is defined %}
 {{   ifconfig(loopback,alias='alias') }}
 {% endif %}
 {% for intf in interfaces %}
 {{   ifconfig(intf) }}
 {% endfor %}
+
+{% if role == 'router' %}
+#
+# (re-)start RA daemon
+#
+pkill -q rad || true
+rad
+{% endif %}
+

--- a/netsim/ansible/templates/routing/openbsd.j2
+++ b/netsim/ansible/templates/routing/openbsd.j2
@@ -11,7 +11,7 @@ set -x
 {% set sr_list = routing.static|default([]) %}
 {% for intf in sr_list|map(attribute='nexthop.intf',default='')|unique if intf %}
 echo Flushing routes to {{ intf }}
-route flush -iface {{ intf }} -priority static
+route -n flush -iface {{ intf }} -priority static
 {% endfor %}
 #
 #

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -9,6 +9,8 @@ features:
     static: true
   initial:
     roles: [ host ]
+    ipv6:
+      lla: true
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -8,7 +8,7 @@ features:
   routing:
     static: true
   initial:
-    roles: [ host ]
+    roles: [ host, router ]
     ipv6:
       lla: true
 libvirt:

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -10,6 +10,7 @@ features:
   initial:
     roles: [ host, router ]
     ipv6:
+      use_ra: true
       lla: true
 libvirt:
   create_template: openbsd.xml.j2


### PR DESCRIPTION
- Configure and start rad on a router to send out RAs
- Utilise SLAAC on IPv6 enabled interfaces on a host
- Allow setting only IPv6 LLA