### PR TITLE
Disable 'provider changed' warnings in DHCP integration tests

### DIFF
--- a/tests/integration/dhcp/03-ipv4-server.yml
+++ b/tests/integration/dhcp/03-ipv4-server.yml
@@ -1,3 +1,10 @@
+message: |
+  Use this topology to test the DHCPv4 server on your device. Use 'netlab
+  validate' to check whether your device allocated IPv4 addresses to DHCP
+  clients running on Linux VMs.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   clients:
     members: [ c1, c2 ]
@@ -36,8 +43,3 @@ validate:
       linux: "ip addr show eth1 | grep inet | grep dynamic || true"
     valid:
       linux: stdout.rstrip()
-
-message: |
-  Use this topology to test the DHCPv4 server on your device. Use 'netlab
-  validate' to check whether your device allocated IPv4 addresses to DHCP
-  clients running Cumulus Linux.

--- a/tests/integration/dhcp/04-ipv6-server.yml
+++ b/tests/integration/dhcp/04-ipv6-server.yml
@@ -1,3 +1,10 @@
+message: |
+  Use this topology to test the DHCPv6 server on your device. Use 'netlab
+  validate' to check whether your device allocated IPv6 addresses to Cisco
+  IOS clients.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 addressing.lan:
   ipv4: false
   ipv6: 2001:db8:cafe::/48
@@ -34,8 +41,3 @@ validate:
     exec: "show ipv6 interface brief {{ interfaces[0].ifname }}"
     valid: >-
       "CAFE" in stdout
-
-message: |
-  Use this topology to test the DHCPv6 server on your device. Use 'netlab
-  validate' to check whether your device allocated IPv6 addresses to DHCPv6
-  clients running Cumulus Linux.

--- a/tests/integration/dhcp/11-ipv4-relay.yml
+++ b/tests/integration/dhcp/11-ipv4-relay.yml
@@ -1,3 +1,11 @@
+---
+message: |
+  Use this topology to test the DHCPv4 relay functionality of your device. Use
+  'netlab validate' to check whether your device propagated DHCPv4 requests from
+  DHCP clients (Linux VMs) to DHCP servers.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 module: [ dhcp ]
 
 groups:
@@ -80,8 +88,3 @@ validate:
     valid:
       eos: len(vrfs.default.ipv4ActiveLeases) == 2
       dnsmasq: stdout.rstrip() == '2'
-
-message: |
-  Use this topology to test the DHCPv4 relay functionality of your device. Use
-  'netlab validate' to check whether your device propagated DHCPv4 requests from
-  DHCP clients to DHCP servers.

--- a/tests/integration/dhcp/21-ipv4-relay-vrf-global.yml
+++ b/tests/integration/dhcp/21-ipv4-relay-vrf-global.yml
@@ -1,3 +1,12 @@
+---
+message: |
+  Use this topology to test the inter-VRF DHCPv4 relay functionality of your
+  device. Use 'netlab validate' to check whether your device propagated DHCPv4
+  requests from DHCP clients (Linux VMs) in VRF c_vrf to DHCP servers in global
+  routing table.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   _auto_create: true
   clients:
@@ -49,9 +58,3 @@ validate:
       linux: "ip addr show eth1 | grep inet | grep dynamic || true"
     valid:
       linux: stdout.rstrip()
-
-message: |
-  Use this topology to test the inter-VRF DHCPv4 relay functionality of your
-  device. Use 'netlab validate' to check whether your device propagated DHCPv4
-  requests from DHCP clients in VRF c_vrf to DHCP servers in global routing
-  table.

--- a/tests/integration/warnings.yml
+++ b/tests/integration/warnings.yml
@@ -3,3 +3,6 @@
 devices:
   eos.warnings.ospf_stub: False
   sros.warnings.loopback_ipv6: False
+
+warnings:
+  providers.change: False


### PR DESCRIPTION
The IPv4 DHCP integration tests use Linux VMs as DHCP clients, resulting in irrelevant 'top provider changed' warnings when testing DHCP server/relays running as containers.