### PR TITLE
Cleanup clab group_vars for IOS-like devices

### DIFF
--- a/netsim/devices/csr.yml
+++ b/netsim/devices/csr.yml
@@ -6,10 +6,6 @@ ifindex_offset: 2
 virtualbox:
   image: cisco/csr1000v
 clab:
-  group_vars:
-    ansible_ssh_pass: admin
-    ansible_user: admin
-    netlab_check_retries: 50
   image: vrnetlab/vr-csr:17.03.04
   node:
     kind: cisco_csr1000v

--- a/netsim/devices/iol.yml
+++ b/netsim/devices/iol.yml
@@ -5,9 +5,6 @@ interface_name: Ethernet{ifindex // 4}/{ifindex % 4}
 
 clab:
   group_vars:
-    ansible_user: admin
-    ansible_ssh_pass: admin
-    ansible_become_password: admin
     netlab_device_type: iol
     netlab_check_retries: 20
   interface.name: Ethernet{ifindex // 4}/{ifindex % 4}

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -20,6 +20,13 @@ group_vars:
   # yamllint disable-line rule:line-length
   netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
 
+clab:
+  group_vars:
+    ansible_ssh_pass: admin
+    ansible_user: admin
+    ansible_become_password: admin
+    netlab_check_retries: 50
+
 role: router
 routing:
   _rm_per_af: True

--- a/netsim/devices/iosv.yml
+++ b/netsim/devices/iosv.yml
@@ -18,10 +18,6 @@ features:
     min_mtu: 64
     max_mtu: 9600
 clab:
-  group_vars:
-    ansible_ssh_pass: admin
-    ansible_user: admin
-    netlab_check_retries: 50
   image: vrnetlab/cisco_vios:15.9.3
   node:
     kind: linux

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -27,10 +27,6 @@ libvirt:
   build: https://netlab.tools/labs/iosvl2/
   create_template: iosv.xml.j2
 clab:
-  group_vars:
-    ansible_ssh_pass: admin
-    ansible_user: admin
-    netlab_check_retries: 50
   image: vrnetlab/cisco_viosl2:15.2
   node:
     kind: linux


### PR DESCRIPTION
* Use the same username/password for all devices, defined in ios.yml
* Use 'netlab_check_retries: 50' for most devices, override the value for IOL (IOLL2 inherits from IOL)

Closes #2454