### PR TITLE
SRLinux: Use Linux-style /etc/hosts files

### DIFF
--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -25,7 +25,9 @@ clab:
   image: ghcr.io/nokia/srlinux:25.3.3
   node:
     kind: srl
-    type: ixrd2
+    type: ixr-d2
+    config_templates:
+      hosts: /etc/hosts
   interface:
     name: e1-{ifindex}
   group_vars:

--- a/netsim/templates/provider/clab/srlinux/hosts-common.j2
+++ b/netsim/templates/provider/clab/srlinux/hosts-common.j2
@@ -1,0 +1,1 @@
+../../../../ansible/templates/initial/linux/hosts-common.j2

--- a/netsim/templates/provider/clab/srlinux/hosts.j2
+++ b/netsim/templates/provider/clab/srlinux/hosts.j2
@@ -1,0 +1,15 @@
+#
+# Created by netlab (containerlab Linux host)
+#
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet
+ff00::0	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+#
+{% if _hosts_entries is defined %}
+{{ _hosts_entries }}
+{% else %}
+{% include 'hosts-common.j2' %}
+{% endif %}


### PR DESCRIPTION
We cannot define host-to-IP mappings with the SR Linux CLI because containerlab already defined the hosts in /etc/hosts (see #2676 for details). However, we can create /etc/hosts file in advance, and then containerlab only adds its entries which due to some SRL magic work as expected across multiple network instances.