### PR TITLE
Initial implementation of iol2 STP

### DIFF
--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -12,18 +12,20 @@ The following table describes per-platform support of individual STP features:
 | Operating system   | STP | MSTP | RSTP | Per-VLAN<br>RSTP | Enable<br>per port |
 | ------------------ |:---:|:---:|:---:|:---:|:---:|
 | Arista EOS[^EOS]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
+| Cisco IOL L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Aruba AOS-CX[^AOSCX] | ❗  | ✅  | ❌  | ✅ |  ✅ |
 | Cumulus Linux 4.x[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
 | Cumulus 5.x (NVUE)[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
 | Dell OS10[^OS10]   | ✅  | ✅  | ✅  | ❗ |  ✅ |
 | FRR[^FRR]          | ✅  |  ❌  |  ❌  |  ❌ | ❌   |
 
+
 [^EOS]: MSTP is enabled by default
 [^AOSCX]: MSTP is enabled by default; STP is stated as not supported, but it is configured as MSTP (see tip below).
 [^CL]: STP is enabled by default
 [^OS10]: PVRST is enabled by default, but will require custom VLAN templates as Netlab uses virtual networks (which don't support STP)
 [^FRR]: STP is disabled by default; STP is not supported on VLAN trunks as FRR sends BPDUs tagged, you could use Cumulus instead
-
+[^IOLL2]: Per Vlan RSTP is enabled by default. STP,RSTP are emulated with MSTP.
 ```{tip}
 MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
 ```

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -26,6 +26,7 @@ The following table describes per-platform support of individual STP features:
 [^OS10]: PVRST is enabled by default, but will require custom VLAN templates as Netlab uses virtual networks (which don't support STP)
 [^FRR]: STP is disabled by default; STP is not supported on VLAN trunks as FRR sends BPDUs tagged, you could use Cumulus instead
 [^IOLL2]: Per Vlan RSTP is enabled by default. STP,RSTP are emulated with MSTP.
+
 ```{tip}
 MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.
 ```

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -1,4 +1,4 @@
-{% if  stp.enable == False %}
+{% if not stp.enable|default(True)  %}
 no spanning-tree vlan 1-4094
 {% else %}
 

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -21,13 +21,13 @@ spanning-tree mst 0 priority {{ stp.priority }}
 {% endif %}
 
 {# Check for per-VLAN enable and priority; implies Rapid-PVST #}
-{% if vlans is defined %}
+{% if vlans is defined and stp.protocol == 'pvrst' %}
 {%   for vname,vdata in vlans.items() %}
-{%     if not vdata.stp.enable|default(stp.enable)|default(True) %}
+{%     if not vdata.stp.enable|default(True) %}
 no spanning-tree vlan {{ vdata.id }}
 {%     elif vdata.stp.priority is defined %}
 spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
-{%     elif stp.protocol == 'pvrst' and stp.priority is defined %}
+{%     elif  stp.priority is defined %}
 spanning-tree vlan {{ vdata.id }} priority {{ stp.priority }}
 {%     endif %}
 {%   endfor +%}

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -8,7 +8,7 @@ no spanning-tree vlan 1-4094
 {# options are stp  rstp, rapid-pvst or mstp (default if not set) #}
 
 spanning-tree mode {{ mode }} 
-
+spanning-tree pathcost method long
 
 {% if stp.port.type is defined and stp.port.type == 'auto' %}
 spanning-tree portfast default

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -53,7 +53,7 @@ interface {{ ifdata.ifname }}
 {%   endif %}
 {%   if ifdata.stp.port_type is defined %}
 {%   set _ptype = ifdata.stp.port_type %}
-{%    if _ptype == 'network' %}
+{%    if _ptype == 'network' or _ptype == 'normal'%}
  no spanning-tree portfast 
 {%    elif _ptype == 'edge' %}
  spanning-tree portfast

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -1,0 +1,65 @@
+{% if not stp.enable|default(True) %}
+{%  set mode = "none" %}
+{% else %}
+{%  set proto_map = { 'stp': 'mst', 'rstp': 'mst', 'pvrst': 'rapid-pvst', 'mstp': 'mst' } %}
+{%  set mode = proto_map[stp.protocol] %}
+{% endif %}
+{# options are 'none', rstp, rapid-pvst or mstp (default if not set) #}
+{% if mode == 'none' %}
+no spanning-tree vlan 1
+{% else %}
+spanning-tree mode {{ mode }} 
+{% endif %}
+
+{% if stp.port.type is defined and stp.port.type == 'auto' %}
+spanning-tree portfast default
+{% endif %}
+
+{% if 'priority' in stp %}
+{% if stp.protocol != 'pvrst' %}
+spanning-tree mst 0 priority {{ stp.priority }}
+{% endif %}
+{% endif %}
+
+{# Check for per-VLAN enable and priority; implies Rapid-PVST #}
+{% if vlans is defined %}
+{%   for vname,vdata in vlans.items() %}
+{%     if not vdata.stp.enable|default(stp.enable)|default(True) %}
+no spanning-tree vlan {{ vdata.id }}
+{%     elif vdata.stp.priority is defined %}
+spanning-tree vlan {{ vdata.id }} priority {{ vdata.stp.priority }}
+{%     elif stp.protocol == 'pvrst' and stp.priority is defined %}
+spanning-tree vlan {{ vdata.id }} priority {{ stp.priority }}
+{%     endif %}
+{%   endfor +%}
+{% endif %}
+
+{% for ifdata in interfaces if 'stp' in ifdata %}
+{%   if ifdata.vlan.trunk_id is defined or ifdata.vlan.access_id is defined %}
+interface {{ ifdata.ifname }}
+{%    if not ifdata.stp.enable|default(True) %}
+ ! Disable STP on this interface, i.e. dont receive or send BPDUs
+ spanning-tree bpdufilter enable
+{%    elif 'port_priority' in ifdata.stp %}
+#
+# Use 16x port_priority to get the correct 4-bit value on the wire
+#
+{%      if stp.protocol == 'pvrst' %}
+ spanning-tree port-priority {{ ifdata.stp.port_priority * 16 }}
+{%      else %}
+ spanning-tree mst 0 port-priority {{ ifdata.stp.port_priority * 16 }}        
+{%      endif %} 
+{%    endif %} 
+{%   endif %}
+{%   if ifdata.stp.port_type is defined %}
+{%   set _ptype = ifdata.stp.port_type %}
+{%    if _ptype == 'network' %}
+ no spanning-tree portfast 
+{%    elif _ptype == 'edge' %}
+ spanning-tree portfast
+{%      if ifdata.vlan.trunk_id is defined%}
+ spanning-tree portfast trunk
+{%      endif %} 
+{%    endif %} {# _ptype #}
+{%   endif %} {# end ifdata.stp.port.type#}
+{% endfor %}

--- a/netsim/ansible/templates/stp/ios.j2
+++ b/netsim/ansible/templates/stp/ios.j2
@@ -1,15 +1,14 @@
-{% if not stp.enable|default(True) %}
-{%  set mode = "none" %}
+{% if  stp.enable == False %}
+no spanning-tree vlan 1-4094
 {% else %}
+
 {%  set proto_map = { 'stp': 'mst', 'rstp': 'mst', 'pvrst': 'rapid-pvst', 'mstp': 'mst' } %}
 {%  set mode = proto_map[stp.protocol] %}
-{% endif %}
-{# options are 'none', rstp, rapid-pvst or mstp (default if not set) #}
-{% if mode == 'none' %}
-no spanning-tree vlan 1
-{% else %}
+
+{# options are stp  rstp, rapid-pvst or mstp (default if not set) #}
+
 spanning-tree mode {{ mode }} 
-{% endif %}
+
 
 {% if stp.port.type is defined and stp.port.type == 'auto' %}
 spanning-tree portfast default
@@ -61,5 +60,6 @@ interface {{ ifdata.ifname }}
  spanning-tree portfast trunk
 {%      endif %} 
 {%    endif %} {# _ptype #}
-{%   endif %} {# end ifdata.stp.port.type#}
+{%   endif %} {# ifdata.stp.port.type#}
 {% endfor %}
+{% endif %} {# stp.enable #}

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -9,6 +9,10 @@ features:
     native_routed: True
     mixed_trunk: False
     subif_name: "{ifname}.{subif_index}"
+  stp:
+    supported_protocols: [ stp, rstp, mstp, pvrst ]
+    enable_per_port: True
+    port_type: True  
 clab:
   group_vars:
     netlab_device_type: ioll2


### PR DESCRIPTION
Based on Arista. 

It passes all netlab integration tests and was also validated on a lot of topologies from:

 `https://github.com/ipspace/netlab-examples/tree/master/STP/examples`

Doesn't handle stub port types (does any template ???)