### PR TITLE
Fix: Set next-hop-self in Junos BGP policies only for AF IPv4/IPv6

### DIFF
--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -1,4 +1,5 @@
 {% import "junos.macro.j2" as bgpcfg with context %}
+{% set JUNOS_AF = { 'ipv4': 'inet', 'ipv6': 'inet6' } %}
 
 routing-options {
   autonomous-system {{ bgp.as }};
@@ -14,7 +15,7 @@ routing-options {
 {% endif %}
 }
 
-{% include "junos.policy.j2" %}
+{% include "junos.policy.j2" with context %}
 
 protocols {
   delete: bgp;
@@ -43,7 +44,7 @@ protocols {
 {%     endif %}
         description {{ n.name }};
 {%     if n.activate[af]|default(false) %}
-        family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
+        family {{ JUNOS_AF[af] }} {
           unicast;
         }
 {%     else %}
@@ -70,7 +71,7 @@ protocols {
         local-as {{ n.local_as }}{% if n.replace_global_as|default(True) %} no-prepend-global-as{% endif +%};
 {%     endif %}
 {%     if n.activate[af]|default(false) %}
-        family {{ 'inet' if af == 'ipv4' else 'inet6' }} {
+        family {{ JUNOS_AF[af] }} {
           unicast;
         }
 {%     else %}

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -17,26 +17,30 @@ policy-options community x-route-permit-mark members large:65535:0:65536;
 policy-options {
   delete: policy-statement bgp-advertise;
   delete: policy-statement bgp-redistribute;
+  delete: policy-statement next-hop-self;
   delete: route-filter-list bgp-announce;
 }
 
 policy-options {
 
   route-filter-list bgp-announce {
-{%   for pfx in bgp.originate|default([]) %}
+{% for pfx in bgp.originate|default([]) %}
     {{ pfx|ipaddr('0') }} exact;
-{%   endfor %}
+{% endfor %}
   }
 
   policy-statement next-hop-self {
-    term next-hop-self {
+{% for af in ('ipv4','ipv6') %}
+    term next-hop-self-{{ af }} {
       from {
+        family {{ JUNOS_AF[af] }};
         route-type external;
       }
       then {
         next-hop self;
       }
     }
+{% endfor %}
   }
 
   policy-statement bgp-advertise {


### PR DESCRIPTION
The current 'next-hop-self' policy changed next hop on all external routes, effectively destroying EVPN connectivity when a Junos router propagated EVPN routes