### PR TITLE
Specify the lab topology in netlab create/up command as filename or URL

### DIFF
--- a/docs/netlab/create.md
+++ b/docs/netlab/create.md
@@ -50,7 +50,7 @@ usage: netlab create [-h] [--log] [-q] [-v] [--defaults DEFAULTS] [-d DEVICE]
 Create provider- and automation configuration files
 
 positional arguments:
-  topology              Topology file (default: topology.yml)
+  topology              Topology file or URL (default: topology.yml)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -80,6 +80,12 @@ For a complete list of output formats please consult the documentation
 ```
 
 For more details on topology file format, please read the [lab topology overview](../topology-overview.md) and [reference documentation](../topology-reference.md).
+
+```{tip}
+You can specify the lab topology with a URL. The contents from the specified URL will be downloaded, saved into `downloaded.yml`, and used as the lab topology.
+
+The lab topology downloaded from a URL must be self-contained. Any external files it needs must be embedded in the lab topology with the **[‌files](plugin-files)** plugin.
+```
 
 (netlab-create-output-formats)=
 ## Output Formats

--- a/docs/netlab/up.md
+++ b/docs/netlab/up.md
@@ -29,7 +29,7 @@ After configuring the lab with **netlab initial**, **netlab up** displays the [h
 
 ## Usage
 
-You can use `netlab up` to create configuration files and start the lab, or use `netlab up --snapshot` to start a previously created lab or restart a lab after a server reboot ([more details](netlab-up-restart)) using the transformed lab topology stored in `netlab.snapshot.yml` snapshot file.
+You can use `netlab up` to create configuration files and start the lab, or use `netlab up --snapshot` to start a previously created lab or restart a lab after a server reboot ([more details](netlab-up-restart)) using the transformed lab topology stored in the `netlab.snapshot.yml` snapshot file.
 
 ```text
 usage: netlab up [-h] [--log] [-v] [-q] [--defaults [DEFAULTS ...]] [-d DEVICE]
@@ -40,7 +40,7 @@ usage: netlab up [-h] [--log] [-v] [-q] [--defaults [DEFAULTS ...]] [-d DEVICE]
 Create configuration files, start a virtual lab, and configure it
 
 positional arguments:
-  topology              Topology file (default: topology.yml)
+  topology              Topology file or URL (default: topology.yml)
 
 options:
   -h, --help            show this help message and exit
@@ -65,6 +65,12 @@ options:
   --fast-config         Use fast device configuration (Ansible strategy = free)
   --snapshot [SNAPSHOT]
                         Use netlab snapshot file created by a previous lab run
+```
+
+```{tip}
+You can specify the lab topology with a URL. The contents from the specified URL will be downloaded, saved into `downloaded.yml`, and used as the lab topology.
+
+The lab topology downloaded from a URL must be self-contained. Any external files it needs must be embedded in the lab topology with the **[‌files](plugin-files)** plugin.
 ```
 
 ```{warning}

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -176,12 +176,12 @@ def fs_cleanup(filelist: typing.List[str], verbose: bool = False) -> None:
       except Exception as ex:                             # Finally, report an error if we cannot remove the file
         log.fatal(f"Cannot remove {fname}: {ex}")
 
-# Common topology loader (used by create and down)
+# Common topology loader (used by create)
 
 def load_topology(args: typing.Union[argparse.Namespace,Box]) -> Box:
   log.set_logging_flags(args)
   relative_name = 'test' in args and args.test and 'errors' in args.test
-  topology = _read.load(args.topology.name,args.defaults,relative_topo_name=relative_name)
+  topology = _read.load(args.topology,args.defaults,relative_topo_name=relative_name)
 
   if args.settings or args.device or args.provider or args.plugin:
     topology.nodes = augment.nodes.create_node_dict(topology.nodes)
@@ -268,25 +268,6 @@ def check_modified_source(snapshot: str, topology: typing.Optional[Box] = None) 
       flag='snapshot.modified',
       more_data=f'after the snapshot {snapshot} has been created',
       hint='recreate')
-
-# Load snapshot or topology -- used by 'netlab initial'
-#
-def load_snapshot_or_topology(args: typing.Union[argparse.Namespace,Box]) -> typing.Optional[Box]:
-  log.set_logging_flags(args)
-  if args.device or args.provider or args.settings:     # If we have -d, -p or -s flag
-    if not args.topology:                               # ... then the user wants to use the topology file
-      args.topology = 'topology.yml'                    # ... so let's set the default value if needed
-
-  topology = None
-  if args.topology:
-    topology = load_topology(args)
-    augment.main.transform(topology)
-    log.exit_on_error()
-  else:
-    args.snapshot = args.snapshot or 'netlab.snapshot.yml'
-    return load_snapshot(args)
-
-  return topology
 
 # get_message: get action-specific message from topology file
 #

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 mypy
 types-Jinja2
 types-PyYAML
+types-requests
 typing-extensions
 sphinx
 recommonmark

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ importlib_resources
 typing-extensions>=4.3.0
 filelock >= 3.16.1
 packaging
+requests
 rich


### PR DESCRIPTION
The specified URL is downloaded, sanity-checked for YAML correctness, saved in 'downloaded.yml' and used as the lab topology.

Implements #1388