### PR TITLE
Add '--debug: paths' option to help troubleshoot custom templates

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -23,6 +23,12 @@ If you want to change the provisioning- or device configuration templates, you c
 
 [^MIN]: Initial device configurations are stored in **templates/initial** directory.
 
+```{tip}
+Use the **‌netlab create --debug paths** command to display the components of individual search paths and the directories _netlab_ uses when searching those paths (non-existent directories are removed from the search paths).
+
+You can use the same command to troubleshoot template errors; the debugging printouts display every template file _netlab_ searched for and the search path it used for the search.
+```
+
 Finally, you might want to use external tools or devices not yet supported by _netlab_:
 
 * [Adding external tools](dev/extools.md) is relatively easy.

--- a/docs/dev/config/deploy.md
+++ b/docs/dev/config/deploy.md
@@ -41,6 +41,10 @@ After finding the Jinja2 template, the initial configuration deployment playbook
 | **paths.deploy.dirs** | Directory search paths for configuration deployment task lists |
 | **paths.deploy.files** | Filename search patterns for module configuration deployment task lists |
 
+```{tip}
+Use the **‌netlab create --debug paths** command to display the components of individual search paths and the directories _netlab_ uses when searching those paths (non-existent directories are removed from the search paths)
+```
+
 (dev-find-custom)=
 ## Finding Custom Configuration Templates
 

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -29,7 +29,7 @@ def parser_add_debug(parser: argparse.ArgumentParser) -> None:
   parser.add_argument('--debug', dest='debug', action='store',nargs='*',
                   choices=sorted([
                     'all','addr','cli','links','libvirt','clab','modules','plugin','template',
-                    'vlan','vrf','quirks','validate','addressing','groups','status',
+                    'vlan','vrf','quirks','validate','addressing','groups','status','paths',
                     'external','defaults','lag']),
                   help=argparse.SUPPRESS)
   parser.add_argument('--test', dest='test', action='store',nargs='*',

--- a/netsim/utils/files.py
+++ b/netsim/utils/files.py
@@ -7,6 +7,7 @@ import importlib.util
 import os
 import pathlib
 import sys
+import textwrap
 import typing
 
 from ..data import global_vars
@@ -121,7 +122,13 @@ def find_file(path: str, search_path: typing.List[str]) -> typing.Optional[str]:
   for dirname in search_path:
     candidate = os.path.join(dirname, path)
     if os.path.exists(candidate):
+      if log.debug_active('paths'):
+        log.info(f'Searching for {path} in:',more_data=textwrap.indent('\n'.join(search_path),'  - '))
+        log.info(f'Found {candidate}')
       return candidate
+
+  if log.debug_active('paths'):
+    log.info(f'Failed to find {path} in:',more_data=textwrap.indent('\n'.join(search_path),'  - '))
 
   return None
 


### PR DESCRIPTION
Replaces the solution proposed in #2660