### PR TITLE
Use 'files' plugin to implement inline configuration templates

### DIFF
--- a/docs/plugins/files.md
+++ b/docs/plugins/files.md
@@ -8,6 +8,15 @@ The plugin defines two new topology attributes:
 * **files** -- a dictionary or list of extra files to create in the lab directory
 * **configlets** -- a dictionary of custom configuration templates
 
+It also extends the meaning of the node/group **config** attribute and adds the **config.inline** attribute to validation tests.
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+```
+
 (plugin-files-create)=
 ## Creating Extra Files
 
@@ -60,8 +69,14 @@ For example, the following **configlets** dictionary creates **ifup.j2** and **i
 
 ```
 configlets:
-  ifup: ip link set eth1 up
-  ifdown: ip link set eth1 down
+  ifup: |
+    ip link set eth1 up
+  ifdown: |
+    ip link set eth1 down
+```
+
+```{tip}
+Always use the YAML *literal ‌block scalar header* (`|`) for the configlet content; otherwise, the whole content will be folded into a single line.
 ```
 
 You can use a more structured **configlets** dictionary to create custom configuration templates for multiple nodes, devices, or providers. For example, the following dictionary creates **ifup/eos.j2** and **ifup/frr.j2** files that can then be used as `ifup` custom configuration templates on Arista EOS or FRR:
@@ -110,3 +125,72 @@ configlets:
         interface Management1
           description Management interface
 ```
+
+## Inline Node/Group Configuration Templates
+
+The **files** plugin allows you to specify the contents of custom configuration templates directly in the node- or group **config** attribute.
+
+If you enabled the **files** plugin, and the content of the **config** attribute is a dictionary, the **files** plugin copies the dictionary into the **configlets** dictionary and replaces it with a list of custom configuration templates (the dictionary keys).
+
+If you don't care about the configuration template names, use the **config.inline** template. **files** plugin will auto-generate a template name and use it to apply extra configuration to the node (or group of nodes) where the **config.inline** template is defined.
+
+For example, the following lab topology creates a template `_n_x1.j2` that is then used to add a route map and extra BGP configuration to X1:
+
+```
+plugin: [ files ]
+module: [ bgp ]
+
+nodes:
+  dut:
+    bgp.as: 65000
+
+  x1:
+    id: 10
+    bgp.as: 65010
+    bgp.originate: 172.0.42.0/24
+    config.inline: |
+      route-map setcomm permit 10
+      set community 65000:1 additive
+      set extcommunity bandwidth 100
+      set large-community 65000:0:1 additive
+      exit
+      !
+      router bgp {{ bgp.as }}
+      !
+      address-family ipv4 unicast
+      {% for n in bgp.neighbors %}
+        neighbor {{ n.ipv4 }} route-map setcomm out
+      {% endfor %}
+
+  x2:
+    id: 11
+    bgp.as: 65011
+```
+
+```{tip}
+Always use the YAML *literal ‌block scalar header* (`|`) for the custom configuration content; otherwise, the whole content will be folded into a single line.
+```
+
+## Inline Configuration Changes in Validation Tests
+
+Once the **files** plugin is activated, the validation tests can use the **config.inline** attribute to specify the changes that should be made to the device configuration directly in the validation test, for example:
+
+```
+validate:
+...
+  bgp_lbd:
+    description: Shut down the loopback interface
+    config:
+      inline:
+        frr: |
+          #!/bin/bash
+          ip link set lo down
+    pass: BGP prefix is no longer announced
+    nodes: [ xf ]
+```
+
+```{tip}
+Always use the YAML *literal ‌block scalar header* (`|`) for the configuration content; otherwise, the whole content will be folded into a single line.
+```
+
+

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -92,7 +92,12 @@ node:
   device: device
   box: str
   id: { type: int, min_value: 1, max_value: 150 }
-  config: list
+  config:
+    type: dict
+    _subtype:
+      type: error
+      _err_msg: Enable "files" plugin to use the inline node/group configuration template(s)
+    _alt_types: [ list ]
   group: list
   role: { type: str, valid_values: [ router, host, bridge, gateway ] }
   mgmt:
@@ -183,6 +188,9 @@ _v_entry:                   # Validation entry
   config:
     template: str
     variable: dict
+    inline:
+      type: error
+      _err_msg: Enable "files" plugin to use the "inline" configuration template
     _alt_types: [ str ]
   valid: _v_option
   suzieq:

--- a/tests/errors/group-invalid-node-config.log
+++ b/tests/errors/group-invalid-node-config.log
@@ -1,3 +1,4 @@
-IncorrectType in nodes: attribute 'nodes.a.config' must be a scalar or a list, found dictionary
-... use 'netlab show attributes node' to display valid attributes
+IncorrectAttr in nodes: Incorrect node attribute 'x' in nodes.a.config
+... Enable "files" plugin to use the inline node/group configuration template(s)
+IncorrectAttr in nodes: Incorrect node attribute 'y' in nodes.a.config
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/integration/ospf/ospfv2/21-default-policy.yml
+++ b/tests/integration/ospf/ospfv2/21-default-policy.yml
@@ -6,6 +6,7 @@ message: |
 
 defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
 module: [ ospf ]
+plugin: [ files ]
 
 groups:
   probes:
@@ -62,8 +63,10 @@ validate:
   bgp_lbd:
     description: Shut down the loopback interface
     config:
-      template: bgp_loopback
-      variable.lb_state: down
+      inline:
+        frr: |
+          #!/bin/bash
+          ip link set lo down
     pass: BGP prefix is no longer announced
     nodes: [ xf ]
   df_c:
@@ -75,7 +78,9 @@ validate:
   bgp_lbe:
     description: Enable the loopback interface
     config:
-      template: bgp_loopback
-      variable.lb_state: up
+      inline:
+        frr: |
+          #!/bin/bash
+          ip link set lo up
     pass: BGP prefix should be announced
     nodes: [ xf ]

--- a/tests/integration/ospf/ospfv2/bgp_loopback.j2
+++ b/tests/integration/ospf/ospfv2/bgp_loopback.j2
@@ -1,2 +1,0 @@
-#!/bin/bash
-ip link set lo {{ lb_state|default('up') }}

--- a/tests/integration/vrf/16-vrf-bgp-community.yml
+++ b/tests/integration/vrf/16-vrf-bgp-community.yml
@@ -8,6 +8,8 @@ message: |
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
+plugin: [ files ]
+
 groups:
   probes:
     members: [ x1, x2 ]
@@ -25,11 +27,25 @@ nodes:
   dut:
     bgp.as: 65000
     module: [ vrf, bgp ]
+
   x1:
     id: 10
     bgp.as: 65010
     bgp.originate: 172.0.42.0/24
-    config: [ frr-community ]
+    config.inline: |
+      route-map setcomm permit 10
+      set community 65000:1 additive
+      set extcommunity bandwidth 100
+      set large-community 65000:0:1 additive
+      exit
+      !
+      router bgp {{ bgp.as }}
+      !
+      address-family ipv4 unicast
+      {% for n in bgp.neighbors %}
+        neighbor {{ n.ipv4 }} route-map setcomm out
+      {% endfor %}
+
   x2:
     id: 11
     bgp.as: 65011


### PR DESCRIPTION
This change adds support for inline custom configuration templates in node-, group- and validation test definitions. It allows the user to specify small additions to device configurations directly in the node- or group definition, or to define small changes to device configurations directly in the validation tests.