### PR TITLE
Use 'bgp_community_type' subtype in bgp.community values validation

### DIFF
--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -84,7 +84,7 @@ def check_bgp_parameters(node: Box, topology: Box) -> None:
           parent=node.bgp.community,
           path=f'nodes.{node.name}.bgp.community',
           key=k,
-          valid_values=topology['defaults.bgp.attributes.global.community.ibgp'],
+          valid_values=topology['defaults.attributes.global.bgp_community_type.valid_values'],
           module='bgp')
 
 def validate_bgp_sessions(node: Box, sessions: Box, attribute: str) -> bool:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -27,6 +27,14 @@ _top:                         # Define custom data types used by the BGP module
         ibgp:
         ebgp:
         localas_ibgp:
+    bgp_community_type:
+      _description: BGP community types
+      type: str
+      valid_values:
+        standard:
+        extended:
+        large:
+        2octet:
 
 attributes:
   global:
@@ -45,8 +53,8 @@ attributes:
     advertise_loopback: bool
     advertise_roles: list
     community:
-      ibgp: [ standard, extended, large, 2octet ]
-      ebgp: [ standard, extended, large, 2octet ]
+      ibgp: { type: list, _subtype: bgp_community_type }
+      ebgp: { type: list, _subtype: bgp_community_type }
       _alt_types: [ str, BoxList ]
     replace_global_as: bool
     confederation:
@@ -74,7 +82,7 @@ attributes:
     advertise_loopback:
     sessions:
     activate:
-    community:
+    community: { copy: global }
     router_id: { type: ipv4, use: id }
     local_as: asn
     replace_global_as: bool


### PR DESCRIPTION
Using bgp_community_type as a subtype of individual bgp.community elements was perfectly fine, but we have to do another validation later in the BGP module when transforming strings/lists into community dictionaries.

That call now uses the 'valid_values' of the 'bgp_community_type'

Closes #2467