### PR TITLE
Add '--format' parameter to 'netlab graph' command

### DIFF
--- a/docs/netlab/graph.md
+++ b/docs/netlab/graph.md
@@ -10,9 +10,8 @@ You will have to install [Graphviz](https://graphviz.org/download/) or [D2](http
 ## Usage
 
 ```text
-usage: netlab graph [-h] [-t {topology,bgp}] [-e {graphviz,d2}] [-i INSTANCE]
-                    [--snapshot [SNAPSHOT]]
-                    [output]
+usage: netlab graph [-h] [-t {topology,bgp}] [-f G_FORMAT] [-e {graphviz,d2}]
+                    [-i INSTANCE] [--snapshot [SNAPSHOT]] [output]
 
 Create a graph description in Graphviz or D2 format
 
@@ -23,6 +22,8 @@ options:
   -h, --help            show this help message and exit
   -t {topology,bgp}, --type {topology,bgp}
                         Graph type
+  -f, --format G_FORMAT
+                        Graph formatting parameters separated by commas
   -e {graphviz,d2}, --engine {graphviz,d2}
                         Graphing engine
   -i INSTANCE, --instance INSTANCE
@@ -39,3 +40,4 @@ When executed with the `--instance` option, **‌netlab graph** creates the grap
 
 * **netlab graph** creates lab topology graph in Graphviz format
 * **netlab graph -e d2 -t bgp** creates a graph of BGP sessions in D2 format.
+* **netlab graph -t bgp -f vrf** creates a graph of BGP sessions with VRF sessions show as dashed lines ([more details](outputs-graph-bgp-parameters))

--- a/docs/outputs/graph.md
+++ b/docs/outputs/graph.md
@@ -44,7 +44,7 @@ These default settings modify how the BGP graphs look:
 * **outputs.graph.bgp.af._af_** (default: all address families) -- when one or more **af** parameters (valid keys: **ipv4**, **ipv6**, **vpnv4**, **vpnv6**, **6pe**, **evpn**) are set to *True*, the graph is limited to BGP sessions of the specified address families.
 * **outputs.graph.bgp.novrf** (default: False) -- do not include VRF BGP sessions in the graph
 
-You can specify the above BGP parameters in the *graph format* CLI argument.
+You can specify the above BGP parameters in the *graph format* CLI argument, for example `netlab create -o graph:bgp:vrf` or `netlab graph -t bgp -f vrf`.
 
 (outputs-graph-styles)=
 ## Graph Object Styles

--- a/netsim/cli/graph.py
+++ b/netsim/cli/graph.py
@@ -24,6 +24,10 @@ def graph_parse(args: typing.List[str]) -> argparse.Namespace:
     choices=['topology','bgp'],
     help='Graph type')
   parser.add_argument(
+    '-f','--format',
+    dest='g_format', action='store',
+    help='Graph formatting parameters separated by commas')
+  parser.add_argument(
     '-e','--engine',
     dest='engine', action='store',
     default='graphviz',
@@ -42,6 +46,8 @@ def run(cli_args: typing.List[str]) -> None:
   topology = load_snapshot(args)
   o_module = 'graph' if args.engine == 'graphviz' else 'd2'
   o_param  = f'{o_module}:{args.g_type or "topology"}'
+  if args.g_format:
+    o_param += ':'+args.g_format.replace(',',':')
   if args.output:
     o_param += f'={args.output}'
 


### PR DESCRIPTION
We need a way to specify formatting parameters for BGP graphs in the 'netlab graph' command (it's too late to change topology defaults as the lab is already running).