### PR TITLE
VyOS: Implement configuration templates using only 'set' commands

### DIFF
--- a/netsim/ansible/tasks/deploy-config/vyos-script.j2
+++ b/netsim/ansible/tasks/deploy-config/vyos-script.j2
@@ -1,0 +1,19 @@
+{% if 'vbash' in script_content %}
+{{   script_content }}
+{% else %}
+#!/bin/vbash
+source /opt/vyatta/etc/functions/script-template
+
+if [ "$(id -g -n)" != 'vyattacfg' ] ; then
+    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
+fi
+
+# Configuration items start here
+configure
+
+{{ script_content }}
+
+commit
+save
+exit
+{% endif %}

--- a/netsim/ansible/tasks/deploy-config/vyos.yml
+++ b/netsim/ansible/tasks/deploy-config/vyos.yml
@@ -1,21 +1,9 @@
-- block:
-  - wait_for_connection:
-      timeout: 120
-      sleep: 3
-  - wait_for:
-      timeout: 120
-      path: /tmp/vyos-config-status
-  when: |
-    node_provider == 'clab' and vyos_booted is not defined
-
 - set_fact:
-    vyos_booted: 1
-
-- set_fact:
+    script_content: "{{ lookup('template',config_template) }}"
     destination_script: "/tmp/config-{{ netsim_action|replace('/', '_') }}.sh"
 
 - template:
-    src: "{{ config_template }}"
+    src: vyos-script.j2
     dest: "{{ destination_script }}"
 
 - name: "execute config-{{ netsim_action }}.sh to deploy {{ netsim_action }} config from {{ config_template }}"

--- a/netsim/ansible/tasks/fetch-config/vyos.yml
+++ b/netsim/ansible/tasks/fetch-config/vyos.yml
@@ -1,10 +1,7 @@
 #
-# Fetch VyOS boot configuration files
+# Fetch VyOS configuration commands
 #
-- fetch:
-    src: "{{ item }}"
-    dest: "{{ config_dir }}/{{ inventory_hostname }}/"
-    flat: yes
-  become: True
-  loop:
-  - /config/config.boot
+- name: Collect VyOS configuration
+  shell: /bin/vbash -cil 'show configuration commands'
+  register: config
+- set_fact: ansible_net_config={{ config.stdout }}

--- a/netsim/ansible/tasks/readiness-check/vyos-clab.yml
+++ b/netsim/ansible/tasks/readiness-check/vyos-clab.yml
@@ -1,0 +1,6 @@
+- wait_for_connection:
+    timeout: 120
+    sleep: 3
+- wait_for:
+    timeout: 120
+    path: /tmp/vyos-config-status

--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -1,14 +1,4 @@
-#!/bin/vbash
-source /opt/vyatta/etc/functions/script-template
-
-if [ "$(id -g -n)" != 'vyattacfg' ] ; then
-    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
-fi
-
-# Configuration items start here
 {% import "vyos.macro.j2" as bgpcfg %}
-
-configure
 
 set protocols bgp system-as {{ bgp.as }}
 
@@ -64,10 +54,3 @@ set protocols bgp address-family {{ af }}-unicast redistribute {{ s_proto }}{%
 {% for pfx in bgp.originate|default([]) %}
 set protocols static route {{ pfx|ipaddr('0') }} blackhole
 {% endfor %}
-
-# Commit, save and exit from subshell
-
-commit
-save
-exit
-

--- a/netsim/ansible/templates/isis/vyos.j2
+++ b/netsim/ansible/templates/isis/vyos.j2
@@ -1,15 +1,4 @@
-#!/bin/vbash
-source /opt/vyatta/etc/functions/script-template
-
-if [ "$(id -g -n)" != 'vyattacfg' ] ; then
-    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
-fi
-
-# Configuration items start here
-configure
-
 set protocols isis level {{ isis.type }}
-
 set protocols isis dynamic-hostname
 set protocols isis lsp-gen-interval 1
 set protocols isis spf-interval 1
@@ -41,8 +30,3 @@ set protocols isis interface {{ l.ifname }} bfd profile netsim
 {%   endif %}
 
 {% endfor %}
-# Commit, save and exit from subshell
-
-commit
-save
-exit


### PR DESCRIPTION
VyOS configuration templates are vbash scripts that include a lot of
setup and cleanup code. The same code is replicated in every template.
That is not good by itself, but it doesn't allow the users to use
simple custom config templates with just the 'set' commands.

This change implements configuration deployment similar to what
we're doing for FRR: if the configuration code includes 'vbash',
it's executed as-is, otherwise it's wrapped in a standard vbash
script.

Also changed:

* The 'are we ready' check has been moved from the 'deploy config'
  task list to 'readyness check' task list
* The 'fetch config' task list fetches device configuration as
  'set' commands, allowing it to be used directly as a custom config
  template. That should allow 'netlab up --reload' to work with
  VyOS.