### PR TITLE
bgp.as_list support for wildcard/regexp member/rr attributes

### DIFF
--- a/docs/groups.md
+++ b/docs/groups.md
@@ -38,6 +38,7 @@ groups:
     members: [ d,e,f ]
 ```
 
+(groups-members)=
 The elements in the **members** list can be:
 
 * node/VLAN/VRF names

--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -138,6 +138,7 @@ bgp:
   rr_list: [ s1, s2 ]
 ```
 
+(bgp-aslist)=
 When building a more complex lab with multiple autonomous systems, you might want to use **bgp.as_list** -- a global parameter that specifies a dictionary of autonomous systems. Every autonomous system in the **bgp.as_list** could have these elements:
 
 * **members** (mandatory) -- list of nodes within the autonomous system.
@@ -145,7 +146,8 @@ When building a more complex lab with multiple autonomous systems, you might wan
 * **name** (optional) -- a name for the autonomous system that will be used in topology and BGP graphs.
 
 ```{tip}
-You can override the **‌bgp.as_list** settings with the node attributes.
+* The elements of the **‌members** and **‌rr** lists can be wildcard- or regular expressions (see [group members](groups-members) for more details)
+* You can override the **‌bgp.as_list** settings with the node attributes.
 ```
 
 For example, use the following configuration to build a core network connected to two external autonomous systems:
@@ -154,13 +156,15 @@ For example, use the following configuration to build a core network connected t
 bgp:
   as_list:
     65000:
-      members: [ rr1, rr2, pe1, pe2 ]
-      rr: [ rr1, rr2 ]
+      members: [ rr*, pe* ]
+      rr: [ rr* ]
       name: core
     65001:
       members: [ e1 ]
     65002:
       members: [ e2 ]
+
+nodes: [ rr1, rr2, pe1, pe2, e1, e2 ]
 ``` 
 
 ## Advanced Global Configuration Parameters

--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -131,7 +131,8 @@ def expand_group_members(
 
     # Simple case: the member belongs to the group objects
     if m_id in g_objects or m_id in g_list:
-      members.append(m_id)
+      if m_id not in members:
+        members.append(m_id)
 
     # Regular expression, identified by a string starting with ~
     elif m_id.startswith('~'):
@@ -152,7 +153,9 @@ def expand_group_members(
           category=log.IncorrectType,
           module='groups')
         continue
-      members.extend(g_match)                     # All good, add re-matched members
+
+      # All good, add new re-matched members
+      members += [ m for m in g_match if m not in members ]
       continue
 
     elif re.search('[\\[\\].*?!]',m_id):            # Using regexp to identify a potential glob pattern
@@ -173,7 +176,9 @@ def expand_group_members(
           category=log.IncorrectType,
           module='groups')
         continue
-      members.extend(g_match)
+
+      # All good, add new wildcard-matched members
+      members += [ m for m in g_match if m not in members ]
 
     elif not g_prune:
       log.error(

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -95,11 +95,11 @@ attributes:
       name: str
       members:
         type: list
-        _subtype: node_id
+        _subtype: str
         _required: True
       rr:
         type: list
-        _subtype: node_id
+        _subtype: str
 features:
   local_as: Supports local-as functionality
   vrf_local_as: Supports local-as within a VRF

--- a/tests/errors/bgp-as-list-attr.log
+++ b/tests/errors/bgp-as-list-attr.log
@@ -1,10 +1,6 @@
 IncorrectType in bgp: attribute 'bgp.as_list.65000' must be a dictionary, found str
 ... use 'netlab show attributes --module bgp as_list' to display valid attributes
 IncorrectType in bgp: attribute 'bgp.as_list.65001' must be a dictionary, found NoneType
-IncorrectValue in bgp: attribute 'bgp.as_list.65002.members[1]' must be valid node name (found x)
-... Valid node names are r1, r2, r3
 IncorrectType in bgp: attribute 'bgp.as_list.65003.members' must be a scalar or a list, found dictionary
-IncorrectValue in bgp: attribute 'bgp.as_list.65004.rr[1]' must be valid node name (found x)
-IncorrectValue in bgp: attribute 'bgp.as_list.65006.rr[1]' must be valid node name (found x )
 MissingValue in bgp: Mandatory attribute 'bgp.as_list.65006.members' is missing
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/bgp-as-list-semantics.log
+++ b/tests/errors/bgp-as-list-semantics.log
@@ -1,10 +1,9 @@
-IncorrectType in bgp: attribute 'bgp.as_list.65000' must be a dictionary, found str
-... use 'netlab show attributes --module bgp as_list' to display valid attributes
-IncorrectType in bgp: attribute 'bgp.as_list.65001' must be a dictionary, found NoneType
-IncorrectValue in bgp: attribute 'bgp.as_list.65002.members[1]' must be valid node name (found x)
-... Valid node names are r1, r2, r3
-IncorrectType in bgp: attribute 'bgp.as_list.65003.members' must be a scalar or a list, found dictionary
-IncorrectValue in bgp: attribute 'bgp.as_list.65004.rr[1]' must be valid node name (found x)
-IncorrectValue in bgp: attribute 'bgp.as_list.65006.rr[1]' must be valid node name (found x )
-MissingValue in bgp: Mandatory attribute 'bgp.as_list.65006.members' is missing
+IncorrectType in groups: Wildcard expression x* used in bgp.as_list.65003 group members does not match anything
+IncorrectValue in bgp: BGP module supports at most 1 AS per node; r1 is already member of 65001 and cannot also be part of 65003
+IncorrectValue in bgp: Node r1 is specified as route reflector in AS 65003 but is not in member list
+IncorrectValue in bgp: Node a1 is specified as route reflector in AS 65003 but is not in member list
+IncorrectValue in bgp: Node a2 is specified as route reflector in AS 65003 but is not in member list
+IncorrectValue in groups: Invalid regular expression ~* used in bgp.as_list.65004 group members
+... nothing to repeat at position 0
+IncorrectType in groups: Regular expression ~b.* used in bgp.as_list.65004 group members does not match anything
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/bgp-as-list-semantics.yml
+++ b/tests/errors/bgp-as-list-semantics.yml
@@ -1,32 +1,17 @@
 #
-# BGP AS List error: should be a dictionary
-#
+# BGP AS member errors
 #
 module: [ bgp ]
-
-defaults:
-  device: iosv
+defaults.device: none
 
 bgp:
   as_list:
-    65000: wtf
     65001:
-    65002:
-      members: [ x ]
-    65003:
-      members:
-        r1: wrong
-    65004:
-      members: [ r2 ]
-      rr: [ x ]
-    65005:
       members: [ r1 ]
-      rr: [ r3 ]
-    65006:
-      rr: [ x ]
+    65003:
+      members: [ r*, x* ]
+      rr: [ r*, '~a[12]' ]
+    65004:
+      members: [ a1, a*, '~*', '~b.*' ]
 
-nodes:
-- name: r1
-- name: r2
-  bgp.as: 65101
-- name: r3
+nodes: [ r1, r2, r3, a1, a2, a3 ]

--- a/tests/topology/input/bgp-members.yml
+++ b/tests/topology/input/bgp-members.yml
@@ -12,8 +12,8 @@ defaults:
 bgp:
   as_list:
     65000:
-      members: [rr1, rr2, pe1, pe2]
-      rr: [rr1, rr2]
+      members: [ rr1, rr*, pe*, pe2 ]
+      rr: [ '~rr[12]' ]
     65001:
       members: [e1]
 


### PR DESCRIPTION
Also: ensure the expanded group members do not contain duplicate node names (irrelevant for regular groups, quite important for as_list)

Closes #2685