### PR TITLE
Formatting modifiers for BGP graphs

### DIFF
--- a/docs/outputs/d2.md
+++ b/docs/outputs/d2.md
@@ -8,7 +8,7 @@ The *d2* output module is invoked by specifying the `-o d2` parameter in the **[
 A single formatting modifier can be used to specify the graph type:
 
 * **topology** (default) -- Includes point-to-point links, multi-access bridges, and stub subnets. When the network topology contains BGP information, the graph groups nodes into autonomous systems. Alternatively, you could set **defaults.outputs.graph.groups** attribute to use topology **[groups](topo-groups)** to group graph nodes.
-* **bgp** -- Include autonomous systems, nodes, and BGP sessions. With the **rr** option (specified with `netlab create -o graph:bgp:rr`), RR-client sessions are drawn as directed arrows.
+* **bgp** -- Include autonomous systems, nodes, and BGP sessions. The formatting modifier can include the [BGP formatting parameters](outputs-d2-bgp-parameters). For example, `netlab create -o graph:bgp:vrf` draws VRF BGP sessions as dotted lines.
 
 ```{tip}
 The network topology graph description contains nodes and links, but no placement information. D2 is pretty good at figuring out how to draw the required graph, but it pays off to test out the [layout engines](https://d2lang.com/tour/layouts). Changing the [order of links](outputs-d2-link-node-attributes) might also unclutter the diagrams.
@@ -23,9 +23,18 @@ Graphing routines use **[default](topo-defaults)** topology settings to modify t
 * **outputs.d2.node_address_label** (default: True) -- add node loopback IP addresses or IP addresses of the first interface (for hosts) to node labels.
 * **outputs.d2.node_interfaces** (default: False) -- add list of interfaces and their IP addresses to nodes[^DG].
 * **outputs.d2.as_clusters** (default: True) -- use BGP autonomous systems to cluster nodes in the topology graph. BGP AS clusters are always used in BGP graphs.
-* **outputs.d2.rr_sessions** (default: True) -- draw IBGP sessions between BGP route reflectors and clients as directional connections.
 
 [^DG]: The results look disgusting. If you find a better way to get it done, please submit a PR. Thank you!
+
+(outputs-d2-bgp-parameters)=
+These default settings modify how the BGP graphs look:
+
+* **outputs.d2.bgp.rr** (default: True) -- draw arrows on BGP sessions to indicate peer-to-peer versus reflector-client sessions
+* **outputs.d2.bgp.vrf** (default: False) -- draw VRF BGP sessions as dotted lines
+* **outputs.d2.bgp.af._af_** (default: all address families) -- when one or more **af** parameters (valid keys: **ipv4**, **ipv6**, **vpnv4**, **vpnv6**, **6pe**, **evpn**) are set to *True*, the graph is limited to BGP sessions of the specified address families.
+* **outputs.d2.bgp.novrf** (default: False) -- do not include VRF BGP sessions in the graph
+
+You can specify the above BGP parameters in the *graph format* CLI argument.
 
 (outputs-d2-link-node-attributes)=
 ## Modifying Link and Node Attributes

--- a/docs/outputs/graph.md
+++ b/docs/outputs/graph.md
@@ -9,7 +9,7 @@ The *graph* output module is invoked with the **[netlab graph](netlab-graph)** c
 A single formatting modifier can be used to specify the graph type:
 
 * **topology** (default) -- Display inter-node links, multi-access- and stub subnets. When the network topology contains BGP information, the graph groups nodes into autonomous systems. Alternatively, you could set **defaults.outputs.graph.groups** attribute to use topology **[groups](topo-groups)** to group graph nodes.
-* **bgp** -- Include autonomous systems, nodes, and BGP sessions. With the **rr** option (specified with `netlab create -o graph:bgp:rr`), RR-client sessions are drawn as directed arrows.
+* **bgp** -- Include autonomous systems, nodes, and BGP sessions. The formatting modifier can include [BGP formatting parameters](outputs-graph-bgp-parameters). For example, `netlab create -o graph:bgp:rr` draws RR-client sessions as directed arrows.
 
 ## Modifying Graph Attributes
 
@@ -19,7 +19,16 @@ Graphing routines use **[default](topo-defaults)** topology settings to modify t
 * **outputs.graph.groups** -- use the specified list of groups (or all groups when set to *True*) to create graph clusters
 * **outputs.graph.interface_labels** -- Add IP addresses to links in **topology** graph. Results in a cluttered image (but feel free to fix that and submit a pull request).
 * **outputs.graphs.node_address_label** (default: *True*) -- add node loopback IP addresses or IP addresses of the first interface (for hosts) to node labels.
-* **outputs.graph.rr_sessions** (default: *False*) -- draw IBGP sessions between BGP route reflectors and clients as directional connections.
+
+(outputs-graph-bgp-parameters)=
+These default settings modify how the BGP graphs look:
+
+* **outputs.graph.bgp.rr** (default: True) -- draw arrows on BGP sessions to indicate peer-to-peer versus reflector-client sessions
+* **outputs.graph.bgp.vrf** (default: False) -- draw VRF BGP sessions as dotted lines
+* **outputs.graph.bgp.af._af_** (default: all address families) -- when one or more **af** parameters (valid keys: **ipv4**, **ipv6**, **vpnv4**, **vpnv6**, **6pe**, **evpn**) are set to *True*, the graph is limited to BGP sessions of the specified address families.
+* **outputs.graph.bgp.novrf** (default: False) -- do not include VRF BGP sessions in the graph
+
+You can specify the above BGP parameters in the *graph format* CLI argument.
 
 (outputs-graph-link-node-attributes)=
 ## Modifying Link and Node Attributes

--- a/netsim/outputs/d2.py
+++ b/netsim/outputs/d2.py
@@ -9,7 +9,7 @@ from ..data import get_box
 from ..utils import files as _files
 from ..utils import log
 from . import _TopologyOutput
-from ._graph import bgp_graph, map_style, topology_graph
+from ._graph import bgp_graph, map_style, parse_bgp_params, topology_graph
 
 '''
 Copy default settings into a D2 map converting Python dictionaries into
@@ -169,13 +169,8 @@ def graph_topology(topology: Box, fname: str, settings: Box,g_format: typing.Opt
   return True
 
 def graph_bgp(topology: Box, fname: str, settings: Box, g_format: typing.Optional[list]) -> bool:
-  rr_session = settings.get('rr_sessions',False)
-  g_format = g_format or []
-  for kw in g_format[1:]:
-    if kw == 'rr':
-      rr_session = True
-
-  graph = bgp_graph(topology,settings,'d2',rr_sessions=rr_session)
+  parse_bgp_params(settings,g_format)
+  graph = bgp_graph(topology,settings,'d2')
   if graph is None:
     return False
 
@@ -187,6 +182,8 @@ def graph_bgp(topology: Box, fname: str, settings: Box, g_format: typing.Optiona
   for edge in graph.edges:
     if edge.nodes[0].type in settings:
       edge.attr.format = settings[edge.nodes[0].type] + edge.attr.format
+    if 'vrf' in edge.nodes[0] or 'vrf' in edge.nodes[1]:
+      edge.attr.format = settings.vrf + edge.attr.format
 
   d2_links(f,graph,topology,settings)
 

--- a/netsim/outputs/d2.yml
+++ b/netsim/outputs/d2.yml
@@ -4,7 +4,8 @@
 node_address_label: True
 interface_labels: False
 as_clusters: True
-rr_sessions: True
+bgp:
+  rr: True
 
 router:
   shape: oval
@@ -57,6 +58,10 @@ confed_ebgp:
     shape: arrow
   target-arrowhead:
     shape: arrow
+
+vrf:
+  style:
+    stroke-dash: 3
 
 style_map:
   color: stroke

--- a/netsim/outputs/graph.py
+++ b/netsim/outputs/graph.py
@@ -8,7 +8,7 @@ from box import Box
 from ..utils import files as _files
 from ..utils import log
 from . import _TopologyOutput
-from ._graph import bgp_graph, map_style, topology_graph
+from ._graph import bgp_graph, map_style, parse_bgp_params, topology_graph
 
 
 def edge_label(f : typing.TextIO, direction: str, data: Box, subnet: bool = True) -> None:
@@ -143,6 +143,8 @@ def gv_links(f: typing.TextIO, graph: Box, topology: Box, settings: Box) -> None
     for n_data in edge.nodes:
       if 'type' in n_data:
         attr = attr + settings.styles[n_data.type]
+      if 'vrf' in n_data:
+        attr = attr + settings.styles.vrf
 
     if '<-' in dir:
       attr.arrowtail = 'normal'
@@ -190,13 +192,8 @@ def graph_topology(topology: Box, fname: str, settings: Box,g_format: typing.Opt
   return True
 
 def graph_bgp(topology: Box, fname: str, settings: Box,g_format: typing.Optional[list]) -> bool:
-  rr_session = settings.get('rr_sessions',False)
-  g_format = g_format or []
-  for kw in g_format[1:]:
-    if kw == 'rr':
-      rr_session = True
-
-  graph = bgp_graph(topology,settings,'graph',rr_sessions=rr_session)
+  parse_bgp_params(settings,g_format)
+  graph = bgp_graph(topology,settings,'graph')
   if graph is None:
     return False
 

--- a/netsim/outputs/graph.yml
+++ b/netsim/outputs/graph.yml
@@ -27,6 +27,8 @@ styles:
   confed_ebgp:
     color: '#d26400'
     penwidth: 2
+  vrf:
+    style: dashed
   graph:
     bgcolor: transparent
     nodesep: 0.5

--- a/netsim/utils/log.py
+++ b/netsim/utils/log.py
@@ -22,8 +22,9 @@ QUIET : bool = False
 RAISE_ON_ERROR : bool = False
 WARNING : bool = False
 
-AF_LIST = ['ipv4','ipv6']
-BGP_SESSIONS = ['ibgp','ebgp']
+AF_LIST = ('ipv4','ipv6')
+BGP_AF  = ('ipv4','ipv6','vpnv4','vpnv6','6pe','evpn')
+BGP_SESSIONS = ('ibgp','ebgp')
 
 _ERROR_LOG: list = []
 _WARNING_LOG: list = []

--- a/tests/platform-integration/graph/bgp.yml
+++ b/tests/platform-integration/graph/bgp.yml
@@ -1,7 +1,8 @@
 defaults.device: frr
 defaults.provider: clab
 
-module: [ ospf, bgp ]
+module: [ ospf, bgp, vrf, vlan, vxlan, evpn ]
+defaults.vrf.warnings.inactive: False
 
 bgp.as_list:
   65000:
@@ -12,6 +13,11 @@ bgp.as_list:
 
 nodes: [ r1, r2, r3, r4, r5, r6 ]
 
+vrfs:
+  tenant:
+    evpn.transit_vni: True
+    links: [ r1-r4, r3-r6 ]
+
 links:
 - interfaces: [ r2, r1 ]
   graph.linkorder: 1
@@ -21,5 +27,3 @@ links:
 - r4-r5
 - r5-r6
 - r4-r6
-- r1-r4
-- r3-r6

--- a/tests/platform-integration/graph/create-d2.sh
+++ b/tests/platform-integration/graph/create-d2.sh
@@ -14,5 +14,7 @@ if [[ "$OPTS" == *"topo"* ]]; then
 fi
 if [[ "$OPTS" == *"bgp"* ]]; then
   netlab create -o d2:bgp bgp.yml && d2 graph.d2 d2-bgp-default.svg
-  NETLAB_OUTPUTS_D2_RR__SESSIONS=False netlab create -o d2:bgp bgp.yml && d2 graph.d2 d2-bgp-no-rr.svg
+  NETLAB_OUTPUTS_D2_BGP_RR=False netlab create -o d2:bgp bgp.yml && d2 graph.d2 d2-bgp-no-rr.svg
+  netlab create -o d2:bgp:vrf bgp.yml && d2 graph.d2 d2-bgp-vrf.svg
+  netlab create -o d2:bgp:evpn bgp.yml && d2 graph.d2 d2-bgp-evpn.svg
 fi

--- a/tests/platform-integration/graph/create-graphviz.sh
+++ b/tests/platform-integration/graph/create-graphviz.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 graph() {
+  echo -n "graph $3 from $1 into $2 "
   netlab create -o graph$3 $1 && dot graph.dot -Tsvg -o $2
 }
 OPTS=${*:-bgp topo}
@@ -13,5 +14,8 @@ if [[ "$OPTS" == *"topo"* ]]; then
 fi
 if [[ "$OPTS" == *"bgp"* ]]; then
   graph bgp.yml dot-bgp-default.svg :bgp
-  NETLAB_OUTPUTS_GRAPH_RR__SESSIONS=True graph bgp.yml dot-bgp-rr.svg :bgp
+  graph bgp.yml dot-bgp-rr.svg :bgp:rr
+  graph bgp.yml dot-bgp-vrf.svg :bgp:vrf
+  graph bgp.yml dot-bgp-novrf.svg :bgp:novrf
+  graph bgp.yml dot-bgp-evpn.svg :bgp:evpn:rr
 fi


### PR DESCRIPTION
New formatting options for BGP graphs:

* VRF sessions are either omitted or shown as dotted lines
* The graph can be limited to a subset of address families

Unified parsing of BGP formatting options:

* D2 and Graph output modules use the same code to parse BGP formatting parameters

Changes in integration tests:

* The BGP topology includes VRFs and EVPN
* The graph creation scripts create more BGP graphs with various formatting options