### PR TITLE
OpenBSD OSPF: add missing redistribution part

### DIFF
--- a/netsim/ansible/templates/ospf/openbsd.j2
+++ b/netsim/ansible/templates/ospf/openbsd.j2
@@ -1,5 +1,6 @@
 {% import "openbsd.ospfv2.j2" as ospfv2 %}
 {% import "openbsd.ospfv3.j2" as ospfv3 %}
+#!/bin/sh
 {% if ospf.af.ipv4 is defined %}
 {{   ospfv2.config(False,ospf,netlab_interfaces) }}
 {% endif %}

--- a/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
@@ -1,7 +1,5 @@
 {% macro config(ospf_vrf,ospf_data,intf_data) %}
 {%- set areas = intf_data|selectattr('ipv4', 'defined')|map(attribute='ospf.area', default='')|reject('eq', '')|sort|unique %}
-#!/bin/sh
-
 cat <<OSPFD_CONF >/etc/ospfd.conf
 {% if ospf_data.router_id|ipv4 %}
 router-id {{ ospf_data.router_id }}
@@ -11,6 +9,11 @@ spf-holdtime msec 200
 {% if ospf_data.default is defined %}
 {%   set dfd = ospf_data.default %}
 redistribute default set { metric {{ dfd.cost|default(100) }} type {{ dfd.type|default('e1')|replace('e','') }} }
+{% endif %}
+{% if ospf_data.import is defined %}
+{%   for proto in ospf_data.import %}
+redistribute {{ proto }}
+{%   endfor %}
 {% endif %}
 
 {% for a in areas %}

--- a/netsim/ansible/templates/ospf/openbsd.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/openbsd.ospfv3.j2
@@ -1,7 +1,5 @@
 {% macro config(ospf_vrf,ospf_data,intf_data) %}
 {%- set areas = intf_data|selectattr('ipv6', 'defined')|map(attribute='ospf.area', default='')|reject('eq', '')|sort|unique %}
-#!/bin/sh
-
 cat <<OSPFD_CONF >/etc/ospf6d.conf
 {% if ospf_data.router_id is defined %}
 router-id {{ ospf_data.router_id }}
@@ -11,6 +9,11 @@ spf-holdtime 1
 {% if ospf_data.default is defined %}
 {%   set dfd = ospf_data.default %}
 redistribute default set { metric {{ dfd.cost|default(100) }} type {{ dfd.type|default('e1')|replace('e','') }} }
+{% endif %}
+{% if ospf_data.import is defined %}
+{%   for proto in ospf_data.import %}
+redistribute {{ proto }} 
+{%   endfor %}
 {% endif %}
 
 {% for a in areas %}


### PR DESCRIPTION
I missed the redistribution part previously. 
I think we do not need to filter for the protocols since the supported ones are listed in device features.

While here: move the shebang so it only gets printed once.