### PR TITLE
Add '--suffix' parameter to 'netlab collect'

### DIFF
--- a/docs/netlab/collect.md
+++ b/docs/netlab/collect.md
@@ -1,21 +1,22 @@
 (netlab-collect)=
 # Collecting Device Configurations
 
-**netlab collect** command uses Ansible *device facts* modules (or an equivalent list of Ansible tasks) to collect device configurations and store them in specified output directory.
+The **netlab collect** command collects device configurations using Ansible *device facts* modules (or an equivalent list of Ansible tasks). The configurations are stored in the specified output directory (default: *config*).
 
-A single configuration file in the output directory is created for most network devices; multiple files are collected from FRR and Cumulus VX.
+A single configuration file in the output directory is created for most network devices; multiple files are collected from FRR and Cumulus VX. The configuration files have a `.cfg` suffix unless you specify a different suffix (without the leading dot) with the `--suffix` parameter.
 
-After collecting the device configurations, you can save them in a tar archive with the `--tar` option and clean up the working directory with `--cleanup` option.
+After collecting the device configurations, you can save them in a tar archive with the `--tar` option and clean up the working directory with the `--cleanup` option.
 
 ```{tip}
-* **netlab collect** command is just a thin wrapper around an Ansible playbook which uses Ansible inventory created by **netlab create** or **netlab up** command.
+* The **netlab collect** command is just a thin wrapper around an Ansible playbook which uses the Ansible inventory created by the **netlab create** or **netlab up** command.
 * When executed with the `-i` option, **‌netlab collect** switches to the lab directory to execute the Ansible playbook, but stores the results within the directory from which it was executed.
 ```
 
 ## Usage
 
 ```text
-usage: netlab collect [-h] [-v] [-q] [-o [OUTPUT]] [--tar TAR] [--cleanup] [-i INSTANCE]
+usage: netlab collect [-h] [-v] [-q] [-o [OUTPUT]] [--suffix SUFFIX] [--tar TAR]
+                      [--cleanup] [-i INSTANCE]
 
 Collect device configurations
 
@@ -23,12 +24,13 @@ options:
   -h, --help            show this help message and exit
   -v, --verbose         Verbose logging
   -q, --quiet           Run Ansible playbook and tar with minimum output
-  -o [OUTPUT], --output [OUTPUT]
+  -o, --output [OUTPUT]
                         Output directory (default: config)
+  --suffix SUFFIX       Configure file(s) suffix (default: cfg)
   --tar TAR             Create configuration tarball
   --cleanup             Clean up config directory and modified configuration file after
                         creating tarball
-  -i INSTANCE, --instance INSTANCE
+  -i, --instance INSTANCE
                         Specify lab instance to collect configuration from
 
 All other arguments are passed directly to ansible-playbook

--- a/netsim/ansible/collect-configs.ansible
+++ b/netsim/ansible/collect-configs.ansible
@@ -5,6 +5,7 @@
   gather_facts: false
   vars:
     config_dir: "{{ lookup('env','PWD') }}/{{ target|default('config') }}"
+    cfg_suffix: "{{ suffix|default('cfg') }}"
     node_provider: "{{ provider|default(netlab_provider) }}"
   tasks:
   - name: Set variables that cannot be set with VARS
@@ -37,6 +38,6 @@
   - name: Copy collected configuration to '{{ config_dir }}' directory
     copy:
       content: "{{ ansible_net_config }}"
-      dest: "{{ config_dir }}/{{ inventory_hostname }}.cfg"
+      dest: "{{ config_dir }}/{{ inventory_hostname }}.{{ cfg_suffix }}"
     delegate_to: localhost
     when: ansible_net_config is defined

--- a/netsim/ansible/tasks/fetch-config/cumulus.yml
+++ b/netsim/ansible/tasks/fetch-config/cumulus.yml
@@ -8,7 +8,7 @@
   register: config
 - name: Save FRR configuration to {{ ofile }}
   vars:
-    ofile: "{{ config_dir }}/{{ inventory_hostname }}.cfg"
+    ofile: "{{ config_dir }}/{{ inventory_hostname }}.{{ cfg_suffix }}"
   copy:
     content: |
       {{ config.stdout }}

--- a/netsim/ansible/tasks/fetch-config/frr.yml
+++ b/netsim/ansible/tasks/fetch-config/frr.yml
@@ -8,14 +8,7 @@
   command: cat /etc/frr/frr.conf
   become: true
   register: config
-- name: Save FRR configuration to {{ ofile }}
-  vars:
-    ofile: "{{ config_dir }}/{{ inventory_hostname }}.cfg"
-  copy:
-    content: |
-      {{ config.stdout }}
-    dest: "{{ ofile }}"
-  delegate_to: localhost
+- set_fact: ansible_net_config={{ config.stdout }}
 
 - name: Collect FRR daemons configuration
   command: cat /etc/frr/daemons

--- a/netsim/ansible/tasks/fetch-config/srlinux.yml
+++ b/netsim/ansible/tasks/fetch-config/srlinux.yml
@@ -12,8 +12,4 @@
       datastore: running
   register: get_result
 
-- name: Save fetched config
-  delegate_to: localhost
-  ansible.builtin.copy:
-    content: "{{ get_result.result[0] | to_nice_json }}"
-    dest: "{{ config_dir }}/{{ inventory_hostname }}.cfg"
+- set_fact: ansible_net_config={{ get_result.result[0] | to_nice_json }}

--- a/netsim/cli/collect.py
+++ b/netsim/cli/collect.py
@@ -41,6 +41,12 @@ def collect_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, ty
     default='config',
     help='Output directory (default: config)')
   parser.add_argument(
+    '--suffix',
+    dest='suffix',
+    action='store',
+    default='cfg',
+    help='Configure file(s) suffix (default: cfg)')
+  parser.add_argument(
     '--tar',
     dest='tar',
     action='store',
@@ -77,6 +83,9 @@ def run(cli_args: typing.List[str]) -> None:
     rest = ['-v'] + rest
 
   rest = ['-e','target='+args.output ] + rest
+
+  if args.suffix:
+    rest += ['-e','suffix='+args.suffix]
 
   if args.tar and not args.quiet:
     external_commands.print_step(1,"Collecting device configurations")


### PR DESCRIPTION
The 'netlab collect' command usually saves configuration files with the '.cfg' suffix (which can then be used in 'netlab up --reload' process). However, when building a multi-platform solution, it might be helpful to save the configuration files with a platform-specific suffix, for example 'eos.j2'. The '--suffix' parameter allows you to replace the standard 'cfg' suffix with something else

As a few 'fetch-config' task lists used hardcoded '.cfg' suffix, most of them were either fixed to use the 'cfg_suffix' variable or (even better) set 'ansible_net_config' fact instead of creating the output file directly.