### PR TITLE
Fix: run on-push actions in pull requests from third-party repos

### DIFF
--- a/.github/workflows/t-pull.yml
+++ b/.github/workflows/t-pull.yml
@@ -23,6 +23,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt -r requirements-dev.txt
+    - name: Run Mypy
+      if: ${{ github.repository != 'ipspace/netlab' }}
+      run: |
+        set -e
+        mypy -p netsim
+        for file in netsim/extra/*/plugin.py; do
+          python3 -m mypy $file
+        done
+    - name: Run transformation tests
+      if: ${{ github.repository != 'ipspace/netlab' }}
+      run: |
+        cd tests
+        PYTHONPATH="../" pytest
     - name: Check integration tests
       run: |
         cd tests


### PR DESCRIPTION
The 'on-push' GH actions are not executed (within the context of main netlab repo) if the pull request comes from another repository, so we don't know whether they would pass.

This change brings mypy and transformation tests back to the 'on-pull' workflow, but hopefully executes them only if the source repo is not 'ipspace/netlab'