### PR TITLE
'netlab graph' command can use Graphviz/D2 to create the final image

### DIFF
--- a/docs/netlab/graph.md
+++ b/docs/netlab/graph.md
@@ -13,7 +13,8 @@ _netlab_ generates the graph description files. You will have to install [Graphv
 
 ```text
 usage: netlab graph [-h] [-t {topology,bgp,isis}] [-f G_FORMAT] [-e {graphviz,d2}]
-                    [-i INSTANCE] [--snapshot [SNAPSHOT]] [output]
+                    [-i INSTANCE] [--snapshot [SNAPSHOT]]
+                    [output]
 
 Create a graph description in Graphviz or D2 format
 
@@ -22,16 +23,20 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -t {topology,bgp,isis}, --type {topology,bgp,isis}
+  -t, --type {topology,bgp,isis}
                         Graph type
   -f, --format G_FORMAT
                         Graph formatting parameters separated by commas
-  -e {graphviz,d2}, --engine {graphviz,d2}
+  -e, --engine {graphviz,d2}
                         Graphing engine
-  -i INSTANCE, --instance INSTANCE
+  -i, --instance INSTANCE
                         Specify lab instance to create a graph from
   --snapshot [SNAPSHOT]
                         Transformed topology snapshot file
+
+If you specify an image file as the output file (filename ending in png/svg/jpg), netlab
+graph command tries to run graphviz (dot) or d2 on the generated graph description file
+to create the image file you want.
 ```
 
 The graph type parameter can take one of these values:
@@ -59,8 +64,15 @@ These formatting parameters can be applied to a **bgp** graph:
 * You can use [_netlab_ environment variables](defaults-env) to change the graph appearance ([graphviz](outputs-graph-appearance), [d2](outputs-d2-graph-appearance))
 ```
 
+## Generating Image Files
+
+If you specify an image file name (for example, `graph.png`) as the output file, **netlab graph** tries to execute Graphviz (dot) or D2 after generating the graph description file to create the desired image file.
+
+**netlab graph** recognizes `gif`, `png`, `pdf`, `svg`, `jpg`, and `jpeg` as valid image file types. You can modify the **netlab.graph.types** [system default](topo-defaults) to extend that list (assuming the desired file types are recognized by Graphviz/D2).
+
 ## Examples
 
-* **netlab graph** creates lab topology graph in Graphviz format
+* **netlab graph** creates a lab topology graph in Graphviz format
+* **netlab graph graph.png** creates a lab topology graph in `graph.dot` Graphviz graph description file and executes `dot graph.dot -T png -o graph.png` to create `graph.png`.
 * **netlab graph -e d2 -t bgp** creates a graph of BGP sessions in D2 format.
 * **netlab graph -t bgp -f vrf** creates a graph of BGP sessions with VRF sessions show as dashed lines ([more details](outputs-graph-bgp-parameters))

--- a/netsim/cli/graph.py
+++ b/netsim/cli/graph.py
@@ -4,12 +4,16 @@
 # Connect a graph description for Graphviz or D2
 #
 import argparse
+import textwrap
 import typing
+from pathlib import Path
+
+from box import Box
 
 from ..outputs import _TopologyOutput
-from ..utils import log
+from ..utils import log, strings
 from ..utils import read as _read
-from . import load_snapshot, parser_lab_location
+from . import external_commands, load_snapshot, parser_lab_location
 
 
 #
@@ -18,7 +22,12 @@ from . import load_snapshot, parser_lab_location
 def graph_parse(args: typing.List[str]) -> argparse.Namespace:
   parser = argparse.ArgumentParser(
     prog="netlab graph",
-    description='Create a graph description in Graphviz or D2 format')
+    description='Create a graph description in Graphviz or D2 format',
+    epilog=textwrap.dedent("""
+      If you specify an image file as the output file (filename ending in
+      png/svg/jpg), netlab graph command tries to run graphviz (dot) or d2 on
+      the generated graph description file to create the image file you want.
+      """))
   parser.add_argument(
     '-t','--type',
     dest='g_type', action='store',
@@ -42,19 +51,58 @@ def graph_parse(args: typing.List[str]) -> argparse.Namespace:
   parser_lab_location(parser,instance=True,snapshot=True,action='create a graph from')
   return parser.parse_args(args)
 
+def parse_output(args: argparse.Namespace, topology: Box) -> typing.Tuple[typing.Optional[str],typing.Optional[str]]:
+  if not args.output:
+    return (None,None)
+  o_path = Path(args.output)
+  sfx = o_path.suffix[1:]
+  if sfx in topology.defaults.netlab.graph.types:
+    g_sfx = '.dot' if args.engine == 'graphviz' else '.d2'
+    return (sfx,str(o_path.with_suffix(g_sfx)))
+  else:
+    return (None,args.output)
+
+"""
+Execute the graphviz/D2 command to create the final graph
+"""
+def create_graph(o_type: str, o_name: str, args: argparse.Namespace, topology: Box) -> None:
+  g_settings = topology.defaults.outputs['graph' if args.engine == 'graphviz' else 'd2']
+  if 'command' not in g_settings:                 # Do we know what command to execute?
+    log.warning(
+      text=f"Don't know how to create a {args.engine} graph, you'll have to do it yourself",
+      module='graph')
+    return
+  cmd = g_settings.command                        # Get the command (template) to execute
+  c_exec = cmd.split(' ')[0]                      # Get the program name
+  if not external_commands.run_command(f'which {c_exec}',check_result=True,ignore_errors=True):
+    log.warning(
+      text=f"Cannot find the {c_exec} command. You will have to install additional software",
+      more_hints="You could use 'netlab install graph' on Ubuntu to install graphviz and D2",
+      module='graph')                             # Looks like we can't find the program we need
+    return
+
+  o_stem = Path(o_name).with_suffix('')
+  cmd = strings.eval_format(cmd,{'gfile': o_name, 'gtype': o_type, 'gname': o_stem})
+  if external_commands.run_command(cmd,ignore_errors=True):
+    log.info(text=f'Created {o_stem}.{o_type} from {o_name}')
+
 def run(cli_args: typing.List[str]) -> None:
   args = graph_parse(cli_args)
   topology = load_snapshot(args)
   _read.include_environment_defaults(topology)
   o_module = 'graph' if args.engine == 'graphviz' else 'd2'
   o_param  = f'{o_module}:{args.g_type or "topology"}'
+  (o_type,o_name) = parse_output(args,topology)
   if args.g_format:
     o_param += ':'+args.g_format.replace(',',':')
-  if args.output:
-    o_param += f'={args.output}'
+  if o_name:
+    o_param += f'={o_name}'
 
   graph_module = _TopologyOutput.load(o_param,topology.defaults.outputs[o_module])
   if graph_module:
     graph_module.write(topology)
   else:
     log.fatal('Cannot load the graphing output module, aborting')
+
+  if o_type and o_name:
+    create_graph(o_type,o_name,args,topology)

--- a/netsim/defaults/netlab.yml
+++ b/netsim/defaults/netlab.yml
@@ -1,3 +1,6 @@
 capture:
   command: "tcpdump -i {intf}"
   command_args: "--immediate-mode -l -vv"
+
+graph:
+  types: [ gif, png, pdf, svg, jpg, jpeg ]

--- a/netsim/outputs/d2.yml
+++ b/netsim/outputs/d2.yml
@@ -1,6 +1,8 @@
 # D2 defaults
 #
 ---
+command: "d2 {gfile} {gname}.{gtype}"
+
 node_address_label: True
 interface_labels: False
 as_clusters: True

--- a/netsim/outputs/graph.yml
+++ b/netsim/outputs/graph.yml
@@ -1,5 +1,7 @@
 # Settings for graph output module
 #
+command: "dot {gfile} -T {gtype} -o {gname}.{gtype}"
+
 interface_labels: False
 node_address_label: True
 as_clusters: True


### PR DESCRIPTION
When the 'output' parameter of the 'netlab graph' command has an image file type, the code tries to execute 'dot' or 'd2' after creating the graph description file.