### PR TITLE
Fix 'when' conditions in Ansible playbooks/task lists

### DIFF
--- a/netsim/ansible/collect-configs.ansible
+++ b/netsim/ansible/collect-configs.ansible
@@ -31,7 +31,7 @@
 
   - include_tasks: "{{ collect_script }}"
     name: Collect device configurations
-    when: collect_script
+    when: collect_script is string and collect_script != ''
     args:
       apply:
         vars:

--- a/netsim/ansible/tasks/create-config.yml
+++ b/netsim/ansible/tasks/create-config.yml
@@ -19,7 +19,7 @@
       template:
         src: "{{ config_template }}"
         dest: "{{config_dir}}/{{inventory_hostname}}.{{item}}.cfg"
-    when: config_template
+    when: config_template is string and config_template != ''
 
   - block:
     - name: Throw an error message if we can't find the configuration template
@@ -41,6 +41,6 @@
       copy:
         src: "{{ deploy_script }}"
         dest: "{{config_dir}}/{{inventory_hostname}}.{{item}}.yml"
-      when: deploy_script
+      when: deploy_script is string and deploy_script != ''
 
     when: not config_template

--- a/netsim/ansible/tasks/deploy-config/sros.yml
+++ b/netsim/ansible/tasks/deploy-config/sros.yml
@@ -3,7 +3,7 @@
   set_fact: yaml_config={{ lookup('template',config_template) }}
 
 - name: Update {{ netsim_action }} node configuration from gNMI template {{ config_template  }}
-  when: d or u or r
+  when: d != [] or u != [] or r != []
   vars:
     cfg: "{{ yaml_config | from_yaml }}"
     d: "{{ cfg.delete if 'delete' in cfg and cfg.delete is not string else [] }}"
@@ -21,4 +21,4 @@
   tags: [ print_action, always ]
 
 - debug: var=gnmi_set_result
-  when: ansible_verbosity
+  when: ansible_verbosity > 0

--- a/netsim/ansible/tasks/deploy-custom-config.yml
+++ b/netsim/ansible/tasks/deploy-custom-config.yml
@@ -66,7 +66,7 @@
 - name: Run the configuration deployment script
   include_tasks: "{{ deploy_task }}"
   tags: [ custom ]
-  when: deploy_task
+  when: deploy_task is string and deploy_task != ''
   vars:
     node_provider: "{{ provider|default(netlab_provider) }}"
   args:

--- a/netsim/ansible/tasks/deploy-module.yml
+++ b/netsim/ansible/tasks/deploy-module.yml
@@ -47,7 +47,7 @@
         paths: "{{ paths_deploy.dirs }}"
         files: "{{ paths_deploy.files }}"
 
-  - when: config_template or netlab_config_tasks|default(False)
+  - when: (config_template is string and config_template != '') or (netlab_config_tasks|default(False))
     block:
     - name: "Print deployed configuration when running in verbose mode"
       debug:
@@ -59,7 +59,7 @@
 
     - name: "Deploy {{ config_module }} configuration"
       include_tasks: "{{ deploy_script }}"
-      when: do_deploy and deploy_script
+      when: do_deploy and (deploy_script is string and deploy_script != '')
       args:
         apply:
           vars:

--- a/netsim/ansible/tasks/wait-for-ready.yml
+++ b/netsim/ansible/tasks/wait-for-ready.yml
@@ -13,7 +13,7 @@
 
   - name: Wait for device to become ready
     include_tasks: "{{ ready_script }}"
-    when: ready_script|default('')
+    when: ready_script is string and ready_script != ''
     args:
       apply:
         tags: [ always ]


### PR DESCRIPTION
Ansible release 12 hates having non-bool expressions in 'when:' conditions, and we sloppily used 'when: string' all over the place.

This commit ensures every expression used in a 'when' condition is a true bool and uses 'when: x is string and x != ""' expression instead of 'when: x' (adding 'x is string' because the Ansible documentation is confusing enough that I don't trust what exactly they might do in a future release)