### PR TITLE
Add lab host entries to SRL nodes

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -109,3 +109,22 @@ updates:
 
 {% endfor %}
 {% endif %}
+
+
+{# 
+Add Host Entries
+----------------
+Clab already adds management IPs to SR Linux nodes' /etc/hosts file with the node names
+which take precedence, so here we append .netlab to differentiate the inband addresses.
+#}
+{% for hname,hdata in hosts.items() if 'ipv4' in hdata and hname != inventory_hostname %}
+- path: /system/dns/host-entry[name={{ hname|replace('_','') }}.netlab]
+  value:
+    ipv4-address: {{ hdata.ipv4[0] }}
+{% endfor %}
+
+{% for hname,hdata in hosts.items() if 'ipv6' in hdata and hname != inventory_hostname %}
+- path: /system/dns/host-entry[name={{ hname|replace('_','') }}.netlab]
+  value:
+    ipv6-address: {{ hdata.ipv6[0] }}
+{% endfor %}


### PR DESCRIPTION
Adding host entries to SRL is interesting because the Clab node deployment process for SRL already adds the node name to /etc/hosts and trying to override that in the config with an inline address does not work. I went ahead and gave a go here where I'm appending .netlab to the name. I don't love it but it works. :)