### PR TITLE
Fix: Simplify SR-OS IS-IS template with 'configure_router' macro

### DIFF
--- a/netsim/ansible/templates/initial/sros.j2
+++ b/netsim/ansible/templates/initial/sros.j2
@@ -2,7 +2,7 @@
 {{ name or i.ifname }}
 {%- endmacro %}
 
-{% macro declare_router(i,sub_path="",intf_cfg=False) -%}
+{% macro declare_router(i,sub_path="",intf_cfg=False,vrf_config=True) -%}
 {#
     This macro selects the SR/OS service in which the current object
     is configured. The global routing instance is "router Base" unless
@@ -32,7 +32,7 @@
                     else "service/vprn[service-name="+service_name+"]" %}
 
 {# Minimal service config must exist #}
-{%  if not in_base %}
+{%  if not in_base and vrf_config %}
 - path: configure/{{ base_path }}
   val:
    customer: "1"
@@ -42,6 +42,20 @@
 {%  endif %}
 
 - path: configure/{{ base_path }}{{ sub_path }}
+{%- endmacro %}
+
+{#
+   This macro is just a convenient wrapper around the more generic declare_router
+   macro. That one expects an interface data structure and extracts VRF from it,
+   this one takes VRF as the parameter (it can also be missing) and fakes the minimal
+   data structure that makes declare_router happy
+#}
+{% macro configure_router(vrf="",sub_path="") -%}
+{%   if vrf  %}
+{{     declare_router({ 'vrf': vrf },sub_path=sub_path) }}
+{%   else %}
+{{     declare_router({},sub_path=sub_path) }}
+{%   endif %}
 {%- endmacro %}
 
 {% macro declare_interface(i,name=None) %}

--- a/netsim/ansible/templates/isis/sros.j2
+++ b/netsim/ansible/templates/isis/sros.j2
@@ -1,4 +1,4 @@
-{% from "templates/initial/sros.j2" import if_name, declare_router with context %}
+{% from "templates/initial/sros.j2" import if_name, configure_router with context %}
 {% from 'templates/routing/_redistribute.sros.j2' import import_protocols with context %}
 
 {% macro isis_export_policy(isis,vrf) %}
@@ -10,13 +10,13 @@
 {{  import_protocols(isis.import) | indent(4,first=True) }}
 {% endmacro %}
 
-{% macro isis_router(vrf_data,isis,intf_list) %}
-{% set vname = vrf_data.vrf|default('default') %}
+{% macro isis_router(isis,intf_list=[],vrf_name="") %}
+{% set vname = vrf_name or 'default' %}
 {% if isis.import is defined %}
 {{   isis_export_policy(isis,vname) }}
 {% endif %}
 {% set kw_level = {'level-1': '1', 'level-2': '2', 'level-1-2': '1/2'} %}
-{{ declare_router(vrf_data) }}
+{{ configure_router(vrf_name) }}
   val:
     isis:
     - isis-instance: 0
@@ -71,5 +71,5 @@
 
 updates:
 {% if isis is defined %}
-{{ isis_router({},isis,netlab_interfaces) }}
+{{ isis_router(isis,netlab_interfaces) }}
 {% endif %}

--- a/netsim/ansible/templates/vrf/sros.j2
+++ b/netsim/ansible/templates/vrf/sros.j2
@@ -27,6 +27,6 @@ updates:
 {%     endfor %}
 {%   endif %}
 {%   if 'isis' in vdata and 'af' in vdata %}
-{{     isis_router({ 'vrf': vname },vdata.isis,vdata.isis.interfaces) }}
+{{     isis_router(vdata.isis,vdata.isis.interfaces,vname) }}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
Most SR-OS configuration templates used 'declare_router' macro that would select the correct service configuration path based on interface data, leading to an awkward recreation of interface data in case we really wanted to configure a router, not an interface.

This fix adds another layer of indirection (proving RFC 1925) in front of the 'declare_router' macro to make the routing protocol configuration templates a bit cleaner.