### PR TITLE
Fix: Restructure SR-OS OSPF template

### DIFF
--- a/netsim/ansible/templates/ospf/sros.j2
+++ b/netsim/ansible/templates/ospf/sros.j2
@@ -1,4 +1,4 @@
-{% from "templates/initial/sros.j2" import if_name, declare_router with context %}
+{% from "templates/initial/sros.j2" import if_name, declare_router, configure_router with context %}
 {% from 'templates/routing/_redistribute.sros.j2' import import_protocols with context %}
 
 {% macro ospf_export_policy(ospf,vrf) %}
@@ -10,31 +10,7 @@
 {{  import_protocols(ospf.import|default([])) | indent(4,first=True) }}
 {% endmacro %}
 
-{% macro ospf_config(af,ospf,vrf_interfaces,vname='default') %}
-{% set pid = ospf.process|default(0) %}
-{% set ospfv = 'ospf3' if af=='ipv6' else 'ospf' %}
-
-{% if ospf.import is defined %}
-{{   ospf_export_policy(ospf,vname) }}
-{{   declare_router({ 'vrf': vname } if vname != 'default' else {},sub_path="/"+ospfv+"[ospf-instance="+pid|string + "]") }}
-  val:
-    export-policy: [ ospf_{{ vname }}_export ]
-{%   if vname == 'default' %}
-    asbr: {}
-{%   endif %}
-{% endif %}
-
 {% macro ospf_interface(l) %}
-{{ declare_router(l,sub_path="/"+ospfv+"[ospf-instance="+pid|string + "]") }}
-  val:
-{%   if ospf.reference_bandwidth is defined %}
-    reference-bandwidth: {{ ospf.reference_bandwidth * 1000 }} # in kbps
-{%   endif %}
-    admin-state: enable
-    router-id: {{ ospf.router_id }}
-    area:
-    - area-id: "{{ l.ospf.area }}"
-      interface:
       - interface-name: "{{ if_name(l,l.ifname) }}"
 {%  if l.ospf.passive|default(False) %}
         passive: True
@@ -56,9 +32,53 @@
 {%  endif %}
 {% endmacro %}
 
-{% for intf in vrf_interfaces if 'ospf' in intf and af in intf %}
-{{   ospf_interface(intf) }}
-{% endfor %}
+{% macro ospf_config(af,ospf,vrf_interfaces,vrf_name='') %}
+{%   set vname = vrf_name or 'default' %}
+{%   set pid = ospf.process|default(0) %}
+{%   set ospfv = 'ospf3' if af=='ipv6' else 'ospf' %}
+{%   if ospf.import is defined %}
+{{     ospf_export_policy(ospf,vname) }}
+{%   endif %}
+{{   configure_router(vrf_name,sub_path="/"+ospfv+"[ospf-instance="+pid|string + "]") }}
+  val:
+{%   if ospf.import is defined %}
+    export-policy: [ ospf_{{ vname }}_export ]
+{%     if vname == 'default' %}
+    asbr: {}
+{%     endif %}
+{%   endif %}
+{%   if ospf.reference_bandwidth is defined %}
+    reference-bandwidth: {{ ospf.reference_bandwidth * 1000 }} # in kbps
+{%   endif %}
+    admin-state: enable
+    router-id: {{ ospf.router_id }}
+{#
+   SR OS configures interfaces within areas, so we need a list of areas. netlab
+   does not provide that directly, so we're reverse-engineering it from the
+   interface data:
+
+   * Select all interfaces with the desired AF
+   * Extract 'ospf.area' attribute from those interfaces
+   * This will result in multiple definitions of the same area, so make the
+     list unique
+   * While we're stacking filters, sort the list just to make it look nicer
+
+   Please note that we'll probably have an empty string in the list (default value),
+   so we have to check for that when looping over the areas.
+#}
+{%   set areas = vrf_interfaces|selectattr(af,'defined')|map(attribute='ospf.area',default='')|unique|sort %}
+{%   for area in areas if area %}{# Now iterate over all areas we found (skipping the empty string #}
+{%     if loop.first %}{#           For the first area, we have to start the 'area' dictionary #}
+    area:
+{%     endif %}
+    - area-id: "{{ area }}"
+{%     for intf in vrf_interfaces if intf.ospf.area|default('') == area and af in intf %}
+{%       if loop.first %}{#         For the first interface in an area, we have to start the 'interface' dict #}
+      interface:
+{%       endif %}
+{{       ospf_interface(intf) }}{#  And finally, add OSPF interface data #}
+{%     endfor %}
+{%   endfor %}
 {% endmacro %}
 
 updates:


### PR DESCRIPTION
The SR-OS OSPF template used a dirty trick where the whole OSPF process would be reconfigured for every interface to avoid sorting netlab interface data into OSPF areas (the way SR-OS OSPF configuration works)

This fix restructures the OSPF template to:

* Configure routing protocol parameters
* Collect a list of OSPF areas from interface data
* Configure collected OSPF areas
* Within each area, configure interfaces in that area

The configuration template itself became a bit more convoluted, but hopefully easier to understand (due to the structure that naturally follows the SR-OS configuration data model). Also, it reduces the number of configuration requests as the whole OSPF process is configured in one go.