### PR TITLE
Documentation: spell-checking and a note of using long method in STP calculations

### DIFF
--- a/docs/module/lag.md
+++ b/docs/module/lag.md
@@ -20,7 +20,7 @@ LAG is currently supported on these platforms:
 | JunOS[^Junos]         | ✅ | ✅ | ✅  | ❌ |
 
 [^Junos]: Includes vSRX, vPTX and vJunos-switch. vJunos-router (and vMX) do not support LAG.
-[^iol2]: Port-Channel interfaces will be treated like physical interfaces. Setting LACP rate is not avilable.
+[^iol2]: Port-Channel interfaces are treated like physical interfaces. Setting LACP rate is not available.
 
 ## Parameters
 

--- a/docs/module/stp.md
+++ b/docs/module/stp.md
@@ -26,7 +26,7 @@ The following table describes per-platform support of individual STP features:
 [^CL]: STP is enabled by default
 [^OS10]: PVRST is enabled by default, STP does not work on virtual networks (which are used for VXLAN)
 [^FRR]: STP is disabled by default; STP is not supported on VLAN trunks as FRR sends BPDUs tagged, you could use Cumulus instead
-[^IOLL2]: Per Vlan RSTP is enabled by default. STP,RSTP are emulated with MSTP.
+[^IOLL2]: PVRST is enabled by default. STP,RSTP are emulated with MSTP. All algorithms use the "long" stp pathcost method.
 
 ```{tip}
 MSTP/RSTP ports fall back to regular STP upon receiving a plain STP BPDU.


### PR DESCRIPTION
- spellchecking errors
- mention that we use long stp cost method for ioll2 / iosvl2