### PR TITLE
Enable STP support on Iosvl2 devices

### DIFF
--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -13,6 +13,7 @@ The following table describes per-platform support of individual STP features:
 | ------------------ |:---:|:---:|:---:|:---:|:---:|
 | Arista EOS[^EOS]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Cisco IOL L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
+| Cisco IOSV L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Aruba AOS-CX[^AOSCX] | ❗  | ✅  | ❌  | ✅ |  ✅ |
 | Cumulus Linux 4.x[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
 | Cumulus 5.x (NVUE)[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -13,7 +13,7 @@ The following table describes per-platform support of individual STP features:
 | ------------------ |:---:|:---:|:---:|:---:|:---:|
 | Arista EOS[^EOS]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Cisco IOL L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
-| Cisco IOSV L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
+| Cisco IOSv L2^[IOLL2]   | ✅  | ✅  | ✅  | ✅ |  ✅ |
 | Aruba AOS-CX[^AOSCX] | ❗  | ✅  | ❌  | ✅ |  ✅ |
 | Cumulus Linux 4.x[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |
 | Cumulus 5.x (NVUE)[^CL] | ✅  |  ❌  | ✅  | ❌   |  ✅ |

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -16,7 +16,7 @@ features:
   stp:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
-    port_type: True    
+    port_type: True
 libvirt:
   image: cisco/iosvl2
   build: https://netlab.tools/labs/iosvl2/

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -13,6 +13,10 @@ features:
     model: l3-switch
     svi_interface_name: Vlan{vlan}
     mixed_trunk: False
+  stp:
+    supported_protocols: [ stp, rstp, mstp, pvrst ]
+    enable_per_port: True
+    port_type: True    
 libvirt:
   image: cisco/iosvl2
   build: https://netlab.tools/labs/iosvl2/


### PR DESCRIPTION
Enable STP support on Iosvl2 devices, and update platform support in stp module documentation.

Passes all current integration tests, as expected. 