### PR TITLE
Fix: More robust suzieq tool definition

### DIFF
--- a/netsim/tools/suzieq.yml
+++ b/netsim/tools/suzieq.yml
@@ -4,9 +4,9 @@
 runtime: docker     # Default: start in a Docker container
 docker:
   up:
-    docker run --rm -itd --name '{name}_suzieq'
+    docker run -itd --name '{name}_suzieq'
       {sys.docker_net}
-      -v '{name}_suzieq':/parquet
+      -v '{name}_suzieq_data':/parquet
       -v './suzieq':/suzieq
       netenglabs/suzieq-demo -c 'sq-poller -I /suzieq/suzieq-inventory.yml'
   message:
@@ -14,9 +14,10 @@ docker:
   connect:
     docker exec -it '{name}_suzieq' /usr/local/bin/suzieq-cli
   down:
-    docker kill '{name}_suzieq'
+    docker kill '{name}_suzieq';
+    docker rm '{name}_suzieq'
   cleanup:
-    docker volume rm '{name}_suzieq'
+    docker volume rm '{name}_suzieq_data'
 config:
 - dest: suzieq-inventory.yml
   template: suzieq.inventory.j2


### PR DESCRIPTION
This fix uses a different name for suzieq container and parquet volume, allowing 'netlab up' to check whether the container has started (otherwise 'docker inspect' returns volume info when asked about the container).

It also creates container without the 'auto remove' flag, so the user can inspect container logs in case of a fatal suzieq failure.

The 'tool.down' command was modified accordingly to kill the container and then remove it.