### PR TITLE
Set node attributes from device/all groups

### DIFF
--- a/tests/errors/group-device-no-members.log
+++ b/tests/errors/group-device-no-members.log
@@ -1,2 +1,2 @@
-IncorrectValue in groups: Cannot use "module" or "device" attribute on in group g2 that has no direct or indirect members
+IncorrectValue in groups: Cannot use "device" attribute in group g2 that has no direct or indirect members
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -11,6 +11,10 @@ groups:
   as65000:
     members:
     - e
+  eos:
+    members: []
+    module:
+    - dhcp
   g1:
     members:
     - a
@@ -62,6 +66,7 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 module:
+- dhcp
 - ospf
 - bgp
 name: input
@@ -157,7 +162,8 @@ nodes:
       ifname: Management1
       ipv4: 192.168.121.103
       mac: ca:fe:00:03:00:00
-    module: []
+    module:
+    - dhcp
     name: c
     role: router
   d:

--- a/tests/topology/input/groups-hierarchy.yml
+++ b/tests/topology/input/groups-hierarchy.yml
@@ -30,6 +30,8 @@ groups:
     device: iosv
     ospf.area: 51
     bgp.as: 65000
+  eos:
+    module: [ dhcp ]
 
 links:
 - a-e-d


### PR DESCRIPTION
The device/all groups are not allowed to have static members. It was thus impossible to set node attributes in a device/all group.

This change adds dynamic calculation of group members for device/all groups. Making that work reliably required several other changes:

* The 'set node device/module' function has to apply group values in two passes. It has to apply group.device in the first pass and group.module in the second pass because changing node.device could change group membership for a device group.
* Computing members of a BGP autogroup now takes into account whether the global BGP module will be propagated into a node during the module initialization.
* The 'should we propagate modules' check was refactored into a separate function because it's used during module initialization as well as during BGP autogroup creation.
* node.device could be unspecified when BGP autogroup function calls the 'propagate_global_modules' check, but we know the only possible value that could be applied later on is the default device (because group-based devices were already set).