### PR TITLE
The 'files' plugin: embed files or custom config templates in topology

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,6 +15,7 @@
    plugins/bgp.originate.md
    plugins/check.config.md
    plugins/fabric.md
+   plugins/files.md
    plugins/mlag.vtep.md
    plugins/multilab.md
    plugins/node.clone.md

--- a/docs/plugins/files.md
+++ b/docs/plugins/files.md
@@ -1,0 +1,112 @@
+(plugin-files)=
+# Embed Files and Configuration Templates in Lab Topology
+
+The **files** plugin allows you to include small files and custom configuration templates directly in the lab topology, enabling the deployment of a complete solution as a single lab topology file.
+
+The plugin defines two new topology attributes:
+
+* **files** -- a dictionary or list of extra files to create in the lab directory
+* **configlets** -- a dictionary of custom configuration templates
+
+(plugin-files-create)=
+## Creating Extra Files
+
+The **files** attribute can be a list of file paths and their contents. Every element of the list has to have two attributes:
+
+* **path**: The file path relative to the lab directory
+* **content**: File content
+
+Example:
+
+```
+plugin: [ files ]
+
+files:
+- path: README.md
+  content: |
+    The README.md file
+```
+
+```{tip}
+Always use the YAML *literal ‌block scalar header* (`|`) for the file content; otherwise, the whole content will be folded into a single line.
+```
+
+The **files** attribute can also be specified as a dictionary of  file paths and content, for example:
+
+```
+plugin: [ files ]
+
+files:
+  hey/README.md: |
+    The README.md file
+```
+
+```{tip}
+The **files** dictionary is converted to a list of files before the lab topology transformation. If you want to use the contents of this attribute in plugins or custom templates/reports, use the list format.
+```
+
+The files specified in the **files** attribute are created just before the output modules are called from the **netlab create** command (also used in **netlab up**). They are automatically removed by the **netlab down --cleanup** command.
+
+```{warning}
+* The plugin will overwrite the existing files.
+* The files specified in the **‌files** list will be removed during the `netlab down --cleanup` process, even when they existed before the `netlab up` was executed.
+```
+
+## Creating Custom Configuration Templates
+
+The **configlets** dictionary can be used to create custom configuration templates. Its contents are automatically converted to [elements of the **files** list](plugin-files-create), but provide a more intuitive way of specifying the templates.
+
+For example, the following **configlets** dictionary creates **ifup.j2** and **ifdown.j2** custom configuration templates in the lab directory:
+
+```
+configlets:
+  ifup: ip link set eth1 up
+  ifdown: ip link set eth1 down
+```
+
+You can use a more structured **configlets** dictionary to create custom configuration templates for multiple nodes, devices, or providers. For example, the following dictionary creates **ifup/eos.j2** and **ifup/frr.j2** files that can then be used as `ifup` custom configuration templates on Arista EOS or FRR:
+
+```
+configlets:
+  ifup:
+    eos: |
+      interface Ethernet1
+        no shutdown
+    frr: |
+      ip link set eth1 up
+```
+
+The **configlets** dictionary structure can be recursive, creating more specific configuration templates. For example, the following dictionary results in **ifup/r1.eos.j2**, **ifup/r1.frr.j2** and **ifup/r2.j2** files:
+
+```
+configlets:
+  ifup:
+    r1:
+      eos: |
+        interface Ethernet1
+          no shutdown
+      frr: |
+        ip link set eth1 up
+    r2: |
+      ip link set eth2 up
+```
+
+```{tip}
+Due to the structure of the custom configuration filenames, the **‌files** plugin prepends `-` to provider names. All other filename components are separated by dots.
+
+Use the **netlab show defaults paths.custom.files** command to display the order of components _netlab_ expects you to use in the custom configuration template names. The `.j2` suffix is automatically appended to the names generated from the **‌configlets** dictionary.
+```
+
+Finally, you might want to create a variant of a configuration template for a specific provider, and a more generic one for all other providers. That cannot be easily expressed as a dictionary structure, so the **files** plugin treats **content** key as a special case, meaning *do not append anything to the file name*. The following example will thus create **ifup/eos.j2**  and **ifup/eos-clab.j2** files:
+
+```
+configlets:
+  mgmt:
+    eos:
+      clab: |
+        interface Management0
+          description Management interface
+      content: |
+        interface Management1
+          description Management interface
+```

--- a/docs/plugins/files.md
+++ b/docs/plugins/files.md
@@ -97,7 +97,7 @@ Due to the structure of the custom configuration filenames, the **‌files** plu
 Use the **netlab show defaults paths.custom.files** command to display the order of components _netlab_ expects you to use in the custom configuration template names. The `.j2` suffix is automatically appended to the names generated from the **‌configlets** dictionary.
 ```
 
-Finally, you might want to create a variant of a configuration template for a specific provider, and a more generic one for all other providers. That cannot be easily expressed as a dictionary structure, so the **files** plugin treats **content** key as a special case, meaning *do not append anything to the file name*. The following example will thus create **ifup/eos.j2**  and **ifup/eos-clab.j2** files:
+Finally, you might want to create a variant of a configuration template for a specific provider, and a more generic one for all other providers. That cannot be easily expressed as a dictionary structure, so the **files** plugin treats **base** key as a special case, meaning *do not append anything to the file name*. The following example will thus create **ifup/eos.j2**  and **ifup/eos-clab.j2** files:
 
 ```
 configlets:
@@ -106,7 +106,7 @@ configlets:
       clab: |
         interface Management0
           description Management interface
-      content: |
+      base: |
         interface Management1
           description Management interface
 ```

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -10,6 +10,7 @@ import argparse
 import os
 import shutil
 import typing
+from pathlib import Path
 
 from box import Box
 
@@ -163,8 +164,16 @@ def fs_cleanup(filelist: typing.List[str], verbose: bool = False) -> None:
       if verbose:
         print(f"... removing {fname}")
       try:
-        os.remove(fname)
-      except Exception as ex:
+        os.remove(fname)                                  # Remove the file
+        if '/' not in fname:                              # ... and move on if it was from current directory
+          continue
+        try:                                              # Otherwise try to remove the parent directory
+          f_parent = Path(fname).parent
+          f_parent.rmdir()
+          print(f"... removing empty directory {str(f_parent)}")
+        except Exception as ex:                           # No worries if we cannot do that
+          pass
+      except Exception as ex:                             # Finally, report an error if we cannot remove the file
         log.fatal(f"Cannot remove {fname}: {ex}")
 
 # Common topology loader (used by create and down)

--- a/netsim/cli/create.py
+++ b/netsim/cli/create.py
@@ -87,6 +87,15 @@ def run(cli_args: typing.List[str],
     os.remove('netlab.lock')
     lab_status_log(topology,'Configuration files have been recreated')
 
+  # Iterate over plugins that registered 'output' hook
+  # We have to reload the plugin as the original 'Plugin' dictionary was removed
+  # as the last step in the topology transformation process
+  #
+  for p_name in topology.defaults.netlab.create.get('output',[]):
+    plugin = augment.plugin.load_plugin(p_name,topology)
+    if plugin:
+      augment.plugin.execute_plugin_hook('output',plugin,topology)
+
   for output_format in args.output:
     output_module = _TopologyOutput.load(output_format,topology.defaults.outputs[output_format.split(':')[0]])
     if output_module:

--- a/netsim/cli/down.py
+++ b/netsim/cli/down.py
@@ -16,6 +16,7 @@ from . import external_commands,set_dry_run,is_dry_run
 from . import lab_status_change,fs_cleanup,load_snapshot,parser_lab_location,change_lab_instance
 from .. import providers
 from ..utils import status,strings,log,read as _read
+from ..data import append_to_list
 from .up import provider_probes
 #
 # CLI parser for 'netlab down' command
@@ -64,6 +65,9 @@ def down_cleanup(topology: Box, verbose: bool = False) -> None:
       cleanup_list.append(s_filename)
 
   cleanup_list.extend(topology.defaults.automation.ansible.cleanup)
+  for v in topology.get('_cleanup',{}).values():
+    cleanup_list += v if isinstance(v,list) else [ v ]
+
   cleanup_list.append('netlab.snapshot.yml')
   fs_cleanup(cleanup_list,verbose)
 

--- a/netsim/extra/files/defaults.yml
+++ b/netsim/extra/files/defaults.yml
@@ -1,0 +1,7 @@
+attributes:
+  global:
+    files:
+      type: list
+      _subtype:
+        path: { type: str, _required: True }
+        content: { type: str, _required: True }

--- a/netsim/extra/files/plugin.py
+++ b/netsim/extra/files/plugin.py
@@ -13,7 +13,7 @@ def restructure_files(topology: Box) -> None:
     return                                            # Everything else will be handled in attribute validation code
 
   f_dict = filemaps.box_to_dict(topology.files)       # Recover the original data structure
-  f_list = [ {'path': k, 'content': v} 
+  f_list = [ {'path': k, 'content': v}
                for k,v in f_dict.items() ]            # Create normalized list-based data structure
   topology.files = f_list                             # Replace dict with list
 
@@ -26,7 +26,7 @@ def restructure_configlets(topology: Box) -> None:
     for k,v in cfg.items():                           # Iterate over dictionary contents
       separator = '' if path.endswith('/') else \
                   '-' if k in topology.defaults.providers else '.'
-      if k != 'content':                              # If this is not a 'raw content' element
+      if k != 'base':                                 # If this is not a 'base content' element
         k_path = path + separator + k                 # ... add next bit to file name (provider is prefixed with '-')
       else:
         k_path = path

--- a/netsim/extra/files/plugin.py
+++ b/netsim/extra/files/plugin.py
@@ -1,0 +1,98 @@
+from box import Box
+from netsim.data import filemaps,append_to_list
+from netsim.data.types import must_be_dict
+from netsim.utils import log
+from pathlib import Path
+
+"""
+Restructure 'files' dictionary into a list of files to avoid Box-dotting
+problems
+"""
+def restructure_files(topology: Box) -> None:
+  if not isinstance(topology.files,Box):
+    return                                            # Everything else will be handled in attribute validation code
+
+  f_dict = filemaps.box_to_dict(topology.files)       # Recover the original data structure
+  f_list = [ {'path': k, 'content': v} 
+               for k,v in f_dict.items() ]            # Create normalized list-based data structure
+  topology.files = f_list                             # Replace dict with list
+
+"""
+Change the 'configlets' into list of files
+"""
+def restructure_configlets(topology: Box) -> None:
+
+  def build_files(cfg: Box, path: str) -> None:       # Recursively transform configlets dictionary into files
+    for k,v in cfg.items():                           # Iterate over dictionary contents
+      separator = '' if path.endswith('/') else \
+                  '-' if k in topology.defaults.providers else '.'
+      if k != 'content':                              # If this is not a 'raw content' element
+        k_path = path + separator + k                 # ... add next bit to file name (provider is prefixed with '-')
+      else:
+        k_path = path
+      if isinstance(v,str):                           # Did we get to the end of the tree?
+        append_to_list(                               # Add a new file to the list of files
+          topology,                                   # ... file path is created from the dictionary structure
+          'files',                                    # ... with '.j2' suffix because it's a template
+          {'path': k_path+'.j2', 'content': v})       # ... and the file content is the value
+      elif isinstance(v,Box):                         # Do we need to go further down the dictionary?
+        build_files(v,k_path)                         # ... recursively do the same thing
+      else:                                           # Nothing else but str or dict makes sense
+        log.error(
+          f'Configlet {k_path} should be a string value',
+          category=log.IncorrectType,
+          module='files')
+
+  if not must_be_dict(topology,'configlets','',create_empty=False):
+    return                                            # Check that the value is really a dict
+
+  for k,v in topology.configlets.items():             # Iterate over configlets
+    if isinstance(v,str):                             # Simple file with no options?
+      append_to_list(                                 # Add content to the list of files
+        topology,
+        'files',
+        {'path': k+'.j2', 'content': v })
+    elif isinstance(v,Box):                           # Config template with options, has to be a directory
+      build_files(v,k+'/')
+    else:
+      log.error(
+        f'Configlet {k} should be a dictionary or a string',
+        category=log.IncorrectType,
+        module='files')
+
+  topology.pop('configlets',None)                     # We no longer need this
+
+"""
+Restructure the 'files' and 'configlets'
+"""
+def init(topology: Box) -> None:
+  output_hook = False
+  if 'files' in topology:
+    restructure_files(topology)
+    output_hook = True
+  if 'configlets' in topology:
+    restructure_configlets(topology)
+    output_hook = True
+
+  if output_hook:
+    append_to_list(topology.defaults.netlab.create,'output','files')
+
+"""
+Create the output files when called from 'netlab create'
+"""
+def output(topology: Box) -> None:
+  f_list = topology.get('files',[])
+  if not f_list:                                            # No files to create, we're done ;)
+    return
+
+  for file in f_list:                                       # Try to create individual files
+    try:
+      filepath = Path(file.path)
+      filepath.parent.mkdir(parents=True, exist_ok=True)    # Create parent directories if needed
+      filepath.write_text(file.content)                     # Write file content
+      log.info(text=f'Created {file.path}',module='files')  # ... and report success
+    except Exception as ex:                                 # ... or failure
+      log.error(f'Cannot create {file.path}: {str(ex)}',category=log.FatalError,module='files')
+
+  # Create the list of extra files that 'netlab down --cleanup' should remove
+  topology._cleanup.files = [ file.path for file in f_list ]

--- a/tests/integration/bgp/05-community.yml
+++ b/tests/integration/bgp/05-community.yml
@@ -9,6 +9,7 @@ message: |
   one, an extended one, and a long one (standard communitiy using 4-octet AS)
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+plugin: [ files ]
 
 module: [ bgp, ospf ]
 
@@ -80,3 +81,18 @@ validate:
         community={
           'extendedCommunity': 'LB:65000:12500000'},
         state='missing')
+
+configlets:
+  frr-community: |
+    route-map setcomm permit 10
+    set community 65000:1 additive
+    set extcommunity bandwidth 100
+    set large-community 65000:0:1 additive
+    exit
+    !
+    router bgp {{ bgp.as }}
+    !
+    address-family ipv4 unicast
+    {% for n in bgp.neighbors %}
+      neighbor {{ n.ipv4 }} route-map setcomm out
+    {% endfor %}


### PR DESCRIPTION
The 'files' plugin can be used to embed any file (in particular custom configuration templates) into the lab topology.

The following changes were made to other netlab components to support this functionality:

* 'netlab create' calls 'output' plugin hooks for plugins that register themselves as having on in the defaults.netlab.create.output list
* 'netlab down --cleanup' removes files specified in the _cleanup dictionary
* The 'load plugin' and 'execute plugin hook' code was moved to separate functions so it can be called directly from 'netlab create' (the Plugin list is gone by the time 'netlab create' creates output files)
* The 'fs_cleanup' function tries to remove directories when the files it removes contain a directory component.

Finally, the 'bgp/05-community' integration test uses this functionality as a proof-of-concept

Implements most of the functionality needed to support #1817