### PR TITLE
[B] Device-based groups should not have explicit members

### DIFF
--- a/netsim/augment/groups.py
+++ b/netsim/augment/groups.py
@@ -195,6 +195,7 @@ def check_group_data_structure(
 
   parent = topology.get(parent_path) if parent_path else topology
   grp_namespace = f'{parent_path} ' if parent_path else ''
+  reserved_names = list(topology.defaults.devices) + ['all']
 
   '''
   Sanity checks on global group data
@@ -229,9 +230,10 @@ def check_group_data_structure(
     if not 'members' in gdata:
       gdata.members = []
 
-    if grp == 'all' and gdata.members:
+    if grp in reserved_names and gdata.members:
       log.error(
-        text=f'{grp_namespace}group "all" should not have explicit members',
+        text=f'{grp_namespace}group "{grp}" should not have explicit members',
+        more_hints='Device names or "all" cannot be used as names for user-defined groups',
         category=log.IncorrectValue,
         module='groups')
 

--- a/tests/errors/invalid-group-all-members.log
+++ b/tests/errors/invalid-group-all-members.log
@@ -1,2 +1,4 @@
 IncorrectValue in groups: group "all" should not have explicit members
+... Device names or "all" cannot be used as names for user-defined groups
+IncorrectValue in groups: group "eos" should not have explicit members
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/invalid-group-all-members.yml
+++ b/tests/errors/invalid-group-all-members.yml
@@ -3,5 +3,7 @@ defaults.device: iosv
 groups:
   all:
     members: [ a1 ]
+  eos:
+    members: [ a1 ]
 
 nodes: [ a1, a2 ]


### PR DESCRIPTION
Like with the 'all' group, we should not be able to specify members of groups that are based on device names as those groups are populated in Ansible output module.