### PR TITLE
IS-IS: Enable setting circuit type at interface level

### DIFF
--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -34,12 +34,12 @@ The following table describes per-platform support of individual IS-IS features:
 | Cisco ASAv         | ✅  |  ❌  | ✅  | ✅  |
 | Cisco IOS/XE[^18v] | ✅  | ✅  | ✅  | ✅  |
 | Cisco IOS XRv      | ✅  |  ❌  | ✅  | ✅  |
-| Cisco Nexus OS     | ✅  |  ❌  | ✅  | ✅  |
+| Cisco Nexus OS     | ✅  | ✅  | ✅  | ✅  |
 | FRR                | ✅  | ✅  | ✅  | ✅  |
-| Junos[^Junos]      | ✅  |  ❌  | ✅  | ✅  |
-| Nokia SR Linux     | ✅  |  ❌  | ✅  | ✅  |
-| Nokia SR OS        | ✅  |  ❌  | ✅  | ✅  |
-| VyOS               | ✅  |  ❌  | ✅  | ✅  |
+| Junos[^Junos]      | ✅  | ✅  | ✅  | ✅  |
+| Nokia SR Linux     | ✅  | ✅  | ✅  | ✅  |
+| Nokia SR OS        | ✅  | ✅  | ✅  | ✅  |
+| VyOS               | ✅  | ✅  | ✅  | ✅  |
 
 These platforms support additional IS-IS features:
 

--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -121,9 +121,9 @@ The IS-IS configuration module is automatically removed from a node that does no
 
 IS-IS is automatically started on all interfaces within an autonomous system (interfaces with no EBGP neighbors; see also [](routing_external)). To disable IS-IS on an intra-AS link, set the **isis** link parameter to *False* (see also [](routing_disable)).
 
-You can also set these parameters:
+You can also set these parameters on links or interfaces:
 
-* **isis.type** -- Set link type (**level-1**, **level-2** or **level-1-2**).
+* **isis.type** -- Set interface circuit type (the type of adjacency that can be established over this link -- **level-1**, **level-2** or **level-1-2**).
 * **isis.network_type** -- Set IS-IS network type. Valid values are **point-to-point** or *False* (do not set the network type). See also [Default Link Parameters](#default-link-parameters).
 * **isis.metric** or **isis.cost** -- Interface cost. Both parameters are recognized to make IS-IS configuration similar to OSPF (*metric* takes precedence over *cost*)
 * **isis.bfd** -- enable or disable BFD on individual interfaces. Like with the node-level **isis.bfd** parameter, this parameter could be a boolean value (*True* to enable BFD for all address families, *False* to disable IS-IS BFD on the interface) or a dictionary of address families, for example:

--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -1,12 +1,12 @@
 (module-isis)=
 # IS-IS Configuration Module
 
-This configuration module configures the IS-IS routing process on Cisco IOS, Cisco NX-OS, Arista EOS, Junos (tested on vSRX), Nokia SR OS, and Nokia SR Linux.
+This configuration module configures the IS-IS routing process on Arista EOS, Cisco ASAv, Cisco IOS, Cisco IOS-XR, Cisco NX-OS,  FRRouting, Junos, Nokia SR OS, Nokia SR Linux, and VyOS.
 
 The module supports the following IS-IS features:
 
 * IPv4 and IPv6
-* IS type (L1 and/or L2)
+* IS type and circuit type (L1 and/or L2)
 * Multi-topology IPv6 (enabled by default as soon as the node has at least one IPv6 address, cannot be disabled)
 * Wide metrics (enabled by default, cannot be turned off)
 * Unnumbered IPv4 interfaces
@@ -28,21 +28,33 @@ The module supports the following IS-IS features:
 
 The following table describes per-platform support of individual IS-IS features:
 
-| Operating system   | IS type | IPv6<br>AF | Multi<br>topology | Unnumbered<br />interfaces | Route<br>import | VRF<br>instances |
-|------------------- | :-: | :-: | :-: | :-: | :-: | :-: |
-| Arista EOS         | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
-| Cisco ASAv         | ✅  | ✅  | ✅  |  ❌  |  ❌  |  ❌  |
-| Cisco IOSv/IOSvL2  | ✅  | ✅  | ✅  | ✅  | ✅  |  ❌  |
-| Cisco IOS XE[^18v] | ✅  | ✅  | ✅  | ✅  | ✅  |  ❌  |
-| Cisco IOS XRv      | ✅  | ✅  | ✅  | ✅  |  ❌  |  ❌  |
-| Cisco Nexus OS     | ✅  | ✅  | ✅  | ✅  |  ❌  |  ❌  |
-| FRR                | ✅  | ✅  | ✅  | ✅  | ✅  | ✅  |
-| Junos[^Junos]      | ✅  | ✅  | ✅  | ✅  |  ❌  |  ❌  |
-| Nokia SR Linux     | ✅  | ✅  | ✅  | ✅  | ✅ [❗](caveats-srlinux) | ✅  |
-| Nokia SR OS        | ✅  | ✅  | ✅  | ✅  | ✅ [❗](caveats-sros) | ✅  |
-| VyOS               | ✅  | ✅  | ✅  |  ❌  |  ❌  |  ❌  |
+| Operating system   | IS type | Circuit<br>type | IPv6<br>AF | Multi<br>topology |
+|------------------- | :-: | :-: | :-: | :-: |
+| Arista EOS         | ✅  | ✅  | ✅  | ✅  |
+| Cisco ASAv         | ✅  |  ❌  | ✅  | ✅  |
+| Cisco IOS/XE[^18v] | ✅  | ✅  | ✅  | ✅  |
+| Cisco IOS XRv      | ✅  |  ❌  | ✅  | ✅  |
+| Cisco Nexus OS     | ✅  |  ❌  | ✅  | ✅  |
+| FRR                | ✅  | ✅  | ✅  | ✅  |
+| Junos[^Junos]      | ✅  |  ❌  | ✅  | ✅  |
+| Nokia SR Linux     | ✅  |  ❌  | ✅  | ✅  |
+| Nokia SR OS        | ✅  |  ❌  | ✅  | ✅  |
+| VyOS               | ✅  |  ❌  | ✅  | ✅  |
 
-[^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
+These platforms support additional IS-IS features:
+
+| Operating system   | Unnumbered<br />interfaces | Route<br>import | VRF<br>instances |
+|------------------- | :-: | :-: | :-: |
+| Arista EOS         | ✅  | ✅  | ✅  |
+| Cisco IOS/XE[^18v] | ✅  | ✅  |  ❌  |
+| Cisco IOS XRv      | ✅  |  ❌  |  ❌  |
+| Cisco Nexus OS     | ✅  |  ❌  |  ❌  |
+| FRR                | ✅  | ✅  | ✅  |
+| Junos[^Junos]      | ✅  |  ❌  |  ❌  |
+| Nokia SR Linux     | ✅  | ✅ [❗](caveats-srlinux) | ✅  |
+| Nokia SR OS        | ✅  | ✅ [❗](caveats-sros) | ✅  |
+
+[^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
 
 [^Junos]: Includes vMX, vSRX, vPTX, vJunos-switch, and vJunos-router
 
@@ -111,7 +123,7 @@ IS-IS is automatically started on all interfaces within an autonomous system (in
 
 You can also set these parameters:
 
-* **isis.type** -- Link type (**level-1**, **level-2** or **level-1-2**). Recognized as a valid attribute, but not implemented for all platforms. Currently supported on ios family, eos and frr devices. Please feel free to fix the configuration templates and submit a pull request.
+* **isis.type** -- Set link type (**level-1**, **level-2** or **level-1-2**).
 * **isis.network_type** -- Set IS-IS network type. Valid values are **point-to-point** or *False* (do not set the network type). See also [Default Link Parameters](#default-link-parameters).
 * **isis.metric** or **isis.cost** -- Interface cost. Both parameters are recognized to make IS-IS configuration similar to OSPF (*metric* takes precedence over *cost*)
 * **isis.bfd** -- enable or disable BFD on individual interfaces. Like with the node-level **isis.bfd** parameter, this parameter could be a boolean value (*True* to enable BFD for all address families, *False* to disable IS-IS BFD on the interface) or a dictionary of address families, for example:

--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -111,7 +111,7 @@ IS-IS is automatically started on all interfaces within an autonomous system (in
 
 You can also set these parameters:
 
-* **isis.type** -- Link type (**level-1**, **level-2** or **level-1-2**). Recognized as a valid attribute but not implemented. Please feel free to fix the configuration templates and submit a pull request.
+* **isis.type** -- Link type (**level-1**, **level-2** or **level-1-2**). Recognized as a valid attribute, but not implemented for all platforms. Currently supported on ios family, eos and frr devices. Please feel free to fix the configuration templates and submit a pull request.
 * **isis.network_type** -- Set IS-IS network type. Valid values are **point-to-point** or *False* (do not set the network type). See also [Default Link Parameters](#default-link-parameters).
 * **isis.metric** or **isis.cost** -- Interface cost. Both parameters are recognized to make IS-IS configuration similar to OSPF (*metric* takes precedence over *cost*)
 * **isis.bfd** -- enable or disable BFD on individual interfaces. Like with the node-level **isis.bfd** parameter, this parameter could be a boolean value (*True* to enable BFD for all address families, *False* to disable IS-IS BFD on the interface) or a dictionary of address families, for example:

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -28,11 +28,14 @@ interface {{ l.ifname }}
 {%   if l.isis.network_type is defined %}
   isis network {{ l.isis.network_type }}
 {%   endif %}
+{% if l.isis.type is defined %}
+ isis circuit-type {{ l.isis.type }}
+{% endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
   isis metric {{ l.isis.metric|default(l.isis.cost) }}
 {%     if 'ipv6' in isis.af and 'ipv6' in l %}
   isis ipv6 metric {{ l.isis.metric|default(l.isis.cost) }}
-{%     endif %}}
+{%     endif %}
 {%   endif %}
 {%   if l.isis.bfd.ipv4|default(False) %}
   isis bfd

--- a/netsim/ansible/templates/isis/frr.macro.j2
+++ b/netsim/ansible/templates/isis/frr.macro.j2
@@ -33,6 +33,9 @@ interface {{ l.ifname }}
 {%   if l.isis.network_type is defined %}
  isis network {{ l.isis.network_type }}
 {%   endif %}
+{% if l.isis.type is defined %}
+ isis circuit-type {{ l.isis.type }}
+{% endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
  isis metric {{ l.isis.metric|default(l.isis.cost) }}
 {%   endif %}

--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -20,7 +20,7 @@ interface {{ l.ifname }}
   isis three-way-handshake ietf
 {%   endif %}
 {% if l.isis.type is defined %}
- isis circuit-type {{ l.isis.type }}
+  isis circuit-type {{ l.isis.type }}
 {% endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
   isis metric {{ l.isis.metric|default(l.isis.cost) }}

--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -19,6 +19,9 @@ interface {{ l.ifname }}
 {%   if l.isis.network_type is defined and l.isis.network_type == "point-to-point" %}
   isis three-way-handshake ietf
 {%   endif %}
+{% if l.isis.type is defined %}
+ isis circuit-type {{ l.isis.type }}
+{% endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
   isis metric {{ l.isis.metric|default(l.isis.cost) }}
 {%     if ('ipv6' in l or 'ipv6' in l.dhcp.client|default({})) and 'ipv6' in isis.af  %}

--- a/netsim/ansible/templates/isis/junos.j2
+++ b/netsim/ansible/templates/isis/junos.j2
@@ -1,3 +1,9 @@
+{% macro disable_level(l_type) %}
+{%   for level in ['1','2'] if level not in l_type|default('1-2') %}
+    level {{ level }} disable;
+{%   endfor %}
+{% endmacro %}
+
 protocols {
   delete: isis;
 }
@@ -8,9 +14,7 @@ protocols {
       ipv6-unicast;
     }
 {% endif %}
-{% for level in ['1','2'] if level not in isis.type|default('1-2') %}
-    level {{ level }} disable;
-{% endfor %}
+{{ disable_level(isis.type) }}
     level 1 wide-metrics-only;
     level 2 wide-metrics-only;
     interface lo0.0;
@@ -19,6 +23,7 @@ protocols {
 {%   if l.isis.network_type is defined %}
       {{ l.isis.network_type }};
 {%   endif %}
+{{   disable_level(l.isis.type)|indent(2,first=True) }}
 {%   if l.isis.passive %}
       passive;
 {%   endif %}

--- a/netsim/ansible/templates/isis/nxos.j2
+++ b/netsim/ansible/templates/isis/nxos.j2
@@ -36,6 +36,9 @@ interface {{ l.ifname }}
 {%   if l.isis.network_type is defined %}
   isis network {{ l.isis.network_type }}
 {%   endif %}
+{% if l.isis.type is defined %}
+  isis circuit-type {{ l.isis.type }}
+{% endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
   isis metric {{ l.isis.metric|default(l.isis.cost) }} level-1
   isis metric {{ l.isis.metric|default(l.isis.cost) }} level-2

--- a/netsim/ansible/templates/isis/srlinux.macro.j2
+++ b/netsim/ansible/templates/isis/srlinux.macro.j2
@@ -13,12 +13,12 @@
 {% endif %}
 {% if isis.af.ipv6 is defined %}
      ipv6-unicast:
-      admin-state: enable
+       admin-state: enable
 {%   if clab.type in ['ixr6','ixr10','ixr6e','ixr10e'] %}
-      multi-topology: {{ 'sr' not in module|default([]) }}
-      _annotate_multi-topology: "Not supported in combination with SR"
+       multi-topology: {{ 'sr' not in module|default([]) }}
+       _annotate_multi-topology: "Not supported in combination with SR"
 {%   else %}
-      multi-topology: True
+       multi-topology: True
 {%   endif %}
 {% endif %}
 {% if ldp is defined and ldp.igp_sync|default(True) %}
@@ -31,9 +31,9 @@
      - interface-name: system0.0
        passive: True
        ipv4-unicast:
-        admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
+         admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
        ipv6-unicast:
-        admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
+         admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
 {% endif %}
 {% for l in interfaces if (l.vlan is not defined or l.vlan.mode|default('irb')!='bridge') and l.subif_index is not defined %}
 {%   set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
@@ -44,23 +44,24 @@
        circuit-type: {{ l.isis.network_type|default("broadcast") }}
        passive: {{ l.isis.passive }}
        ipv4-unicast:
-        admin-state: {{ 'enable' if 'ipv4' in l and 'ipv4' in isis.af else 'disable' }}
-        enable-bfd: {{ l.isis.bfd.ipv4|default(False) }}
+         admin-state: {{ 'enable' if 'ipv4' in l and 'ipv4' in isis.af else 'disable' }}
+         enable-bfd: {{ l.isis.bfd.ipv4|default(False) }}
 {%     if 'ipv6' in l and 'ipv6' in isis.af  %}
        ipv6-unicast:
-        admin-state: enable
-        enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
+         admin-state: enable
+         enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
 {%     endif %}
-{%     if l.isis.metric is defined or l.isis.cost is defined %}
+{%     if l.isis.metric is defined or l.isis.cost is defined or l.isis.type is defined %}
        level:
-{%       if isis.type!='level-2' %}
-       - level-number: 1
+{%       for level in ['1','2'] %}
+{%         if level not in l.isis.type|default('level-1-2') %}
+       - level-number: {{ level }}
+         disable: True
+{%         elif l.isis.metric is defined or l.isis.cost is defined %}
+       - level-number: {{ level }}
          metric: {{ l.isis.metric|default(l.isis.cost) }}
-{%       endif %}
-{%       if isis.type!='level-1' %}
-       - level-number: 2
-         metric: {{ l.isis.metric|default(l.isis.cost) }}
-{%       endif %}
+{%         endif %}
+{%       endfor %}
 {%     endif %}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/isis/sros.j2
+++ b/netsim/ansible/templates/isis/sros.j2
@@ -45,6 +45,9 @@
       - interface-name: {{ if_name(l,l.ifname) }}
         interface-type: {{ l.isis.network_type|default('broadcast') }}
         passive: {{ l.isis.passive }}
+{%     if l.isis.type is defined %}
+        level-capability: "{{ kw_level[l.isis.type] }}"
+{%     endif %}
 {%     if l.isis.bfd is defined %}
         bfd-liveness:
 {%     if l.isis.bfd.ipv4|default(False) %}

--- a/netsim/ansible/templates/isis/vyos.j2
+++ b/netsim/ansible/templates/isis/vyos.j2
@@ -26,6 +26,9 @@ set protocols isis interface {{ l.ifname }}
 {%   if l.isis.network_type is defined and l.isis.network_type == 'point-to-point' %}
 set protocols isis interface {{ l.ifname }} network point-to-point
 {%   endif %}
+{%   if l.isis.type is defined %}
+set protocols isis interface {{ l.ifname }} circuit-type {{ l.isis.type }}
+{%   endif %}
 {%   if l.isis.cost is defined or l.isis.metric is defined %}
 set protocols isis interface {{ l.ifname }} metric {{ l.isis.metric|default(l.isis.cost) }}
 {%   endif %}

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -52,11 +52,12 @@ features:
   gateway:
     protocol: [ anycast, vrrp ]
   isis:
+    circuit_type: true
+    import: [ bgp, ospf, ripv2, connected, static, vrf ]
     unnumbered:
       ipv4: true
       ipv6: true
       network: true
-    import: [ bgp, ospf, ripv2, connected, static, vrf ]
   lag:
     mlag:
       peer:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -80,6 +80,7 @@ features:
   gateway:
     protocol: [ vrrp, anycast ]
   isis:
+    circuit_type: true
     import: [ bgp, ripv2, ospf, connected, static, vrf ]
     unnumbered:
       ipv4: true

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -53,6 +53,7 @@ features:
     roles: [ host, router, bridge ]
     mgmt_vrf: true
   isis:
+    circuit_type: true
     import: [ bgp, ospf, ripv2, connected, static ]
     unnumbered:
       ipv4: true

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -29,6 +29,7 @@ features:
   gateway:
     protocol: [ anycast, vrrp ]
   isis:
+    circuit_type: true
     unnumbered:
       ipv4: true
       ipv6: true

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -42,6 +42,7 @@ features:
   gateway:
     protocol: [ vrrp ]
   isis:
+    circuit_type: true
     unnumbered:
       ipv4: true
       ipv6: true

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -58,6 +58,7 @@ features:
   gateway:
     protocol: [ anycast ]
   isis:
+    circuit_type: true
     unnumbered:
       ipv4: True
       ipv6: True

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -43,6 +43,7 @@ features:
     irb: True
     asymmetrical_irb: True
   isis:
+    circuit_type: true
     unnumbered:
       ipv4: True
       ipv6: True

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -30,7 +30,8 @@ features:
     irb: true
   gateway:
     protocol: [ vrrp ]
-  isis: true
+  isis:
+    circuit_type: true
   lag:
     passive: False
   mpls:

--- a/tests/integration/isis/03-dual-stack.yml
+++ b/tests/integration/isis/03-dual-stack.yml
@@ -8,11 +8,12 @@ module: [ isis ]
 
 defaults.interfaces.mtu: 1500
 defaults.sources.extra: [ defaults-ds.yml, ../wait_times.yml, ../warnings.yml ]
+defaults.isis.warnings.circuit_type: False
 
 groups:
   probes:
     provider: clab
-    members: [ x1, x2 ]
+    members: [ x1, x2, x3 ]
 
 isis.type: level-1-2
 
@@ -20,6 +21,7 @@ nodes:
   dut:
   x1:
   x2:
+  x3:
 
 links:
 - dut:
@@ -28,6 +30,10 @@ links:
 - dut:
   x2:
 
+- dut:
+    isis.type: level-1
+  x3:
+
 validate:
   adj:
     description: Check IS-IS adjacencies
@@ -35,6 +41,18 @@ validate:
     wait: isis_adj_p2p
     nodes: [ x1, x2 ]
     plugin: isis_neighbor('dut',level='L1L2')
+  adj_x3:
+    description: Check the DUT-X3 IS-IS adjacency
+    wait_msg: Waiting for IS-IS adjacency process to complete
+    wait: isis_adj_p2p
+    nodes: [ x3 ]
+    plugin: isis_neighbor('dut')
+  adj_ct:
+    description: Check the level of DUT-X3 IS-IS adjacency
+    fail: The IS-IS adjacency is not limited by the circuit type on DUT
+    nodes: [ x3 ]
+    plugin: isis_neighbor('dut',level='L1')
+    level: warning
   pfx_v4:
     description: Check IS-IS IPv4 prefix
     wait_msg: Waiting for IS-IS SPF run


### PR DESCRIPTION
IS-IS Enable setting circuit type at interface level.
Implemented for ios, eos, frr. 