### PR TITLE
Clab: Use node id in bridge interface name for multilab deployments

### DIFF
--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -118,7 +118,7 @@ topology:
 {%       if defaults.multilab.id|default(False) %}
     - "{{ l.bridge }}:{{ name[:6] }}_{{ n.id }}_{{ nl.ifindex }}"
 {%       else %}
-    - "{{ l.bridge }}:{{ n.name[:10] }}_{{ clab.name|default(nl.ifname) }}"
+    - "{{ l.bridge }}:{{ n.id }}_{{ clab.name|default(nl.ifname) }}"
 {%       endif %}
 {%     endfor %}
 {%   endfor %}


### PR DESCRIPTION
Instead of the name, which may not be unique in the first 10 characters

Fixes #2564