### PR TITLE
Generate MAC addresses for Ethernet/SVI interfaces

### DIFF
--- a/docs/dev/config/initial.md
+++ b/docs/dev/config/initial.md
@@ -132,6 +132,7 @@ It might also have these (optional) parameters:
 
 * **virtual_interface** -- the interface is a virtual interface (loopback, VLAN interface, subinterface...). Use this parameter to skip physical interface configuration (for example, bandwidth)
 * **role** -- link role (as set by **role** link attribute)
+* **mac** -- interface MAC address when requested by the **features.initial.generate_mac** device setting
 * **mtu** -- interface MTU
 * **_use_ip_mtu** -- a hint that the interface MTU is lower than the **min_phy_mtu** accepted by your device and that you should configure IPv4/IPv6 MTU instead of interface MTU.
 * **bandwidth** -- interface bandwidth

--- a/docs/dev/devices.md
+++ b/docs/dev/devices.md
@@ -106,6 +106,7 @@ After creating the device parameters file, you'll be able to use your device in 
 Device parameters file can also include numerous *features*. The following features control the initial device configuration; additional features are described in the developer documentation for individual modules.
 
 * **features.initial.system_mtu** -- The device supports system MTU settings
+* **features.initial.generate_mac** -- Optional list of interface types that need configured MAC addresses. Recognized values are **ethernet** and **svi**. See Cisco IOSvL2 and EOS device definitions and configuration templates for more details.
 * **features.initial.min_mtu** -- The minimum IPv4 MTU supported by your device (the minimum IPv6 MTU cannot be lower than 1280)
 * **features.initial.max_mtu** -- The maximum MTU supported by your device (the maximum MTU cannot be higher than 9216)
 * **features.initial.min_phy_mtu** -- The minimum physical MTU that can be configured on your device (many devices won't accept the physical MTU lower than 1500 bytes).

--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -101,9 +101,11 @@ interface {{ l.ifname }}
 ! Invalid IPv6 address {{ l.ipv6 }}
 {%   endif %}
 {% endif %}
+{% if l.mac_address is defined %}
+ mac-address {{ l.mac_address }}
+{% endif %}
 {% if l.virtual_interface is not defined %}
 !
- mac-address {{ '52dc.cafe.%02x%02x' % ( id,l.ifindex % 100 ) }}
  no shutdown
 {% endif %}
 !

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -129,8 +129,8 @@ interface {{ l.ifname }}
  ipv6 address {{ l.ipv6|upper }}
 {%   endif %}
 {% endif %}
-{% if l.type == 'svi' and netlab_device_type in ['iosvl2','ioll2'] %}
- mac-address {{ '4001.cafe.%02x%02x' % ( id,l.ifindex % 100 ) }}
+{% if l.mac_address is defined %}
+ mac-address {{ l.mac_address }}
 {% endif %}
  no shutdown
 !

--- a/netsim/ansible/templates/initial/nxos.j2
+++ b/netsim/ansible/templates/initial/nxos.j2
@@ -30,7 +30,9 @@ interface {{ l.ifname }}
  no shutdown
 {% if l.virtual_interface is not defined %}
  no switchport
- mac-address {{ '52dc.cafe.%02x%02x' % ( id,l.ifindex % 100 ) }}
+{% endif %}
+{% if l.mac_address is defined %}
+ mac-address {{ l.mac_address }}
 {% endif %}
 {% if l.vrf is defined %}
   vrf member {{ l.vrf }}

--- a/netsim/ansible/templates/normalize/eos.j2
+++ b/netsim/ansible/templates/normalize/eos.j2
@@ -3,5 +3,7 @@
 interface {{ intf.ifname }}
 {# 'no switchport' allocates an internal VLAN in range 1006-, causing issues when overlapping with topology vlans #}
  shutdown
- mac-address {{ '52dc.cafe.%02x%02x' % ( id,intf.ifindex % 100 ) }}
+{% if l.mac_address is defined %}
+ mac-address {{ l.mac_address }}
+{% endif %}
 {% endfor %}

--- a/netsim/ansible/templates/normalize/iosvl2.j2
+++ b/netsim/ansible/templates/normalize/iosvl2.j2
@@ -3,5 +3,7 @@
 interface {{ intf.ifname }}
 {# 'no switchport' allocates an internal VLAN in range 1006-, causing issues when overlapping with topology vlans #}
  shutdown
- mac-address {{ '52dc.cafe.%02x%02x' % ( id,intf.ifindex % 100 ) }}
+{% if l.mac_address is defined %}
+ mac-address {{ l.mac_address }}
+{% endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -12,7 +12,7 @@ fi
 {% for i in interfaces if i.type == 'svi' %}
 if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   ip link add {{ i.ifname }} type bridge
-  ip link set dev {{ i.ifname }} address {{ '52:dc:ca:fd:%02x:%02x' % ( id,i.ifindex % 100 ) }}
+  ip link set dev {{ i.ifname }} address {{ i.mac_address|hwaddr('linux') }}
 {# If STP is required, enable it before bringing up the bridge device to avoid any forwarding loops #}
 {%  if 'stp' in module|default([]) and (i.stp|default(stp)).enable|default(True) %}
   ip link set {{ i.ifname }} type bridge stp_state 1

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -29,6 +29,7 @@ features:
     ra: true
     roles: [ host, router, bridge ]
     mgmt_vrf: true
+    generate_mac: [ ethernet ]
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -59,6 +59,7 @@ features:
       use_ra: true
     ra: true
     roles: [ host, router ]
+    generate_mac: [ svi ]
   bfd: True
   bgp:
     activate_af: true

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -4,6 +4,8 @@ parent: iol
 lag_interface_name: "Port-channel{lag.ifindex}"
 
 features:
+  initial:
+    generate_mac: [ ethernet, svi ]
   vlan:
     model: l3-switch
     svi_interface_name: Vlan{vlan}

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -11,6 +11,7 @@ features:
     min_mtu: 68
     min_phy_mtu: 1500
     max_mtu: 4700
+    generate_mac: [ ethernet, svi ]
   vlan:
     model: l3-switch
     svi_interface_name: Vlan{vlan}

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -34,6 +34,7 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+    generate_mac: [ ethernet ]
   bfd: true
   bgp: true
   eigrp: true

--- a/netsim/modules/vlan.py
+++ b/netsim/modules/vlan.py
@@ -879,6 +879,8 @@ def create_svi_interfaces(node: Box, topology: Box) -> dict:
       vlan_ifdata.vlan.name = access_vlan
       vlan_ifdata.type = "svi"
       vlan_ifdata.ifindex = links.get_unique_ifindex(node,iftype='svi',start=SVI_IFINDEX_OFFSET)
+      if 'svi' in features.get('initial.generate_mac',[]):
+        vlan_ifdata.mac_address = links.generate_interface_mac(node,vlan_ifdata,topology.defaults)
       vlan_ifdata.ifname = strings.eval_format_args(
                               fmt=svi_name,
                               vlan=vlan_data.id,

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -791,6 +791,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r1 -> [r2,h1,h2]
       neighbors:
       - gateway:
@@ -832,6 +833,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.1/30
       linkindex: 7
+      mac_address: caf0.0002.0003
       name: r1 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -931,6 +933,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: r2 -> [r1,h1,h2]
       neighbors:
       - gateway:
@@ -980,6 +983,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.42.42.1/28
       linkindex: 4
+      mac_address: caf0.0003.0003
       name: r2 -> h4
       neighbors:
       - ifname: eth2
@@ -1003,6 +1007,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.42.43.2/29
       linkindex: 5
+      mac_address: caf0.0003.0004
       name: r2 -> h4
       neighbors:
       - ifname: eth3
@@ -1028,6 +1033,7 @@ nodes:
       ipv4: 172.31.31.3/24
       ipv6: 2001:db8:cafe:1::3/64
       linkindex: 6
+      mac_address: caf0.0003.0005
       name: r2 -> h4
       neighbors:
       - ifname: eth4
@@ -1046,6 +1052,7 @@ nodes:
       ifname: Ethernet6
       ipv4: 10.1.0.5/30
       linkindex: 8
+      mac_address: caf0.0003.0006
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet2
@@ -1134,6 +1141,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 7
+      mac_address: caf0.0004.0001
       name: r3 -> r1
       neighbors:
       - ifname: Ethernet3
@@ -1148,6 +1156,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.6/30
       linkindex: 8
+      mac_address: caf0.0004.0002
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet6

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -141,6 +141,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.2/24
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: lb2 -> stub
       neighbors: []
       role: stub
@@ -246,6 +247,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.1.4/24
       linkindex: 2
+      mac_address: caf0.0004.0001
       name: nl2 -> stub
       neighbors: []
       role: stub

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -140,6 +140,7 @@ nodes:
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: l1 -> s1
       neighbors:
       - ifname: Ethernet1/1
@@ -157,6 +158,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 3
+      mac_address: caf0.0001.0002
       name: l1 -> s2
       neighbors:
       - ifname: Ethernet1/1
@@ -258,6 +260,7 @@ nodes:
       ifname: Ethernet1
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0002.0001
       name: l2 -> s1
       neighbors:
       - ifname: Ethernet1/2
@@ -274,6 +277,7 @@ nodes:
       ifname: Ethernet2
       ipv4: true
       linkindex: 4
+      mac_address: caf0.0002.0002
       name: l2 -> s2
       neighbors:
       - ifname: Ethernet1/2
@@ -386,6 +390,7 @@ nodes:
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: s1 -> l1
       neighbors:
       - ifname: Ethernet1/1
@@ -402,6 +407,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0003.0002
       name: s1 -> l2
       neighbors:
       - ifname: Ethernet1
@@ -513,6 +519,7 @@ nodes:
       ifname: Ethernet1/1
       ipv4: true
       linkindex: 3
+      mac_address: caf0.0004.0001
       name: s2 -> l1
       neighbors:
       - ifname: Ethernet1/2
@@ -529,6 +536,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 4
+      mac_address: caf0.0004.0002
       name: s2 -> l2
       neighbors:
       - ifname: Ethernet2

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -136,6 +136,7 @@ nodes:
       ipv4: 10.1.0.1/30
       ipv6: 2001:db8:1::1/64
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r1 -> x1
       neighbors:
       - ifname: Ethernet1
@@ -149,6 +150,7 @@ nodes:
       ipv4: 10.1.0.5/30
       ipv6: 2001:db8:1:1::1/64
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -245,6 +247,7 @@ nodes:
       ipv4: 10.1.0.6/30
       ipv6: 2001:db8:1:1::2/64
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet2
@@ -335,6 +338,7 @@ nodes:
       ipv4: 10.1.0.2/30
       ipv6: 2001:db8:1::2/64
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: x1 -> r1
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -144,6 +144,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -155,6 +156,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 10.1.0.5/30
+      mac_address: caf0.0001.0002
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
@@ -176,6 +178,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 10.1.0.9/30
+      mac_address: caf0.0001.0003
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
@@ -309,6 +312,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -319,6 +323,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -333,6 +338,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.1/30
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: r2 -> r2
       neighbors:
       - bgp:
@@ -353,6 +359,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.1.0.2/30
       linkindex: 3
+      mac_address: caf0.0002.0004
       name: r2 -> r2
       neighbors:
       - bgp:
@@ -370,6 +377,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 10.1.0.6/30
+      mac_address: caf0.0002.0005
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
@@ -391,6 +399,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 10.1.0.10/30
+      mac_address: caf0.0002.0006
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
@@ -412,6 +421,7 @@ nodes:
       ifindex: 7
       ifname: Ethernet2.1
       ipv4: 10.1.0.13/30
+      mac_address: caf0.0002.0007
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
@@ -433,6 +443,7 @@ nodes:
       ifindex: 8
       ifname: Ethernet2.2
       ipv4: 10.1.0.17/30
+      mac_address: caf0.0002.0008
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
@@ -606,6 +617,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2
@@ -617,6 +629,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 10.1.0.14/30
+      mac_address: caf0.0003.0002
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
@@ -638,6 +651,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 10.1.0.18/30
+      mac_address: caf0.0003.0003
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -87,6 +87,7 @@ nodes:
       ipv4: 10.2.0.4/26
       ipv6: 2001:db8:1::4/64
       linkindex: 1
+      mac_address: caf0.0004.0001
       name: a_eos -> [c_ios,c_csr,c_nxos,j_vsrx]
       neighbors:
       - ifname: GigabitEthernet0/1
@@ -112,6 +113,7 @@ nodes:
       ipv4: 10.2.0.68/26
       ipv6: 2001:db8:1:1::4/64
       linkindex: 3
+      mac_address: caf0.0004.0002
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
@@ -262,6 +264,7 @@ nodes:
       ipv4: 10.2.0.3/26
       ipv6: 2001:db8:1::3/64
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: c_nxos -> [c_ios,c_csr,a_eos,j_vsrx]
       neighbors:
       - ifname: GigabitEthernet0/1
@@ -287,6 +290,7 @@ nodes:
       ipv4: 10.2.0.67/26
       ipv6: 2001:db8:1:1::3/64
       linkindex: 3
+      mac_address: caf0.0003.0002
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -221,6 +221,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -234,6 +235,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> r3
       neighbors:
       - bgp:
@@ -248,6 +250,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.9/30
       linkindex: 3
+      mac_address: caf0.0001.0003
       name: r1 -> rr
       neighbors:
       - ifname: Ethernet1
@@ -261,6 +264,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.1.0.13/30
       linkindex: 4
+      mac_address: caf0.0001.0004
       name: r1 -> r2
       neighbors:
       - bgp:
@@ -400,6 +404,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -414,6 +419,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.14/30
       linkindex: 4
+      mac_address: caf0.0002.0002
       name: r2 -> r1
       neighbors:
       - bgp:
@@ -556,6 +562,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r1
       neighbors:
       - bgp:
@@ -648,6 +655,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.10/30
       linkindex: 3
+      mac_address: caf0.0004.0001
       name: rr -> r1
       neighbors:
       - ifname: Ethernet3

--- a/tests/topology/expected/eigrp-feature-test.yml
+++ b/tests/topology/expected/eigrp-feature-test.yml
@@ -333,6 +333,7 @@ nodes:
       ifname: Ethernet1/1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: c_nxos -> c_ios
       neighbors:
       - ifname: GigabitEthernet0/1
@@ -347,6 +348,7 @@ nodes:
       ipv4: 172.31.0.1/24
       ipv6: 2008:db8:1::1/64
       linkindex: 3
+      mac_address: caf0.0001.0002
       name: c_nxos -> [c_ios,c_csr]
       neighbors:
       - ifname: GigabitEthernet0/3
@@ -366,6 +368,7 @@ nodes:
       ifname: Ethernet1/3
       ipv4: 172.16.0.1/24
       linkindex: 4
+      mac_address: caf0.0001.0003
       name: c_nxos -> stub
       neighbors: []
       role: stub
@@ -375,6 +378,7 @@ nodes:
       ifname: Ethernet1/4
       ipv4: 172.16.3.1/24
       linkindex: 7
+      mac_address: caf0.0001.0004
       name: c_nxos -> [c_ios,c_csr]
       neighbors:
       - ifname: GigabitEthernet0/5

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -456,6 +456,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.1/30
       linkindex: 5
+      mac_address: caf0.0001.0003
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet3
@@ -784,6 +785,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.2/30
       linkindex: 5
+      mac_address: caf0.0002.0003
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet3

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -85,6 +85,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.1.1/24
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: a -> stub
       neighbors: []
       role: stub

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -79,6 +79,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.1.1/24
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: a -> stub
       neighbors: []
       role: stub

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -632,6 +632,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: l1 -> S1
       neighbors:
       - ifname: swp1
@@ -643,6 +644,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: l1 -> S2
       neighbors:
       - ifname: swp1
@@ -657,6 +659,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.0.1/24
       linkindex: 9
+      mac_address: caf0.0001.0003
       name: l1 -> h1
       neighbors:
       - ifname: eth1
@@ -729,6 +732,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.10/30
       linkindex: 3
+      mac_address: caf0.0002.0001
       name: l2 -> S1
       neighbors:
       - ifname: swp2
@@ -740,6 +744,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.14/30
       linkindex: 4
+      mac_address: caf0.0002.0002
       name: l2 -> S2
       neighbors:
       - ifname: swp2
@@ -754,6 +759,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.1.2/24
       linkindex: 10
+      mac_address: caf0.0002.0003
       name: l2 -> h2
       neighbors:
       - ifname: eth1
@@ -826,6 +832,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.18/30
       linkindex: 5
+      mac_address: caf0.0003.0001
       name: l3 -> S1
       neighbors:
       - ifname: swp3
@@ -837,6 +844,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.22/30
       linkindex: 6
+      mac_address: caf0.0003.0002
       name: l3 -> S2
       neighbors:
       - ifname: swp3
@@ -909,6 +917,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.26/30
       linkindex: 7
+      mac_address: caf0.0004.0001
       name: l4 -> S1
       neighbors:
       - ifname: swp4
@@ -920,6 +929,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.30/30
       linkindex: 8
+      mac_address: caf0.0004.0002
       name: l4 -> S2
       neighbors:
       - ifname: swp4

--- a/tests/topology/expected/group-data-vlan.yml
+++ b/tests/topology/expected/group-data-vlan.yml
@@ -83,6 +83,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -98,6 +99,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -236,6 +238,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -374,6 +377,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r1
       neighbors:
       - ifname: Ethernet2

--- a/tests/topology/expected/group-data-vrf.yml
+++ b/tests/topology/expected/group-data-vrf.yml
@@ -60,6 +60,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -145,6 +146,7 @@ nodes:
             ifname: Ethernet1
             ipv4: 10.1.0.1/30
             linkindex: 1
+            mac_address: caf0.0001.0001
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1
@@ -191,6 +193,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -276,6 +279,7 @@ nodes:
             ifname: Ethernet1
             ipv4: 10.1.0.2/30
             linkindex: 1
+            mac_address: caf0.0002.0001
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1

--- a/tests/topology/expected/igp-af.yml
+++ b/tests/topology/expected/igp-af.yml
@@ -119,6 +119,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -141,6 +142,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -209,6 +211,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -277,6 +280,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r1
       neighbors:
       - ifname: Ethernet2
@@ -299,6 +303,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 3
+      mac_address: caf0.0003.0002
       name: r3 -> r4
       neighbors:
       - ifname: Ethernet1
@@ -366,6 +371,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 3
+      mac_address: caf0.0004.0001
       name: r4 -> r3
       neighbors:
       - ifname: Ethernet2
@@ -387,6 +393,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 4
+      mac_address: caf0.0004.0002
       name: r4 -> r5
       neighbors:
       - ifname: Ethernet1
@@ -455,6 +462,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 4
+      mac_address: caf0.0005.0001
       name: r5 -> r4
       neighbors:
       - ifname: Ethernet2
@@ -473,6 +481,7 @@ nodes:
       isis:
         passive: true
       linkindex: 5
+      mac_address: caf0.0005.0002
       name: r5 -> stub
       neighbors: []
       ospf:

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -274,6 +274,7 @@ nodes:
         metric: 30
         passive: false
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: a_eos -> [c_nxos,c_csr,j_vsrx]
       neighbors:
       - ifname: Ethernet1/1
@@ -294,6 +295,7 @@ nodes:
       isis:
         passive: true
       linkindex: 4
+      mac_address: caf0.0003.0002
       name: a_eos -> stub
       neighbors: []
       role: stub
@@ -307,6 +309,7 @@ nodes:
         metric: 50
         passive: true
       linkindex: 6
+      mac_address: caf0.0003.0003
       name: a_eos -> [c_nxos,c_csr,j_vsrx]
       neighbors:
       - ifname: Ethernet1/3
@@ -328,6 +331,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 172.16.1.3/24
       linkindex: 7
+      mac_address: caf0.0003.0004
       name: a_eos -> [c_nxos,c_csr,j_vsrx]
       neighbors:
       - ifname: Ethernet1/4
@@ -350,6 +354,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 8
+      mac_address: caf0.0003.0005
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/5
@@ -363,6 +368,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 11
+      mac_address: caf0.0003.0006
       name: a_eos -> j_vsrx
       neighbors:
       - ifname: ge-0/0/5
@@ -378,6 +384,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 12
+      mac_address: caf0.0003.0007
       name: a_eos -> c_csr
       neighbors:
       - ifname: GigabitEthernet7
@@ -387,6 +394,7 @@ nodes:
     - ifindex: 8
       ifname: Ethernet8
       linkindex: 14
+      mac_address: caf0.0003.0008
       name: L2-only link to test removal of isis context
       neighbors:
       - ifname: Ethernet1/8
@@ -587,6 +595,7 @@ nodes:
         metric: 10
         passive: false
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: c_nxos -> [c_csr,a_eos,j_vsrx]
       neighbors:
       - ifname: GigabitEthernet2
@@ -607,6 +616,7 @@ nodes:
       isis:
         passive: true
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: c_nxos -> stub
       neighbors: []
       role: stub
@@ -620,6 +630,7 @@ nodes:
         metric: 50
         passive: true
       linkindex: 6
+      mac_address: caf0.0001.0003
       name: c_nxos -> [c_csr,a_eos,j_vsrx]
       neighbors:
       - ifname: GigabitEthernet4
@@ -641,6 +652,7 @@ nodes:
       ifname: Ethernet1/4
       ipv4: 172.16.1.1/24
       linkindex: 7
+      mac_address: caf0.0001.0004
       name: c_nxos -> [c_csr,a_eos,j_vsrx]
       neighbors:
       - ifname: GigabitEthernet5
@@ -663,6 +675,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 8
+      mac_address: caf0.0001.0005
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet5
@@ -678,6 +691,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 9
+      mac_address: caf0.0001.0006
       name: c_nxos -> c_csr
       neighbors:
       - ifname: GigabitEthernet6
@@ -691,6 +705,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 10
+      mac_address: caf0.0001.0007
       name: c_nxos -> j_vsrx
       neighbors:
       - ifname: ge-0/0/4
@@ -700,6 +715,7 @@ nodes:
     - ifindex: 8
       ifname: Ethernet1/8
       linkindex: 14
+      mac_address: caf0.0001.0008
       name: L2-only link to test removal of isis context
       neighbors:
       - ifname: Ethernet8

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -202,6 +202,7 @@ nodes:
           self: 169.254.127.0/31
           vlan: 4094
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: a1 -> a2
       neighbors:
       - ifname: Ethernet1
@@ -278,6 +279,7 @@ nodes:
       lag:
         _parentindex: 25
       linkindex: 6
+      mac_address: caf0.0001.0002
       name: a1 -> b1
       neighbors:
       - ifname: Ethernet2
@@ -288,6 +290,7 @@ nodes:
       lag:
         _parentindex: 15
       linkindex: 8
+      mac_address: caf0.0001.0003
       name: a1 -> b1
       neighbors:
       - ifname: Ethernet3
@@ -298,6 +301,7 @@ nodes:
       lag:
         _parentindex: 10
       linkindex: 10
+      mac_address: caf0.0001.0004
       name: a1 -> b1
       neighbors:
       - ifname: Ethernet4
@@ -388,6 +392,7 @@ nodes:
           self: 169.254.127.1/31
           vlan: 4094
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: a2 -> a1
       neighbors:
       - ifname: Ethernet1
@@ -464,6 +469,7 @@ nodes:
       lag:
         _parentindex: 25
       linkindex: 7
+      mac_address: caf0.0002.0002
       name: a2 -> b2
       neighbors:
       - ifname: Ethernet2
@@ -474,6 +480,7 @@ nodes:
       lag:
         _parentindex: 15
       linkindex: 9
+      mac_address: caf0.0002.0003
       name: a2 -> b2
       neighbors:
       - ifname: Ethernet3
@@ -484,6 +491,7 @@ nodes:
       lag:
         _parentindex: 10
       linkindex: 11
+      mac_address: caf0.0002.0004
       name: a2 -> b2
       neighbors:
       - ifname: Ethernet4
@@ -561,6 +569,7 @@ nodes:
           self: 169.254.127.0/31
           vlan: 4094
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: b1 -> b2
       neighbors:
       - ifname: Ethernet1
@@ -637,6 +646,7 @@ nodes:
       lag:
         _parentindex: 25
       linkindex: 6
+      mac_address: caf0.0003.0002
       name: b1 -> a1
       neighbors:
       - ifname: Ethernet2
@@ -647,6 +657,7 @@ nodes:
       lag:
         _parentindex: 15
       linkindex: 8
+      mac_address: caf0.0003.0003
       name: b1 -> a1
       neighbors:
       - ifname: Ethernet3
@@ -657,6 +668,7 @@ nodes:
       lag:
         _parentindex: 20
       linkindex: 10
+      mac_address: caf0.0003.0004
       name: b1 -> a1
       neighbors:
       - ifname: Ethernet4
@@ -734,6 +746,7 @@ nodes:
           self: 169.254.127.1/31
           vlan: 4094
       linkindex: 2
+      mac_address: caf0.0004.0001
       name: b2 -> b1
       neighbors:
       - ifname: Ethernet1
@@ -810,6 +823,7 @@ nodes:
       lag:
         _parentindex: 25
       linkindex: 7
+      mac_address: caf0.0004.0002
       name: b2 -> a2
       neighbors:
       - ifname: Ethernet2
@@ -820,6 +834,7 @@ nodes:
       lag:
         _parentindex: 15
       linkindex: 9
+      mac_address: caf0.0004.0003
       name: b2 -> a2
       neighbors:
       - ifname: Ethernet3
@@ -830,6 +845,7 @@ nodes:
       lag:
         _parentindex: 20
       linkindex: 11
+      mac_address: caf0.0004.0004
       name: b2 -> a2
       neighbors:
       - ifname: Ethernet4

--- a/tests/topology/expected/link-group.yml
+++ b/tests/topology/expected/link-group.yml
@@ -113,6 +113,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -128,6 +129,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.9/30
       linkindex: 3
+      mac_address: caf0.0001.0002
       name: r1 -> r3
       neighbors:
       - ifname: Ethernet2
@@ -144,6 +146,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.0.1/24
       linkindex: 4
+      mac_address: caf0.0001.0003
       name: r1 -> stub
       neighbors: []
       ospf:
@@ -186,6 +189,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -201,6 +205,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -217,6 +222,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.1.2/24
       linkindex: 5
+      mac_address: caf0.0002.0003
       name: r2 -> stub
       neighbors: []
       ospf:
@@ -259,6 +265,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2
@@ -274,6 +281,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.10/30
       linkindex: 3
+      mac_address: caf0.0003.0002
       name: r3 -> r1
       neighbors:
       - ifname: Ethernet2
@@ -290,6 +298,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.2.3/24
       linkindex: 6
+      mac_address: caf0.0003.0003
       name: r3 -> stub
       neighbors: []
       ospf:

--- a/tests/topology/expected/link-tunnel.yml
+++ b/tests/topology/expected/link-tunnel.yml
@@ -99,6 +99,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.2.1/24
       linkindex: 4
+      mac_address: caf0.0001.0001
       name: r1 -> [r2,r3]
       neighbors:
       - ifname: GigabitEthernet0/1

--- a/tests/topology/expected/link-without-prefix.yml
+++ b/tests/topology/expected/link-without-prefix.yml
@@ -78,6 +78,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -89,6 +90,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.1/24
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> [r2,r3]
       neighbors:
       - ifname: Ethernet2
@@ -101,6 +103,7 @@ nodes:
     - ifindex: 3
       ifname: Ethernet3
       linkindex: 3
+      mac_address: caf0.0001.0003
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet3
@@ -110,6 +113,7 @@ nodes:
       ifindex: 4
       ifname: Ethernet4
       linkindex: 4
+      mac_address: caf0.0001.0004
       name: r1 -> [r2,r3]
       neighbors:
       - ifname: Ethernet4
@@ -141,6 +145,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -152,6 +157,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.2/24
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> [r1,r3]
       neighbors:
       - ifname: Ethernet2
@@ -164,6 +170,7 @@ nodes:
     - ifindex: 3
       ifname: Ethernet3
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet3
@@ -173,6 +180,7 @@ nodes:
       ifindex: 4
       ifname: Ethernet4
       linkindex: 4
+      mac_address: caf0.0002.0004
       name: r2 -> [r1,r3]
       neighbors:
       - ifname: Ethernet4
@@ -205,6 +213,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> [r1,r2]
       neighbors:
       - ifname: Ethernet2
@@ -218,6 +227,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet2
       linkindex: 4
+      mac_address: caf0.0003.0002
       name: r3 -> [r1,r2]
       neighbors:
       - ifname: Ethernet4

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -207,6 +207,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 2
+      mac_address: caf0.0002.0001
       name: c2 -> e1
       neighbors:
       - ifname: GigabitEthernet3
@@ -220,6 +221,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 4
+      mac_address: caf0.0002.0002
       name: c2 -> e2
       neighbors:
       - ifname: Ethernet2
@@ -429,6 +431,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 3
+      mac_address: caf0.0004.0001
       name: e2 -> c1
       neighbors:
       - ifname: GigabitEthernet3
@@ -442,6 +445,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 4
+      mac_address: caf0.0004.0002
       name: e2 -> c2
       neighbors:
       - ifname: Ethernet2

--- a/tests/topology/expected/node.clone-plugin-lag.yml
+++ b/tests/topology/expected/node.clone-plugin-lag.yml
@@ -589,6 +589,7 @@ nodes:
           self: 169.254.127.0/31
           vlan: 4094
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -665,6 +666,7 @@ nodes:
       lag:
         _parentindex: 8
       linkindex: 8
+      mac_address: caf0.0001.0002
       name: r1 -> h-01
       neighbors:
       - ifname: eth1
@@ -675,6 +677,7 @@ nodes:
       lag:
         _parentindex: 8
       linkindex: 9
+      mac_address: caf0.0001.0003
       name: r1 -> h-01
       neighbors:
       - ifname: eth2
@@ -685,6 +688,7 @@ nodes:
       lag:
         _parentindex: 9
       linkindex: 10
+      mac_address: caf0.0001.0004
       name: r1 -> h-02
       neighbors:
       - ifname: eth1
@@ -695,6 +699,7 @@ nodes:
       lag:
         _parentindex: 9
       linkindex: 11
+      mac_address: caf0.0001.0005
       name: r1 -> h-02
       neighbors:
       - ifname: eth2
@@ -705,6 +710,7 @@ nodes:
       lag:
         _parentindex: 10
       linkindex: 16
+      mac_address: caf0.0001.0006
       name: r1 -> h2-01
       neighbors:
       - ifname: eth1
@@ -715,6 +721,7 @@ nodes:
       lag:
         _parentindex: 11
       linkindex: 18
+      mac_address: caf0.0001.0007
       name: r1 -> h2-02
       neighbors:
       - ifname: eth1
@@ -787,6 +794,7 @@ nodes:
           self: 169.254.127.1/31
           vlan: 4094
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -797,6 +805,7 @@ nodes:
       lag:
         _parentindex: 10
       linkindex: 17
+      mac_address: caf0.0002.0002
       name: r2 -> h2-01
       neighbors:
       - ifname: eth2
@@ -807,6 +816,7 @@ nodes:
       lag:
         _parentindex: 11
       linkindex: 19
+      mac_address: caf0.0002.0003
       name: r2 -> h2-02
       neighbors:
       - ifname: eth2
@@ -831,6 +841,7 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 12
+      mac_address: caf0.0002.0006
       name: r2 -> h-01
       neighbors:
       - ifname: eth3
@@ -841,6 +852,7 @@ nodes:
       lag:
         _parentindex: 1
       linkindex: 13
+      mac_address: caf0.0002.0007
       name: r2 -> h-01
       neighbors:
       - ifname: eth4
@@ -851,6 +863,7 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 14
+      mac_address: caf0.0002.0008
       name: r2 -> h-02
       neighbors:
       - ifname: eth3
@@ -861,6 +874,7 @@ nodes:
       lag:
         _parentindex: 2
       linkindex: 15
+      mac_address: caf0.0002.0009
       name: r2 -> h-02
       neighbors:
       - ifname: eth4

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -231,6 +231,7 @@ nodes:
       ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.2/24
+      mac_address: caf4.0002.0000
       mtu: 1500
       name: VLAN red (1000) -> [r,h-07]
       neighbors:
@@ -335,6 +336,7 @@ nodes:
       ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.3/24
+      mac_address: caf4.0003.0000
       mtu: 1500
       name: VLAN red (1000) -> [h-03,r]
       neighbors:
@@ -726,6 +728,7 @@ nodes:
       ifindex: 40000
       ifname: vlan1000
       ipv4: 172.16.0.1/24
+      mac_address: caf4.0001.0000
       mtu: 1500
       name: VLAN red (1000) -> [h-03,h-07]
       neighbors:

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -226,6 +226,7 @@ nodes:
       ipv4: 172.19.0.3/24
       ipv6: 2001:db8:1::3/64
       linkindex: 1
+      mac_address: caf0.0003.0001
       mtu: 1500
       name: Common link
       neighbors:
@@ -252,6 +253,7 @@ nodes:
       ifname: Ethernet2
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0003.0002
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
@@ -270,6 +272,7 @@ nodes:
       ifname: Ethernet3
       ipv4: true
       linkindex: 5
+      mac_address: caf0.0003.0003
       name: a_eos -> j_vsrx
       neighbors:
       - ifname: ge-0/0/2
@@ -288,6 +291,7 @@ nodes:
       ifname: Ethernet4
       ipv4: true
       linkindex: 6
+      mac_address: caf0.0003.0004
       name: a_eos -> c_csr
       neighbors:
       - ifname: GigabitEthernet4
@@ -306,6 +310,7 @@ nodes:
       ipv4: 172.19.2.3/24
       ipv6: 2001:db8:1:2::3/64
       linkindex: 9
+      mac_address: caf0.0003.0005
       name: a_eos -> stub
       neighbors: []
       ospf:
@@ -319,6 +324,7 @@ nodes:
       ipv4: 172.19.3.3/24
       ipv6: 2001:db8:1:3::3/64
       linkindex: 10
+      mac_address: caf0.0003.0006
       name: a_eos -> [c_nxos,c_csr,j_vsrx]
       neighbors:
       - ifname: Ethernet1/6
@@ -521,6 +527,7 @@ nodes:
       ipv4: 172.19.0.1/24
       ipv6: 2001:db8:1::1/64
       linkindex: 1
+      mac_address: caf0.0001.0001
       mtu: 1500
       name: Common link
       neighbors:
@@ -547,6 +554,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0001.0002
       mtu: 1400
       name: c_nxos -> a_eos
       neighbors:
@@ -566,6 +574,7 @@ nodes:
       ifname: Ethernet1/3
       ipv4: true
       linkindex: 3
+      mac_address: caf0.0001.0003
       mtu: 1400
       name: c_nxos -> c_csr
       neighbors:
@@ -585,6 +594,7 @@ nodes:
       ifname: Ethernet1/4
       ipv4: true
       linkindex: 4
+      mac_address: caf0.0001.0004
       mtu: 1400
       name: c_nxos -> j_vsrx
       neighbors:
@@ -604,6 +614,7 @@ nodes:
       ipv4: 172.19.1.1/24
       ipv6: 2001:db8:1:1::1/64
       linkindex: 8
+      mac_address: caf0.0001.0005
       mtu: 8192
       name: c_nxos -> stub
       neighbors: []
@@ -618,6 +629,7 @@ nodes:
       ipv4: 172.19.3.1/24
       ipv6: 2001:db8:1:3::1/64
       linkindex: 10
+      mac_address: caf0.0001.0006
       mtu: 1400
       name: c_nxos -> [c_csr,a_eos,j_vsrx]
       neighbors:

--- a/tests/topology/expected/rt-vlan-anycast.yml
+++ b/tests/topology/expected/rt-vlan-anycast.yml
@@ -169,6 +169,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.1.2/24
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s1 -> h
       neighbors:
       - ifname: eth1
@@ -192,6 +193,7 @@ nodes:
     - ifindex: 3
       ifname: Ethernet3
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -267,6 +269,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 3
+      mac_address: caf0.0003.0001
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet3

--- a/tests/topology/expected/rt-vlan-native-routed.yml
+++ b/tests/topology/expected/rt-vlan-native-routed.yml
@@ -55,6 +55,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.2/24
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: ros -> [s1]
       neighbors:
       - ifname: Vlan1000
@@ -72,6 +73,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.1.2/24
+      mac_address: caf0.0002.0002
       name: ros -> [s1]
       neighbors:
       - ifname: Vlan1001

--- a/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
+++ b/tests/topology/expected/rt-vlan-trunk-partial-overlap.yml
@@ -50,6 +50,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: s1 -> [s2,s3]
       neighbors:
       - ifname: Ethernet1
@@ -135,6 +136,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s2 -> [s1,s3]
       neighbors:
       - ifname: Ethernet1
@@ -220,6 +222,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: s3 -> [s1,s2]
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -408,6 +408,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0006.0001
       name: port_type network configured on link
       neighbors:
       - ifname: Ethernet1
@@ -426,6 +427,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.1/30
       linkindex: 2
+      mac_address: caf0.0006.0002
       name: no port_type on IP interface
       neighbors:
       - ifname: Ethernet1
@@ -435,6 +437,7 @@ nodes:
     - ifindex: 3
       ifname: Ethernet3
       linkindex: 3
+      mac_address: caf0.0006.0003
       name: Inherit node port_type on L2 interface
       neighbors:
       - ifname: Ethernet2
@@ -443,6 +446,7 @@ nodes:
     - ifindex: 4
       ifname: Ethernet4
       linkindex: 5
+      mac_address: caf0.0006.0004
       name: port_type on l2 interface override node
       neighbors:
       - ifname: Ethernet4
@@ -557,6 +561,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0007.0001
       name: port_type network configured on link
       neighbors:
       - ifname: Ethernet1
@@ -719,6 +724,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 2
+      mac_address: caf0.0001.0001
       name: no port_type on IP interface
       neighbors:
       - ifname: Ethernet2
@@ -728,6 +734,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 3
+      mac_address: caf0.0001.0002
       name: Inherit node port_type on L2 interface
       neighbors:
       - ifname: Ethernet3
@@ -752,6 +759,7 @@ nodes:
     - ifindex: 4
       ifname: Ethernet4
       linkindex: 5
+      mac_address: caf0.0001.0004
       name: port_type on l2 interface override node
       neighbors:
       - ifname: Ethernet4

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -409,6 +409,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      mac_address: caf0.0001.0001
       name: P2P L2 link with STP disabled on link
       neighbors:
       - ifname: Ethernet2
@@ -558,6 +559,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s2 -> s3
       neighbors:
       - ifname: Ethernet1
@@ -573,6 +575,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: P2P L2 link with STP disabled on link
       neighbors:
       - ifname: Ethernet1
@@ -583,6 +586,7 @@ nodes:
     - ifindex: 3
       ifname: Ethernet3
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: P2P L2 link with STP disabled on s3 interface
       neighbors:
       - ifname: Ethernet2
@@ -703,6 +707,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0007.0001
       name: s3 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -718,6 +723,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 3
+      mac_address: caf0.0007.0002
       name: P2P L2 link with STP disabled on s3 interface
       neighbors:
       - ifname: Ethernet3

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -98,6 +98,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> external
       neighbors:
       - ifname: Ethernet1
@@ -110,6 +111,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.1/24
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> h1
       neighbors:
       - ifname: eth1

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -91,6 +91,7 @@ nodes:
       ipv4: 172.19.0.2/24
       ipv6: 2001:db8:1::2/64
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: a_eos -> [c_nxos,j_vsrx,n_c...
       neighbors:
       - ifname: Ethernet1/1
@@ -112,6 +113,7 @@ nodes:
       ifname: Ethernet2
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
@@ -125,6 +127,7 @@ nodes:
       ifname: Ethernet3
       ipv4: true
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: a_eos -> n_cumulus
       neighbors:
       - ifname: swp2
@@ -160,6 +163,7 @@ nodes:
       ipv4: 172.19.0.1/24
       ipv6: 2001:db8:1::1/64
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: c_nxos -> [a_eos,j_vsrx,n_c...
       neighbors:
       - ifname: Ethernet1
@@ -181,6 +185,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: true
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2
@@ -194,6 +199,7 @@ nodes:
       ifname: Ethernet1/3
       ipv4: true
       linkindex: 4
+      mac_address: caf0.0001.0003
       name: c_nxos -> j_vsrx
       neighbors:
       - ifname: ge-0/0/1

--- a/tests/topology/expected/vbox.yml
+++ b/tests/topology/expected/vbox.yml
@@ -51,6 +51,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.2/24
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: a_eos -> [c_nxos,a_eos_2]
       neighbors:
       - ifname: Ethernet1/1
@@ -64,6 +65,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.1/30
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: a_eos -> c_nxos
       neighbors:
       - ifname: Ethernet1/2
@@ -95,6 +97,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: a_eos_2 -> [c_nxos,a_eos]
       neighbors:
       - ifname: Ethernet1/1
@@ -129,6 +132,7 @@ nodes:
       ifname: Ethernet1/1
       ipv4: 172.16.0.1/24
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: c_nxos -> [a_eos,a_eos_2]
       neighbors:
       - ifname: Ethernet1
@@ -142,6 +146,7 @@ nodes:
       ifname: Ethernet1/2
       ipv4: 10.1.0.2/30
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: c_nxos -> a_eos
       neighbors:
       - ifname: Ethernet2

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -114,6 +114,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.1/24
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> [s1,r2]
       neighbors:
       - ifname: Vlan1000
@@ -189,6 +190,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r2 -> [r1,s1]
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -292,6 +292,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0004.0001
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -408,6 +409,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0005.0001
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vlan-routed-access.yml
+++ b/tests/topology/expected/vlan-routed-access.yml
@@ -149,6 +149,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r2 -> [r1,s1]
       neighbors:
       - ifname: GigabitEthernet0/1
@@ -237,6 +238,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.1.2/24
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: s1 -> stub
       neighbors: []
       ospf:

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -48,6 +48,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r -> s
       neighbors:
       - ifname: eth1
@@ -58,6 +59,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.1.1/24
+      mac_address: caf0.0001.0002
       name: r -> [s]
       neighbors:
       - ifname: vlan1001
@@ -75,6 +77,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 172.16.0.1/24
+      mac_address: caf0.0001.0003
       name: r -> [s]
       neighbors:
       - ifname: vlan1000
@@ -180,6 +183,7 @@ nodes:
       ifindex: 40000
       ifname: vlan1001
       ipv4: 172.16.1.2/24
+      mac_address: caf4.0002.0000
       mtu: 1500
       name: VLAN blue (1001) -> [r]
       neighbors:
@@ -195,6 +199,7 @@ nodes:
       ifindex: 40001
       ifname: vlan1000
       ipv4: 172.16.0.2/24
+      mac_address: caf4.0002.0001
       mtu: 1500
       name: VLAN red (1000) -> [r]
       neighbors:

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -716,6 +716,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet2
       linkindex: 4
+      mac_address: caf0.0003.0002
       name: s1 -> s2
       neighbors:
       - ifname: eth3
@@ -735,6 +736,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet3
       linkindex: 5
+      mac_address: caf0.0003.0003
       name: s1 -> r1
       neighbors:
       - ifname: eth1
@@ -1058,6 +1060,7 @@ nodes:
     - bridge_group: 1
       ifindex: 40000
       ifname: vlan1001
+      mac_address: caf4.0004.0000
       name: VLAN blue (1001) -> [r1,r2,s1,h2]
       neighbors:
       - ifname: eth1.1001
@@ -1081,6 +1084,7 @@ nodes:
     - bridge_group: 2
       ifindex: 40001
       ifname: vlan1002
+      mac_address: caf4.0004.0001
       name: VLAN green (1002) -> [r1,r2,s1,h3]
       neighbors:
       - ifname: eth1.1002
@@ -1107,6 +1111,7 @@ nodes:
     - bridge_group: 3
       ifindex: 40002
       ifname: vlan1000
+      mac_address: caf4.0004.0002
       name: VLAN red (1000) -> [r1,r2,h1,s1]
       neighbors:
       - ifname: eth1.1000

--- a/tests/topology/expected/vlan-router-stick.yml
+++ b/tests/topology/expected/vlan-router-stick.yml
@@ -123,6 +123,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.0.3/24
       linkindex: 3
+      mac_address: caf0.0003.0001
       name: r1 -> [s1,s2,ros]
       neighbors:
       - ifname: Vlan1000
@@ -173,6 +174,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 172.16.1.4/24
       linkindex: 4
+      mac_address: caf0.0004.0001
       name: r2 -> [s1,s2,ros]
       neighbors:
       - ifname: Vlan1001
@@ -221,6 +223,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      mac_address: caf0.0005.0001
       name: ros -> s2
       neighbors:
       - ifname: Ethernet2
@@ -231,6 +234,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 172.16.1.5/24
+      mac_address: caf0.0005.0002
       name: ros -> [r2,s1,s2]
       neighbors:
       - ifname: Ethernet1
@@ -257,6 +261,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 172.16.0.5/24
+      mac_address: caf0.0005.0003
       name: ros -> [r1,s1,s2]
       neighbors:
       - ifname: Ethernet1
@@ -335,6 +340,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -454,6 +460,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet1
@@ -469,6 +476,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: s2 -> ros
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -411,6 +411,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 7
+      mac_address: caf0.0008.0001
       name: h5 -> r1
       neighbors:
       - ifname: Ethernet4
@@ -442,6 +443,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -454,6 +456,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.0.1/24
       linkindex: 3
+      mac_address: caf0.0001.0002
       name: r1 -> h1
       neighbors:
       - ifname: eth1
@@ -470,6 +473,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.1.1/24
       linkindex: 4
+      mac_address: caf0.0001.0003
       name: r1 -> h3
       neighbors:
       - ifname: eth1
@@ -485,6 +489,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.1.0.2/30
       linkindex: 7
+      mac_address: caf0.0001.0004
       name: r1 -> h5
       neighbors:
       - ifname: Ethernet1
@@ -498,6 +503,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 10.1.0.5/30
+      mac_address: caf0.0001.0005
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.1
@@ -518,6 +524,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 10.1.0.9/30
+      mac_address: caf0.0001.0006
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1.2
@@ -590,6 +597,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.1.1/24
             linkindex: 4
+            mac_address: caf0.0001.0003
             name: r1 -> h3
             neighbors:
             - ifname: eth1
@@ -608,6 +616,7 @@ nodes:
             ifindex: 5
             ifname: Ethernet1.1
             ipv4: 10.1.0.5/30
+            mac_address: caf0.0001.0005
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.1
@@ -654,6 +663,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 172.16.0.1/24
             linkindex: 3
+            mac_address: caf0.0001.0002
             name: r1 -> h1
             neighbors:
             - ifname: eth1
@@ -673,6 +683,7 @@ nodes:
             ifname: Ethernet4
             ipv4: 10.1.0.2/30
             linkindex: 7
+            mac_address: caf0.0001.0004
             name: r1 -> h5
             neighbors:
             - ifname: Ethernet1
@@ -690,6 +701,7 @@ nodes:
             ifindex: 6
             ifname: Ethernet1.2
             ipv4: 10.1.0.9/30
+            mac_address: caf0.0001.0006
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1.2
@@ -724,6 +736,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -733,6 +746,7 @@ nodes:
     - ifindex: 2
       ifname: Ethernet2
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -745,6 +759,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.2.2/24
       linkindex: 5
+      mac_address: caf0.0002.0003
       name: r2 -> h2
       neighbors:
       - ifname: eth1
@@ -761,6 +776,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 172.16.3.2/24
       linkindex: 6
+      mac_address: caf0.0002.0004
       name: r2 -> h4
       neighbors:
       - ifname: eth1
@@ -775,6 +791,7 @@ nodes:
       ifindex: 5
       ifname: Ethernet1.1
       ipv4: 10.1.0.6/30
+      mac_address: caf0.0002.0005
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.1
@@ -795,6 +812,7 @@ nodes:
       ifindex: 6
       ifname: Ethernet1.2
       ipv4: 10.1.0.10/30
+      mac_address: caf0.0002.0006
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1.2
@@ -815,6 +833,7 @@ nodes:
       ifindex: 7
       ifname: Ethernet2.1
       ipv4: 10.1.0.13/30
+      mac_address: caf0.0002.0007
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.1
@@ -835,6 +854,7 @@ nodes:
       ifindex: 8
       ifname: Ethernet2.2
       ipv4: 10.1.0.17/30
+      mac_address: caf0.0002.0008
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1.2
@@ -907,6 +927,7 @@ nodes:
             ifname: Ethernet4
             ipv4: 172.16.3.2/24
             linkindex: 6
+            mac_address: caf0.0002.0004
             name: r2 -> h4
             neighbors:
             - ifname: eth1
@@ -925,6 +946,7 @@ nodes:
             ifindex: 5
             ifname: Ethernet1.1
             ipv4: 10.1.0.6/30
+            mac_address: caf0.0002.0005
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.1
@@ -949,6 +971,7 @@ nodes:
             ifindex: 7
             ifname: Ethernet2.1
             ipv4: 10.1.0.13/30
+            mac_address: caf0.0002.0007
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.1
@@ -995,6 +1018,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.2.2/24
             linkindex: 5
+            mac_address: caf0.0002.0003
             name: r2 -> h2
             neighbors:
             - ifname: eth1
@@ -1013,6 +1037,7 @@ nodes:
             ifindex: 6
             ifname: Ethernet1.2
             ipv4: 10.1.0.10/30
+            mac_address: caf0.0002.0006
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1.2
@@ -1037,6 +1062,7 @@ nodes:
             ifindex: 8
             ifname: Ethernet2.2
             ipv4: 10.1.0.17/30
+            mac_address: caf0.0002.0008
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1.2
@@ -1071,6 +1097,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2
@@ -1081,6 +1108,7 @@ nodes:
       ifindex: 2
       ifname: Ethernet1.1
       ipv4: 10.1.0.14/30
+      mac_address: caf0.0003.0002
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.1
@@ -1101,6 +1129,7 @@ nodes:
       ifindex: 3
       ifname: Ethernet1.2
       ipv4: 10.1.0.18/30
+      mac_address: caf0.0003.0003
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2.2
@@ -1171,6 +1200,7 @@ nodes:
             ifindex: 2
             ifname: Ethernet1.1
             ipv4: 10.1.0.14/30
+            mac_address: caf0.0003.0002
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.1
@@ -1215,6 +1245,7 @@ nodes:
             ifindex: 3
             ifname: Ethernet1.2
             ipv4: 10.1.0.18/30
+            mac_address: caf0.0003.0003
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2.2

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -303,6 +303,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -454,6 +455,7 @@ nodes:
     - ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -168,6 +168,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -193,6 +194,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.9/30
       linkindex: 4
+      mac_address: caf0.0001.0002
       name: r1 -> r3
       neighbors:
       - ifname: Ethernet2
@@ -253,6 +255,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 10.1.0.9/30
             linkindex: 4
+            mac_address: caf0.0001.0002
             name: r1 -> r3
             neighbors:
             - ifname: Ethernet2
@@ -300,6 +303,7 @@ nodes:
             ifname: Ethernet1
             ipv4: 10.1.0.1/30
             linkindex: 1
+            mac_address: caf0.0001.0001
             name: r1 -> r2
             neighbors:
             - ifname: Ethernet1
@@ -401,6 +405,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -415,6 +420,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> r3
       neighbors:
       - ifname: Ethernet1
@@ -475,6 +481,7 @@ nodes:
             ifname: Ethernet1
             ipv4: 10.1.0.2/30
             linkindex: 1
+            mac_address: caf0.0002.0001
             name: r2 -> r1
             neighbors:
             - ifname: Ethernet1
@@ -493,6 +500,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 10.1.0.5/30
             linkindex: 2
+            mac_address: caf0.0002.0002
             name: r2 -> r3
             neighbors:
             - ifname: Ethernet1
@@ -580,6 +588,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r3 -> r2
       neighbors:
       - ifname: Ethernet2
@@ -594,6 +603,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.10/30
       linkindex: 4
+      mac_address: caf0.0003.0002
       name: r3 -> r1
       neighbors:
       - ifname: Ethernet2
@@ -665,6 +675,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 10.1.0.10/30
             linkindex: 4
+            mac_address: caf0.0003.0002
             name: r3 -> r1
             neighbors:
             - ifname: Ethernet2
@@ -726,6 +737,7 @@ nodes:
             ifname: Ethernet1
             ipv4: 10.1.0.6/30
             linkindex: 2
+            mac_address: caf0.0003.0001
             name: r3 -> r2
             neighbors:
             - ifname: Ethernet2

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -237,6 +237,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - ifname: Ethernet1
@@ -251,6 +252,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1-r2 no ISIS
       neighbors:
       - ifname: Ethernet2
@@ -265,6 +267,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.9/30
       linkindex: 3
+      mac_address: caf0.0001.0003
       name: r1-r2 OSPF
       neighbors:
       - ifname: Ethernet3
@@ -277,6 +280,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.1.0.13/30
       linkindex: 4
+      mac_address: caf0.0001.0004
       name: r1-r2 no OSPF
       neighbors:
       - ifname: Ethernet4
@@ -289,6 +293,7 @@ nodes:
       ifname: Ethernet5
       ipv4: 10.1.0.17/30
       linkindex: 5
+      mac_address: caf0.0001.0005
       name: r1-r2 no VRF OSPF
       neighbors:
       - ifname: Ethernet5
@@ -304,6 +309,7 @@ nodes:
       ifname: Ethernet6
       ipv4: 172.16.0.1/24
       linkindex: 6
+      mac_address: caf0.0001.0006
       name: r1 force OSPF
       neighbors: []
       role: stub
@@ -313,6 +319,7 @@ nodes:
       ifname: Ethernet7
       ipv4: 10.1.0.21/30
       linkindex: 7
+      mac_address: caf0.0001.0007
       name: r1 -> x
       neighbors:
       - ifname: Ethernet1
@@ -326,6 +333,7 @@ nodes:
       ifname: Ethernet8
       ipv4: 10.1.0.25/30
       linkindex: 8
+      mac_address: caf0.0001.0008
       name: r1 -> x
       neighbors:
       - bgp: false
@@ -340,6 +348,7 @@ nodes:
       ifname: Ethernet9
       ipv4: 10.1.0.29/30
       linkindex: 9
+      mac_address: caf0.0001.0009
       name: r1 -> x
       neighbors:
       - ifname: Ethernet3
@@ -472,6 +481,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 3
+            mac_address: caf0.0001.0003
             name: r1-r2 OSPF
             neighbors:
             - ifname: Ethernet3
@@ -487,6 +497,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 4
+            mac_address: caf0.0001.0004
             name: r1-r2 no OSPF
             neighbors:
             - ifname: Ethernet4
@@ -530,6 +541,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 10.1.0.9/30
             linkindex: 3
+            mac_address: caf0.0001.0003
             name: r1-r2 OSPF
             neighbors:
             - ifname: Ethernet3
@@ -592,6 +604,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 5
+            mac_address: caf0.0001.0005
             name: r1-r2 no VRF OSPF
             neighbors:
             - ifname: Ethernet5
@@ -638,6 +651,7 @@ nodes:
             ifname: Ethernet6
             ipv4: 172.16.0.1/24
             linkindex: 6
+            mac_address: caf0.0001.0006
             name: r1 force OSPF
             neighbors: []
             ospf:
@@ -702,6 +716,7 @@ nodes:
         network_type: point-to-point
         passive: false
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - ifname: Ethernet1
@@ -716,6 +731,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r1-r2 no ISIS
       neighbors:
       - ifname: Ethernet2
@@ -730,6 +746,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.10/30
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: r1-r2 OSPF
       neighbors:
       - ifname: Ethernet3
@@ -742,6 +759,7 @@ nodes:
       ifname: Ethernet4
       ipv4: 10.1.0.14/30
       linkindex: 4
+      mac_address: caf0.0002.0004
       name: r1-r2 no OSPF
       neighbors:
       - ifname: Ethernet4
@@ -754,6 +772,7 @@ nodes:
       ifname: Ethernet5
       ipv4: 10.1.0.18/30
       linkindex: 5
+      mac_address: caf0.0002.0005
       name: r1-r2 no VRF OSPF
       neighbors:
       - ifname: Ethernet5
@@ -847,6 +866,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 3
+            mac_address: caf0.0002.0003
             name: r1-r2 OSPF
             neighbors:
             - ifname: Ethernet3
@@ -862,6 +882,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 4
+            mac_address: caf0.0002.0004
             name: r1-r2 no OSPF
             neighbors:
             - ifname: Ethernet4
@@ -905,6 +926,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 10.1.0.10/30
             linkindex: 3
+            mac_address: caf0.0002.0003
             name: r1-r2 OSPF
             neighbors:
             - ifname: Ethernet3
@@ -967,6 +989,7 @@ nodes:
               network_type: point-to-point
               passive: false
             linkindex: 5
+            mac_address: caf0.0002.0005
             name: r1-r2 no VRF OSPF
             neighbors:
             - ifname: Ethernet5
@@ -1016,6 +1039,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.22/30
       linkindex: 7
+      mac_address: caf0.0003.0001
       name: x -> r1
       neighbors:
       - ifname: Ethernet7
@@ -1029,6 +1053,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.26/30
       linkindex: 8
+      mac_address: caf0.0003.0002
       name: x -> r1
       neighbors:
       - bgp: false
@@ -1043,6 +1068,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.30/30
       linkindex: 9
+      mac_address: caf0.0003.0003
       name: x -> r1
       neighbors:
       - ifname: Ethernet9

--- a/tests/topology/expected/vrrp-interface-granularity.yml
+++ b/tests/topology/expected/vrrp-interface-granularity.yml
@@ -118,6 +118,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/27
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: r1 -> r2
       neighbors:
       - gateway: false
@@ -129,6 +130,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.33/27
       linkindex: 2
+      mac_address: caf0.0001.0002
       name: r1 -> r2
       neighbors:
       - gateway:
@@ -157,6 +159,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.65/27
       linkindex: 3
+      mac_address: caf0.0001.0003
       name: r1 -> r2
       neighbors:
       - gateway: false
@@ -193,6 +196,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/27
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: r2 -> r1
       neighbors:
       - gateway:
@@ -220,6 +224,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.34/27
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: r2 -> r1
       neighbors:
       - gateway: false
@@ -231,6 +236,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.66/27
       linkindex: 3
+      mac_address: caf0.0002.0003
       name: r2 -> r1
       neighbors:
       - gateway:

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -81,6 +81,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 2
+      mac_address: caf0.0003.0001
       name: r1 -> s2
       neighbors:
       - ifname: Ethernet2
@@ -215,6 +216,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: s1 -> s2
       neighbors:
       - ifname: Ethernet1
@@ -310,6 +312,7 @@ nodes:
       ifindex: 1
       ifname: Ethernet1
       linkindex: 1
+      mac_address: caf0.0002.0001
       name: s2 -> s1
       neighbors:
       - ifname: Ethernet1
@@ -328,6 +331,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.2/30
       linkindex: 2
+      mac_address: caf0.0002.0002
       name: s2 -> r1
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -279,6 +279,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0001.0001
       name: s1 -> s3
       neighbors:
       - ifname: Ethernet1
@@ -423,6 +424,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0002.0001
       name: s2 -> s3
       neighbors:
       - ifname: Ethernet2
@@ -567,6 +569,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0003.0001
       name: s3 -> s1
       neighbors:
       - ifname: Ethernet1
@@ -581,6 +584,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0003.0002
       name: s3 -> s2
       neighbors:
       - ifname: Ethernet1

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -304,6 +304,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.1/30
       linkindex: 1
+      mac_address: caf0.0009.0001
       name: c -> s1
       neighbors:
       - ifname: Ethernet1
@@ -318,6 +319,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 10.1.0.5/30
       linkindex: 2
+      mac_address: caf0.0009.0002
       name: c -> s2
       neighbors:
       - ifname: Ethernet1
@@ -332,6 +334,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 10.1.0.9/30
       linkindex: 3
+      mac_address: caf0.0009.0003
       name: c -> s3
       neighbors:
       - ifname: Ethernet1
@@ -533,6 +536,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.2/30
       linkindex: 1
+      mac_address: caf0.0006.0001
       name: s1 -> c
       neighbors:
       - ifname: Ethernet1
@@ -548,6 +552,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.2.6/24
       linkindex: 4
+      mac_address: caf0.0006.0002
       name: s1 -> rh1
       neighbors:
       - ifname: eth1
@@ -561,6 +566,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.5.6/24
       linkindex: 7
+      mac_address: caf0.0006.0003
       name: s1 -> bh1
       neighbors:
       - ifname: eth1
@@ -679,6 +685,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.5.6/24
             linkindex: 7
+            mac_address: caf0.0006.0003
             name: s1 -> bh1
             neighbors:
             - ifname: eth1
@@ -735,6 +742,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 172.16.2.6/24
             linkindex: 4
+            mac_address: caf0.0006.0002
             name: s1 -> rh1
             neighbors:
             - ifname: eth1
@@ -794,6 +802,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.6/30
       linkindex: 2
+      mac_address: caf0.0007.0001
       name: s2 -> c
       neighbors:
       - ifname: Ethernet2
@@ -809,6 +818,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.3.7/24
       linkindex: 5
+      mac_address: caf0.0007.0002
       name: s2 -> rh2
       neighbors:
       - ifname: eth1
@@ -822,6 +832,7 @@ nodes:
       ifname: Ethernet3
       ipv4: 172.16.6.7/24
       linkindex: 8
+      mac_address: caf0.0007.0003
       name: s2 -> bh2
       neighbors:
       - ifname: eth1
@@ -940,6 +951,7 @@ nodes:
             ifname: Ethernet3
             ipv4: 172.16.6.7/24
             linkindex: 8
+            mac_address: caf0.0007.0003
             name: s2 -> bh2
             neighbors:
             - ifname: eth1
@@ -996,6 +1008,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 172.16.3.7/24
             linkindex: 5
+            mac_address: caf0.0007.0002
             name: s2 -> rh2
             neighbors:
             - ifname: eth1
@@ -1055,6 +1068,7 @@ nodes:
       ifname: Ethernet1
       ipv4: 10.1.0.10/30
       linkindex: 3
+      mac_address: caf0.0008.0001
       name: s3 -> c
       neighbors:
       - ifname: Ethernet3
@@ -1070,6 +1084,7 @@ nodes:
       ifname: Ethernet2
       ipv4: 172.16.4.8/24
       linkindex: 6
+      mac_address: caf0.0008.0002
       name: s3 -> rh3
       neighbors:
       - ifname: eth1
@@ -1162,6 +1177,7 @@ nodes:
             ifname: Ethernet2
             ipv4: 172.16.4.8/24
             linkindex: 6
+            mac_address: caf0.0008.0002
             name: s3 -> rh3
             neighbors:
             - ifname: eth1


### PR DESCRIPTION
Some devices need a configured MAC address for Ethernet or VLAN interfaces. This commit moves that logic from device configuration templates into link/VLAN transformation code.

The changed MAC generation procedure applies to IOLL2, IOSvL2, EOS, FRR, and NexusOS.