### PR TITLE
netlab inspect: disable markup when printing table-formatted YAML data

### DIFF
--- a/netsim/cli/inspect.py
+++ b/netsim/cli/inspect.py
@@ -90,7 +90,7 @@ def inspect_node(topology: Box, node_list: list, args: argparse.Namespace) -> No
       hdr_row.append(node)
       data_row.append(value)
 
-  strings.print_table(hdr_row,[ data_row ])
+  strings.print_table(hdr_row,[ data_row ],markup=False)    # Print the resulting table, disabling Rich markup in cells
 
 def run(cli_args: typing.List[str]) -> None:
   args = inspect_parse(cli_args)

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -165,11 +165,22 @@ def confirm(prompt: str,blank_line: bool = False) -> bool:
 
 """
 print text table
+
+    heading:        list of headings
+    rows:           list of row values. Each row value has N columns
+    inter_row_line: do we want to have lines between individual rows?
+    markup:         do cells contain Rich markup?
+
+The default Rich behavior is to interpret cell values as having Rich markup,
+which works well unless you print YAML stuff that can contain things like [b].
+The 'markup' parameter was added to solve #2698; the default value is "we want
+markup" just in case some other caller expects the default Rich behavior.
 """
 def print_table(
       heading: typing.List[str],
       rows: typing.List[typing.List[str]],
-      inter_row_line: bool = True) -> None:
+      inter_row_line: bool = True,
+      markup: bool = True) -> None:
 
   global rich_console
 
@@ -192,7 +203,7 @@ def print_table(
   for r in rows:
     table.add_row(*r)
 
-  rich_console.print(table)
+  rich_console.print(table,markup=markup)
 
 """
 colored_text: Print colored text using rich library


### PR DESCRIPTION
Fixes #2698