### PR TITLE
Use per-device validation wait times in BGP integration tests

### DIFF
--- a/tests/integration/bgp/04-originate.yml
+++ b/tests/integration/bgp/04-originate.yml
@@ -62,13 +62,13 @@ validate:
   originate:
     description: Check whether DUT originates the beacon prefix
     wait_msg: Wait for prefix origination and BGP convergence
-    wait: bgp_scan_long
+    wait: bgp_v4_originate
     nodes: [ x1, x2, r1 ]
     plugin: bgp_prefix('172.42.42.0/24')
   loopback:
     description: Check whether DUT2 originates the loopback prefix
     wait_msg: Wait for prefix origination and BGP convergence
-    wait: bgp_scan_long
+    wait: bgp_v4_originate
     nodes: [ x1, x2, r1 ]
     plugin: bgp_prefix('10.0.0.2/32')
   stub:

--- a/tests/integration/bgp/14-ipv6-originate.yml
+++ b/tests/integration/bgp/14-ipv6-originate.yml
@@ -38,9 +38,6 @@ links:
   prefix.ipv6: 2001:db8:cafe:e42::/64
   bgp.advertise: True
 
-defaults.devices.cisco8000v.netlab_validate.stub.wait: 80
-defaults.devices.cisco8000v.netlab_validate.loopback.wait: 80
-
 validate:
   s_dut:
     description: Check EBGP sessions with DUT (wait up to 20 seconds)
@@ -50,13 +47,13 @@ validate:
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
   stub:
     description: Check whether DUT originates a stub prefix (wait up to 15 seconds)
-    wait: bgp_ios_redist
+    wait: bgp_v6_originate
     wait_msg: Waiting for the stub prefix to be originated and propagated
     nodes: [ x1, x2 ]
     plugin: bgp_prefix('2001:db8:cafe:e42::/64',af='ipv6')
   loopback:
     description: Check whether DUT2 originates the loopback prefix (wait up to 15 seconds)
-    wait: bgp_scan_long
+    wait: bgp_v6_originate
     wait_msg: Waiting for the loopback prefix to be originated and propagated
     nodes: [ x1, x2 ]
     plugin: bgp_prefix(nodes.dut2.loopback.ipv6,af='ipv6')

--- a/tests/integration/bgp/30-import-ds-ospf.yml
+++ b/tests/integration/bgp/30-import-ds-ospf.yml
@@ -82,12 +82,12 @@ validate:
     plugin: bgp_prefix(nodes.r2.loopback.ipv6,af='ipv6')
   p_static_4:
     description: Check whether static IPv4 prefix is redistributed into BGP
-    wait: bgp_scan_time
+    wait: bgp_v4_redist
     nodes: [ x1 ]
     plugin: bgp_prefix(nodes.dut.routing.static[0].ipv4)
   p_static_6:
     description: Check whether static IPv6 prefix is redistributed into BGP
     wait_msg: Waiting for static IPv6 prefix to appear in the BGP table
-    wait: bgp_ios_redist
+    wait: bgp_v6_redist
     nodes: [ x1 ]
     plugin: bgp_prefix(nodes.dut.routing.static[1].ipv6,af='ipv6')

--- a/tests/integration/bgp/31-import-policy.yml
+++ b/tests/integration/bgp/31-import-policy.yml
@@ -79,13 +79,13 @@ validate:
     plugin: ospf6_neighbor(nodes.dut.ospf.router_id)
   import_v4:
     description: Check whether R2 IPv4 prefix is redistributed into BGP
-    wait: bgp_scan_long
+    wait: bgp_v4_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(prefix.beacon.ipv4)
   import_v6:
     description: Check whether R2 IPv6 prefix is redistributed into BGP
-    wait: bgp_ios_redist
+    wait: bgp_v6_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(prefix.beacon.ipv6,af='ipv6')

--- a/tests/integration/isis/21-import-ds.yml
+++ b/tests/integration/isis/21-import-ds.yml
@@ -125,13 +125,13 @@ validate:
     plugin: isis_prefix(pfx=nodes.dut.routing.static[1].ipv6,af='ipv6')
   bgp_v4:
     description: Check whether R3 IS-IS IPv4 prefix is redistributed into BGP
-    wait: bgp_scan_time
+    wait: bgp_v4_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(pfx=nodes.r3.loopback.ipv4,af='ipv4')
   bgp_v6:
     description: Check whether R3 IS-IS IPv6 prefix is redistributed into BGP
-    wait: bgp_ios_redist
+    wait: bgp_v6_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(pfx=nodes.r3.loopback.ipv6,af='ipv6')

--- a/tests/integration/ripv2/21-import-ds.yml
+++ b/tests/integration/ripv2/21-import-ds.yml
@@ -113,13 +113,13 @@ validate:
     plugin: ospf6_prefix(pfx=nodes.r3.interfaces[0].ipv6)
   bgp_v4:
     description: Check whether R3 RIP IPv4 prefix is redistributed into BGP
-    wait: bgp_scan_time
+    wait: bgp_v4_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(pfx=nodes.r3.loopback.ipv4,af='ipv4')
   bgp_v6:
     description: Check whether R3 RIP IPv6 prefix is redistributed into BGP
-    wait: bgp_ios_redist
+    wait: bgp_v6_redist
     wait_msg: Waiting for the loopback prefix to be originated and redistributed
     nodes: [ x1 ]
     plugin: bgp_prefix(pfx=nodes.r3.interfaces[0].ipv6,af='ipv6')

--- a/tests/integration/ripv2/31-vrf-ipv4.yml
+++ b/tests/integration/ripv2/31-vrf-ipv4.yml
@@ -71,7 +71,7 @@ validate:
     description: Check for RIPv2 prefix in BGP
     wait_msg: Waiting for RIPv2 and BGP convergence
     fail: RIPv2 is not redistributed into BGP
-    wait: bgp_scan_time
+    wait: bgp_v4_redist
     nodes: [ r2 ]
     plugin: bgp_prefix(nodes.r1.loopback.ipv4)
   red_lb_ping:

--- a/tests/integration/ripv2/32-vrf-ipv6.yml
+++ b/tests/integration/ripv2/32-vrf-ipv6.yml
@@ -74,7 +74,7 @@ validate:
     description: Check for RIPng prefix in BGP
     wait_msg: Waiting for RIPng and BGP convergence
     fail: RIPng is not redistributed into BGP
-    wait: bgp_ios_redist
+    wait: bgp_v6_redist
     nodes: [ r2 ]
     plugin: bgp_prefix(nodes.r1.interfaces[0].ipv6,af='ipv6')
   red_lb_ping:

--- a/tests/integration/wait_times.yml
+++ b/tests/integration/wait_times.yml
@@ -21,7 +21,10 @@ const.validate:
   ibgp_session: 30
   bgp_scan_time: 5
   bgp_scan_long: 15       # Needed for things that might require multiple scans like aggregate prefixes
-  bgp_ios_redist: 60      # The ridiculously long time it takes Cisco IOS/XE to start redistribution into IPv6 AF
+  bgp_v4_originate: 15    # Time needed for BGP to wake up and start originating IPv4 prefixes
+  bgp_v6_originate: 15    # Time needed for BGP to wake up and start originating IPv6 prefixes
+  bgp_v4_redist: 15       # The time it takes for BGP to redistribute IPv4 routes
+  bgp_v6_redist: 15       # The time it takes for BGP to redistribute IPv6 routes
 
   isis_adj_p2p: 20
   isis_adj_lan: 50
@@ -35,3 +38,8 @@ const.validate:
 
   stp_forwarding: 40
   lacp_setup: 10
+
+# Device-specific wait times
+  xr.bgp_v4_originate: 80                         # BGP on IOS XR takes "forever" to wake up
+  xr.bgp_v6_originate: 80                         # ... and make BGP routes valid
+  ios.bgp_v6_redist: 60                           # IOS XE takes "forever" to redistribute static routes


### PR DESCRIPTION
This change cleans up the kludges introduced to make Cisco IOS, IOS XE, and IOS XR pass BGP validation tests.

Even though the configuration templates were correct, it takes Cisco BGP implementations in some cases an incredibly long time to start announcing originated or redistributed routes.

The BGP origination and redistribution tests were modified to use more granular wait time constants. The default value of these constants is identical to what has been used in the past (so it should not impact any other integration test), but the IOS- and XR-specific values were turned up to 11 (OK, 60 or 80)