### PR TITLE
Iosl2 lag implementation.

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -10,6 +10,8 @@ LAG is currently supported on these platforms:
 | --------------------- |:--:|:--:|:--:|:---:|
 | Arista EOS [❗](caveats-eos) | ✅ | ✅ | ✅ | ✅ |
 | Aruba AOS-CX [❗](caveats-aruba) | ✅ | ✅ | ✅ | ✅ |
+| Cisco IOL L2[^iol2] | ✅ | ✅ | ✅ | ❌ |
+| Cisco IOSV L2[^iol2]  | ✅ | ✅ | ✅ | ❌ |
 | Cumulus Linux 4.x     | ✅ | ✅ | ❌  | ❌ |
 | Cumulus 5.x (NVUE)    | ✅ | ✅ | ❌  | ✅ |
 | Dell OS10             | ✅ | ✅ | ✅  | ✅ |
@@ -18,6 +20,7 @@ LAG is currently supported on these platforms:
 | JunOS[^Junos]         | ✅ | ✅ | ✅  | ❌ |
 
 [^Junos]: Includes vSRX, vPTX and vJunos-switch. vJunos-router (and vMX) do not support LAG.
+[^iol2]: Port-Channel interfaces will be treated like physical interfaces. Setting LACP rate is not avilable.
 
 ## Parameters
 

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -51,7 +51,7 @@ interface {{ mgmt.ifname|default('GigabitEthernet0/0') }}
 interface {{ l.ifname }}
 {% if l.type == 'vlan_member' and l.vlan.access_id is defined %}
  encapsulation dot1Q {{ l.vlan.access_id }}
-{% elif (l.type == 'lag' or l.virtual_interface is not defined) and netlab_device_type in ['iosvl2','ioll2'] %}
+{% elif l.virtual_interface is not defined and netlab_device_type in ['iosvl2','ioll2'] %}
  no switchport
 {% endif %}
 {% if l.vrf is defined %}

--- a/netsim/ansible/templates/lag/ios.j2
+++ b/netsim/ansible/templates/lag/ios.j2
@@ -1,0 +1,20 @@
+{% for intf in interfaces if intf.type == 'lag' %}
+{% set _switchport = intf.vlan is defined %}
+interface {{ intf.ifname }}
+ description {{ intf.name }}
+{% if _switchport %}
+ switchport 
+{% endif %}
+{% for ch in interfaces if ch.lag._parentindex|default(None) == intf.lag.ifindex %}
+{% set lag_mode = 
+'on' if intf.lag.lacp|default('') == 'off' else
+'active' if intf.lag.lacp_mode|default('') == 'active' else
+'passive' %}
+interface {{ ch.ifname }}
+ description {{ ch.name }} in channel-group {{ intf.lag.ifindex }}
+{% if _switchport %}
+ switchport 
+{% endif %}
+ channel-group {{ intf.lag.ifindex }} mode {{ lag_mode }}
+{% endfor %}
+{% endfor %}

--- a/netsim/devices/ioll2.py
+++ b/netsim/devices/ioll2.py
@@ -5,7 +5,7 @@ from box import Box
 
 from . import _Quirks
 
-from .iosvl2 import check_reserved_vlans,vlan_1_tagged
+from .iosvl2 import check_reserved_vlans,vlan_1_tagged,lag_remove_virtual
 from .iol import IOSXE as _IOSXE
 
 class IOSL2(_IOSXE):
@@ -17,3 +17,5 @@ class IOSL2(_IOSXE):
     if 'vlan' in mods:
       vlan_1_tagged(node,topology)
       check_reserved_vlans(node,topology)
+    if 'lag' in mods:
+        lag_remove_virtual(node,topology)  

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -13,6 +13,9 @@ features:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
     port_type: True
+  lag:
+    mlag: False
+    passive: True   
 clab:
   group_vars:
     netlab_device_type: ioll2

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -1,6 +1,7 @@
 ---
 description: IOSv L2 image
 parent: iol
+lag_interface_name: "Port-channel{lag.ifindex}"
 
 features:
   vlan:

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -16,7 +16,7 @@ features:
     port_type: True
   lag:
     mlag: False
-    passive: True   
+    passive: True
 clab:
   group_vars:
     netlab_device_type: ioll2

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -41,13 +41,7 @@ IOSv (classic) layer-2 image treats Port-Channel interfaces as physical interfac
 def lag_remove_virtual(node: Box, topology: Box) -> None:
   for intf in node.interfaces:
     if intf.get('type') == 'lag' and 'virtual_interface' in intf:
-        del intf['virtual_interface']
-        report_quirk(
-            f'Cisco IOS layer-2 image: PortChannel interface will be treated as a physical interface.',
-            more_data=f'Removing virtual_interface tag from (node {node.name} {intf.ifname})',
-            node=node,
-            quirk='lag_remove_virtual',
-            category=Warning)
+      del intf['virtual_interface']
 
 class IOSvL2(_IOS):
   @classmethod

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -43,7 +43,7 @@ def lag_remove_virtual(node: Box, topology: Box) -> None:
     if intf.get('type') == 'lag' and 'virtual_interface' in intf:
         del intf['virtual_interface']
         report_quirk(
-            f'Cisco IOS layer-2 image PortChannel interface will be treated as physical.',
+            f'Cisco IOS layer-2 image: PortChannel interface will be treated as a physical interface.',
             more_data=f'Removing virtual_interface tag from (node {node.name} {intf.ifname})',
             node=node,
             quirk='lag_remove_virtual',

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -35,6 +35,20 @@ def vlan_1_tagged(node: Box, topology: Box) -> None:
         quirk='vlan.tagged_1',
         category=Warning)
 
+'''
+IOSv (classic) layer-2 image treats Port-Channel interfaces as physical interfaces
+'''
+def lag_remove_virtual(node: Box, topology: Box) -> None:
+  for intf in node.interfaces:
+    if intf.get('type') == 'lag' and 'virtual_interface' in intf:
+        del intf['virtual_interface']
+        report_quirk(
+            f'IOSv (classic) layer-2 image PortChannelinterface will be treated as physical.',
+            more_data=f'Removing virtual_interface tag from (node {node.name} {intf.ifname})',
+            node=node,
+            quirk='lag_remove_virtual',
+            category=Warning)
+
 class IOSvL2(_IOS):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
@@ -42,5 +56,6 @@ class IOSvL2(_IOS):
     if 'vlan' in mods:
       vlan_1_tagged(node,topology)
       check_reserved_vlans(node,topology)
-
+    if 'lag' in mods:
+        lag_remove_virtual(node,topology)
     common_ios_quirks(node,topology)

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -43,7 +43,7 @@ def lag_remove_virtual(node: Box, topology: Box) -> None:
     if intf.get('type') == 'lag' and 'virtual_interface' in intf:
         del intf['virtual_interface']
         report_quirk(
-            f'IOSv (classic) layer-2 image PortChannel interface will be treated as physical.',
+            f'Cisco IOS layer-2 image PortChannel interface will be treated as physical.',
             more_data=f'Removing virtual_interface tag from (node {node.name} {intf.ifname})',
             node=node,
             quirk='lag_remove_virtual',

--- a/netsim/devices/iosvl2.py
+++ b/netsim/devices/iosvl2.py
@@ -43,7 +43,7 @@ def lag_remove_virtual(node: Box, topology: Box) -> None:
     if intf.get('type') == 'lag' and 'virtual_interface' in intf:
         del intf['virtual_interface']
         report_quirk(
-            f'IOSv (classic) layer-2 image PortChannelinterface will be treated as physical.',
+            f'IOSv (classic) layer-2 image PortChannel interface will be treated as physical.',
             more_data=f'Removing virtual_interface tag from (node {node.name} {intf.ifname})',
             node=node,
             quirk='lag_remove_virtual',

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -1,6 +1,8 @@
 ---
 description: IOSv L2 image
 interface_name: GigabitEthernet{ifindex // 4}/{ifindex % 4}
+lag_interface_name: "Port-channel{lag.ifindex}"
+
 parent: iosv
 group_vars:
   netlab_device_type: iosvl2
@@ -17,6 +19,9 @@ features:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
     port_type: True
+  lag:
+    mlag: False
+    passive: True  
 libvirt:
   image: cisco/iosvl2
   build: https://netlab.tools/labs/iosvl2/

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -21,7 +21,7 @@ features:
     port_type: True
   lag:
     mlag: False
-    passive: True  
+    passive: True
 libvirt:
   image: cisco/iosvl2
   build: https://netlab.tools/labs/iosvl2/


### PR DESCRIPTION
Enabled on ioll2 and iosvl2.

Passes integration tests lag  [01-03-*]. Test 04-lag-vlan-routed-trunk.yml crashes ioll2 image, and !!resets!! the running config of iosvl2. 