### PR TITLE
Fix: Make the ifname of host-side part of vEth pair unique

### DIFF
--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -114,12 +114,25 @@ topology:
 {%       set clab = nl.clab|default({}) %}
   - endpoints:
     - "{{ n.name }}:{{ clab.name|default(nl.ifname) }}"
-{# Use node_intf name for bridge veth interface in standard setup and more cryptic (but unique) name in multilab deployment #}
-{%       if defaults.multilab.id|default(False) %}
-    - "{{ l.bridge }}:{{ name[:6] }}_{{ n.id }}_{{ nl.ifindex }}"
-{%       else %}
-    - "{{ l.bridge }}:{{ n.name[:10] }}_{{ clab.name|default(nl.ifname) }}"
-{%       endif %}
+{# 
+    Whatever we try to do to make the bridge interface names sane, someone
+    inevitably finds a "counter-example" because (for example) one could not
+    possibly make the node names unique in the first 10 characters
+    (see #2564 for details).
+
+    As a desperate attempt to get away from that nasty can of worms, we'll
+    make the bridge interface names cryptic and made of three parts:
+
+    * nbi{multilab.id} to handle the multilab scenarios
+    * n{id} to make interface names unique based on node ID
+    * i{id} to distinguish between interfaces on the node
+
+    None of these components can use 'native' node or interface names, or
+    we run out of the 16-character limit. Please note this only applies to
+    bridge-side part of vEth pair; the overly-long names of VM interfaces
+    connected to a bridge are left to Vagrant).
+#}
+    - "{{ l.bridge }}:bni{{ defaults.multilab.id|default(0) }}n{{ n.id }}i{{ nl.ifindex }}"
 {%     endfor %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
We have to connect the host-side part of a vEth pair to a Linux bridge in a multi-access or multi-provider environment. To do that, we have to have a unique host-side interface name, and the current mechanisms failed for people who couldn't possibly make their node names unique in the first 10 characters.

This fix replaces the 'use the node name prefix' trick that helped keep the device name under 16 characters (until containerlab started using long interface names for SR-SIM) with a totally cryptic interface name that shouldn't exceed 16 characters unless you're doing something truly crazy (for example, 8-digit multilab ID).

As we're not using the bridge-side interface names anywhere else in the code ('netlab capture' command is started within the container NS), this SHOULD NOT (BUT WHO KNOWS) affect anything else.

Fixes #2564