### PR TITLE
Allow 'mgmt: False' to configure nodes with no management network

### DIFF
--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -104,6 +104,8 @@ def validate(topology: Box) -> None:
 Sets missing management interface names and MAC, IPv4, and IPv6 addresses from the mgmt pool
 """
 def augment_mgmt_if(node: Box, defaults: Box, addrs: typing.Optional[Box]) -> None:
+  if not node.mgmt:
+    return
   if 'ifname' not in node.mgmt:
     mgmt_if = devices.get_device_attribute(node,'mgmt_if',defaults)
     if not mgmt_if:

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -120,6 +120,7 @@ node:
     ipv6: { type: ipv6, use: interface }
     mac: str
     ifname: str
+    _alt_types: [ bool ] # JvB: allow bool
   mtu: { type: int, min_value: 64, max_value: 9216 }
   loopback:
     type: dict

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -471,7 +471,8 @@ def validate_mgmt_ip(
       mgmt: Box,
       required: bool = False,
       v4only: bool = False) -> None:
-
+  if not node.mgmt:
+    return
   valid_af = ['ipv4'] if v4only else ['ipv4','ipv6']
   n_mgmt = node.mgmt
   node_af = [ n_af for n_af in n_mgmt.keys() if n_af in valid_af ]

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -17,11 +17,15 @@ topology:
 {% for name,n in nodes.items() if not (n.unmanaged|default(False)) %}
 {%   set clab = n.clab|default({}) %}
     {{ name }}:
-{%   if n.mgmt.ipv4 is defined %}
+{%   if not n.mgmt %}
+      network-mode: none
+{%   else %}
+{%     if n.mgmt.ipv4 is defined %}
       mgmt-ipv4: {{ n.mgmt.ipv4 }}
-{%   endif %}
-{%   if n.mgmt.ipv6 is defined %}
+{%     endif %}
+{%     if n.mgmt.ipv6 is defined %}
       mgmt-ipv6: {{ n.mgmt.ipv6 }}
+{%     endif %}
 {%   endif %}
 {%   set kind = clab.kind | default(n.device) %}
       kind: {{ kind }}


### PR DESCRIPTION
Useful for large scale topologies

Context: #2733 

Note: Could be modified to only allow this for the 'clab' provider, need to fix test errors