### PR TITLE
OSPF support for OpenBSD devices

### DIFF
--- a/netsim/ansible/templates/ospf/openbsd.j2
+++ b/netsim/ansible/templates/ospf/openbsd.j2
@@ -1,0 +1,8 @@
+{% import "openbsd.ospfv2.j2" as ospfv2 %}
+{% import "openbsd.ospfv3.j2" as ospfv3 %}
+{% if ospf.af.ipv4 is defined %}
+{{   ospfv2.config(False,ospf,netlab_interfaces) }}
+{% endif %}
+{% if ospf.af.ipv6 is defined %}
+{{   ospfv3.config(False,ospf,netlab_interfaces) }}
+{% endif %}

--- a/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
@@ -1,0 +1,55 @@
+{% macro config(ospf_vrf,ospf_data,intf_data) %}
+{%- set areas = intf_data|selectattr('ipv4', 'defined')|map(attribute='ospf.area', default='')|reject('eq', '')|sort|unique %}
+#!/bin/sh
+
+cat <<OSPFD_CONF >/etc/ospfd.conf
+{% if ospf_data.router_id|ipv4 %}
+router-id {{ ospf_data.router_id }}
+{% endif %}
+spf-delay msec 100
+spf-holdtime msec 200
+{% if ospf_data.default is defined %}
+{%   set dfd = ospf_data.default %}
+redistribute default set {{ '{' }} metric {{ dfd.cost or '100' }} type {{ dfd.type.replace('e','') or '1' }} {{ '}' }}
+{% endif %}
+
+{% for a in areas %}
+area {{ a }} {{ '{' }}
+{%   for l in intf_data if l.ospf.area is defined and l.ospf.area is eq a and 'ipv4' in l %}
+{%     if l.ifname == "lo0" %}
+    interface {{ l.ifname }}:{{ l.ipv4 | ipaddr('address') }} {{ '{ '}} 
+{%     else %}
+    interface {{ l.ifname }} {{ '{ '}} 
+{%     endif %}
+{%     if l.ospf.network_type is defined and l.ospf.network_type == 'point-to-point' %}
+        type p2p
+{%     endif %}
+{%     if l.ospf.passive|default(False) %}
+        passive
+{%     endif %}
+{%     if l.ospf.cost is defined %}
+        metric {{ l.ospf.cost }}
+{%     endif %}
+{%     if l.ospf.timers.hello is defined %}
+        hello-interval {{ l.ospf.timers.hello }}
+{%     endif %}
+{%     if l.ospf.timers.dead is defined %}
+        router-dead-time {{ l.ospf.timers.dead }}
+{%     endif %}
+{%     if l.ospf.priority is defined %}
+        router-priority {{ l.ospf.priority }}
+{%     endif %}
+{%     if l.ospf.password is defined %}
+        auth-key {{ l.ospf.password }}
+        auth-type simple
+{%     endif %}
+    {{ '}' }}
+{%   endfor -%} 
+{{ '}' }}
+{% endfor %} 
+OSPFD_CONF
+
+chmod 640 /etc/ospfd.conf
+rcctl enable ospfd
+rcctl restart ospfd
+{% endmacro %}

--- a/netsim/ansible/templates/ospf/openbsd.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/openbsd.ospfv3.j2
@@ -1,0 +1,47 @@
+{% macro config(ospf_vrf,ospf_data,intf_data) %}
+{%- set areas = intf_data|selectattr('ipv6', 'defined')|map(attribute='ospf.area', default='')|reject('eq', '')|sort|unique %}
+#!/bin/sh
+
+cat <<OSPFD_CONF >/etc/ospf6d.conf
+{% if ospf_data.router_id is defined %}
+router-id {{ ospf_data.router_id }}
+{% endif %}
+spf-delay 1
+spf-holdtime 1
+{% if ospf_data.default is defined %}
+{%   set dfd = ospf_data.default %}
+redistribute default set {{ '{' }} metric {{ dfd.cost or '100' }} type {{ dfd.type.replace('e','') or '1' }} {{ '}' }}
+{% endif %}
+
+{% for a in areas %}
+area {{ a }} {{ '{' }}
+{%   for l in intf_data if l.ospf.area is defined and l.ospf.area is eq a and 'ipv6' in l %}
+    interface {{ l.ifname }} {{ '{ '}} 
+{%     if l.ospf.network_type is defined and l.ospf.network_type == 'point-to-point' %}
+        type p2p
+{%     endif %}
+{%     if l.ospf.passive|default(False) %}
+        passive
+{%     endif %}
+{%     if l.ospf.cost is defined %}
+        metric {{ l.ospf.cost }}
+{%     endif %}
+{%     if l.ospf.timers.hello is defined %}
+        hello-interval {{ l.ospf.timers.hello }}
+{%     endif %}
+{%     if l.ospf.timers.dead is defined %}
+        router-dead-time {{ l.ospf.timers.dead }}
+{%     endif %}
+{%     if l.ospf.priority is defined %}
+        router-priority {{ l.ospf.priority }}
+{%     endif %}
+    {{ '}' }}
+{%   endfor -%} 
+{{ '}' }}
+{% endfor %} 
+OSPFD_CONF
+
+chmod 640 /etc/ospf6d.conf
+rcctl enable ospf6d
+rcctl restart ospf6d
+{% endmacro %}

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -5,7 +5,7 @@ interface_name: vio{ifindex}
 loopback_interface_name: lo{ifindex}
 ifindex_offset: 1
 mgmt_if: vio0
-role: host
+role: router
 features:
   routing:
     static: true
@@ -14,6 +14,13 @@ features:
     ipv6:
       use_ra: true
       lla: true
+  ospf:
+    unnumbered: false
+    import: [ connected, static ]
+    default: true
+    password: true
+    priority: true
+    timers: true
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd


### PR DESCRIPTION
This adds OSPFv2 and OSPFv3 support for OpenBSD.

I had to change the role from 'host' to 'router'. Overwriting it in the topology did not work (ospf templates were not evalutated).