### PR TITLE
Implement select IGP parameters on the primary loopback interface

### DIFF
--- a/docs/module/isis.md
+++ b/docs/module/isis.md
@@ -122,7 +122,7 @@ The IS-IS configuration module is automatically removed from a node that does no
 
 ## Link Parameters
 
-IS-IS is automatically started on all interfaces within an autonomous system (interfaces with no EBGP neighbors; see also [](routing_external)). To disable IS-IS on an intra-AS link, set the **isis** link parameter to *False* (see also [](routing_disable)).
+IS-IS is automatically started on all interfaces within an autonomous system (interfaces with no EBGP neighbors; see also [](routing_external)). To disable IS-IS on an intra-AS link or a loopback interface, set the **isis** link/interface parameter to *False* (see also [](routing_disable)).
 
 You can also set these parameters on links or interfaces:
 
@@ -130,6 +130,10 @@ You can also set these parameters on links or interfaces:
 * **isis.network_type** -- Set IS-IS network type. Valid values are **point-to-point** or *False* (do not set the network type). See also [Default Link Parameters](#default-link-parameters).
 * **isis.metric** or **isis.cost** -- Interface cost. Both parameters are recognized to make IS-IS configuration similar to OSPF (*metric* takes precedence over *cost*)
 * **isis.bfd** -- enable or disable BFD on individual interfaces. Like with the node-level **isis.bfd** parameter, this parameter could be a boolean value (*True* to enable BFD for all address families, *False* to disable IS-IS BFD on the interface) or a dictionary of address families, for example:
+
+You can also set **isis.type** and **isis.metric** on the **loopback** interface[^LBI].
+
+[^LBI]: Loopback metrics might not be implemented in all IS-IS configuration templates.
 
 Example:
 

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -11,7 +11,7 @@ This configuration module configures OSPFv2 and OSPFv3 routing processes on most
 ```
 
 ```{note}
-Use **[netlab report](../netlab/report.md)** or **[netlab create -o report](../netlab/create.md)** commands to create reports on OSPF areas, routers, and interfaces. Use **[‌netlab show reports ospf](netlab-show-reports)** command to display available OSPF reports.
+Use **[netlab report](../netlab/report.md)** or **[netlab create -o report](../netlab/create.md)** commands to create reports on OSPF areas, routers, and interfaces. Use the **[‌netlab show reports ospf](netlab-show-reports)** command to display available OSPF reports.
 ```
 
 ## Supported Features
@@ -48,7 +48,7 @@ Need one of those? Create a plugin and contribute it.
 (ospf-platform)=
 ## Platform Support
 
-The following table describes per-platform support of individual router-level OSPF features:
+The following table describes the per-platform support of individual router-level OSPF features:
 
 | Operating system         | Areas | Reference<br/>bandwidth | OSPFv3 | Route<br>import | Default<br>route |
 | ------------------------ |:-:|:-:|:-:|:-:|:-:|
@@ -146,7 +146,7 @@ OSPF routing daemons support these interface-level features:
 
 **Notes:**
 * Routing daemons usually have a single interface. Running OSPF on them seems frivolous unless you need OSPF to get paths toward remote endpoints of IBGP sessions.
-* Unnumbered IPv4 interface support requires single unnumbered peer 
+* Unnumbered IPv4 interface support requires a single unnumbered peer 
 
 (ospf-interface-optional-support)=
 These devices also support optional OSPF interface attributes:
@@ -174,7 +174,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 
 * **ospf.process** -- process ID (default: 1)
 * **ospf.af** -- [OSPF address families](routing_af), usually set by the data transformation code. Configures OSPFv2 when **ospf.af.ipv4** is set to `True` and OSPFv3 (on devices that support OSPFv3) when **ospf.af.ipv6** is set to `True`. 
-* **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links without explicit OSPF area and the loopback interface.
+* **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
 * **ospf.default** -- External default route origination ([more details](ospf-default))
@@ -207,13 +207,18 @@ You can specify most node parameters as global values (top-level topology elemen
 * **ospf.network_type** -- Set OSPF network type. Allowed values are **point-to-point**, **point-to-multipoint**, **broadcast** and **non-broadcast**[^NS]. See also [Default Link Parameters](#default-link-parameters)
 * **ospf.passive** -- explicitly enable or disable [passive interfaces](routing_passive)
 * **ospf.password** -- OSPFv2 cleartext interface authentication password
-* **ospf.timers** -- set OSPF interface timers. A dictionary containing **dead** and **hello** values (from 1 to 8192 seconds)[^TNVC]. Setting **dead** timer to one enables a sub-second hello timer on platforms supporting it.
+* **ospf.timers** -- set OSPF interface timers. A dictionary containing **dead** and **hello** values (from 1 to 8192 seconds)[^TNVC]. Setting the **dead** timer to one enables a sub-second hello timer on platforms supporting it.
 
 [^NS]: Some OSPF network types (non-broadcast or point-to-multipoint) are not supported by all platforms.
 
-[^TNVC]: The values of **hello** and **dead** timer are not checked. It is possible to configure a **hello** timer that is larger than the corresponding **dead** timer, resulting in potential network device configuration errors.
+[^TNVC]: The values of **hello** and **dead** timer are not checked. It is possible to configure a **hello** timer larger than the corresponding **dead** timer, resulting in potential network device configuration errors.
 
-**Note:** The same parameters can be specified for individual link nodes.
+**Notes:**
+
+* The same parameters can be specified for individual link nodes.
+* You can also set **ospf.area** and **ospf.cost** on the **loopback** interface[^LBI].
+
+[^LBI]: The loopback OSPF area is implemented in all OSPF configuration templates, but some might not set the loopback OSPF cost.
 
 OSPF is automatically started on all interfaces within an autonomous system (interfaces with no EBGP neighbors; see also [](routing_external)). To disable OSPF on an intra-AS link, set **ospf** to *False* (see also [](routing_disable)).
 
@@ -273,7 +278,7 @@ ospf:
   area: 0.0.0.0
 ```
 
-R1 and R2 are in default OSPF area (no need to specify per-node area):
+R1 and R2 are in the default OSPF area (no need to specify per-node area):
 
 ```
 nodes:
@@ -323,7 +328,7 @@ links:
 
 **Interesting details**:
 
-* The default value for interface OSPF area is the node OSPF area
+* The default value for the interface OSPF area is the node OSPF area
 * The default value for node OSPF area is the global OSPF area (default value: 0.0.0.0).
 * Due to the propagation of default values, the OSPF area for the R2-R3 link would be area 0 on R2 and area 1 on R3 -- you have to specify the OSPF area within the link definition or an individual node connected to the link.
 

--- a/docs/module/routing_protocols.md
+++ b/docs/module/routing_protocols.md
@@ -131,13 +131,15 @@ As a workaround, set the **‌nodes._node_.vlans._name_.role** node VLAN paramet
 (routing_disable)=
 ## Disabling a Routing Protocol on a Link/Interface
 
-IGP protocols are usually configured on all internal interfaces (see [](routing_external) for more details). You can disable an IGP protocol on a link or an individual interface with the **_protocol_: False** attribute, for example:
+IGP protocols are usually configured on all internal interfaces (see [](routing_external) for more details). You can disable an IGP protocol on a link, an individual interface, or a loopback interface with the **_protocol_: False** attribute, for example:
 
 ```
 module: [ ospf ]
 
 nodes:
   r1:
+    loopback:
+      ospf: False   # Do not include loopback in the OSPF process
   r2:
 
 links:

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -90,6 +90,15 @@ def validate(topology: Box) -> None:
       module='nodes',                                 # Function is called from 'nodes' module
       ignored=['_','netlab_','ansible_'],             # Ignore attributes starting with _, netlab_ or ansible_
       extra_attributes=extra)                         # Allow provider- and tool-specific settings
+    if 'loopback' in n_data and isinstance(n_data.loopback,Box):
+      validate_attributes(
+        data=n_data.loopback,                         # Validate loopback data
+        topology=topology,
+        data_path=f'nodes.{n_name}.loopback',         # Topology path to node loopback
+        data_name=f'loopback',
+        attr_list=['loopback'],                       # We're checking loopback attributes
+        modules=n_data.get('module',[]),              # ... against node modules
+        module='nodes')                               # Function is called from 'nodes' module
 
 """
 Sets missing management interface names and MAC, IPv4, and IPv6 addresses from the mgmt pool

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -45,7 +45,7 @@ internal:                   # Internal attributes, not validated
 
 global_extra_ns: [ providers, outputs ]
 
-can_be_false: [ link, interface ]
+can_be_false: [ link, interface, loopback ]
 
 link:                       # Global link attributes
   bandwidth: int
@@ -122,14 +122,18 @@ node:
     ifname: str
   mtu: { type: int, min_value: 64, max_value: 9216 }
   loopback:
-    ipv4: { type: ipv4, use: host_prefix, _alt_types: [ bool ] }
-    ipv6: { type: ipv6, use: host_prefix, _alt_types: [ bool ] }
-    pool: addr_pool
+    type: dict
     _alt_types: [ bool ]
   provider: id
   cpu:
   memory: int
   unmanaged: bool
+
+loopback:
+  ipv4: { type: ipv4, use: host_prefix, _alt_types: [ bool ] }
+  ipv6: { type: ipv6, use: host_prefix, _alt_types: [ bool ] }
+  pool: addr_pool
+  _alt_types: [ bool ]
 
 pool:                       # Address pool definition
   ipv4: { type: ipv4, use: subnet_prefix }

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -133,7 +133,6 @@ loopback:
   ipv4: { type: ipv4, use: host_prefix, _alt_types: [ bool ] }
   ipv6: { type: ipv6, use: host_prefix, _alt_types: [ bool ] }
   pool: addr_pool
-  _alt_types: [ bool ]
 
 pool:                       # Address pool definition
   ipv4: { type: ipv4, use: subnet_prefix }

--- a/netsim/modules/_routing.py
+++ b/netsim/modules/_routing.py
@@ -201,6 +201,9 @@ def add_loopback_igp(node: Box, proto: str, topology: Box) -> None:
   if 'loopback' not in node:                                # Node working in host mode, no loopback
     return
 
+  if node.loopback.get(proto) is False:
+    return
+
   d_feature = devices.get_device_features(node,topology.defaults)
   lb_data = d_feature[proto].get('loopback',{})             # Get device-specific loopback info (if present)
   if not isinstance(lb_data,Box):                           # Sanity check
@@ -362,6 +365,9 @@ def remove_unaddressed_intf(node: Box, proto: str) -> None:
 # remove_unused_igp -- remove IGP module if it's not configured on any interface
 #
 def remove_unused_igp(node: Box, proto: str, remove_module: bool = True) -> bool:
+  if 'loopback' in node and node.loopback.get(proto) is False:              # Deal with IGP disabled on the loopback interface
+    node.loopback.pop(proto,None)
+
   if not any(proto in ifdata for ifdata in node.interfaces):                # Is protocol configured on any non-loopback interface?
     node.pop(proto,None)                                                    # ... no, remove protocol data from node
 
@@ -820,11 +826,11 @@ def igp_post_transform(
   if propagate is not None:
     propagate(node,topology)
   
+  add_loopback_igp(node,proto,topology)
   check_interface_af(node,proto)
   if remove_unused_igp(node,proto):
     return
 
-  add_loopback_igp(node,proto,topology)
   process_imports(node,proto,topology,['bgp','connected'])
   process_default_route(node,proto,topology)
 

--- a/netsim/modules/_routing.py
+++ b/netsim/modules/_routing.py
@@ -370,6 +370,8 @@ def remove_unused_igp(node: Box, proto: str, remove_module: bool = True) -> bool
 
   if not any(proto in ifdata for ifdata in node.interfaces):                # Is protocol configured on any non-loopback interface?
     node.pop(proto,None)                                                    # ... no, remove protocol data from node
+    if isinstance(node.get('loopback',None),Box):                           # Do we have a usable loopback interface on the node?
+      node.loopback.pop(proto,None)                                         # ... remove protocol data from loopback
 
   if proto in node and 'af' in node[proto] and node[proto].af:              # Is at least one global AF active for the protocol?
     return False                                                            # ... OK, we're good

--- a/netsim/modules/isis.yml
+++ b/netsim/modules/isis.yml
@@ -41,6 +41,10 @@ attributes:
       valid_values: [ point-to-point ]
       _alt_types: [ bool ]
     passive: bool
+  loopback:
+    type: { copy: link }
+    metric: { copy: link }
+    cost: { copy: link }
 features:
   unnumbered:
     ipv4: IPv4 unnumbered interfaces

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -60,8 +60,10 @@ def propagate_node_attributes(node: Box, topology: Box) -> None:
   if 'ospf' not in node:
     return
 
-  if 'loopback' in node and 'area' in node.ospf:
-    node.loopback.ospf.area = node.ospf.area
+  if 'loopback' in node:
+    if node.loopback.get('ospf') is not False:
+      if 'area' in node.ospf and 'area' not in node.loopback.ospf:
+        node.loopback.ospf.area = node.ospf.area
 
   if not 'vrfs' in node:
     return

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -78,6 +78,10 @@ attributes:
   interface:
     priority: { copy: node }
 
+  loopback:
+    area: { copy: global }
+    cost: { copy: link }
+
 features:
   default: Originate external default route
   digest: MD5 authentication

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -496,6 +496,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -510,6 +512,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -524,6 +528,8 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
+          isis:
+            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -544,6 +550,8 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::1/128
+      isis:
+        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -496,8 +496,6 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
-          isis:
-            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -512,8 +510,6 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
-          isis:
-            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -528,8 +524,6 @@ nodes:
           ifindex: 0
           ifname: Loopback0
           ipv6: 2001:db8::1/128
-          isis:
-            passive: false
           neighbors: []
           type: loopback
           virtual_interface: true
@@ -550,8 +544,6 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::1/128
-      isis:
-        passive: false
       neighbors: []
       type: loopback
       virtual_interface: true

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -162,9 +162,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.5/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -179,9 +176,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.5/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -220,9 +214,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.5/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -255,9 +246,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.6/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -272,9 +260,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.6/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -313,9 +298,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.6/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -348,9 +330,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.7/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -365,9 +344,6 @@ nodes:
           ifname: Loopback0
           ipv4: 10.0.0.7/32
           neighbors: []
-          ospf:
-            area: 0.0.0.0
-            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -406,9 +382,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.7/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -164,6 +164,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -180,6 +181,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -220,6 +222,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -254,6 +257,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -270,6 +274,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -310,6 +315,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -344,6 +350,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -360,6 +367,7 @@ nodes:
           neighbors: []
           ospf:
             area: 0.0.0.0
+            passive: false
           type: loopback
           virtual_interface: true
         activate:
@@ -400,6 +408,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -129,9 +129,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -220,9 +217,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -334,9 +328,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -131,6 +131,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -221,6 +222,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -334,6 +336,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -351,6 +351,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -349,9 +349,6 @@ nodes:
       ipv4: 10.0.0.1/32
       ipv6: 2001:db8:0:1::1/64
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -89,9 +89,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -223,9 +220,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -122,9 +122,6 @@ nodes:
       ifname: lo
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.42
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -146,9 +143,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -173,9 +167,6 @@ nodes:
       ifname: lo
       ipv4: 10.0.0.4/32
       neighbors: []
-      ospf:
-        area: 0.0.0.42
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -263,9 +254,6 @@ nodes:
       ifname: lo
       ipv4: 10.0.0.6/32
       neighbors: []
-      ospf:
-        area: 0.0.0.42
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -124,6 +124,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.42
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -147,6 +148,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -173,6 +175,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.42
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -262,6 +265,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.42
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -42,20 +42,25 @@ input:
 - package:topology-defaults.yml
 links:
 - _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: swp1
-    ipv4: 10.1.0.1/30
+    ipv4: 172.16.0.1/24
     node: a
   - ifindex: 1
     ifname: GigabitEthernet0/1
-    ipv4: 10.1.0.2/30
+    ipv4: 172.16.0.5/24
     node: e
+  - ifindex: 1
+    ifname: swp1
+    ipv4: 172.16.0.4/24
+    node: d
   linkindex: 1
-  node_count: 2
+  node_count: 3
   prefix:
-    ipv4: 10.1.0.0/30
-  type: p2p
+    ipv4: 172.16.0.0/24
+  type: lan
 module:
 - ospf
 - bgp
@@ -71,20 +76,23 @@ nodes:
     device: cumulus
     id: 1
     interfaces:
-    - ifindex: 1
+    - bridge: input_1
+      ifindex: 1
       ifname: swp1
-      ipv4: 10.1.0.1/30
+      ipv4: 172.16.0.1/24
       linkindex: 1
-      name: a -> e
+      name: a -> [e,d]
       neighbors:
       - ifname: GigabitEthernet0/1
-        ipv4: 10.1.0.2/30
+        ipv4: 172.16.0.5/24
         node: e
+      - ifname: swp1
+        ipv4: 172.16.0.4/24
+        node: d
       ospf:
         area: 0.0.0.42
-        network_type: point-to-point
         passive: false
-      type: p2p
+      type: lan
     loopback:
       ifindex: 0
       ifname: lo
@@ -161,21 +169,47 @@ nodes:
     - g2b
     device: cumulus
     id: 4
-    interfaces: []
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: swp1
+      ipv4: 172.16.0.4/24
+      linkindex: 1
+      name: d -> [a,e]
+      neighbors:
+      - ifname: swp1
+        ipv4: 172.16.0.1/24
+        node: a
+      - ifname: GigabitEthernet0/1
+        ipv4: 172.16.0.5/24
+        node: e
+      ospf:
+        area: 0.0.0.42
+        passive: false
+      type: lan
     loopback:
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.4/32
       neighbors: []
+      ospf:
+        area: 0.0.0.42
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
       ifname: eth0
       ipv4: 192.168.121.104
       mac: 08:4f:a9:04:00:00
-    module: []
+    module:
+    - ospf
     mtu: 1500
     name: d
+    ospf:
+      af:
+        ipv4: true
+      area: 0.0.0.42
+      router_id: 10.0.0.4
   e:
     af:
       ipv4: true
@@ -204,20 +238,23 @@ nodes:
     device: iosv
     id: 5
     interfaces:
-    - ifindex: 1
+    - bridge: input_1
+      ifindex: 1
       ifname: GigabitEthernet0/1
-      ipv4: 10.1.0.2/30
+      ipv4: 172.16.0.5/24
       linkindex: 1
-      name: e -> a
+      name: e -> [a,d]
       neighbors:
       - ifname: swp1
-        ipv4: 10.1.0.1/30
+        ipv4: 172.16.0.1/24
         node: a
+      - ifname: swp1
+        ipv4: 172.16.0.4/24
+        node: d
       ospf:
         area: 0.0.0.51
-        network_type: point-to-point
         passive: false
-      type: p2p
+      type: lan
     loopback:
       ifindex: 0
       ifname: Loopback0

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -351,9 +351,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -592,9 +589,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.4/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -508,8 +508,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.5/32
       ipv6: 2001:db8:0:5::1/64
-      isis:
-        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -31,9 +31,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -33,6 +33,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -184,6 +184,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -260,6 +261,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -182,9 +182,6 @@ nodes:
       ipv4: 10.0.0.5/32
       ipv6: 2001:db8:0:5::1/64
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -259,9 +256,6 @@ nodes:
       ipv4: 10.0.0.6/32
       ipv6: 2001:db8:0:6::1/64
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -539,9 +539,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -859,9 +856,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -1128,9 +1122,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -230,9 +230,6 @@ nodes:
       isis:
         passive: false
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -487,9 +484,6 @@ nodes:
       isis:
         passive: false
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -206,9 +206,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -431,9 +428,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -624,9 +618,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.3/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -1056,9 +1056,12 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
+      isis:
+        passive: false
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -1056,12 +1056,7 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
-      isis:
-        passive: false
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -354,6 +354,7 @@ nodes:
       neighbors: []
       ospf:
         area: 0.0.0.0
+        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -166,9 +166,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.1/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:
@@ -352,9 +349,6 @@ nodes:
       ifname: Loopback0
       ipv4: 10.0.0.2/32
       neighbors: []
-      ospf:
-        area: 0.0.0.0
-        passive: false
       type: loopback
       virtual_interface: true
     mgmt:

--- a/tests/topology/input/groups-hierarchy.yml
+++ b/tests/topology/input/groups-hierarchy.yml
@@ -32,4 +32,4 @@ groups:
     bgp.as: 65000
 
 links:
-- a-e
+- a-e-d

--- a/tests/topology/input/igp-af.yml
+++ b/tests/topology/input/igp-af.yml
@@ -32,6 +32,7 @@ nodes:
   r4:
     isis.af:
   r5:
+    loopback.isis: False
 
 links:
 - r1-r2


### PR DESCRIPTION
* The loopback data is checked as a new 'loopback' type to allow IGP modules to register a subset of link/interface attributes as begin valid on the loopback interface
* The loopback interface must be validated with the top-level 'validate_attributes' function, otherwise the module attributes are not recognized.
* Loopback data is thus checked first as a dict/bool within the node data, and then rechecked against the new 'loopback' type (assuming the 'loopback' attribute is not set to True/False).
* The 'module attribute can be False' list is extended to include the 'loopback' data type
* We have to deal with 'is the IGP set to False on loopback' in numerous places within the generic routing code until we finally remove 'igp: False' data in 'remove_unused_igp' function
* To make that work, the 'add_loopback_igp' call had to be moved, resulting in IGP information appearing on the loopback interface even when the IGP module is removed from the node.

Fixes #2625 and solves #2624