### PR TITLE
Use wait time constants in BGP session integration tests

### DIFF
--- a/tests/integration/bgp.session/01-allowas-in.yml
+++ b/tests/integration/bgp.session/01-allowas-in.yml
@@ -6,6 +6,8 @@ message: |
 plugin: [ bgp.session, bgp.policy ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -44,18 +46,22 @@ links:
   x3:
     bgp.prepend.path: "65000"
 
+defaults.devices.arubacx.netlab_validate:
+  pfx_v4_deny.wait: 20
+  pfx_v6_deny.wait: 20
+
 validate:
   session_v4:
     description: Check IPv4 EBGP sessions with dut
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2, x3 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv4')
 
   session_v6:
     description: Check IPv6 EBGP sessions with dut
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2, x3 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 
@@ -67,28 +73,28 @@ validate:
 
   pfx_v4_allow:
     description: Check whether DUT disabled AS check on IPv4 EBGP session with X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('172.42.42.0/24')
 
   pfx_v6_allow:
     description: Check whether DUT disabled AS check on IPv6 EBGP session with X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('2001:db8:a01::/64',af='ipv6')
 
   pfx_v4_deny:
     description: Check whether DUT still performs AS check on IPv4 EBGP session with X3
-    wait: 20      # Aruba CX takes 'forever' to get this done ;)
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('172.42.43.0/24',state='missing')
 
   pfx_v6_deny:
     description: Check whether DUT still performs AS check on IPv6 EBGP session with X3
-    wait: 10      # Aruba CX takes 'forever' to get this done ;)
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('2001:db8:a02::/64',af='ipv6',state='missing')

--- a/tests/integration/bgp.session/02-as-override.yml
+++ b/tests/integration/bgp.session/02-as-override.yml
@@ -7,6 +7,8 @@ message: |
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -46,41 +48,41 @@ validate:
   session_v4:
     description: Check IPv4 EBGP sessions with dut
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv4')
 
   session_v6:
     description: Check IPv6 EBGP sessions with dut
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 
   pfx_x1_v4:
     description: Check whether DUT replaced AS 65100 in the IPv4 EBGP update sent to X1
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('172.42.43.0/24')
 
   pfx_x1_v6:
     description: Check whether DUT replaced AS 65100 in the IPv6 EBGP update sent to X1
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('2001:db8:a03::/64',af='ipv6')
 
   pfx_x2_v4:
     description: Check whether DUT replaced AS 65100 in the EBGP update sent to X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x2 ]
     plugin: bgp_prefix('172.42.42.0/24')
 
   pfx_x2_v6:
     description: Check whether DUT replaced AS 65100 in the IPv6 EBGP update sent to X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('2001:db8:a02::/64',af='ipv6')

--- a/tests/integration/bgp.session/04-default-originate.yml
+++ b/tests/integration/bgp.session/04-default-originate.yml
@@ -46,24 +46,24 @@ validate:
   ebgp_v4:
     description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
   ebgp_v6:
     description: Check IPv6 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
   def_ipv4:
     description: Check whether DUT advertises IPv4 default route to X1
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('0.0.0.0/0')
   def_ipv6:
     description: Check whether DUT advertises IPv6 default route to X1
-    wait: 10
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('::/0',af='ipv6')

--- a/tests/integration/bgp.session/06-passive.yml
+++ b/tests/integration/bgp.session/06-passive.yml
@@ -7,6 +7,8 @@ message: |
 plugin: [ bgp.session, bgp.policy ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -40,7 +42,7 @@ validate:
   session:
     description: Check EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 30
+    wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 

--- a/tests/integration/bgp.session/08-remove-private-as.yml
+++ b/tests/integration/bgp.session/08-remove-private-as.yml
@@ -7,6 +7,8 @@ message: |
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -44,27 +46,27 @@ validate:
   session_v4:
     description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
   session_v6:
     description: Check IPv6 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 20
+    wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 
   pfx_x2_v4:
     description: Check for X1 IPv4 prefix on X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x2 ]
     plugin: bgp_prefix('172.42.42.0/24')
 
   pfx_x2_v6:
     description: Check for X1 IPv6 prefix on X2
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x2 ]
     plugin: bgp_prefix('2001:db8:a01::/64',af='ipv6')

--- a/tests/integration/bgp.session/10-timers.yml
+++ b/tests/integration/bgp.session/10-timers.yml
@@ -5,6 +5,8 @@ message:
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -44,14 +46,14 @@ validate:
   session_v4:
     description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 30    # Aruba CX takes its sweet time...
+    wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
   session_v6:
     description: Check IPv6 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 30    # Aruba CX takes its sweet time...
+    wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 

--- a/tests/integration/bgp.session/11-rs-client.yml
+++ b/tests/integration/bgp.session/11-rs-client.yml
@@ -7,6 +7,8 @@ message: |
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -33,13 +35,13 @@ validate:
   session:
     description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 10
+    wait: ebgp_session
     nodes: [ rs, r3 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
   pfx:
     description: Check that DUT propagates the R2 loopback to R3
     wait_msg: Waiting for EBGP update propagation
-    wait: 10
+    wait: bgp_scan_time
     nodes: [ r3 ]
     plugin: bgp_prefix(nodes.r2.loopback.ipv4)

--- a/tests/integration/bgp.session/12-rs.yml
+++ b/tests/integration/bgp.session/12-rs.yml
@@ -6,6 +6,8 @@ message: |
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -29,14 +31,14 @@ validate:
   session:
     description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 10
+    wait: ebgp_session
     nodes: [ r1, r2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
   pfx:
     description: Check that DUT propagates the R2 loopback to R3
     wait_msg: Waiting for EBGP update propagation
-    wait: 10
+    wait: bgp_scan_time
     nodes: [ r1 ]
     plugin: bgp_prefix(nodes.r2.loopback.ipv4)
 

--- a/tests/integration/bgp.session/24-default-unnumbered.yml
+++ b/tests/integration/bgp.session/24-default-unnumbered.yml
@@ -7,6 +7,8 @@ message:
 plugin: [ bgp.session ]
 module: [ bgp ]
 
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
 groups:
   probes:
     device: frr
@@ -39,18 +41,18 @@ validate:
   session:
     description: Check EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
-    wait: 30
+    wait: ebgp_session
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',intf=node.interfaces[0].ifname)
   def_ipv4:
     description: Check whether DUT advertises IPv4 default route to X1
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('0.0.0.0/0')
   def_ipv6:
     description: Check whether DUT advertises IPv6 default route to X1
-    wait: 5
+    wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x1 ]
     plugin: bgp_prefix('::/0',af='ipv6')


### PR DESCRIPTION
Fixes the underlying problem described in #2693