### PR TITLE
Set 'rr_client' and 'next_hop_self' attributes on BGP neighbor data

### DIFF
--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -358,6 +358,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: pe2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -473,6 +474,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: pe1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -136,6 +136,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -151,6 +152,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -166,6 +168,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.7
@@ -291,6 +294,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -306,6 +310,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -321,6 +326,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.21
@@ -443,6 +449,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -458,6 +465,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -473,6 +481,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:1::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.42
@@ -573,6 +582,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:7::1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -588,6 +598,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:15::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -603,6 +614,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2a::1
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -112,6 +112,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -127,6 +128,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -142,6 +144,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.7
@@ -236,6 +239,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -251,6 +255,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -266,6 +271,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.21
@@ -373,6 +379,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -388,6 +395,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -403,6 +411,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::1
         name: r4
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.42
@@ -495,6 +504,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::7
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -508,6 +518,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::15
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -521,6 +532,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8::2a
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -69,6 +69,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -147,6 +148,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -171,6 +171,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: a2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -186,6 +187,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: a3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -259,6 +261,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.5
         name: a1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -274,6 +277,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: a3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -347,6 +351,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.5
         name: a1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -362,6 +367,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: a2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -436,6 +442,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -514,6 +521,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -628,6 +636,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -724,6 +733,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -740,6 +751,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -756,6 +769,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: l3
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -84,6 +84,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -97,6 +98,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -169,6 +171,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -182,6 +185,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -257,6 +261,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -270,6 +275,7 @@ nodes:
         as: 4259840001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -109,6 +109,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -123,6 +124,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -226,6 +228,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -240,6 +243,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -334,6 +338,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -347,6 +353,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -360,6 +368,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: s2
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true
@@ -456,6 +465,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: l1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -469,6 +480,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: l2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -482,6 +495,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: s1
+        next_hop_self: true
         rr: true
         type: ibgp
       next_hop_self: true

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -274,6 +274,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -288,6 +289,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -378,6 +380,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -392,6 +395,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -482,6 +486,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -496,6 +501,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -509,6 +516,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -582,6 +591,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -596,6 +606,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -609,6 +621,8 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -108,6 +108,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:3::1
         name: r2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -225,6 +226,7 @@ nodes:
         as: 65000
         ipv6: 2001:db8:0:2::1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -455,6 +455,7 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -472,6 +473,7 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -590,6 +592,7 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -607,6 +610,7 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - activate:
@@ -725,6 +729,7 @@ nodes:
         ipv4: 10.0.0.2
         ipv6: 2001:db8:0:2::1
         name: rr2
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -742,6 +747,8 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -758,6 +765,8 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -859,6 +868,7 @@ nodes:
         ipv4: 10.0.0.1
         ipv6: 2001:db8:0:1::1
         name: rr1
+        next_hop_self: true
         rr: true
         type: ibgp
       - _source_intf:
@@ -876,6 +886,8 @@ nodes:
         ipv4: 10.0.0.3
         ipv6: 2001:db8:0:3::1
         name: pe1
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -892,6 +904,8 @@ nodes:
         ipv4: 10.0.0.4
         ipv6: 2001:db8:0:4::1
         name: pe2
+        next_hop_self: true
+        rr_client: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -365,6 +365,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.2
         name: c2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -452,6 +453,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -542,6 +544,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: pod_1_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -558,6 +561,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: pod_1_s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -574,6 +578,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: pod_1_s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4
@@ -743,6 +748,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.4
         name: pod_1_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -759,6 +765,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: pod_1_s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -775,6 +782,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: pod_1_s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.6
@@ -944,6 +952,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.4
         name: pod_1_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -960,6 +969,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: pod_1_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -976,6 +986,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.8
         name: pod_1_s2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1085,6 +1096,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.4
         name: pod_1_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1101,6 +1113,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.6
         name: pod_1_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1117,6 +1130,7 @@ nodes:
         as: 65101
         ipv4: 10.0.0.7
         name: pod_1_s1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1226,6 +1240,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.12
         name: pod_2_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1242,6 +1257,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: pod_2_s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1258,6 +1274,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: pod_2_s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.10
@@ -1427,6 +1444,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.10
         name: pod_2_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1443,6 +1461,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: pod_2_s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1459,6 +1478,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: pod_2_s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.12
@@ -1628,6 +1648,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.10
         name: pod_2_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1644,6 +1665,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.12
         name: pod_2_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1660,6 +1682,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.14
         name: pod_2_s2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -1769,6 +1792,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.10
         name: pod_2_l1_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1785,6 +1809,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.12
         name: pod_2_l2_leaf
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -1801,6 +1826,7 @@ nodes:
         as: 65102
         ipv4: 10.0.0.13
         name: pod_2_s1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -173,6 +173,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: rr
+        next_hop_self: true
         password: Secret
         rr: true
         type: ibgp
@@ -614,7 +615,9 @@ nodes:
         as: 65001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         password: Secret
+        rr_client: true
         timers:
           hold: 10
           keepalive: 3

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -410,6 +410,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -737,6 +738,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -77,6 +77,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -172,6 +173,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -105,6 +105,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -231,6 +232,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -390,6 +390,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -407,6 +408,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.3
         name: s3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -601,6 +603,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -618,6 +621,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.3
         name: s3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -759,6 +763,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: s1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -776,6 +781,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: s2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -257,6 +257,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.6
         name: S2
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -384,6 +385,7 @@ nodes:
         as: 65100
         ipv4: 10.0.0.5
         name: S1
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -85,6 +85,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: b
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -98,6 +99,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: c
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -152,6 +154,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: a
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -165,6 +168,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: c
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -219,6 +223,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: a
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -232,6 +237,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: b
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
@@ -286,6 +292,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.5
         name: e
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -299,6 +306,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.6
         name: f
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4
@@ -353,6 +361,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: d
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -366,6 +375,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.6
         name: f
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.5
@@ -420,6 +430,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.4
         name: d
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -433,6 +444,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.5
         name: e
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.6

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -116,6 +116,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: e1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -129,6 +130,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: e2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -280,6 +282,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -293,6 +296,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.4
         name: e2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3
@@ -394,6 +398,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: c1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -409,6 +414,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: e1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -104,6 +104,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
         vpnv4: 10.0.0.2
       next_hop_self: true
@@ -238,6 +239,7 @@ nodes:
         as: 65001
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
         vpnv4: 10.0.0.1
       next_hop_self: true

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -406,6 +406,7 @@ nodes:
         ipv6: 2001:db8:0:2::1
         ipv6_label: true
         name: pe2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -424,6 +425,7 @@ nodes:
         ipv6: 2001:db8:0:4::1
         ipv6_label: true
         name: rr
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -546,6 +548,7 @@ nodes:
         ipv6: 2001:db8:0:1::1
         ipv6_label: true
         name: pe1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -564,6 +567,7 @@ nodes:
         ipv6: 2001:db8:0:4::1
         ipv6_label: true
         name: rr
+        next_hop_self: true
         type: ibgp
       - activate:
           ipv4: true
@@ -683,6 +687,7 @@ nodes:
         ipv4_label: true
         ipv6: 2001:db8:0:1::1
         name: pe1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -700,6 +705,7 @@ nodes:
         ipv4_label: true
         ipv6: 2001:db8:0:2::1
         name: pe2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.4

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -73,6 +73,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.2
         name: n2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -159,6 +160,7 @@ nodes:
         evpn: true
         ipv4: 10.0.0.1
         name: n1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -156,6 +156,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: pe2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -413,6 +414,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: pe1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -134,6 +134,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -147,6 +148,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -368,6 +370,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -381,6 +384,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.3
         name: r3
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2
@@ -548,6 +552,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       - _source_intf:
           ifindex: 0
@@ -561,6 +566,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.3

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -222,6 +222,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.2
         name: r2
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.1
@@ -685,6 +686,7 @@ nodes:
         as: 65000
         ipv4: 10.0.0.1
         name: r1
+        next_hop_self: true
         type: ibgp
       next_hop_self: true
       router_id: 10.0.0.2


### PR DESCRIPTION
The BGP neighbor 'rr_client' and 'next_hop_self' attributes will make the configuration templates much cleaner as we'll avoid all the crazy logic that is repeated in every template.

Note that the existing attributes are not changed, so there's no rush to migrate the templates to the new attributes. That can be done at any time we feel like cleaning them up.

Also: refactor and cleanup the IBGP session generation logic to avoid duplicate code