### PR TITLE
Add per-device validation wait time constants

### DIFF
--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -95,12 +95,13 @@ def increase_pass_count(v_entry: Box) -> None:
 list_tests: display validation tests defined for the current lab topology
 '''
 def list_tests(topology: Box) -> None:
-  heading = [ 'Test','Description','Nodes','Devices' ]
+  heading = [ 'Test','Description','Nodes','Devices','Wait' ]
   rows = [
     [ v_entry.name,
       v_entry.description or '',
       ",".join(v_entry.nodes),
-      ",".join(v_entry.devices) ]
+      ",".join(v_entry.devices),
+      str(v_entry.get('wait','')) ]
     for v_entry in topology.validate ]
   strings.print_table(heading,rows)
 
@@ -1111,22 +1112,22 @@ def run(cli_args: typing.List[str]) -> None:
     else:
       log.fatal('No validation tests defined for the current lab, exiting')
 
-  if args.list:
-    list_tests(topology)
-    return
-
   filter_by_tests(args,topology)
   filter_by_nodes(args,topology)
   log.exit_on_error()
+  topology._v_len = max([ len(v_entry.name) for v_entry in topology.validate ] + [ 7 ])
+  extend_first_wait_time(args,topology)
+
+  if args.list:
+    list_tests(topology)
+    return
 
   templates.load_ansible_filters()
 
   ERROR_ONLY = args.error_only
   cnt = 0
-  topology._v_len = max([ len(v_entry.name) for v_entry in topology.validate ] + [ 7 ])
   start_time = _status.lock_timestamp() or time.time()
   log.init_log_system(header=False)
-  extend_first_wait_time(args,topology)
 
   for v_entry in topology.validate:
     extend_device_wait_time(v_entry,topology)


### PR DESCRIPTION
Some devices are really slow in performing a particular operation (for example, Cisco IOS needs a minute to start redistribution routes into BGP IPv6 AF). Instead of tweaking device timers in individual tests, or using ridiculously long timers for all devices, this change allows us to specify per-device validation time constants.

For example, the default "redistribute IPv6 prefix into BGP" wait time is 15 seconds; the wait time for Cisco IOS devices is 60.

Also:

* Added 'wait time' to validation test printouts
* Reordered initial steps in 'netlab validate' command to get wait times updated before printing the test table (if requested with the '--list' command)