### PR TITLE
Add missing 'bgp.as_list.name' attribute we lost in the mists of time

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -138,10 +138,11 @@ bgp:
   rr_list: [ s1, s2 ]
 ```
 
-When building a more complex lab with multiple autonomous systems, you might want to use **bgp.as_list** -- a global parameter that specifies a dictionary of autonomous systems. Every autonomous system in the **bgp.as_list** should have two elements:
+When building a more complex lab with multiple autonomous systems, you might want to use **bgp.as_list** -- a global parameter that specifies a dictionary of autonomous systems. Every autonomous system in the **bgp.as_list** could have these elements:
 
-* **members** -- list of nodes within the autonomous system
-* **rr** -- list of route reflectors within the autonomous system.
+* **members** (mandatory) -- list of nodes within the autonomous system.
+* **rr** (optional) -- list of route reflectors within the autonomous system.
+* **name** (optional) -- a name for the autonomous system that will be used in topology and BGP graphs.
 
 ```{tip}
 You can override the **‌bgp.as_list** settings with the node attributes.
@@ -155,6 +156,7 @@ bgp:
     65000:
       members: [ rr1, rr2, pe1, pe2 ]
       rr: [ rr1, rr2 ]
+      name: core
     65001:
       members: [ e1 ]
     65002:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -92,6 +92,7 @@ attributes:
     type: dict
     _keytype: int
     _subtype:
+      name: str
       members:
         type: list
         _subtype: node_id

--- a/netsim/outputs/_graph.py
+++ b/netsim/outputs/_graph.py
@@ -44,13 +44,15 @@ def build_nodes(topology: Box, g_type: str) -> Box:
     for name,n in topology.nodes.items():
       bgp_as = n.get('bgp.as',None)
       if bgp_as:
-        bgp_as = f'AS_{bgp_as}'
-        maps.bgp[bgp_as].nodes[n.name] = n
+        map_asn = f'AS_{bgp_as}'
+        maps.bgp[map_asn].nodes[n.name] = n
+        maps.bgp[map_asn].title = f'AS {bgp_as}'
 
-  if 'bgp' in topology and 'as_list' in topology.bgp:
+  if topology.get('bgp.as_list'):
     for (asn,asdata) in topology.bgp.as_list.items():
-      if 'name' in asdata and asn in maps.bgp:
-        maps.bgp[asn].name = asdata.name
+      map_asn = f'AS_{asn}'
+      if 'name' in asdata and map_asn in maps.bgp:
+        maps.bgp[map_asn].title = f'{asdata.name} (AS {asn})'
 
   return maps
 


### PR DESCRIPTION
In a version far far ago, the bgp.as_list entry could have a 'name' attribute that was used in topology and BGP graphs. That attribute was lost once we implemented the strict data checking (because nobody remembered it at the time), and the graph refactoring done in 25.09 borked its use in graphs.

This PR is fixing both blunders and closes #2675