### PR TITLE
IS-IS: Add IPv6 BFD support for all interfaces

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -17,6 +17,7 @@
 * Use **libvirt.uuid** node property to ensure a vEOS VM does not change its serial number every time you start the lab.
 * Anycast gateways and DHCP/DHCPv6 clients do not work on Arista cEOS Ethernet interfaces.
 * Arista EOS cannot configure OSPF NSSA type-7 address ranges.
+* IPv6 BFD for IS-IS cannot be enabled on individual interfaces.  If you set **isis.bfd.ipv6** to *True*, BFD is enabled on all IS-IS interfaces.
 * cEOS MPLS data plane was introduced in release 4.32.1F.
 * Arista cEOS disables OSPFv2 on broadcast container stub interfaces (implemented as _dummy_ interfaces). _netlab_ automatically changes the OSPF network type for Arista cEOS dummy interfaces to **point-to-point**.
 * Arista EOS virtual machines and containers use [proprietary control-plane messages to indicate the loss of Ethernet line protocol](https://blog.ipspace.net/2025/03/arista-spooky-action-distance/). Set the **netlab_phy_control** node variable to *False* to disable this functionality.

--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -70,7 +70,7 @@ Some platforms can use BFD to speed up IS-IS convergence:
 
 | Operating system      | IPv4<br />BFD | IPv6<br />BFD |
 | ------------------ | :-: | :-: |
-| Arista EOS         | ✅  | ❌  |
+| Arista EOS         | ✅  | ✅  |
 | Cisco IOSv/IOSvL2  | ✅  | ✅ | 
 | Cisco IOS XE[^18v] | ✅  | ✅ | 
 | Cisco Nexus OS     | ✅  |  ❌ |
@@ -78,6 +78,9 @@ Some platforms can use BFD to speed up IS-IS convergence:
 | Nokia SR Linux     | ✅  | ✅ | 
 | Nokia SR OS        | ✅  | ✅ | 
 | VyOS               | ✅  | ✅ |
+
+**Notes:**
+* On Arista EOS, IPv6 BFD is only supported on all interfaces.
 
 ```{tip}
 See [IS-IS Integration Tests Results](https://release.netlab.tools/_html/coverage.isis) for more details.

--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -62,15 +62,17 @@ These platforms support additional IS-IS features:
 * On Arista EOS, IPv6 is enabled on all interfaces as soon as one has an IPv6 address. Arista EOS implementation of IS-IS refuses to work on interfaces with missing address families.
 * On VyOS, IPv6 is enabled on all interfaces as soon as one has an IPv6 address.
 * Cisco ASA does not support P2P IS-IS links. You could add `isis.network_type: false` to point-to-point links connecting ASA to other devices.
-* See [IS-IS](https://release.netlab.tools/_html/isis)  Integration Tests Results for more details.
-
 * Use the `netlab show modules -m isis` command to display the route types that can be imported into IS-IS.
+
+```{tip}
+See [IS-IS Integration Tests Results](https://release.netlab.tools/_html/coverage.isis) for more details.
+```
 
 Some platforms can use BFD to speed up IS-IS convergence:
 
 | Operating system      | IPv4<br />BFD | IPv6<br />BFD |
 | ------------------ | :-: | :-: |
-| Arista EOS         | ✅  | ✅  |
+| Arista EOS         | ✅  | ✅❗|
 | Cisco IOSv/IOSvL2  | ✅  | ✅ | 
 | Cisco IOS XE[^18v] | ✅  | ✅ | 
 | Cisco Nexus OS     | ✅  |  ❌ |
@@ -80,11 +82,7 @@ Some platforms can use BFD to speed up IS-IS convergence:
 | VyOS               | ✅  | ✅ |
 
 **Notes:**
-* On Arista EOS, IPv6 BFD is only supported on all interfaces.
-
-```{tip}
-See [IS-IS Integration Tests Results](https://release.netlab.tools/_html/coverage.isis) for more details.
-```
+* On Arista EOS, IPv6 BFD for IS-IS is enabled globally (on all IS-IS-enabled interfaces).
 
 ## Global Parameters
 

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -19,6 +19,9 @@ router isis {{ isis.instance }}{% if vrf %} vrf {{ vrf }}{% endif +%}
 {% if isis.af.ipv6 is defined %}
   address-family ipv6 unicast
     multi-topology
+{%   if isis.bfd.ipv6|default(False) %}
+    bfd all-interfaces
+{%   endif %}
 {% endif %}
 !
 {% for l in interfaces|default([]) if 'isis' in l %}
@@ -41,7 +44,7 @@ interface {{ l.ifname }}
   isis bfd
 {%   endif %}
 {%   if l.isis.bfd.ipv6|default(False) %}
-! BFD is not supported for IPv6 ISIS
+! BFD for IPv6 ISIS is only supported on all interfaces
 {%   endif %}
 {%   if l.isis.passive %}
   isis passive


### PR DESCRIPTION
Arista EOS knob to enable IPv6 ISIS BFD for all interfaces