### PR TITLE
Use pickled data as snapshot file

### DIFF
--- a/docs/dev/config/deploy.md
+++ b/docs/dev/config/deploy.md
@@ -193,7 +193,7 @@ The filename search patterns can use Jinja2 expressions that rely on [Ansible va
 | `package:` | **networklab** package (system file) |
 | `topology:` | Directory containing the current lab topology |
 
-The directory search patterns are evaluated during the [data transformation process](../transform.md), and the absolute paths are stored in the Ansible inventory (in the **all** group) and the `netlab.snapshot.yml` file. You can use the **netlab inspect defaults.paths** command to display the transformed values (**netlab inspect** command is available after starting the lab or executing the **netlab create** command).
+The directory search patterns are evaluated during the [data transformation process](../transform.md), and the absolute paths are stored in the Ansible inventory (in the **all** group) and the `netlab.snapshot.pickle` file. You can use the **netlab inspect defaults.paths** command to display the transformed values (**netlab inspect** command is available after starting the lab or executing the **netlab create** command).
 
 For example, the default custom configuration template directory  search path (**defaults.paths.custom.dirs**) contains these entries:
 
@@ -206,7 +206,7 @@ custom:                         # Custom configuration templates
   - "package:extra"
 ```
 
-The evaluated search path that is stored in `netlab.snapshot.yml` might contain these values (the topology directory is equal to the current directory, **netlab** is executed from local Git directory):
+The evaluated search path that is stored in `netlab.snapshot.pickle` might contain these values (the topology directory is equal to the current directory, **netlab** is executed from local Git directory):
 
 ```
 $ netlab inspect defaults.paths.custom.dirs

--- a/docs/netlab/connect.md
+++ b/docs/netlab/connect.md
@@ -35,7 +35,7 @@ The rest of the arguments are passed to SSH or docker exec command
 
 ## Collecting Device Data
 
-**netlab connect** uses the lab snapshot file (default: `netlab.snapshot.yml`) to read device- and node information. You can overwrite the default snapshot file with the `--snapshot` command line parameter.
+**netlab connect** uses the lab snapshot file (default: `netlab.snapshot.pickle`) to read device- and node information. You can overwrite the default snapshot file with the `--snapshot` command line parameter.
 
 **netlab connect** command uses the following device data. Most of that data is derived from the device **group_vars**, although you can override it on [node-](node-ansible-data) or [custom group](groups-object-data) level; use the **[`netlab inspect --node _name_`](inspect.md)** command to inspect it.
 

--- a/docs/netlab/create.md
+++ b/docs/netlab/create.md
@@ -22,16 +22,17 @@ You can influence the data model transformation with optional [configuration mod
 
 **netlab create** uses transformed node- and link-level data structures to create:
 
-* Snapshot of the transformed topology in the **netlab.snapshot.yml** file. This file is used by **netlab down** command to find the virtualization provider and link (bridge) names.
+* Pickled transformed topology data in the **netlab.snapshot.pickle** file. This file is used by many other **netlab** commands to get the information about the currently running lab topology.
+* Snapshot of the transformed topology in the **netlab.snapshot.yml** file. You can use this file to get the information about the current lab topology in your own scripts.
 * **Vagrantfile** supporting *[libvirt](lab-libvirt)* environment
 * **clab.yml** file used by *containerlab*.
 * Ansible inventory[^1], either as a single-file data structure, or as a minimal inventory file with data stored primarily in **host_vars** and **group_vars**
 * Various graphs in *graphviz* DOT format
 * YAML or JSON representation of transformed lab topology or parts of the transformed data model
-* Configuration file for *graphite* visualization tool
+* Configuration files for [external tools](extools.md)
 
 ```{warning}
-**‌netlab create** command refuses to create provider configuration files, Ansible inventory, or `netlab.snapshot.yml` file if it finds `netlab.lock` file in the current directory. 
+**‌netlab create** command refuses to create provider configuration files, Ansible inventory, or `netlab.snapshot.pickle` file if it finds `netlab.lock` file in the current directory. 
 
 `netlab.lock` file is created by the **‌netlab up** command to ensure subsequent **‌netlab create** commands don't overwrite the provider configuration files. It is automatically removed after a successful completion of **‌netlab down** command.
 ```
@@ -71,6 +72,7 @@ optional arguments:
 
 output files created when no output is specified:
 
+  * Pickled transformed data in netlab.snapshot.pickle
   * Transformed topology snapshot in netlab.snapshot.yml
   * Virtualization provider file with provider-specific filename
     (Vagrantfile or clab.yml)

--- a/docs/netlab/down.md
+++ b/docs/netlab/down.md
@@ -27,7 +27,7 @@ options:
 Notes:
 
 * **netlab down** needs transformed topology data to find the virtualization provider and link (bridge) names.
-* **netlab down** reads the transformed topology from `netlab.snapshot.yml` file created by **netlab up** or **netlab create**.
+* **netlab down** reads the transformed topology from `netlab.snapshot.pickle` file created by **netlab up** or **netlab create**.
 * With the `--instance` flag, you can shut down a lab instance running in a different directory. Use the `netlab status --all` command to display all running instances.
 * Use the `--cleanup` flag to delete all Ansible-, Vagrant- or containerlab-related configuration files.
 * Use the `--force` flag with the `--cleanup` flag if you want to clean up the directory even when the virtualization provider fails during the shutdown process.

--- a/docs/netlab/graph.md
+++ b/docs/netlab/graph.md
@@ -1,7 +1,7 @@
 (netlab-graph)=
 # Creating Physical or BGP Topology Graphs
 
-**netlab graph** command creates a graph description in [Graphviz](https://graphviz.org/) or [D2](https://d2lang.com/) format from the transformed lab topology data (usually stored in `netlab.snapshot.yml`) created by **netlab create** command. It's replicating the functionality of **netlab create -o graph:_name_** command with a more convenient user interface. 
+**netlab graph** command creates a graph description in [Graphviz](https://graphviz.org/) or [D2](https://d2lang.com/) format from the transformed lab topology data (usually stored in `netlab.snapshot.pickle`) created by **netlab create** command. It's replicating the functionality of **netlab create -o graph:_name_** command with a more convenient user interface. 
 
 ```{note}
 You will have to install [Graphviz](https://graphviz.org/download/) or [D2](https://d2lang.com/tour/install) and use them to create the actual graphs in PNG/JPEG/PDF format.

--- a/docs/netlab/initial.md
+++ b/docs/netlab/initial.md
@@ -26,7 +26,7 @@ Jinja2 templates are used together with **_device_\_config** Ansible modules to 
 [^init]: For example, Juniper vMX requires an evaluation license to be applied after the device boots.
 
 ```{tip}
-* The **netlab initial** command reads the transformed lab data from the `netlab.snapshot.yml` file created by the **netlab up** command.
+* The **netlab initial** command reads the transformed lab data from the `netlab.snapshot.pickle` file created by the **netlab up** command.
 * When run with the **-v** parameter, the command displays device configurations before deploying them.
 ```
 

--- a/docs/netlab/inspect.md
+++ b/docs/netlab/inspect.md
@@ -1,7 +1,7 @@
 (netlab-inspect)=
 # Inspect Data Structures in Transformed Lab Topology
 
-**netlab inspect** prints data structures in transformed lab topology (usually stored in `netlab.snapshot.yml`) created by the **netlab create** command. You can display data in YAML or JSON format and select a subset of data from the transformed topology or an individual node.
+**netlab inspect** prints data structures in transformed lab topology (usually stored in `netlab.snapshot.pickle`) created by the **netlab create** command. You can display data in YAML or JSON format and select a subset of data from the transformed topology or an individual node.
 
 When selecting data from an individual node, _netlab_ adds group variables to node data, effectively displaying what you would see in the Ansible inventory.
 

--- a/docs/netlab/report.md
+++ b/docs/netlab/report.md
@@ -1,7 +1,7 @@
 (netlab-report)=
 # Creating a Report
 
-The **netlab report** command creates a report from the transformed lab topology data (usually stored in `netlab.snapshot.yml`) created by the **netlab create** command. It replicates the functionality of the **netlab create -o report:_name_** command with a more convenient user interface.
+The **netlab report** command creates a report from the transformed lab topology data (usually stored in `netlab.snapshot.pickle`) created by the **netlab create** or **netlab up** command. It replicates the functionality of the **netlab create -o report:*name*** command with a more convenient user interface.
 
 ## Usage
 

--- a/docs/netlab/restart.md
+++ b/docs/netlab/restart.md
@@ -1,6 +1,6 @@
 # Restart Virtual Lab
 
-**netlab restart** executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the transformed lab topology stored in `netlab.snapshot.yml` snapshot file.
+**netlab restart** executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the transformed lab topology stored in `netlab.snapshot.pickle` snapshot file.
 
 You can use **netlab restart** to restart the existing lab (use `--snapshot` keyword) or recreate the lab configuration files if you changed the lab topology.
 

--- a/docs/netlab/status.md
+++ b/docs/netlab/status.md
@@ -115,7 +115,7 @@ The **netlab status cleanup _instance_** command shuts down the specified lab in
 $ netlab status --cleanup
 Cleanup will remove lab instance "default" in /home/user/net101/tools/X. Are you sure? [y/n]y
 Shutting down lab default in /home/user/net101/tools/X
-Read transformed lab topology from snapshot file netlab.snapshot.yml
+Read transformed lab topology from snapshot file netlab.snapshot.pickle
 
 ┌──────────────────────────────────────────────────────────────────────────────────┐
 │ CHECKING virtualization provider installation                                    │
@@ -147,4 +147,5 @@ INFO[0001] Removing containerlab host entries from /etc/hosts file
 ... removing directory tree group_vars
 ... removing directory tree host_vars
 ... removing netlab.snapshot.yml
+... removing netlab.snapshot.pickle
 ```

--- a/docs/netlab/up.md
+++ b/docs/netlab/up.md
@@ -29,7 +29,7 @@ After configuring the lab with **netlab initial**, **netlab up** displays the [h
 
 ## Usage
 
-You can use `netlab up` to create configuration files and start the lab, or use `netlab up --snapshot` to start a previously created lab or restart a lab after a server reboot ([more details](netlab-up-restart)) using the transformed lab topology stored in the `netlab.snapshot.yml` snapshot file.
+You can use `netlab up` to create configuration files and start the lab, or use `netlab up --snapshot` to start a previously created lab or restart a lab after a server reboot ([more details](netlab-up-restart)) using the transformed lab topology stored in the `netlab.snapshot.pickle` snapshot file.
 
 ```text
 usage: netlab up [-h] [--log] [-v] [-q] [--defaults [DEFAULTS ...]] [-d DEVICE]

--- a/docs/topology/validate.md
+++ b/docs/topology/validate.md
@@ -175,7 +175,7 @@ A similar approach cannot be used for Cisco IOSv. The only way to validate the c
 
 ```{tip}
 * You can use the **‌netlab validate -vv** command to generate debugging printouts to help you determine why your tests don't work as expected.
-* **‌netlab validate** command takes the tests from the `netlab.snapshot.yml` file created during the **‌netlab up** process. To recreate that file while the lab is running, use the hidden **‌netlab create --unlock** command.
+* **‌netlab validate** command takes the tests from the `netlab.snapshot.pickle` file created during the **‌netlab up** process. To recreate that file while the lab is running, use the hidden **‌netlab create --unlock** command.
 * Use [validation plugins](validate-plugin) to create complex validation tests.
 ```
 

--- a/netsim/cli/create.py
+++ b/netsim/cli/create.py
@@ -34,6 +34,7 @@ def create_topology_parse(
     epilog = textwrap.dedent('''
       output files created when no output is specified:
 
+        * Pickled transformed data in netlab.snapshot.pickle
         * Transformed topology snapshot in netlab.snapshot.yml
         * Virtualization provider file with provider-specific filename
           (Vagrantfile or clab.yml)
@@ -125,7 +126,7 @@ def run(cli_args: typing.List[str],
     args.topology = http_fetch_content(args.topology,args)
 
   if not args.output:
-    args.output = ['provider','yaml=netlab.snapshot.yml','tools']
+    args.output = ['provider','yaml=netlab.snapshot.yml','pickle','tools']
     args.output.append('devices' if args.devices else 'ansible:dirs')
   elif args.devices:
     log.error('--output and --devices flags are mutually exclusive',log.IncorrectValue,'create')

--- a/netsim/cli/down.py
+++ b/netsim/cli/down.py
@@ -55,7 +55,7 @@ def down_parse(args: typing.List[str]) -> argparse.Namespace:
     dest='force',
     action='count', default = 0,
     help='Force shutdown or cleanup (use at your own risk)')
-  parser_lab_location(parser,instance=True,action='shut down')
+  parser_lab_location(parser,instance=True,snapshot=True,action='shut down')
 
   return parser.parse_args(args)
 
@@ -77,6 +77,7 @@ def down_cleanup(topology: Box, verbose: bool = False) -> None:
     cleanup_list += v if isinstance(v,list) else [ v ]
 
   cleanup_list.append('netlab.snapshot.yml')
+  cleanup_list.append('netlab.snapshot.pickle')
   fs_cleanup(cleanup_list,verbose)
 
 #

--- a/netsim/cli/up.py
+++ b/netsim/cli/up.py
@@ -70,7 +70,7 @@ def up_parse_args(standalone: bool) -> argparse.ArgumentParser:
     dest='snapshot',
     action='store',
     nargs='?',
-    const='netlab.snapshot.yml',
+    const='netlab.snapshot.pickle',
     help='Use netlab snapshot file created by a previous lab run')
   parser.add_argument(
     '--validate',

--- a/netsim/outputs/__init__.py
+++ b/netsim/outputs/__init__.py
@@ -69,5 +69,22 @@ class _TopologyOutput(Callback):
 
     return None
 
+  def select_output_file(self, defname: typing.Optional[str] = None, writeable: bool = False) -> str:
+    modname = type(self).__name__
+    outfile = self.settings.get('filename',None) or defname
+
+    if hasattr(self,'filenames'):
+      outfile = self.filenames[0]
+      if len(self.filenames) > 1:
+        log.fatal(f'Extra output filename(s) ignored: {self.filenames[1:]}',module=modname)
+
+    if not outfile or outfile is None:
+      log.fatal('No output file specified',module=modname)
+
+    if defname and outfile == defname and writeable:
+      check_writeable(outfile)
+
+    return outfile
+
   def write(self, topology: Box) -> None:
     log.fatal('someone called the "write" method of TopologyOutput abstract class')

--- a/netsim/outputs/pickle.py
+++ b/netsim/outputs/pickle.py
@@ -1,0 +1,35 @@
+#
+# Create Pickle snapshot of transformed topology
+#
+import pickle
+
+from box import Box
+
+from ..augment import topology
+from ..utils import log
+from . import _TopologyOutput
+
+
+class YAML(_TopologyOutput):
+
+  DESCRIPTION :str = 'Create Pickle snapshot of transformed topology'
+
+  def write(self, topo: Box) -> None:
+    outfile = self.select_output_file('netlab.snapshot.pickle',writeable=True)
+    if outfile == '-':
+      log.fatal('Cannot write pickled data to stdout',module='pickle')
+
+    topodict = topology.cleanup_topology(topo).to_dict()
+    try:
+      output = open(outfile,mode='wb')
+    except Exception as ex:
+      log.fatal(f'Cannot open file {outfile} for writing: {str(ex)}',module='pickle')
+
+    try:
+      pickle.dump(topodict,output)
+      output.close()
+    except Exception as ex:
+      log.fatal(f'Cannot write pickled data to {outfile}: {str(ex)}',module='pickle')
+
+    log.status_created()
+    print(f"pickled transformed topology data into {outfile}")

--- a/netsim/utils/files.py
+++ b/netsim/utils/files.py
@@ -168,8 +168,7 @@ def open_output_file(fname: str) -> typing.TextIO:
   try:
     return open(fname,mode='w')
   except Exception as ex:
-    log.fatal(f'Cannot open file {fname} for writing: {ex}')
-    return sys.stdout
+    log.fatal(f'Cannot open file {fname} for writing: {str(ex)}')
 
 def close_output_file(f: typing.TextIO) -> None:
   try:

--- a/netsim/utils/read.py
+++ b/netsim/utils/read.py
@@ -3,6 +3,7 @@
 #
 import argparse
 import os
+import pickle
 import sys
 import typing
 
@@ -10,6 +11,7 @@ import yaml
 from box import Box
 
 # Related modules
+from ..data import get_box
 from ..data import types as _types
 from ..utils import files as _files
 from ..utils import log, versioning
@@ -335,3 +337,22 @@ def add_cli_args(topo: Box, args: typing.Union[argparse.Namespace,Box]) -> None:
           log.fatal(f"Cannot set topology value {k}\n... {ex}")
       except Exception as ex:
         log.fatal(f"Cannot set topology value {k}\n... {ex}")
+
+"""
+Read pickled snapshot data
+"""
+def load_pickled_data(snapshot: str) -> Box:
+  try:
+    pfile = open(snapshot,'rb')
+  except Exception as ex:
+    log.fatal(f'Cannot open pickle file {pfile}: {str(ex)}')
+
+  try:
+    data = pickle.load(pfile)
+    if not isinstance(data,dict):
+      log.fatal(f'The picked snapshot {snapshot} contains {type(data)}, not a dictionary')
+    pfile.close()
+  except Exception as ex:
+    log.fatal(f'Cannot read pickled data from {pfile}: {str(ex)}')
+
+  return get_box(data)

--- a/tests/platform-integration/large/01-large-topo.yml
+++ b/tests/platform-integration/large/01-large-topo.yml
@@ -1,0 +1,62 @@
+---
+message: |
+  This lab topology creates a lab with more than 300 devices, stressing
+  the netlab capabilities.
+
+plugin: [ fabric, node.clone ]
+
+addressing:
+  mgmt: 192.168.128.0/22
+  lan.prefix: 22
+
+provider: clab
+defaults.device: frr
+defaults.devices.linux.clab.image: busybox:latest
+defaults.const.MAX_NODE_ID: 400
+
+module: [ ospf, vlan ]
+
+vlans:
+  V1:
+  V2:
+  V3:
+  V4:
+  V5:
+  V6:
+
+fabric.spines: 2
+fabric.leafs: 6
+
+nodes:
+  H1:
+    device: linux
+    clone.count: 50
+  H2:
+    device: linux
+    clone.count: 50
+  H3:
+    device: linux
+    clone.count: 50
+  H4:
+    device: linux
+    clone.count: 50
+  H5:
+    device: linux
+    clone.count: 50
+  H6:
+    device: linux
+    clone.count: 50
+
+links:
+- interfaces: [ L1, H1 ]
+  vlan.access: V1
+- interfaces: [ L2, H2 ]
+  vlan.access: V2
+- interfaces: [ L3, H3 ]
+  vlan.access: V3
+- interfaces: [ L4, H4 ]
+  vlan.access: V4
+- interfaces: [ L5, H5 ]
+  vlan.access: V5
+- interfaces: [ L6, H6 ]
+  vlan.access: V6


### PR DESCRIPTION
* Add 'pickle' output module and use it as one of default outputs
* Refactor output file selection into 'select_output_file'. This function can be used by all output modules (future improvement)
* Add 'load_pickled_data' to 'utils.read'
* Read pickled or YAML data in 'load_snapshot' function

Minor changes:

* Change the default value of the 'args.snapshot' parameter
* Change the parser default value of '--snapshot' parameter
* Change the help message in 'netlab create' command
* Add 'snapshot' argument to 'netlab down' to be able to shut down a lab from the YAML snapshot file
* Add 'netlab.snapshot.pickle' as another file to clean up when the lab is shut down
* Fix exception reporting to use 'str(ex)' (just to be on the safe side)

Off-topic:

* Create a large topology in platform-integration tests to test the performance improvements

Finally:

* Updated the documentation to refer to the pickle snapshot file

Implements #2635