### PR TITLE
Set containerlab version in installation configuration

### DIFF
--- a/netsim/install/containerlab.sh
+++ b/netsim/install/containerlab.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Install a specific version of Containerlab
-CONTAINERLAB_VERSION="0.62.2"
+# Install a specific version of Containerlab -- it's now set in 'netlab install' before calling this script
+# CONTAINERLAB_VERSION="0.62.2"
 #
 set -e
 REPLACE="--upgrade"

--- a/netsim/install/install.yml
+++ b/netsim/install/install.yml
@@ -1,3 +1,6 @@
+env:
+  CONTAINERLAB_VERSION: providers.clab.version
+
 scripts:
   ubuntu:
     description: Mandatory and nice-to have Debian/Ubuntu packages

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -6,6 +6,7 @@ config: clab.yml
 lab_prefix: "clab" # Containerlab default, set to "" to remove prefix
 node_config_attributes: [ type, cmd, dns, env, license, ports, startup-delay, restart-policy ]
 template: clab.j2
+version: 0.68.0
 # Preserve env to allow user to configure PATH
 start: sudo -E containerlab deploy --reconfigure -t clab.yml
 stop: sudo -E containerlab destroy --cleanup -t clab.yml


### PR DESCRIPTION
The containerlab installation script expects the CONTAINERLAB_VERSION environment variable to contain the target clab version. We had to modify the installation script each time we wanted to change the version; this commit introduces an alternative mechanism and bumps the containerlab version to 0.68.0:

* The environment variables depending on system defaults are specified in the install.yml configuration file
* CONTAINERLAB_VERSION environment variable depends on clab.version value (now set to 0.68.0)
* The 'netlab install' command sets the environment variables specified in the install.yml configuration file before starting the scripts

Collateral fix:
* 'netlab install' recognized the 'dry-run' flag but did not pass it to 'external_commands' module.

Fixes #2498