### PR TITLE
netlab validate: Allow the use of regular expressions to select tests

### DIFF
--- a/docs/cli-overview.md
+++ b/docs/cli-overview.md
@@ -31,3 +31,6 @@ The following programs, scripts and Ansible playbooks are included with *netlab*
 
 **netlab exec**
 : Use Ansible inventory to connect to one or more lab devices using the inventory names and executes an arbitrary command on them. Device IP address (**ansible_host**) and username/passwords are retrieved from Ansible inventory. Ideal when you use centralized Vagrant or Clab environments and want to execute commands on the devices. [More details...](netlab/exec.md)
+
+**netlab validate**
+: Run validation tests included with the topology. A subset of tests can be selected by using one or more test names, or a regular expression [More details...](topology/validate.md)

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -1044,19 +1044,20 @@ filter_by_test: select only tests specified in arguments
 def filter_by_tests(args: argparse.Namespace, topology: Box) -> None:
   if not args.tests:
     return
-
+  tests_to_execute = {}
   for t in args.tests:
-    find_test = [ v_entry for v_entry in topology.validate if v_entry.name == t ]
+    find_test = { v_entry.name: v_entry for v_entry in topology.validate if re.match(t,v_entry.name) }
     if not find_test:
       log.error(
-        f'Invalid test name {t}, use "netlab validate --list" to list test names',
+        f'Invalid test name or regex expression {t}, use "netlab validate --list" to list test names',
         category=log.IncorrectValue,
         module='validation')
+    tests_to_execute.update(find_test)
 
   if log.pending_errors():
     return
 
-  topology.validate = [ v_entry for v_entry in topology.validate if v_entry.name in args.tests ]
+  topology.validate = tests_to_execute.values()
 
 '''
 filter_by_nodes: select only tests executed on specified node


### PR DESCRIPTION
For example: .*v4 to run only ipv4 tests (assuming they are suitably named), in case a platform doesn't support OSPFv3 in VRFs