### PR TITLE
Expose 'graph.format' and 'd2.format' node/link attributes

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -66,6 +66,8 @@ html[data-theme="dark"] a, html[data-theme="dark"] a:visited {
 .rst-content code.literal, .rst-content tt.literal {
     font-size: 90%;
     color: #d26400;
+    word-break: keep-all;
+    overflow-wrap: normal;
 }
 
 .rst-content table.docutils th {

--- a/docs/outputs/d2.md
+++ b/docs/outputs/d2.md
@@ -1,18 +1,31 @@
 (outputs-d2)=
 # Declarative Diagramming (D2) Output Module
 
-*d2* output module create a description of network topology in [D2 diagram scripting language](https://d2lang.com/tour/intro). You can use that description with [D2 commands](https://d2lang.com/tour/install) to create topology diagrams.
+*d2* output module create a description of network topology in [D2 diagram scripting language](https://d2lang.com/tour/intro). You can use that description with [D2 commands](https://d2lang.com/tour/install) to create topology- or routing protocol diagrams.
 
-The *d2* output module is invoked by specifying the `-o d2` parameter in the **[netlab create](netlab-create)** command or by specifying the **d2** engine in the **[netlab graph](netlab-graph)** command. It takes an optional destination file name (default: `graph.d2`).
+**Note:** The graph descriptions contain nodes and links, but no placement information. D2 is pretty good at figuring out how to draw the required graph, but it pays off to test out the [layout engines](https://d2lang.com/tour/layouts). Changing the [order of nodes or links](outputs-d2-link-node-attributes) might also unclutter the diagrams.
 
-A single formatting modifier can be used to specify the graph type:
+```
 
-* **topology** (default) -- Includes point-to-point links, multi-access bridges, and stub subnets. When the network topology contains BGP information, the graph groups nodes into autonomous systems. Alternatively, you could set **defaults.outputs.graph.groups** attribute to use topology **[groups](topo-groups)** to group graph nodes.
-* **bgp** -- Include autonomous systems, nodes, and BGP sessions. The formatting modifier can include the [BGP formatting parameters](outputs-d2-bgp-parameters). For example, `netlab create -o graph:bgp:vrf` draws VRF BGP sessions as dotted lines.
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+```
+
+## Creating Graph Description File
+
+The *d2* output module is invoked with the **[netlab graph -e d2](netlab-graph)** command or by specifying the `-o d2` parameter in the **[netlab create](netlab-create)** command. It takes an optional destination file name (default: `graph.d2`).
+
+The `-t` parameter of the **netlab graph** command or a formatting modifier in the **netlab create** `-o` parameter can be used to specify the graph type:
+
+* **topology** (default) -- Includes point-to-point links, multi-access bridges, and stub subnets. When the network topology contains BGP information, the graph groups nodes into autonomous systems. Alternatively, you could set the **defaults.outputs.d2.groups** attribute to use topology **[groups](topo-groups)** to group graph nodes.
+* **bgp** -- Include autonomous systems, BGP routers, and color-coded BGP sessions.
 * **isis** -- Create a diagram of IS-IS routing, including areas, color-coded circuit types, and edge subnets (does not work with IS-IS running over VLANs)
 
 ```{tip}
-The network topology graph description contains nodes and links, but no placement information. D2 is pretty good at figuring out how to draw the required graph, but it pays off to test out the [layout engines](https://d2lang.com/tour/layouts). Changing the [order of links](outputs-d2-link-node-attributes) might also unclutter the diagrams.
+The `‑f` parameter of the **netlab graph** command or a formatting modifier of the **‌netlab create** `‑o` parameter can include [BGP formatting parameters](outputs-graph-bgp-parameters). For example, `netlab graph -t bgp -f vrf` draws VRF BGP sessions as dotted lines.
 ```
 
 (outputs-d2-link-node-attributes)=
@@ -30,6 +43,38 @@ You can use the **d2** link and node attributes to change the style of individua
 The generic link- and node attributes can also be specified as **graph._attribute_** (for example, **graph.color**) values to use the same settings for GraphViz and D2 graphs.
 ```
 
+You can also use the **d2.format** node attribute to specify D2 shape [dimensions](https://d2lang.com/tour/dimensions/) or [position](https://d2lang.com/tour/positions/) and the **d2.format.style** node/link[^LFA] attribute to specify the [D2 style](https://d2lang.com/tour/style/) of a shape or a connection.
+
+For example, to draw a node as a rectangle 250 units wide and 70 units high, use:
+
+```
+nodes:
+  spine:
+    d2.format:
+      width: 250
+      height: 70
+      shape: rectangle
+```
+
+To change the fill pattern of a node, use:
+
+```
+nodes:
+  spine:
+    d2.format:
+      style.fill-pattern: grain
+```
+    
+Likewise, to turn a link into a dashed line, use:
+
+```
+links:
+- interfaces: [ a,b ]
+  d2.format.style.stroke-dash: 5
+```
+
+[^LFA]: Link attributes are applied to links between nodes or to the node representing a multi-access subnet.
+
 (outputs-d2-layout)=
 ## Influencing the Graph Layout
 
@@ -37,7 +82,7 @@ _netlab_ uses the node **graph.rank** attribute to sort nodes in link definition
 
 The default value of the **graph.rank** attribute is 100, allowing you to push some nodes (with rank below 100) toward the top of the graph and others (with rank above 100) toward the bottom.
 
-You can also use the **graph.rank** on links to influence how GraphViz draws multi-access links.
+You can also use the **graph.rank** on links to influence how D2 draws multi-access links.
 
 Finally, the link/interface **graph.linkorder** attribute allows you to specify the node order in individual links. The default **graph.linkorder** value is 50 for interfaces and 100 for subnets (multi-access links), resulting in subnets being "below" nodes unless you change the link- or interface **graph.linkorder** value.
 
@@ -64,70 +109,47 @@ You can specify the above BGP parameters in the *graph format* CLI argument.
 
 ## Modifying Shape and Connection Attributes
 
-*d2* output module uses `graphite.icon` device attribute to select the node style defined in **defaults.outputs.d2.styles** settings.
+*d2* output module uses `graphite.icon` device attribute to select the node style defined in **defaults.outputs.d2.styles** settings:
 
-You can also style `lan` shapes, `container` objects (groups or autonomous systems), and BGP session types.
+| graphite icon | D2 style        |
+|---------------|-----------------|
+| router        | oval shape      |
+| switch        | hexagonal shape |
 
-You can use any D2 style attribute in these default settings. The following printout lists the system defaults within **defaults.output.d2.styles** dictionary:
+You can also style these objects:
+
+| Object | Description |
+|--------|-------------|
+| container | Autonomous system/group container formatting |
+| lan    | Subnet formatting |
+| title  | Graph title formatting |
+| graph  | Generic graph formatting |
+| node   | Device formatting |
+| edge   | Link formatting   |
+| ibgp   | IBGP session formatting |
+| ebgp   | IBGP session formatting |
+| localas_ibgp | Local-AS IBGP session formatting |
+| confed_ebgp  | Confederation EBGP session formatting |
+| vrf    | BGP VRF session formatting |
+| level-1 | IS-IS level-1-only link |
+| level-2 | IS-IS level-2-only link |
+| level-1-2 | IS-IS level-1-2 link |
+
+Each style definition is a dictionary of D2 shape/connection attributes and their values. To change the style of a D2 shape or connection, use the **style** dictionary within a style definition.
+
+For example, to change the color of the VRF BGP sessions to red, use:
 
 ```
-confed_ebgp:
-  source-arrowhead:
-    shape: arrow
-  style:
-    stroke: '#d26400'
-    stroke-width: 4
-  target-arrowhead:
-    shape: arrow
-ebgp:
-  source-arrowhead:
-    shape: arrow
-  style:
-    stroke: '#b21a1a'
-    stroke-width: 4
-  target-arrowhead:
-    shape: arrow
-ibgp:
-  source-arrowhead:
-    shape: arrow
-  style:
-    stroke: '#613913'
-    stroke-width: 4
-  target-arrowhead:
-    shape: arrow
-lan:
-  shape: rectangle
-  style:
-    border-radius: 8
-    font-size: 20
-localas_ibgp:
-  source-arrowhead:
-    shape: arrow
-  style:
-    stroke: '#9b652f'
-    stroke-width: 4
-  target-arrowhead:
-    shape: arrow
-router:
-  shape: oval
-  style:
-    font-size: 20
-switch:
-  shape: hexagon
-  style:
-    font-size: 20
-vrf:
-  style:
-    stroke-dash: 3
-```
-
-```{warning}
-_netlab_ releases 25.07 and older specified D2 style attributes in the **‌defaults.outputs.d2** dictionary. The style attributes recognized by those releases are automatically migrated into the **‌defaults.outputs.d2.styles** dictionary.
+defaults.outputs.d2.styles.vrf.style.color: red
 ```
 
 You could specify D2 attributes in your [topology file](defaults-topology) (where you would have to prefix them with **defaults**), in [per-user topology defaults](defaults-user-file), or with [environment variables](defaults-env) (even [more details](../defaults.md)). You could also specify them with the `-s` parameter of the **[netlab create](netlab-create)** command, yet again prefixed with **defaults** ([more details](netlab-create-set)).
 
-Use the **netlab show defaults outputs.d2** [command](netlab-show-defaults) to show the current D2 defaults, including topology file defaults and user defaults.
+To display the current system defaults, use the **‌netlab show defaults outputs.d2.styles** command.
+
+```{warning}
+_netlab_ releases 25.07 and older specified D2 style attributes in the **‌defaults.outputs.d2** dictionary. The style attributes recognized by those releases are automatically migrated into the **‌defaults.outputs.d2.styles** dictionary.
+```
 
 (outputs-d2-styles)=
 ## Extending D2 Style Attributes
@@ -147,3 +169,13 @@ defaults.outputs.d2.style_map.background: fill
 ```
 
 [^AD]: See [](dev-attribute-validation) and [](dev-valid-data-types) for more details.
+
+## Sample Graphs
+
+The lab topologies used for platform integration testing contain numerous examples of graph attributes:
+
+* [Leaf-and-spine topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/topo.yml) used to create topology graphs and test node- and link attributes and custom formatting.
+* [EVPN topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/bgp.yml) used to create BGP graphs
+* [IS-IS topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/isis.yml) used to create IS-IS graphs and test node ranking
+
+You'll find [further graph-creation tips](https://blog.ipspace.net/tag/netlab/#graph) on the ipSpace.net blog.

--- a/docs/outputs/graph.md
+++ b/docs/outputs/graph.md
@@ -1,17 +1,36 @@
 (outputs-graphviz)=
-# Topology Graph (graphviz) Output Module
+# Topology Graph (Graphviz) Output Module
 
-*graph* output module create a description of network topology in [*graphviz* DOT format](https://graphviz.org/doc/info/lang.html). You can use that description with *graphviz* commands to create topology diagrams in [numerous output formats](https://graphviz.org/docs/outputs/).
+*graph* output module create a graph description of network topology or routing protocols in [*Graphviz* DOT format](https://graphviz.org/doc/info/lang.html). You can use that description with *Graphviz* commands to create topology- or routing protocol diagrams in [numerous output formats](https://graphviz.org/docs/outputs/).
 
-**Note**: The network topology graph description contains nodes and links, but no placement information. *graphviz* is pretty good at figuring out how to draw the required graph, but it pays out to test out various [layout engines](https://graphviz.org/docs/layouts/) (hint: use the name of the layout engine as the [CLI command](https://graphviz.org/doc/info/command.html)).
+**Note**: The graph descriptions contain nodes and links, but no placement information. *Graphviz* is pretty good at figuring out how to draw the required graph, but it pays off to test out various [layout engines](https://graphviz.org/docs/layouts/) (hint: use the name of the layout engine as the [CLI command](https://graphviz.org/doc/info/command.html)) and [node ranks](outputs-graph-layout).
 
-The *graph* output module is invoked with the **[netlab graph](netlab-graph)** command or by specifying the `-o graph` parameter in the **netlab create** command. It takes an optional destination file name (default: `graph.dot`).
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+```
 
-A single formatting modifier can be used to specify the graph type:
+## Creating Graph Description File
+
+The *graph* output module is invoked with the **[netlab graph](netlab-graph)** command or by specifying the `-o graph` parameter in the **[netlab create](netlab-create)** command. It takes an optional destination file name (default: `graph.dot`).
+
+The `-t` parameter of the **netlab graph** command or a formatting modifier in the **netlab create** `-o` parameter can be used to specify the graph type:
 
 * **topology** (default) -- Display inter-node links, multi-access-, and stub subnets. When the network topology contains BGP information, the graph groups nodes into autonomous systems. Alternatively, you could set **defaults.outputs.graph.groups** attribute to use topology **[groups](topo-groups)** to group graph nodes.
-* **bgp** -- Include autonomous systems, nodes, and BGP sessions. The formatting modifier can include [BGP formatting parameters](outputs-graph-bgp-parameters). For example, `netlab create -o graph:bgp:rr` draws RR-client sessions as directed arrows.
+* **bgp** -- Include autonomous systems, BGP routers, and color-coded BGP sessions.
 * **isis** -- Create a diagram of IS-IS routing, including areas, color-coded circuit types, and edge subnets (does not work with IS-IS running over VLANs)
+
+```{tip}
+The `‑f` parameter of the **netlab graph** command or a formatting modifier of the **‌netlab create** `‑o` parameter can include [BGP formatting parameters](outputs-graph-bgp-parameters). For example, `netlab graph -t bgp -f rr` draws RR-client sessions as directed arrows.
+```
+
+Use the **dot** command (or another Graphviz command) to create a graph from a graph description file. The Graphviz commands take the `-T` argument to specify the output format (for example, `png` or `svg`) and the `-o` argument to specify the output file. For example, use the following command to create `graph.png`:
+
+```
+$ dot graph.dot -T png -o graph.png
+```
 
 (outputs-graph-link-node-attributes)=
 ## Modifying Global, Link, and Node Attributes
@@ -20,23 +39,41 @@ You can set the graph title with **graph.title** or **defaults.graph.title** top
 
 You can use the **graph** link and node attributes to change the style of individual nodes or links. The following attributes are built into _netlab_[^XS]:
 
-* **graph.color** -- line color (*color* GraphViz attribute)
-* **graph.fill** -- fill color (*fillcolor* GraphViz attribute)
-* **graph.width** -- line width (*penwidth* GraphViz attribute)
+* **graph.color** -- line color (*color* Graphviz attribute)
+* **graph.fill** -- fill color (*fillcolor* Graphviz attribute)
+* **graph.width** -- line width (*penwidth* Graphviz attribute)
 
-[^XS]: You can extend the GraphViz styling capabilities and add new **graph** attributes. See [](outputs-d2-styles) for details.
+[^XS]: You can extend the Graphviz styling capabilities and add new **graph** attributes. See [](outputs-d2-styles) for details.
+
+You can also use the **graph.format** parameter to specify the [Graphviz attributes](https://graphviz.org/doc/info/attrs.html) for individual nodes or links[^LFA]. For example, to change the width of a node to 2 inches, use:
+
+```
+nodes:
+  spine:
+    graph.format.width: 2
+```
+
+Likewise, to turn a link into a dashed line, use:
+
+```
+links:
+- interfaces: [ a,b ]
+  graph.format.style: dashed
+```
+
+[^LFA]: Link attributes are applied to links between nodes or to the node representing a multi-access subnet.
 
 (outputs-graph-layout)=
 ## Influencing the Graph Layout
 
 _netlab_ uses the node **graph.rank** attribute to:
 
-1. Tell GraphViz that nodes with the same **graph.rank** should be at the same rank (vertical position) in the graph
-2. Sort nodes in link definitions to ensure the graph edges are always defined as going from nodes with a lower rank to nodes with a higher rank. The order of nodes in the graph edges influences the GraphViz layout engine.
+1. Tell Graphviz that nodes with the same **graph.rank** should be at the same rank (vertical position) in the graph
+2. Sort nodes in link definitions to ensure the graph edges are always defined as going from nodes with a lower rank to nodes with a higher rank. The order of nodes in the graph edges influences the Graphviz layout engine.
 
 The default value of the **graph.rank** attribute is 100, allowing you to push some nodes (with rank below 100) toward the top of the graph and others (with rank above 100) toward the bottom.
 
-You can also use the **graph.rank** on links to influence how GraphViz draws multi-access links.
+You can also use the **graph.rank** on links to influence how Graphviz draws multi-access links.
 
 Finally, the link/interface **graph.linkorder** attribute allows you to specify the node order in individual links. The default **graph.linkorder** value is 50 for interfaces and 100 for subnets (multi-access links), resulting in subnets being "below" nodes unless you change the link- or interface **graph.linkorder** value.
 
@@ -64,7 +101,7 @@ You can specify the above BGP parameters in the *graph format* CLI argument, for
 (outputs-graph-styles)=
 ## Graph Object Styles
 
-You can also change the formatting of individual graph objects with the **outputs.graph.styles._object_** defaults:
+Finally, you can also change the formatting of individual graph objects with the **outputs.graph.styles._object_** defaults:
 
 | Object | Description |
 |--------|-------------|
@@ -73,76 +110,35 @@ You can also change the formatting of individual graph objects with the **output
 | edge   | Link formatting   |
 | as     | Autonomous system/group container formatting |
 | stub   | Subnet formatting
+| title  | Graph title formatting |
 | ibgp   | IBGP session formatting |
 | ebgp   | IBGP session formatting |
+| vrf    | BGP VRF session formatting |
 | localas_ibgp | Local-AS IBGP session formatting |
 | confed_ebgp  | Confederation EBGP session formatting |
-| title  | Graph title formatting |
+| level-1 | IS-IS level-1-only link |
+| level-2 | IS-IS level-2-only link |
+| level-1-2 | IS-IS level-1-2 link |
 
-Each **styles** parameter is a dictionary of *Graphviz* attributes and their values (see the following printout for an example).
-
-You can also change graph colors and margins with old-style defaults:
-
-* **outputs.graph.colors._object_** -- Specify background color for *as*, *node*, *stub* subnet, *ibgp* or *ebgp* session.
-* **outputs.graph.margins.as** -- Inner margin for graph clusters (BGP autonomous system or groups).
+Each **styles** parameter is a dictionary of *Graphviz* attributes and their values.
 
 You could specify the graph defaults in your [topology file](defaults-topology) (where you would have to prefix them with **defaults**), in [per-user topology defaults](defaults-user-file), or with [environment variables](defaults-env) (even [more details](../defaults.md)). You could also specify them with the `-s` parameter of the **[netlab create](netlab-create)** command, yet again prefixed with **defaults** ([more details](netlab-create-set)).
 
-The system defaults in *netlab* release 25.09 are included below; you can always inspect them with **netlab show defaults outputs.graph**
+To display the current Graphviz styles, use the **netlab show defaults outputs.graph.styles** command.
 
+```{tip}
+Older _netlab_ releases (prior to release 25.09) used different default settings to change a few graph parameters. You can still change those defaults, but don't use them in new projects:
+
+* **outputs.graph.colors._object_** -- Specify background color for *as*, *node*, *stub* subnet, *ibgp* or *ebgp* session.
+* **outputs.graph.margins.as** -- Inner margin for graph clusters (BGP autonomous system or groups).
 ```
-% netlab show defaults outputs.graph
 
-netlab default settings within the outputs.graph subtree
-=============================================================================
+## Sample Graphs
 
-as_clusters: true
-attributes:
-  link:
-    _keys:
-      linkorder:
-        max_value: 200
-        min_value: 1
-        type: int
-      type:
-        type: str
-        valid_values:
-        - lan
-    type: dict
-  shared:
-  - linkorder
-interface_labels: false
-node_address_label: true
-styles:
-  as:
-    bgcolor: '#e8e8e8'
-    color: '#c0c0c0'
-    fontname: Verdana
-    margin: 16
-  ebgp:
-    color: '#b21a1a'
-    penwidth: 2
-  edge:
-    fontname: Verdana
-    labeldistance: 1.5
-    labelfontsize: 8
-  graph:
-    bgcolor: transparent
-    nodesep: 0.5
-    ranksep: 1
-  ibgp:
-    color: '#613913'
-    penwidth: 2
-  node:
-    bgcolor: '#ff9f01'
-    fillcolor: '#ff9f01'
-    fontname: Verdana
-    margin: 0.3,0.1
-    shape: box
-    style: rounded,filled
-  stub:
-    bgcolor: '#d1bfab'
-    fillcolor: '#d1bfab'
-    fontsize: 11
-    margin: 0.3,0.1
-```
+The lab topologies used for platform integration testing contain numerous examples of graph attributes:
+
+* [Leaf-and-spine topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/topo.yml) used to create topology graphs and test node- and link attributes and custom formatting.
+* [EVPN topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/bgp.yml) used to create BGP graphs
+* [IS-IS topology](https://github.com/ipspace/netlab/blob/master/tests/platform-integration/graph/isis.yml) used to create IS-IS graphs and test node ranking
+
+You'll find [further graph-creation tips](https://blog.ipspace.net/tag/netlab/#graph) on the ipSpace.net blog.

--- a/netsim/outputs/d2.yml
+++ b/netsim/outputs/d2.yml
@@ -101,7 +101,9 @@ attributes:
     color: str
     fill: str
     width: { type: int, min_value: 1, max_value: 32 }
+    format: dict
   link:
     color: str
     width: { type: int, min_value: 1, max_value: 32 }
     linkorder: { type: int, min_value: 1, max_value: 200 }
+    format: dict

--- a/netsim/outputs/graph.yml
+++ b/netsim/outputs/graph.yml
@@ -74,6 +74,7 @@ attributes:
     fill: str
     width: { type: int, min_value: 1, max_value: 32 }
     rank: { type: int, min_value: 1, max_value: 200 }
+    format: dict
   link:
     type: dict
     _keys:
@@ -82,4 +83,5 @@ attributes:
       color: str
       width: { type: int, min_value: 1, max_value: 32 }
       rank: { type: int, min_value: 1, max_value: 200 }
+      format: dict
   shared: [ linkorder, color, fill, width ]

--- a/tests/platform-integration/graph/topo.yml
+++ b/tests/platform-integration/graph/topo.yml
@@ -18,6 +18,12 @@ groups:
   spine:
     members: [ s1, s2 ]
     graph.rank: 1
+    graph.format.width: 2
+    d2.format:
+      width: 250
+      height: 70
+      shape: rectangle
+      style.fill-pattern: grain
   leaf:
     members: [ l1, l2 ]
     graph.rank: 2
@@ -31,7 +37,10 @@ links:
 - s1-l1
 - s1-l2
 - s2-l1
-- s2-l2
+- s2:
+  l2:
+  graph.format.style: dashed
+  d2.format.style.stroke-dash: 5
 - l1:
   h1:
     graph.linkorder: 200
@@ -39,6 +48,7 @@ links:
     graph.linkorder: 200
   graph.color: "#FF0000"
   graph.width: 3
+  d2.format.shape: oval
 - interfaces: [ l2, h3 ]
 - interfaces: [ l2, h4 ]
   graph.type: lan


### PR DESCRIPTION
The 'graph.format' and 'd2.format' attributes were already used in the graph generation, but could not be used because the attribute definitions were missing.

Also:
* Streamline D2 attribute processing to merge object-type settings, object settings, and object format for a consistent behavior with strict format/settings/type precedence.
* Update 'platform-integration/graph/topo.yml' topology to include node and link formats for GraphViz and D2
* Rewrite/streamline large parts of graph/d2 documentation
* Add word-break CSS properties to inline code spans trying to prevent line breaks at hyphens (hint: it does not work with Chrome)