### PR TITLE
Allow setting "no switchport" on link agregations on cisco l2 images.

### DIFF
--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -51,7 +51,7 @@ interface {{ mgmt.ifname|default('GigabitEthernet0/0') }}
 interface {{ l.ifname }}
 {% if l.type == 'vlan_member' and l.vlan.access_id is defined %}
  encapsulation dot1Q {{ l.vlan.access_id }}
-{% elif l.virtual_interface is not defined and netlab_device_type in ['iosvl2','ioll2'] %}
+{% elif (l.type == 'lag' or l.virtual_interface is not defined) and netlab_device_type in ['iosvl2','ioll2'] %}
  no switchport
 {% endif %}
 {% if l.vrf is defined %}


### PR DESCRIPTION
Allow setting port channels interfaces as "no switchport". Keep current logic for everything else. 