### PR TITLE
Fix: allow output-specific attributes in group node data

### DIFF
--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -119,9 +119,6 @@ def check_group_data_structure(
 
   list_of_modules = modules.list_of_modules(topology)
 
-  # Allow provider- and tool- specific node attributes
-  extra = get_object_attributes(['providers','tools'],topology)
-
   for grp,gdata in parent.groups.items():
     if grp.startswith('_'):                       # Skip stuff starting with underscore
       continue                                    # ... could be system settings
@@ -182,7 +179,8 @@ def validate_group_data(
   if 'groups' not in parent:
     return
 
-  extra = get_object_attributes(['providers','tools'],topology)
+  # Allow provider-, tool-, and output- specific node attributes
+  extra = get_object_attributes(topology.defaults.attributes.node_extra_ns,topology)
 
   for grp,gdata in parent.groups.items():
     if grp.startswith('_'):                       # Skip stuff starting with underscore

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -75,8 +75,8 @@ def create_node_dict(nodes: Box) -> Box:
 Validate node attributes
 """
 def validate(topology: Box) -> None:
-  # Allow provider- and tool- specific node attributes
-  extra = get_object_attributes(['providers','tools','outputs'],topology)
+  # Allow provider-, tool- and output- specific node attributes
+  extra = get_object_attributes(topology.defaults.attributes.node_extra_ns,topology)
   for n_name,n_data in topology.nodes.items():
     must_be_id(
       parent=None,

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -81,6 +81,8 @@ interface:                  # Interface (node-to-link attachment) attributes
   ifindex: int
   ifname: str
 
+node_extra_ns: [ providers, tools, outputs ]
+
 node:
   name: str                                         # Validity of node name is checked in the nodes module
   interfaces: list


### PR DESCRIPTION
The list of extra attributes namespaces in groups has been synchronized with the one in nodes. Instead of using hard-coded values, both instances use 'node_extra_ns' attribute value.

Closes #2551