### PR TITLE
Fix: Implement 'str.removeprefix' in strings.utils for Python 3.8

### DIFF
--- a/.github/workflows/t-pull.yml
+++ b/.github/workflows/t-pull.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [ "3.11", "3.12", "3.13" ]
+        python-version: [ "3.8", "3.12", "3.13" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -212,7 +212,7 @@ class _Provider(Callback):
         continue
 
       # For shared files, extract the original file name (remove 'shared-' prefix)
-      template_fname = file_rel.removeprefix(self.SHARED_PREFIX)
+      template_fname = strings.removeprefix(file_rel,self.SHARED_PREFIX)
 
       template_name = self.find_extra_template(node, template_fname, topology)
       if not template_name:

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -88,6 +88,12 @@ def extra_data_printout(
   return "\n".join(lines)
 
 """
+Implement removeprefix for Python 3.8
+"""
+def removeprefix(s: str, pfx: str) -> str:
+  return s[len(pfx):] if s.startswith(pfx) else s
+
+"""
 Pad text to specified width
 """
 def pad_text(t: str, w: int = 10) -> str:


### PR DESCRIPTION
As we're not yet ready to say goodbye to our good friend Python 3.8, we still can't use str.removeprefix, so I added it to the strings utility module to keep mypy (and Ubuntu 20.04 users) happy.

Also: add Python 3.8 to pull request CI/CD pipeline to ensure a similar SNAFU won't happen anytime soon.