### PR TITLE
Fix: Gracefully handle apt-get locking errors

### DIFF
--- a/netsim/cli/install.py
+++ b/netsim/cli/install.py
@@ -105,6 +105,11 @@ def set_quiet_flags(args: argparse.Namespace) -> None:
   os.environ['FLAG_APT'] = ''
   os.environ['FLAG_QUIET'] = ''
 
+  if args.verbose and args.quiet:
+    error_and_exit(
+      'Cannot specify --quiet and --verbose at the same time',
+      more_hints='Take a break and make up your mind')
+
   if args.verbose:
     os.environ['FLAG_APT'] = '-V'
     os.environ['FLAG_PIP'] = '-v'
@@ -156,6 +161,7 @@ def check_script(script: str, setup: Box, args: argparse.Namespace) -> None:
         'This script uses apt-get command that is not available on your system',
         more_hints='Most netlab installation scripts work on Ubuntu and Debian)',
         category=log.IncorrectType)
+    os.environ['FLAG_APT'] = os.environ.get('FLAG_APT','') + " -o DPkg::Lock::Timeout=30"
 
   if 'pip' not in s_data.uses:
     return
@@ -229,10 +235,12 @@ def run(cli_args: typing.List[str]) -> None:
 
   set_quiet_flags(args)
   set_sudo_flag()
+  install_path = f'{get_moddir()}/install'
+  os.environ['PATH'] = install_path + ":" + os.environ['PATH']
   for script in setup.scripts.keys():
     if script not in args.script and not args.all:
       continue
-    script_path = f'{get_moddir()}/install/{script}.sh'
+    script_path = f'{install_path}/{script}.sh'
     if not os.path.exists(script_path):
       log.fatal("Installation script {script} does not exist")
 

--- a/netsim/install/apt-get-update.sh
+++ b/netsim/install/apt-get-update.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+retry=6
+sleep=${APT_WAIT:-10}
+echo "Updating APT package lists"
+until $SUDO apt-get $FLAG_QUIET -y update >/dev/null; do
+  echo "Cannot update APT lists, another process is working on them. Retrying in $sleep seconds"
+  sleep $sleep
+  if ! ((retry=retry-1)); then
+    echo
+    echo "I waited long enough, I'm giving up"
+    exit 1
+  fi
+done

--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -8,11 +8,11 @@ REPLACE="--upgrade"
 IGNORE="--ignore-installed"
 #
 echo "Update the package list"
-$SUDO apt-get $FLAG_QUIET update
+. apt-get-update.sh
 #
 echo
 echo "Install support software"
-$SUDO apt-get install -y $FLAG_QUIET ca-certificates curl gnupg lsb-release iptables
+$SUDO apt-get install -y $FLAG_APT ca-certificates curl gnupg lsb-release iptables
 echo "Install Docker GPG key and set up Docker repository"
 
 # Begin code to identify distribution and populate DISTRIBUTION variable - ghostinthenet - 20220417
@@ -45,8 +45,8 @@ curl -fsSL https://download.docker.com/linux/$DISTRIBUTION/gpg | $SUDO gpg --dea
 echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$DISTRIBUTION $(lsb_release -cs) stable" | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
 #
 echo "Install Docker Engine"
-$SUDO apt-get update
-$SUDO apt-get install -y $FLAG_QUIET docker-ce docker-ce-cli containerd.io
+. apt-get-update.sh
+$SUDO apt-get install -y $FLAG_APT docker-ce docker-ce-cli containerd.io
 echo "Install containerlab version $CONTAINERLAB_VERSION"
 $SUDO bash "-c" "$(curl -sL https://get.containerlab.dev)" -- -v $CONTAINERLAB_VERSION
 set +e

--- a/netsim/install/libvirt.sh
+++ b/netsim/install/libvirt.sh
@@ -3,17 +3,17 @@
 set -e
 #
 echo "Update the package list"
-$SUDO apt-get $FLAG_QUIET update
+. apt-get-update.sh
 #
 echo
 echo "Install common libraries and support software"
-$SUDO apt-get install -y $FLAG_QUIET libxslt-dev libxml2-dev zlib1g-dev genisoimage
-$SUDO apt-get install -y $FLAG_QUIET ebtables dnsmasq-base sshpass tree jq bridge-utils curl lsb-release
+$SUDO apt-get install -y $FLAG_APT libxslt-dev libxml2-dev zlib1g-dev genisoimage
+$SUDO apt-get install -y $FLAG_APT ebtables dnsmasq-base sshpass tree jq bridge-utils curl lsb-release
 echo ".. common libraries installed"
 echo
 echo "Install libvirt packages"
-$SUDO apt-get install -y $FLAG_QUIET libvirt-dev qemu-kvm cpu-checker virtinst
-$SUDO apt-get install -y $FLAG_QUIET libvirt-daemon-system libvirt-clients
+$SUDO apt-get install -y $FLAG_APT libvirt-dev qemu-kvm cpu-checker virtinst
+$SUDO apt-get install -y $FLAG_APT libvirt-daemon-system libvirt-clients
 echo ".. libvirt packages installed"
 echo
 echo "Install vagrant"
@@ -40,8 +40,8 @@ Package: vagrant
 Pin: version 2.4.3-1
 Pin-Priority: 1000
 FILE
-$SUDO apt-get update
-$SUDO apt-get install -y --allow-downgrades $FLAG_QUIET ruby-dev ruby-libvirt vagrant=2.4.3-1
+. apt-get-update.sh
+$SUDO apt-get install -y --allow-downgrades $FLAG_APT ruby-dev ruby-libvirt vagrant=2.4.3-1
 vagrant plugin install vagrant-libvirt --plugin-version=0.12.2
 echo ".. vagrant installed"
 echo

--- a/netsim/install/ubuntu.sh
+++ b/netsim/install/ubuntu.sh
@@ -5,7 +5,7 @@ set -e
 # Comment the next line if you want to have verbose installation messages
 #
 echo "Update package list and upgrade the existing packages"
-$SUDO apt-get update -y $FLAG_QUIET 
+. apt-get-update.sh
 $SUDO apt-get upgrade -y $FLAG_APT
 #
 # Install missing packages


### PR DESCRIPTION
* The 'netlab install' script sets DPkg::Lock::Timeout=60 in APT_FLAG
* The APT_FLAG environment variable is used consistently in all apt-get calls
* As 'apt-get update' encounters another lock that cannot be waited upon, we're using a bash script that retries for up to a minute before giving up. That bash script is used consistently as a replacement for 'apt-get update' call.