### PR TITLE
Internal ipaddr/hwaddr Jinja2 filters

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -7,7 +7,7 @@ _netlab_ is designed to be highly extensible and customizable. Starting with the
 * Change the [default device images](default-device-image) to run a specific software version in your lab.
 * Change [system addressing pools](addressing.md) or define your own.
 
-If you want to use _netlab_ to deploy additional device configuration you can:
+If you want to use _netlab_ to deploy additional device configuration, you can:
 
 * Use **[netlab config](netlab/config.md)** to add custom configuration to an already-provisioned lab.
 * List your own configuration templates in [node](node-attributes)- or [group **config** attribute](custom-config) to configure functionality not yet supported by *netlab* during **[netlab up](netlab/up.md)** or **[netlab initial](netlab/initial.md)** process.
@@ -16,7 +16,7 @@ If you want to use _netlab_ to deploy additional device configuration you can:
 You can also augment the _netlab_ data model transformation or add new functionality with [plugins](plugins.md).
 
 (customize-templates)=
-If you want to change the provisioning- or device configuration templates, you can:
+If you want to change the provisioning or device configuration templates, you can:
 
 * Create your own device configuration templates: copy a [system device configuration template](https://github.com/ipspace/netlab/tree/dev/netsim/ansible/templates) into **templates/_module_/_device_.j2** file[^MIN] and modify it. You can have custom device configuration templates in the current directory or in the `~/.netlab` directory.
 * Create your own device provisioning template: copy a [system template](https://github.com/ipspace/netlab/tree/dev/netsim/templates) into **_provider_/_device_-domain.j2** file and modify it.
@@ -27,6 +27,10 @@ If you want to change the provisioning- or device configuration templates, you c
 Use the **‌netlab create --debug paths** command to display the components of individual search paths and the directories _netlab_ uses when searching those paths (non-existent directories are removed from the search paths).
 
 You can use the same command to troubleshoot template errors; the debugging printouts display every template file _netlab_ searched for and the search path it used for the search.
+```
+
+```{warning}
+The device provisioning templates can use only built-in Jinja2 filters and a subset of **‌ipaddr** and **‌hwaddr** filter functionality.
 ```
 
 Finally, you might want to use external tools or devices not yet supported by _netlab_:

--- a/docs/netlab/report.md
+++ b/docs/netlab/report.md
@@ -52,3 +52,15 @@ done
 ```{tip}
 [**netlab inspect** documentation](netlab-inspect-node) describes how to specify the nodes on which the command will be executed.
 ```
+
+## Custom Reports
+
+_netlab_ allows you to create custom reports. Store the Jinja2 template that will generate the report in the **reports** subdirectory of the current directory, user _netlab_ directory (`~/.netlab`), or system _netlab_ directory (`/etc/netlab`).
+
+The reports that create Markdown text should include `.md` in the file name (for example, `vlans.md.j2`); those that create HTML should include `.html` in the file name.
+
+```{warning}
+The custom reports can use only built-in Jinja2 filters and a subset of Ansible's **‌ipaddr** and **‌hwaddr** filter functionality (for example, selecting components from an IP prefix).
+```
+
+

--- a/docs/outputs/report.md
+++ b/docs/outputs/report.md
@@ -1,8 +1,13 @@
+(outputs-report)=
 # Creating Reports with Custom Output Formats
 
 The *report* output module uses its parameter as the name of a Jinja2 formatting template and uses that template to create a custom report. For example, `netlab create -o report:addressing` creates an IP addressing report.
 
-The *report* output module tries to use the **defaults.outputs.report.*rname*** topology setting (*rname* is the report name). If that fails, it tries to read the Jinja2 template from **_rname_.j2** file in **reports** subdirectory of the current directory, user _netlab_ directory (`~/.netlab`), system _netlab_ directory (`/etc/netlab`) and _netlab_ package directory.
+The *report* output module tries to use the **defaults.outputs.report.*rname*** topology setting (*rname* is the report name). If that fails, it tries to read the Jinja2 template from **_rname_.j2** file in **reports** subdirectory of the current directory, user _netlab_ directory (`~/.netlab`), system _netlab_ directory (`/etc/netlab`), and _netlab_ package directory.
+
+```{warning}
+_netlab_ reports can use only built-in Jinja2 filters and a subset of Ansible's **‌ipaddr** and **‌hwaddr** filter functionality (for example, selecting components from an IP prefix).
+```
 
 ## Built-In Reports
 
@@ -14,7 +19,7 @@ Use the **[netlab show reports](netlab-show-reports)** command to display up-to-
 
 If a report name includes `.html`, _netlab_ assumes the template generates HTML markup and adds an HTML wrapper generated from `page.html.j2` to the generated text. The `page.html.j2` template included with _netlab_ contains the `head` and `body` HTML tags and a simple CSS style definition.
 
-If you want to customize the HTML reports, add `page.html.j2` to one of the user directories the _reports_ module searches when locating the template file (see above). Your HTML wrapper might include inline CSS (using the `style` tag) or a link to an external stylesheet.
+If you want to customize the HTML reports, add `page.html.j2` to one of the user directories that the _reports_ module searches when locating the template file (see above). Your HTML wrapper might include inline CSS (using the `style` tag) or a link to an external stylesheet.
 
 ## Generating ASCII reports from Markdown
 

--- a/docs/release/25.11.md
+++ b/docs/release/25.11.md
@@ -1,0 +1,51 @@
+# Changes in Release 25.11
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+```
+
+(release-25.11)=
+## New Functionality
+
+* Something new
+
+**Minor improvements**
+
+* Something new
+
+(release-25.11-device-features)=
+## New Device Features
+
+Arista EOS:
+* Something new
+
+(release-25.11-device-fixes)=
+## Fixes in Configuration Templates
+
+Arista EOS:
+* Something new
+
+(release-25.11-breaking)=
+## Breaking changes
+
+### Built-in ipaddr/hwaddr Jinja2 Filters
+
+The [drastic changes made in Ansible core release 2.19](https://blog.ipspace.net/2025/09/netlab-25-09-post1/) broke several built-in netlab templates, forcing us to use Ansible 11.x with netlab release 25.09-post1.
+
+_netlab_ used core- and **ipaddr** Ansible filters in its Jinja2 templates, but even the import of these filters triggered the changes in Jinja2 behavior, making a clean split with Ansible *in core netlab code* the only viable option. The device configuration templates are not affected as they're rendered within an Ansible playbook.
+
+_netlab_ release 25.11 implements its own version of **ipaddr** and **hwaddr** filters that provide the small subset of functionality required in built-in Jinja2 templates. This change might break customized provider configuration file templates, custom daemon configuration files, complex validation code using Jinja2 expressions, or custom reports.
+
+Please open an issue if you need an Ansible filter or **ipaddr** behavior that we did not implement.
+
+(bug-fixes-25.06)=
+## Bug Fixes
+
+* Bugs were fixed
+
+(doc-fixes-25.06)=
+## Documentation Fixes
+
+* Docs were fixed

--- a/netsim/cli/validate.py
+++ b/netsim/cli/validate.py
@@ -1122,8 +1122,6 @@ def run(cli_args: typing.List[str]) -> None:
     list_tests(topology)
     return
 
-  templates.load_ansible_filters()
-
   ERROR_ONLY = args.error_only
   cnt = 0
   start_time = _status.lock_timestamp() or time.time()

--- a/netsim/reports/bgp-asn.html.j2
+++ b/netsim/reports/bgp-asn.html.j2
@@ -1,6 +1,5 @@
 {# description: BGP autonomous systems (needs Ansible) #}
 {% import 'bgp-prefix.include.j2' as bcode %}
-{% include 'ipaddr.include.html.j2' %}
 {#
    First, figure out if we need RR column
 #}

--- a/netsim/reports/bgp-asn.md.j2
+++ b/netsim/reports/bgp-asn.md.j2
@@ -1,6 +1,5 @@
 {# description: BGP autonomous systems (needs Ansible) #}
 {% import 'bgp-prefix.include.j2' as bcode %}
-{% include 'ipaddr.include.j2' %}
 {#
    First, figure out if we need RR column
 #}

--- a/netsim/reports/bgp-prefix.include.j2
+++ b/netsim/reports/bgp-prefix.include.j2
@@ -11,22 +11,14 @@
     bgp.advertise_loopback is set
 #}
 {%     for af in ['ipv4','ipv6'] if 'loopback' in ndata and af in ndata.loopback and ndata.bgp.advertise_loopback|default(False) %}
-{%       if 'ipaddr' is filter %}
-{%         set ignore = pfx.append(ndata.loopback[af]|ipaddr('subnet')) %}
-{%       else %}
-{%         set ignore = pfx.append(ndata.loopback[af]) %}
-{%       endif %}
+{%       set ignore = pfx.append(ndata.loopback[af]|ipaddr('subnet')) %}
 {%     endfor %}
 {#
     Add interfaces with bgp.advertise attribute to the prefix list
 #}
 {%     for intf in ndata.interfaces if 'bgp' in intf and intf.bgp.advertise|default(False) %}
 {%       for af in ['ipv4','ipv6'] if af in intf and intf[af] is string %}
-{%         if 'ipaddr' is filter %}
-{%           set ignore = pfx.append(intf[af]|ipaddr('subnet')) %}
-{%         else %}
-{%           set ignore = pfx.append(intf[af]) %}
-{%         endif %}
+{%         set ignore = pfx.append(intf[af]|ipaddr('subnet')) %}
 {%       endfor %}
 {%     endfor %}
 {%- endmacro -%}

--- a/netsim/reports/bgp.j2
+++ b/netsim/reports/bgp.j2
@@ -1,6 +1,5 @@
 {# description: BGP autonomous systems and neighbors (needs Ansible)#}
 {% import 'bgp-prefix.include.j2' as bcode %}
-{% include 'ipaddr.include.j2' %}
 {#
    First, figure out if we need RR column
 #}

--- a/netsim/reports/ipaddr.include.html.j2
+++ b/netsim/reports/ipaddr.include.html.j2
@@ -1,7 +1,0 @@
-{% if not ('ipaddr' is filter) %}
-<p>
-This report uses Ansible <em>ipaddr<e/em> Jinja2 filter which is not present.
-The report will display IP addresses instead of subnets. To fix that,
-please install Ansible.
-</p>
-{% endif %}

--- a/netsim/reports/ipaddr.include.j2
+++ b/netsim/reports/ipaddr.include.j2
@@ -1,6 +1,0 @@
-{% if not ('ipaddr' is filter) %}
-This report uses Ansible 'ipaddr' Jinja2 filter which is not present.
-The report will display IP addresses instead of subnets. To fix that,
-please install Ansible.
-
-{% endif %}

--- a/netsim/utils/filters.py
+++ b/netsim/utils/filters.py
@@ -1,0 +1,86 @@
+# Networking-specific Jinja2 filters
+#
+# These filters replace the functionality of Ansible filters for templates rendered inside
+# netlab (provider configurations, reports, container files, daemon configs...) because
+# the crazy "we don't like _" decision introduced in Ansible release 12 breaks too many of them
+#
+# We're using slightly different filter names on purpose to identify any potential use of
+# Ansible filters
+#
+# Please note that the filter names have to start with 'j2_' -- that's how the template module
+# identifies them as Jinja2 filters
+#
+
+import typing
+
+import netaddr
+
+
+def ipaddr_filter(
+      value: typing.Any,
+      version: typing.Optional[int] = None) -> typing.Union[list,str]:
+
+  # If the IP address filter gets a list of values it recursively evaluates itself
+  # on each value in the list, the returns a list of non-empty values
+  #
+  if isinstance(value,list):
+    f_list: list = [ ipaddr_filter(f_value,version) for f_value in f_list ]
+    return [ f_value for f_value in f_list if f_value ]
+
+  try:
+    addr = netaddr.IPAddress(value)
+    return str(addr) if version is None or version == addr.version else ''
+  except:
+    return ''
+
+MAP_IPADDR: dict = {
+  'address': 'ip'
+}
+
+def j2_ipaddr(
+      value: typing.Any,
+      arg: typing.Union[int,str] = '',
+      version: typing.Optional[int] = None) -> typing.Union[list,str]:
+  global MAP_IPADDR
+
+  if arg == '':
+    return ipaddr_filter(value,version)
+
+  addr = netaddr.IPNetwork(value)
+  if isinstance(arg,int):
+    return str(addr[arg])
+  
+  if arg in MAP_IPADDR:
+    arg = MAP_IPADDR[arg]
+
+  if arg in ['prefix','subnet']:
+    return str(addr.network) + "/" + str(addr.prefixlen)
+
+  if arg in dir(addr):
+    return str(getattr(addr,str(arg)))
+
+  raise ValueError(f'Invalid argument {arg} passed to built-in ipaddr filter')
+
+def j2_ipv4(value: typing.Any, arg: typing.Union[int,str]) -> typing.Union[list,str]:
+  return j2_ipaddr(value,arg,4)
+
+def j2_ipv6(value: typing.Any, arg: typing.Union[int,str]) -> typing.Union[list,str]:
+  return j2_ipaddr(value,arg,6)
+
+# Format MAC addresses in Cisco/Unix/... format
+#
+def j2_hwaddr(value: typing.Any, format: str = '') -> str:
+  try:
+    mac = netaddr.EUI(value)                      # Try to parse the value as MAC address
+    if format == 'linux':                         # linux format is a synonym for unix
+      format = 'unix'
+    fmt = getattr(netaddr,f'mac_{format}')        # Try to get formatting constant
+    if not fmt:                                   # ... unknown constant?
+      raise ValueError(f'Invalid format {format} used in built-in hwaddr filter')
+    else:
+      return mac.format(dialect=fmt)              # All good, try to return the formatted MAC address
+  except:                                         # Value is not a MAC address :(
+    if format:                                    # If the user tried to format it, throw an error
+      raise ValueError(f'{value} is not a valid MAC address and cannot be formatted as {format}')
+    else:                                         # Otherwise it was a filter query, return empty string
+      return ''

--- a/tests/integration/initial/01-interfaces.yml
+++ b/tests/integration/initial/01-interfaces.yml
@@ -25,6 +25,7 @@ nodes:
   r:
     id: 132
     loopback: True
+    eos.systemmacaddr: ca-fe-0b-ad-00-01          # Check cEOS ceos-config clab template
   h1:
   h2:
 


### PR DESCRIPTION
Ansible 12.0 (ansible core 2.19) changed the way it handles dictionary keys starting with underscores. That change broke numerous netlab templates, forcing us to stay with Ansible release 11.x.

This is the first change in the get-well process -- replacing imported Ansible filters with built-in ipaddr and hwaddr filters, making netlab core functionality completely independent of Ansible.