### PR TITLE
Fix DHCPv6 client on Ubuntu/Netplan, enable IPv6 LLA on Linux

### DIFF
--- a/netsim/ansible/templates/dhcp/linux.j2
+++ b/netsim/ansible/templates/dhcp/linux.j2
@@ -1,7 +1,8 @@
 # This is a placeholder file. DHCP is configured during initial configuration
 #
 if [ `grep 'ID=ubuntu' /etc/os-release` ]; then
-  echo "DHCP is supported"
+  echo "DHCP is supported, it should work after another plea to netplan"
+  netplan apply
 else
   echo "netlab supports DHCP only on Ubuntu" >&2
   exit 1

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -148,6 +148,10 @@ network:
 {%   endif %}
 {%   if l.dhcp.client.ipv6|default(False) %}
       dhcp6: true
+      accept-ra: true
+{%   endif %}
+{%   if l.ipv6|default(false) is true %}
+      link-local: [ ipv6 ]
 {%   endif %}
 {%   for af in ('ipv4','ipv6') if af in l and l[af] is string %}
 {%     if loop.first %}

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -13,6 +13,7 @@ features:
     ipv4:
       unnumbered: peer
     ipv6:
+      lla: true
       use_ra: true
     roles: [ host ]
 libvirt:


### PR DESCRIPTION
* IPv6 LLA already worked with non-Ubuntu interface config (because it's shared with FRR)
* Added 'link-local' attribute to Netplan interface config for LLA interfaces on Ubuntu
* Added 'accept-ra' attribute to DHCPv6-enabled interfaces to ensure the DHCPv6 client is started if the RA contains "*-config" flag
* Added another 'netplan apply' to Ubuntu DHCP configuration script. Like with kids, it looks like you have to tell 'netplan' twice what it should do, and then hope for the best.