### PR TITLE
Add per-node libvirt port forwarding

### DIFF
--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -211,9 +211,18 @@ You can change the IPv4 address of a device's management interface with the **mg
 (libvirt-port-forwarding)=
 ### Port Forwarding
 
-*netlab* supports *vagrant-libvirt* port forwarding -- mapping of TCP ports on VM management IP address to ports on the host. You can use port forwarding to access the lab devices via the host's external IP address without exposing the management network to the outside world.
+*netlab* supports *vagrant-libvirt* port forwarding -- SSH forwarding of TCP ports on the VM management IP address to ports on the host (see *vagrant-libvirt documentation* for more details). Thus, you can access the lab devices via the host's external IP address without exposing the management network to the outside world.
 
-Port forwarding is turned off by default and can be enabled by configuring the **defaults.providers.libvirt.forwarded** dictionary. Dictionary keys are TCP port names (`ssh`, `http`, `https`, or `netconf`), and dictionary values are the start values of host ports. *netlab* assigns a unique host port to every VM's forwarded port based on the start value and VM node ID.
+Port forwarding is turned off by default. It can be configured for a single node with the **libvirt.ports** node parameter -- a list of port mappings in the `host_port:vm_port` format. For example, the following topology maps the SSH port on node R1 to the host port 2001:
+
+```
+nodes:
+  r1:
+    libvirt.ports:
+    - 2001:22
+```
+
+Port forwarding can also be enabled for all libvirt nodes with the **defaults.providers.libvirt.forwarded** dictionary. Dictionary keys are TCP port names (`ssh`, `http`, `https`, or `netconf`), and dictionary values are the start values of host ports. *netlab* assigns a unique host port to every VM's forwarded port based on the start value and VM node ID, and adds the port mapping to the node **libvirt.ports** list.
 
 For example, when given the following topology...
 

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -16,7 +16,7 @@ import argparse
 from ..data import types,get_empty_box,get_box
 from ..utils import log,strings,linuxbridge
 from ..utils import files as _files
-from . import _Provider,validate_mgmt_ip
+from . import _Provider,validate_mgmt_ip,node_add_forwarded_ports,get_provider_forwarded_ports
 from ..augment import devices
 from ..augment.links import get_link_by_index
 from ..cli import is_dry_run,external_commands
@@ -291,6 +291,14 @@ class Libvirt(_Provider):
         l.type = 'lan'
         if not 'bridge' in l:
           l.bridge = "%s_%d" % (topology.name[0:10],l.linkindex)
+
+  """
+  Add default provider forwarded ports to node data
+  """
+  def augment_node_data(self, node: Box, topology: Box) -> None:
+    node_fp = get_provider_forwarded_ports(node,topology)
+    if node_fp:
+      node_add_forwarded_ports(node,node_fp,topology)
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
     if node.get('_set_ifindex'):

--- a/netsim/providers/libvirt.yml
+++ b/netsim/providers/libvirt.yml
@@ -34,6 +34,7 @@ attributes:
     nic_adapter_count: int
     image: str
     uuid: str
+    ports: list
   link:
     permanent: bool
     public: { type: str, valid_values: [ bridge, vepa, passthrough, private ], true_value: bridge }

--- a/netsim/providers/virtualbox.py
+++ b/netsim/providers/virtualbox.py
@@ -5,7 +5,7 @@
 import typing
 
 from . import _Provider
-from .libvirt import Libvirt
+from .libvirt import Libvirt as _Libvirt
 from box import Box
 
 class Virtualbox(_Provider):

--- a/netsim/templates/provider/libvirt/define-domain.j2
+++ b/netsim/templates/provider/libvirt/define-domain.j2
@@ -39,6 +39,7 @@
 {%   if 'uuid' in n.libvirt %}
       domain.uuid = '{{ n.libvirt.uuid }}'
 {%   endif %}
+{%   include 'forwarded-ports.j2' %}
 {% endif %}
     end
 
@@ -50,5 +51,4 @@
 {%   endif %}
 
 {% endfor %}
-{% include 'forwarded-ports.j2' %}  
   end

--- a/netsim/templates/provider/libvirt/forwarded-ports.j2
+++ b/netsim/templates/provider/libvirt/forwarded-ports.j2
@@ -2,12 +2,10 @@
   Forwarded Libvirt Ports
 #}
 
-{% if defaults.providers.libvirt.forwarded is defined %}
-    {{ name }}.vm.provider :libvirt do |libvirt|
-      libvirt.forward_ssh_port = true
-    end
-{%   for port,base in defaults.providers.libvirt.forwarded.items() %}
+{% if n.libvirt.ports is defined %}
+{%   for p_fwd in n.libvirt.ports %}
+{%     set p_list = p_fwd.split(':') %}
     {{ name }}.vm.network "forwarded_port",
-      guest: {{ defaults.ports[port] }}, host: {{ base + n.id }}, id: "{{ port }}"
+      guest: {{ p_list[1] }}, host: {{ p_list[0] }}, host_ip: "0.0.0.0", gateway_ports: true
 {%   endfor %}
 {% endif %}

--- a/tests/platform-integration/clab/03-port-fwd-validate.sh
+++ b/tests/platform-integration/clab/03-port-fwd-validate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+status=0
+for port in 2001 2002; do
+  echo "Checking SSH port forwarding on port $port"
+  if ! (sshpass -p admin \
+    ssh -p $port \
+      -o UserKnownHostsFile=/dev/null \
+      -o StrictHostKeyChecking=no \
+      -o LogLevel=ERROR \
+      admin@127.0.0.1 show ver | grep EOS >/dev/null && echo "Forwarding on port $port works"); then
+    echo "Forwarding on port $port failed"
+    status=1
+  fi
+done
+
+echo "Checking HTTP port forwarding on 8080"
+if ! (curl -s http://localhost:8080 >/dev/null && echo "HTTP port forwarding works"); then
+  echo "HTTP forwarding to R1 failed"
+  status=1
+fi
+
+exit $status

--- a/tests/platform-integration/clab/03-port-fwd.yml
+++ b/tests/platform-integration/clab/03-port-fwd.yml
@@ -1,0 +1,21 @@
+message: |
+  This lab sets up forwarded SSH and HTTP ports for two EOS devices. It
+  tests the container port forwarding functionality
+
+defaults.device: eos
+provider: clab
+plugin: [ files ]
+
+defaults.providers.clab.forwarded:
+  ssh: 2000
+
+nodes:
+  r1:
+    clab.ports:
+    - 8080:80
+    config.inline: |
+      management http-server
+        protocol http
+  r2:
+
+links: [ r1-r2 ]

--- a/tests/platform-integration/libvirt/04-port-fwd.yml
+++ b/tests/platform-integration/libvirt/04-port-fwd.yml
@@ -1,0 +1,21 @@
+message: |
+  This lab sets up forwarded SSH and HTTP ports for two EOS devices. It
+  tests the container port forwarding functionality
+
+defaults.device: eos
+provider: libvirt
+plugin: [ files ]
+
+defaults.providers.libvirt.forwarded:
+  ssh: 2000
+
+nodes:
+  r1:
+    libvirt.ports:
+    - 8080:80
+    config.inline: |
+      management http-server
+        protocol http
+  r2:
+
+links: [ r1-r2 ]

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -325,6 +325,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: p2p
+    libvirt:
+      ports:
+      - '2201:22'
     loopback:
       ifindex: 0
       ifname: Loopback0
@@ -401,6 +404,9 @@ nodes:
         network_type: point-to-point
         passive: false
       type: lan
+    libvirt:
+      ports:
+      - '2202:22'
     loopback:
       ifindex: 0
       ifname: Loopback0


### PR DESCRIPTION
* Move the clab-specific port forwarding functions into the common provider module
* Use the same functions to build clab- and libvirt ports list
* Use the node libvirt.ports list when building forwarding ports in the Vagrantfile
* Update libvirt documentation, adding the fun fact that vagrant-libvirt module sets up SSH port forwarding (not a NAT rule)
* Add platform integration tests. The 'clab' test can be tested with a host script, I'm clueless about testing the SSH port forwarding

Also:
* Fix libvirt import into virtualbox provider module (the imported class name must start with an underscore)
* Update the libvirt port forwarding transformation test