### PR TITLE
Implement IPv6 RA attributes on EOS, FRR, and IOS

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -76,6 +76,7 @@ A dictionary describing an individual link contains *node names* and *additional
 * **name** -- link name (used for interface description)
 * **pool** -- addressing pool used to assign a prefix to this link. The **pool** attribute is ignored on links with a **prefix** attribute.
 * **prefix** -- [prefix (or a set of prefixes)](links-static-addressing) used on the link. Setting **prefix** to *false* will give you a link without any IP configuration[^NOIP]
+* **ra** -- IPv6 Router Advertisement parameters ([more details](links-ra))
 * **role** -- The link *role* influences the behavior of several configuration modules. Typical link roles include *stub*, *passive*, and *external*. Please read [](module/routing.md) for more details.
 * **type** -- [link type](links-types) (lan, p2p, stub, loopback, tunnel)
 
@@ -346,10 +347,24 @@ links:
 You can also use the **unnumbered** link attribute to get a single unnumbered link. Using an unnumbered pool is recommended when testing network-wide addressing changes.
 ```
 
+(links-ra)=
+## IPv6 Router Advertisement Parameters
+
+_netlab_ configures [routers](node-role-router) to send IPv6 Router Advertisement messages and [hosts](node-role-host) to listen to them and use them to generate an IPv6 default route. Router Advertisement messages are disabled on [bridges](node-role-bridge). The default router advertisement interface is (when possible) set to a few seconds to speed up the IPv6 addressing of attached hosts using SLAAC.
+
+You can use the **ra** link- or interface dictionary to control the contents of the Router Advertisement messages on [devices supporting fine-grained **ra** control](platform-initial-addresses):
+
+* **ra.disable** -- do not send RA messages when set to True
+* **ra.slaac** -- set *autonomous* flag on the link prefix when set to True or missing. Set **ra.slaac** to False to disable SLAAC on attached hosts.
+* **ra.onlink** -- set *on-link* flag on the link prefix when set to True or missing. Set **ra.onlink** to False to disable direct host-to-host communication.
+* **ra.dhcp** -- set *other configuration* flag when set to **other** or *managed configuration* flag when set to **all**. No DHCPv6-related flag is set by default.
+
+While you can set **ra** parameters on individual interfaces (node-to-link attachments), it's best to set them as link parameters to have a consistent set of parameters applied to all attached routers.
+
 (links-mtu)=
 ## Changing MTU
 
-All devices supported by *netlab* are assumed to use ancient default layer-3 MTU value of 1500 bytes. Most VM-based network devices already use that default; container-based devices have their MTU set to 1500 through system settings.
+All devices supported by *netlab* are assumed to use the ancient default layer-3 MTU value of 1500 bytes. Most VM-based network devices already use that default; container-based devices have their MTU set to 1500 through system settings.
 
 Please note that the **mtu** specified by *netlab* is always the layer-3 (IPv4 or IPv6) MTU. The peculiarities of individual device configuration commands are transparently (to the end-user) handled in the device configuration templates.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -260,29 +260,29 @@ The following interface parameters are configured on supported network operating
 (platform-initial-addresses)=
 The following interface addresses are supported on various platforms:
 
-| Operating system      | IPv4<br />addresses | IPv6<br />addresses | Unnumbered<br />IPv4 interfaces |
-| --------------------- | :-: | :-: | :-: |
-| Arista EOS            | ✅  | ✅  | ✅  |
-| Aruba AOS-CX          | ✅  | ✅  |  ✅  |
-| Cisco ASAv            | ✅  | ✅  |  ❌  |
-| Cisco IOSv/IOSvL2     | ✅  | ✅  |  ❌  |
-| Cisco IOS XE[^18v]    | ✅  | ✅  | ✅  |
-| Cisco IOS XRv         | ✅  | ✅  | ✅  |
-| Cisco Nexus OS        | ✅  | ✅  | ✅  |
-| Cumulus Linux         | ✅  | ✅  | ✅  |
-| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅ |
-| Dell OS10             | ✅  | ✅  |  ❌  |
-| Fortinet FortiOS      | ✅  | ✅  |  ❌  |
-| FRR                   | ✅  | ✅  | ✅  |
-| Generic Linux         | ✅  | ✅  |  ❌  |
-| Junos[^Junos]         | ✅  | ✅  | ✅  |
-| Mikrotik RouterOS 6   | ✅  | ✅  |  ❌  |
-| Mikrotik RouterOS 7   | ✅  | ✅  |  ❌  |
-| Nokia SR Linux        | ✅  | ✅  |  ❌  |
-| Nokia SR OS[^SROS]    | ✅  | ✅  | ✅  |
-| OpenBSD               | ✅  | ✅  |  ❌  |
-| Sonic                 | ✅  | ✅  | ✅  |
-| VyOS                  | ✅  | ✅  | ✅  |
+| Operating system      | IPv4<br />addresses | IPv6<br />addresses | Unnumbered<br />IPv4 interfaces | Configurable<br>IPv6 RA |
+| --------------------- | :-: | :-: | :-: | :-: |
+| Arista EOS            | ✅  | ✅  | ✅  | ✅  |
+| Aruba AOS-CX          | ✅  | ✅  | ✅  |  ❌  |
+| Cisco ASAv            | ✅  | ✅  |  ❌  |  ❌  |
+| Cisco IOSv/IOSvL2     | ✅  | ✅  |  ❌  | ✅  |
+| Cisco IOS XE[^18v]    | ✅  | ✅  | ✅  | ✅  |
+| Cisco IOS XRv         | ✅  | ✅  | ✅  |  ❌  |
+| Cisco Nexus OS        | ✅  | ✅  | ✅  |  ❌  |
+| Cumulus Linux         | ✅  | ✅  | ✅  |  ❌  |
+| Cumulus Linux 5.x (NVUE) | ✅ | ✅ | ✅ |  ❌  |
+| Dell OS10             | ✅  | ✅  |  ❌  |  ❌  |
+| Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
+| FRR                   | ✅  | ✅  | ✅  | ✅  |
+| Generic Linux         | ✅  | ✅  |  ❌  |  ❌  |
+| Junos[^Junos]         | ✅  | ✅  | ✅  |  ❌  |
+| Mikrotik RouterOS 6   | ✅  | ✅  |  ❌  |  ❌  |
+| Mikrotik RouterOS 7   | ✅  | ✅  |  ❌  |  ❌  |
+| Nokia SR Linux        | ✅  | ✅  |  ❌  |  ❌  |
+| Nokia SR OS[^SROS]    | ✅  | ✅  | ✅  |  ❌  |
+| OpenBSD               | ✅  | ✅  |  ❌  |  ❌  |
+| Sonic                 | ✅  | ✅  | ✅  |  ❌  |
+| VyOS                  | ✅  | ✅  | ✅  |  ❌  |
 
 ```{tip}
 * Use **‌netlab show modules -m initial** to display optional initial configuration features supported by individual devices

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -70,9 +70,27 @@ interface {{ l.ifname }}
     Set interface IPv6 addresses
 #}
 {% if 'ipv6' in l %}
-{%   if role != 'host' %}
+{%   if role == 'router' %}
+{%     if l.ra.disable|default(false) is true %}
+ ipv6 nd ra disabled all
+{%     else %}
  ipv6 nd ra interval 5
-{%   else %}
+{%       if 'ra' in l and l.ipv6 is string %}
+{%         if l.ra.slaac|default(true) is false %}
+ ipv6 nd prefix {{ l.ipv6|ipaddr(0) }} no-autoconfig
+{%         endif %}
+{%         if l.ra.onlink|default(true) is false %}
+ ipv6 nd prefix {{ l.ipv6|ipaddr(0) }} no-onlink
+{%         endif %}
+{%       endif %}
+{%       if l.ra.dhcp|default(false) == 'all' %}
+ ipv6 nd managed-config-flag
+{%       endif %}
+{%       if l.ra.dhcp|default(false) == 'other' %}
+ ipv6 nd other-config-flag
+{%       endif %}
+{%     endif %}
+{%   elif role == 'host' %}
  ipv6 nd ra rx accept default-route
 {%   endif %}
 {%   if l.ipv6 is sameas True %}

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -171,13 +171,31 @@ interface {{ i.ifname }}
  ! no ip address
 {% endif %}
 {% if i.ipv6 is defined %}
-{%  if i.ipv6 is string and i.ipv6|ipv6 %}
+{%   if i.ipv6 is string and i.ipv6|ipv6 %}
  ipv6 address {{ i.ipv6 }}
-{%  endif %}
-{%  if i.type != 'loopback' and role == 'router' %}
+{%   endif %}
+{%   if i.type != 'loopback' and role == 'router' %}
+{%     if i.ra.disable|default(false) is true %}
+ ipv6 nd suppress-ra
+{%     else %}
  ipv6 nd ra-interval 5
  no ipv6 nd suppress-ra
-{%  endif %}
+{%     endif %}
+{%     if 'ra' in i and i.ipv6 is string %}
+{%       if i.ra.slaac|default(true) is false %}
+ ipv6 nd prefix {{ i.ipv6|ipaddr(0) }} no-autoconfig
+{%       endif %}
+{%       if i.ra.onlink|default(true) is false %}
+ ipv6 nd prefix {{ i.ipv6|ipaddr(0) }} off-link
+{%       endif %}
+{%     endif %}
+{%     if i.ra.dhcp|default(false) == 'all' %}
+ ipv6 nd managed-config-flag
+{%     endif %}
+{%     if i.ra.dhcp|default(false) == 'other' %}
+ ipv6 nd other-config-flag
+{%     endif %}
+{%   endif %}
 {% endif %}
 {% if i.bandwidth is defined %}
  bandwidth {{ i.bandwidth  }}

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -97,9 +97,31 @@ interface {{ l.ifname }}
     Set interface addresses: IPv6
 #}
 {% if 'ipv6' in l %}
-{%   if role == 'host' %}
+{%   if role != 'router' %}
  ipv6 nd ra suppress all
+{%     if role == 'host' %}
  ipv6 nd autoconfig default-route
+{%     endif %}
+{%   else %}{# router #}
+{%     if l.ra.disable|default(false) is true %}
+ ipv6 nd ra suppress all
+{%     else %}
+ ipv6 nd ra interval 5
+{%       if 'ra' in l and l.ipv6 is string %}
+{%         if l.ra.slaac|default(true) is false %}
+ ipv6 nd prefix {{ l.ipv6|ipaddr(0) }} 30 30 no-autoconfig
+{%         endif %}
+{%         if l.ra.onlink|default(true) is false %}
+ ipv6 nd prefix {{ l.ipv6|ipaddr(0) }} 30 30 no-onlink
+{%         endif %}
+{%       endif %}
+{%       if l.ra.dhcp|default(false) == 'all' %}
+ ipv6 nd managed-config-flag
+{%       endif %}
+{%       if l.ra.dhcp|default(false) == 'other' %}
+ ipv6 nd other-config-flag
+{%       endif %}
+{%     endif %}
 {%   endif %}
 {%   if l.ipv6 == True %}
  ipv6 enable

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -58,6 +58,11 @@ link:                       # Global link attributes
       allocation: { type: str, valid_values: [ p2p, sequential, id_based ] }
       _name: str
     _alt_types: [ bool_false, prefix_str, named_pfx ]
+  ra:
+    disable: bool
+    slaac: bool
+    dhcp: { type: str, valid_values: [ all, other ] }
+    onlink: bool
   role: id
   pool: id
   type: { type: str, valid_values: [ lan, p2p, stub, loopback, tunnel, vlan_member ] }

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -26,6 +26,7 @@ features:
       use_ra: true
     max_mtu: 9194
     min_mtu: 68
+    ra: true
     roles: [ host, router, bridge ]
     mgmt_vrf: true
   bfd: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -57,6 +57,7 @@ features:
     ipv6:
       lla: true
       use_ra: true
+    ra: true
     roles: [ host, router ]
   bfd: True
   bgp:

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -52,6 +52,7 @@ features:
       use_ra: true
     roles: [ host, router, bridge ]
     mgmt_vrf: true
+    ra: true
   isis:
     circuit_type: true
     import: [ bgp, ospf, ripv2, connected, static ]

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -67,6 +67,7 @@ features:
     ipv6:
       lla: True
     mgmt_vrf: True
+    ra: True
     roles: [ router, bridge, host ]
   isis:
     import: [ bgp, ospf, ripv2, connected, vrf ]

--- a/tests/integration/initial/08-ra.yml
+++ b/tests/integration/initial/08-ra.yml
@@ -1,0 +1,128 @@
+---
+message:
+  This scenario tests IPv6 RA behavior
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
+addressing:
+  loopback:
+    ipv4: False
+    ipv6: 2001:db8:0::/48
+  lan:
+    ipv4: False
+    ipv6: 2001:db8:1::/48
+
+groups:
+  _auto_create: True
+  hosts:
+    members: [ h0, h1, h2, h3, h4 ]
+    device: frr
+    role: host
+    provider: clab
+
+nodes:
+  dut:
+    module: []
+    id: 132
+    loopback: True
+  h4:
+    device: linux
+    provider: libvirt
+  dhsrv:
+    module: [ dhcp ]
+    device: dnsmasq
+    dhcp.server: true
+    provider: clab
+
+links:
+- name: Regular link (default RA behavior)
+  dut:
+  h0:
+    ipv6: True
+- name: no RA
+  dut:
+  h1:
+    ipv6: True
+  ra.disable: True              # No RA on this link -> no SLAAC, no default route
+- name: No SLAAC
+  dut:
+  h2:
+    ipv6: True
+  ra.slaac: False               # No SLAAC on this link, default route should be present
+- name: No onlink
+  dut:
+  h3:
+    ipv6: True
+  ra.onlink: False              # The prefix should not be in the IPv6 routing table
+- name: DHCPv6 managed config
+  dut:
+  h4:
+    ipv6: dhcp
+  dhsrv:
+  ra.dhcp: all                  # The host should use DHCP to get an IPv6 address
+  ra.slaac: False
+
+# Expected results
+#
+# H0: SLAAC address, default route, prefix in routing table
+# H1: No SLAAC address, no default route, no prefix
+# H2: Default route, prefix, no SLAAC address
+# H3: Default route, SLAAC address, no prefix
+# H4: Default route, SLAAC address, prefix, DHCPv6 address (maybe)
+
+validate:
+  ra:
+    description: Check RA-generated default route
+    wait: ra_send
+    wait_msg: Waiting for RA message to generate the default route
+    nodes: [ h0, h2, h3, h4 ]
+    plugin: default6()
+    stop_on_error: True
+  slaac:
+    description: Check for SLAAC IPv6 address
+    wait: ra_send
+    devices: [ linux ]
+    nodes: [ h0, h3, h4 ]
+    exec: ip addr show dev {{ interfaces[0].ifname }}
+    valid: >-
+      '2001:db8' in stdout
+  onlink:
+    description: Check for onlink prefix
+    wait: ra_send
+    devices: [ linux ]
+    nodes: [ h0, h2, h4 ]
+    exec: ip -6 route
+    valid: >-
+      '2001:db8' in stdout
+  dhcpv6:
+    description: Check for DHCPv6 IPv6 address
+    wait: ra_send
+    devices: [ linux ]
+    nodes: [ h4 ]
+    exec: ip addr show dev {{ interfaces[0].ifname }}
+    valid: >-
+      '2001:db8' in stdout and '/128' in stdout
+  w3:
+    description: Waiting a few seconds just in case...
+    wait: 3
+  no_slaac:
+    description: Check for lack of SLAAC address
+    devices: [ linux ]
+    nodes: [ h1, h2 ]
+    exec: ip addr show dev {{ interfaces[0].ifname }}
+    valid: >-
+      '2001:db8' not in stdout
+  no_link:
+    description: Check for lack of onlink prefix
+    devices: [ linux ]
+    nodes: [ h1, h3 ]
+    exec: ip -6 route
+    valid: >-
+      '2001:db8' not in stdout
+  no_def:
+    description: Check for lack of IPv6 default route
+    devices: [ linux ]
+    nodes: [ h1 ]
+    exec: ip -6 route
+    valid: >-
+      'default' not in stdout

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -261,6 +261,8 @@ links:
     ipv4: 172.31.31.3/24
     ipv6: 2001:db8:cafe:1::3/64
     node: r2
+    ra:
+      slaac: true
   - gateway:
       anycast:
         mac: 0200.cafe.00ff
@@ -1036,6 +1038,8 @@ nodes:
         area: 0.0.0.0
         network_type: point-to-point
         passive: true
+      ra:
+        slaac: true
       role: stub
       type: lan
     - ifindex: 6

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -44,6 +44,8 @@ links:
     ipv4: 192.168.42.2/24
     ipv6: 2001:db8:cafe:d001::2/64
     node: s1
+    ra:
+      slaac: true
   - ifindex: 1
     ifname: eth1
     ipv4: 192.168.42.7/24
@@ -83,6 +85,8 @@ links:
     ifname: eth2
     ipv6: 2001:db8:cafe:1::2/64
     node: s1
+    ra:
+      slaac: true
     vlan:
       access: blue
   - dhcp:
@@ -529,6 +533,8 @@ nodes:
         ipv4: 192.168.42.7/24
         ipv6: 2001:db8:cafe:d001::7/64
         node: dhs
+      ra:
+        slaac: true
       type: lan
     - bridge: input_2
       ifindex: 2


### PR DESCRIPTION
* Define new link/interface 'ra' dictionary
* Implement selective merge of link 'ra' attributes with interface attributes. Link 'ra' attributes are propagated only to router nodes that support 'ra' (features.initial.ra)
* Implement 'ra' attributes on EOS, FRR, and IOS

Implements #1785