### PR TITLE
Fix: ensure bgp.neighbors is defined for BGP-enabled routing instances

### DIFF
--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -728,6 +728,14 @@ def vlan_ebgp_role_set(topology: Box, EBGP_ROLE: str) -> None:
     vdata.pop('_as_set',None)                               # ... and clean up
     vdata.pop('_bgp_attr',None)
 
+"""
+Make sure BGP data always has the expected attributes (currently: neighbors, might be others in the future)
+"""
+def sanitize_bgp_data(node: Box) -> None:
+  for (b_data,_,_) in _rp_utils.rp_data(node,'bgp'):
+    if 'neighbors' not in b_data:
+      b_data.neighbors = []
+
 class BGP(_Module):
   """
   Node pre-transform: set bgp.rr node attribute to _true_ if the node name is in the
@@ -787,3 +795,4 @@ class BGP(_Module):
     bgp_transform_community_list(node,topology)
     _routing.check_vrf_protocol_support(node,'bgp',None,'bgp',topology)
     _routing.process_imports(node,'bgp',topology,global_vars.get_const('vrf_igp_protocols',['connected']))
+    sanitize_bgp_data(node)

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -596,6 +596,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         evpn:
           bundle: vlan_aware
           evi: 1
@@ -922,6 +923,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         evpn:
           bundle: vlan_aware
           evi: 1

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -129,6 +129,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         evpn:
           evi: 1
           rd: 10.0.0.1:1
@@ -223,6 +224,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         evpn:
           evi: 2
           rd: 10.0.0.2:2

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -181,6 +181,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         evpn:
           evi: 1
           rd: 10.0.0.1:1
@@ -306,6 +307,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         evpn:
           evi: 1
           rd: 10.0.0.2:1

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -143,6 +143,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         evpn:
           evi: 1
           rd: 10.0.0.1:1

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -196,6 +196,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65001:1'
         id: 1
@@ -329,6 +330,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65001:1'
         id: 1

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -121,6 +121,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -258,6 +258,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:3'
         id: 3
@@ -514,6 +515,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:3'
         id: 3

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -231,6 +231,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:2'
         id: 2
@@ -277,6 +278,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1
@@ -452,6 +454,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1
@@ -642,6 +645,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:2'
         id: 2
@@ -702,6 +706,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -426,6 +426,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65000:5'
         id: 5
@@ -444,6 +445,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1
@@ -563,6 +565,7 @@ nodes:
               auto: true
             isis:
               auto: true
+          neighbors: []
         export:
         - '65000:2'
         id: 2
@@ -609,6 +612,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:3'
         id: 3
@@ -815,6 +819,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:1'
         id: 1
@@ -934,6 +939,7 @@ nodes:
               auto: true
             isis:
               auto: true
+          neighbors: []
         export:
         - '65000:2'
         id: 2
@@ -1093,6 +1099,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65000:5'
         id: 5

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -193,6 +193,7 @@ nodes:
               auto: true
             ospf:
               auto: true
+          neighbors: []
         export:
         - '65000:3'
         id: 3
@@ -373,6 +374,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65001:5'
         id: 5
@@ -391,6 +393,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65001:4'
         id: 4
@@ -403,6 +406,7 @@ nodes:
           import:
             connected:
               auto: true
+          neighbors: []
         export:
         - '65000:2'
         id: 2


### PR DESCRIPTION
Numerous implementations of ebgp.multihop configuration template assume bgp.neighbors is defined if bgp is defined (in node data or in a VRF). We could either meet that assumption or fix all those templates (and meeting that assumption could result in simpler templates overall).

Fixes #2486