### PR TITLE
FortiOS package update

### DIFF
--- a/docs/labs/fortios.md
+++ b/docs/labs/fortios.md
@@ -18,11 +18,13 @@ FortiOS (FortiGate) is supported by the **netlab libvirt package** command. To b
 
 ## Initial Device Configuration
 
-You'll have to copy-paste initial device configuration during the box-building process. **netlab libvirt config fortios** command displays the build recipe:
+The initial device configuration is prepared on a CD-ROM image that is read by the device during the initial boot process. All you have to do is check the applied configuration and shut down the device.
+
+**netlab libvirt config fortios** command displays the build recipe:
 
 ```{eval-rst}
-.. include:: fortios.txt
-   :literal:
+.. literalinclude:: fortios.txt
+   :language: text
 ```
 
 ```{tip}

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -12,6 +12,7 @@ libvirt:
   image: fortinet/fortios
   build: https://netlab.tools/labs/fortios/
   create_template: fortios.xml.j2
+  create_iso: fortios
 clab:
   node.kind: fortinet_fortigate
   interface.name: "eth{ifindex}"

--- a/netsim/install/libvirt/fortios.txt
+++ b/netsim/install/libvirt/fortios.txt
@@ -1,17 +1,26 @@
 Creating initial configuration for FortiGate 6.x/7.0/7.4/7.6
 ============================================================
 
-Initial configuration for the FortiGate device is prepared in a bootstrap CDROM image.
+Initial configuration for the FortiGate device is prepared in a bootstrap CD-ROM
+image. Once the device boots and the configuration is applied:
 
 * Log in with username 'admin' and password 'admin'
-* Check the applied conifguration with "diagnose debug cloudinit show"
-* Optionally, add any other configuration you might want to have burned into the vagrant box
-    - If you want to start with pristine configuration
-        1. Execute "virsh change-media vm_box sda --eject" in another shell
-        2. Run "execute factoryreset" on the console
-        3. Log in with username 'admin' and empty password
-        4. Set the new 'admin' password to 'admin'
-    - In the past the following configuration was recommended
+* Check the applied configuration with "diagnose debug cloudinit show"
+* Optionally, add any other configuration you might want to have burned into
+  the vagrant box
+* Execute "execute shutdown".
+* Disconnect from console if needed (ctrl-] usually works).
+
+If you don't like our initial configuration and would like to start with a
+pristine one:
+
+1. Execute "virsh change-media vm_box sda --eject" in another shell
+2. Run "execute factoryreset" on the console
+3. Log in with username 'admin' and empty password
+4. Set the new 'admin' password to 'admin'
+5. Apply your initial configuration
+
+In the past, the following initial configuration was recommended
  
 ====================================================
 config system admin
@@ -32,6 +41,3 @@ config system dns
     set primary 1.1.1.1
 end
 ====================================================
-
-* Execute "execute shutdown".
-* Disconnect from console if needed (ctrl-] usually works).

--- a/netsim/install/libvirt/fortios.txt
+++ b/netsim/install/libvirt/fortios.txt
@@ -1,10 +1,18 @@
 Creating initial configuration for FortiGate 6.x/7.0/7.4/7.6
 ============================================================
 
-* Log in with username 'admin' and empty password
-* Set the new 'admin' password to 'admin'
-* Copy-paste the following configuration (see also NOTE below the configuration)
+Initial configuration for the FortiGate device is prepared in a bootstrap CDROM image.
 
+* Log in with username 'admin' and password 'admin'
+* Check the applied conifguration with "diagnose debug cloudinit show"
+* Optionally, add any other configuration you might want to have burned into the vagrant box
+    - If you want to start with pristine configuration
+        1. Execute "virsh change-media vm_box sda --eject" in another shell
+        2. Run "execute factoryreset" on the console
+        3. Log in with username 'admin' and empty password
+        4. Set the new 'admin' password to 'admin'
+    - In the past the following configuration was recommended
+ 
 ====================================================
 config system admin
     edit "vagrant"

--- a/netsim/install/libvirt/fortios.xml.j2
+++ b/netsim/install/libvirt/fortios.xml.j2
@@ -27,10 +27,13 @@
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='{{ user.cwd }}/vm.qcow2'/>
-      <backingStore />
       <target dev='vda' bus='virtio'/>
-      <alias name='virtio-disk0'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </disk>
+    <disk type="file" device="cdrom">
+      <driver name="qemu" type="raw"/>
+      <source file="{{ user.cwd }}/bootstrap.iso"/>
+      <target dev="sda" bus="sata"/>
+      <readonly/>
     </disk>
     <controller type='usb' index='0' model='ich9-ehci1'>
       <alias name='usb'/>

--- a/netsim/install/libvirt/fortios/openstack/latest/user_data
+++ b/netsim/install/libvirt/fortios/openstack/latest/user_data
@@ -13,7 +13,7 @@ config system fortiguard
     set auto-firmware-upgrade disable
 end
 
-diag sys forticonverter set-prompt-visibility hidden
+diagnose sys forticonverter set-prompt-visibility hidden
 
 config system admin
     edit "admin"
@@ -27,8 +27,9 @@ config system api-user
     next
 end
 
-config system dns
-    unset primary
-    unset secondary
+config system interface
+    edit "port1"
+        set lldp-reception disable
+        set lldp-transmission disable
+    next
 end
-

--- a/netsim/install/libvirt/fortios/openstack/latest/user_data
+++ b/netsim/install/libvirt/fortios/openstack/latest/user_data
@@ -1,0 +1,34 @@
+config system global
+    set admin-scp enable
+    set admintimeout 480
+    set fds-statistics disable
+    set gui-auto-upgrade-setup-warning disable
+    set gui-firmware-upgrade-warning disable
+    set lldp-reception enable
+    set lldp-transmission enable
+    set timezone "UTC"
+end
+
+config system fortiguard
+    set auto-firmware-upgrade disable
+end
+
+diag sys forticonverter set-prompt-visibility hidden
+
+config system admin
+    edit "admin"
+        set password admin
+    next
+end
+
+config system api-user
+    edit "netlab"
+        set accprofile "super_admin"
+    next
+end
+
+config system dns
+    unset primary
+    unset secondary
+end
+

--- a/netsim/templates/provider/libvirt/fortios-domain.j2
+++ b/netsim/templates/provider/libvirt/fortios-domain.j2
@@ -1,7 +1,7 @@
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
     {{ name }}.ssh.insert_key = false
-    {{ name }}.ssh.username = "{{ nodes[name].ansible_user }}"
-    {{ name }}.ssh.password = "{{ nodes[name].ansible_password }}"
+    {{ name }}.ssh.username = "{{ n.ansible_user }}"
+    {{ name }}.ssh.password = "{{ n.ansible_ssh_pass }}"
     #{{ name }}.ssh.private_key_path = "~/.ssh/id_ed25519"
 
     {{ name }}.vm.provider :libvirt do |domain|

--- a/netsim/templates/provider/libvirt/fortios-domain.j2
+++ b/netsim/templates/provider/libvirt/fortios-domain.j2
@@ -1,8 +1,13 @@
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
     {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.username = "{{ nodes[name].ansible_user }}"
+    {{ name }}.ssh.password = "{{ nodes[name].ansible_password }}"
+    #{{ name }}.ssh.private_key_path = "~/.ssh/id_ed25519"
 
     {{ name }}.vm.provider :libvirt do |domain|
-      domain.disk_bus = 'ide'
+      domain.disk_bus = 'virtio'
       domain.cpus = 1
       domain.memory = 2048
+      domain.graphics_type = "none"
+      domain.video_type = "none"
     end


### PR DESCRIPTION
This pull request introduces two changes:

## Add OpenStack cloud-init ISO
https://docs.fortinet.com/document/fortigate-private-cloud/7.6.0/kvm-administration-guide/767662/cloud-init
https://docs.fortinet.com/document/fortigate/7.6.4/administration-guide/817099/cloud-init

The user_data file is a config script, i.e. it is amending the FortiOS default factory configuration.
The exact content of this file should be discussed, e.g LLDP and other global configuration.

## Remove the `vagrant` user
From vagrant docs:
> If you are creating a base box for private use, you should try not to follow these, as they open up your base box to security risks (known users, passwords, private keys, etc.).
https://developer.hashicorp.com/vagrant/docs/boxes/base#default-user-settings

Vagrant is instead configured to use whatever user/password is configured for Ansible.

The pull request is a draft as at minimum the documentation should be updated as well, if the overall idea is acceptable.
