### PR TITLE
Build a list of parent device(s) in devices.x._parents

### DIFF
--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -202,10 +202,11 @@ def process_child_device(dname: str, devices: Box) -> None:
   devices[dname].pop('parent',None)                         # ... and remove it to break potential circular references
 
   process_child_device(p_device,devices)                    # Process inheritance in parent device
-  p_data = Box(devices[p_device])                           # Build a copy of parent device data
+  p_data = Box(devices[p_device].to_dict())                 # Build a copy of parent device data
   for kw in ("template","_meta_device"):                    # ... remove the template/meta device flags
     p_data.pop(kw,None)
   devices[dname] = p_data + devices[dname]                  # ... and merge parent settings with the child device
+  data.append_to_list(devices[dname],'_parents',p_device)
 
   data.remove_null_values(devices[dname])                   # Finally, remove null values from the resulting dictionary
 


### PR DESCRIPTION
This QDS will help us inherit parameters like per-device wait times specified for a group of devices on a parent device.

Typical use case: all IOS-based devices need ridiculously long timer when validating BGP redistribution.