### PR TITLE
Compute VRRP MAC/LLA addresses in gateway module

### DIFF
--- a/netsim/ansible/templates/gateway/arubacx.j2
+++ b/netsim/ansible/templates/gateway/arubacx.j2
@@ -29,7 +29,7 @@ interface {{ intf.ifname }}
   address {{ intf.gateway[af]|ipaddr('address') }} primary
 {%       endif %}
 {%       if af == 'ipv6' %}
-  address {{ 'fe80::200:5eff:fe00:02%02x' % ( intf.gateway.vrrp.group ) }} primary
+  address {{ intf.gateway.vrrp.lla }} primary
   address {{ intf.gateway[af]|ipaddr('address') }} secondary
 {%       endif %}
 {%       if intf.gateway.vrrp.preempt|default(True) %}

--- a/netsim/ansible/templates/gateway/cumulus_nvue.j2
+++ b/netsim/ansible/templates/gateway/cumulus_nvue.j2
@@ -36,7 +36,7 @@
                 address:
 {%     if 'ipv6' in intf.gateway %}
 {# Per RFC9568 5.2.9, the link-local ipv6 address MUST be included first. Required for interop with EOS (for example) #}
-                  fe80::200:5eff:fe00:2{{ '%02x' | format(intf.gateway.vrrp.group) }}: {}
+                  {{ intf.gateway.vrrp.lla }}: {}
 - set:
     interface:
       {{ intf.ifname }}:

--- a/netsim/ansible/templates/gateway/dellos10.j2
+++ b/netsim/ansible/templates/gateway/dellos10.j2
@@ -24,7 +24,7 @@ interface {{ intf.ifname }}
   vrrp-group {{ intf.gateway.vrrp.group }}
 {%       elif af == 'ipv6' %}
   vrrp-ipv6-group {{ intf.gateway.vrrp.group }}
-    virtual-address fe80::200:5eff:fe00:2{{ '%02x'|format(intf.gateway.vrrp.group) }}
+    virtual-address {{ intf.gateway.vrrp.lla }}
 {%       endif %}
     virtual-address {{ intf.gateway[af]|ipaddr('address') }}
 {%       if 'priority' in intf.gateway.vrrp %}

--- a/netsim/ansible/templates/gateway/frr.j2
+++ b/netsim/ansible/templates/gateway/frr.j2
@@ -7,7 +7,7 @@ sysctl -w net.ipv6.conf.default.enhanced_dad=0
 {% for intf in interfaces if intf.gateway.protocol|default('none') == 'vrrp' %}
 {%   for afm in ['ipv4','ipv6'] if afm in intf.gateway %}
 {%     set v_if = 'vrrp%s-%s-%s'|format('6' if afm == 'ipv6' else '',intf.ifindex,intf.gateway.vrrp.group) %}
-{%     set v_mac = '00:00:5e:00:%02x:%02x'|format(2 if afm == 'ipv6' else 1,intf.gateway.vrrp.group) %}
+{%     set v_mac = intf.gateway.vrrp.mac[afm] %}
 if [ ! -e /sys/class/net/{{ v_if }} ]; then
   ip link add {{ v_if }} link {{ intf.ifname }} type macvlan mode bridge
   ip link set dev {{ v_if }} address {{ v_mac }} addrgenmode {{ 'none' if afm == 'ipv4' else 'random' }}

--- a/netsim/ansible/templates/gateway/frr.vrrp-config.j2
+++ b/netsim/ansible/templates/gateway/frr.vrrp-config.j2
@@ -14,7 +14,7 @@ interface {{ intf.ifname }}
 {%     endif %}
 {%   if 'ipv6' in intf.gateway %}
 {# Per RFC9568, the link-local ipv6 address MUST be included first. Required for interop with EOS (for example) #}
-  vrrp {{ intf.gateway.vrrp.group }} ipv6 fe80::200:5eff:fe00:2{{ '%02x' | format(intf.gateway.vrrp.group) }}
+  vrrp {{ intf.gateway.vrrp.group }} ipv6 {{ intf.gateway.vrrp.lla }}
 {%   endif %}
 {%   for af in 'ipv4','ipv6' if af in intf.gateway %}
   vrrp {{ intf.gateway.vrrp.group }} {{ af|replace('ipv4','ip') }} {{ intf.gateway[af]|ipaddr('address') }}

--- a/netsim/ansible/templates/gateway/ios.j2
+++ b/netsim/ansible/templates/gateway/ios.j2
@@ -8,7 +8,7 @@ interface {{ intf.ifname }}
 {%     if af == 'ipv4' %}
     address {{ intf.gateway[af]|ipaddr('address') }}
 {%     else %}
-    address {{ 'fe80::200:5eff:fe00:02%02x' % ( intf.gateway.vrrp.group ) }} primary
+    address {{ intf.gateway.vrrp.lla }} primary
     address {{ intf.gateway[af] }}
 {%     endif %}
 {%     if 'priority' in intf.gateway.vrrp %}

--- a/netsim/ansible/templates/gateway/nxos.j2
+++ b/netsim/ansible/templates/gateway/nxos.j2
@@ -9,7 +9,7 @@ interface {{ intf.ifname }}
 {%     for af in 'ipv4','ipv6' if af in intf.gateway %}
   vrrpv3 {{ intf.gateway.vrrp.group }} address-family {{ af }}
 {%       if af == 'ipv6' %}
-    address {{ 'fe80::200:5eff:fe00:02%02x' % ( intf.gateway.vrrp.group ) }} primary
+    address {{ intf.gateway.vrrp.lla }} primary
 {%       endif %}
     address {{ intf.gateway[af]|ipaddr('address') }}
 {%       if 'priority' in intf.gateway.vrrp %}

--- a/netsim/ansible/templates/gateway/sros.j2
+++ b/netsim/ansible/templates/gateway/sros.j2
@@ -21,7 +21,7 @@ updates:
       admin-state: enable
       ping-reply: True
 {%     if af == 'ipv6' and intf.gateway.protocol == 'vrrp' %}
-      backup: [ "{{ 'fe80::200:5eff:fe00:02%02x' % intf.gateway.vrrp.group }}", {{ intf.gateway[af]|ipaddr('address') }} ]
+      backup: [ "{{ intf.gateway.vrrp.lla }}", {{ intf.gateway[af]|ipaddr('address') }} ]
 {%     else %}
       backup: [ "{{ intf.gateway[af]|ipaddr('address') }}" ]
 {%     endif %}

--- a/tests/topology/expected/lag-l3.yml
+++ b/tests/topology/expected/lag-l3.yml
@@ -105,6 +105,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
       ifindex: 30001
       ifname: port-channel2
       ipv4: 10.11.12.12/24

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -335,6 +335,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
           priority: 100
       ifindex: 40000
       ifname: Vlan1000
@@ -372,6 +374,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
       ifindex: 40001
       ifname: Vlan1001
       ipv4: 172.16.1.24/24
@@ -482,6 +486,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
           priority: 200
       ifindex: 40000
       ifname: Vlan1000
@@ -509,6 +515,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
           priority: 180
       ifindex: 40001
       ifname: Vlan1001

--- a/tests/topology/expected/vrrp-interface-granularity.yml
+++ b/tests/topology/expected/vrrp-interface-granularity.yml
@@ -112,6 +112,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
       ifindex: 1
       ifname: Ethernet1
       ipv4: 10.1.0.1/27
@@ -148,6 +150,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
           priority: 100
       ifindex: 3
       ifname: Ethernet3
@@ -210,6 +214,8 @@ nodes:
         protocol: vrrp
         vrrp:
           group: 1
+          mac:
+            ipv4: 00:00:5e:00:01:01
       ifindex: 2
       ifname: Ethernet2
       ipv4: 10.1.0.34/27


### PR DESCRIPTION
This commit moves the burden of computing VRRP MAC/LLA addresses (when needed) to the gateway module, removing all duplicated MAC/LLA address manipulation from the configuration templates.