### PR TITLE
Create a generic FortiOS deploy-config task

### DIFF
--- a/netsim/ansible/tasks/deploy-config/fortinet.fortios.fortios.yml
+++ b/netsim/ansible/tasks/deploy-config/fortinet.fortios.fortios.yml
@@ -1,4 +1,5 @@
 - name: "config-script: deploying {{ netsim_action }} from {{ config_template }}"
+  when: config_template
   fortinet.fortios.fortios_monitor:
     selector: upload.system.config-script
     params:

--- a/netsim/ansible/tasks/deploy-config/fortinet.fortios.fortios.yml
+++ b/netsim/ansible/tasks/deploy-config/fortinet.fortios.fortios.yml
@@ -1,0 +1,6 @@
+- name: "config-script: deploying {{ netsim_action }} from {{ config_template }}"
+  fortinet.fortios.fortios_monitor:
+    selector: upload.system.config-script
+    params:
+      filename: "{{ config_template }}"
+      file_content: "{{ lookup('template',  config_template ) | b64encode }}"

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -31,6 +31,8 @@ group_vars:
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 80
   netlab_console_connection: ssh
+  netlab_skip_missing_template: True
+  netlab_config_tasks: True
 external:
   image: none
 features:

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -31,8 +31,6 @@ group_vars:
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 80
   netlab_console_connection: ssh
-  netlab_skip_missing_template: True
-  netlab_config_tasks: True
 external:
   image: none
 features:


### PR DESCRIPTION
Introducing a generic FortiOS deploy-config task using `config-script` API to enable `netlab config  ...`.
Based on a comment here https://github.com/ipspace/netlab/discussions/2271#discussioncomment-13945877

FortiOS feature documentation: https://docs.fortinet.com/document/fortigate/7.6.3/administration-guide/780930/configuration-scripts
Ansible module: https://ansible-galaxy-fortios-docs.readthedocs.io/en/latest/fortios_monitor.html

I had to update fortios.yml to stop normalize task from failing, although I am not sure what side effects this change might have.
