### PR TITLE
bridge role: Postpone processing until lag module has created its extra links

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -943,12 +943,14 @@ def count_link_nodes(link: Box, nodes: Box) -> None:
 Get the default link type based on number of nodes. Also used for default pool selection
 """
 def get_default_link_type(link: Box) -> str:
-  if link.node_count > 2:
+  if 'type' in link:
+    return link.type
+
+  if link.node_count > 2 or (link.node_count == 2 and link.get('gateway')):
     return 'lan'
   
   if link.get('host_count',0):
     return 'lan'
-  
   return 'p2p' if link.node_count == 2 else 'stub'
 
 def set_link_type_role(link: Box, pools: Box, nodes: Box, defaults: Box) -> None:

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -543,7 +543,7 @@ def get_vlan_interface_mode(intf: Box) -> typing.Optional[str]:
   if not vlan:
     return None
 
-  raise log.ErrorAbort('get_vlan_interface_mode called on an interface witout _vlan_mode')
+  raise log.ErrorAbort(f'get_vlan_interface_mode called on an interface without _vlan_mode: {intf}')
 
 """
 set_link_vlan_prefix: copy link attributes from VLAN for access/native VLAN links

--- a/netsim/roles/bridge.py
+++ b/netsim/roles/bridge.py
@@ -136,6 +136,7 @@ def expand_multiaccess_links(topology: Box) -> None:
     br_node.vlans[vname].id = int_vlan_id                   # ... set its ID
     br_node.vlans[vname].mode = 'bridge'                    # ... and make it a L2-only VLAN
     br_intf.vlan.access = vname                             # ... and use it on the bridge interface
+    br_intf._vlan_mode = 'bridge'
 
     for link_cnt,intf in enumerate(link.interfaces,1):
       l_data = get_box(link_data)                           # Copy the link data
@@ -146,6 +147,9 @@ def expand_multiaccess_links(topology: Box) -> None:
 
     topology.links.remove(link)                             # Finally, remove original link
 
+"""
+pre_link_transform - executes after modules like lag have had a chance to create any extra links
+"""
 def pre_link_transform(topology: Box) -> None:
   if create_default_VLAN(topology):                         # If we have any bridge nodes ...
     add_default_access_vlan(topology)                       # Add 'vlan.access' to non-VLAN bridge ports  

--- a/netsim/roles/bridge.py
+++ b/netsim/roles/bridge.py
@@ -104,7 +104,6 @@ def expand_multiaccess_links(topology: Box) -> None:
     b_name = link.get('bridge',None)
     if not b_name:                                          # Is this one of the relevant links?
       continue                                              # No, move on
-
     if b_name not in topology.nodes:                        # Is the bridge name equal to a node name?
       continue                                              # No, it's a name of a Linux bridge
 
@@ -142,6 +141,7 @@ def expand_multiaccess_links(topology: Box) -> None:
       l_data = get_box(link_data)                           # Copy the link data
       l_data._linkname = f'{link._linkname}.{link_cnt}'     # Create unique link and and linkindex
       l_data.linkindex = links.get_next_linkindex(topology)
+      l_data.type = 'lan'
       l_data.interfaces = [ get_box(br_intf), intf ]        # ... recreate P2P interfaces
       topology.links.append(l_data)                         # ... and append the new P2P link to the links
 

--- a/netsim/roles/bridge.py
+++ b/netsim/roles/bridge.py
@@ -72,6 +72,7 @@ def add_default_access_vlan(topology: Box) -> None:
       if 'vlan' in intf:                                    # The interface has VLAN parameters, skip it
         continue
       intf.vlan.access = BR_DEFAULT
+      intf._vlan_mode = 'bridge'
 
 """
 Get next internal VLAN for an isolated bridge domain
@@ -145,7 +146,7 @@ def expand_multiaccess_links(topology: Box) -> None:
 
     topology.links.remove(link)                             # Finally, remove original link
 
-def pre_transform(topology: Box) -> None:
+def pre_link_transform(topology: Box) -> None:
   if create_default_VLAN(topology):                         # If we have any bridge nodes ...
     add_default_access_vlan(topology)                       # Add 'vlan.access' to non-VLAN bridge ports  
 


### PR DESCRIPTION
Fixes: #2528

```pre_transform``` is too early, the bridge role must wait until after ```module_pre_transform``` in the lag module has created its virtual links (if any)