### PR TITLE
SRLinux: Take global isis.type into account

### DIFF
--- a/netsim/ansible/templates/isis/srlinux.macro.j2
+++ b/netsim/ansible/templates/isis/srlinux.macro.j2
@@ -54,7 +54,7 @@
 {%     if l.isis.metric is defined or l.isis.cost is defined or l.isis.type is defined %}
        level:
 {%       for level in ['1','2'] %}
-{%         if level not in l.isis.type|default('level-1-2') %}
+{%         if level not in l.isis.type|default(isis.type|default('level-1-2')) %}
        - level-number: {{ level }}
          disable: True
 {%         elif l.isis.metric is defined or l.isis.cost is defined %}


### PR DESCRIPTION
In ```integration/isis/12-passive.yml``` the global isis.level is defined as "level-1"

Without this fix, the SR Linux template enables level-2 on all interfaces