### PR TITLE
Fix: ensure that the 'indent' filter is not called on an empty string

### DIFF
--- a/netsim/ansible/templates/bgp/cumulus_nvue.macro.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.macro.j2
@@ -31,7 +31,9 @@
 {%     endif %}
               {{ af }}-unicast:
                 enable: on
+{%     if vrf_bgp.import is defined %}
 {{              redistribute.config(vrf_bgp,af=af)|indent(16,first=True) }}
+{%     endif %}
 {%     set _loopback = [ vrf.loopback[af]|ipaddr(0) ] if vrf.loopback[af] is defined and bgp.advertise_loopback|default(True) else [] %}
 {%     set data = namespace(networks=_loopback) %}
 {%     for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined and l.vrf|default('default')==vrf_name %}

--- a/netsim/ansible/templates/bgp/ios.j2
+++ b/netsim/ansible/templates/bgp/ios.j2
@@ -32,7 +32,9 @@ router bgp {{ bgp.as }}
 {% for af in ['ipv4','ipv6'] if bgp[af] is defined %}
  address-family {{ af }}
   bgp scan-time 5
-{{   redistribute.config(bgp,af=af,ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%   if bgp.import is defined %}
+{{     redistribute.config(bgp,af=af,ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%   endif %}
 !
 {%   if loopback[af] is defined and bgp.advertise_loopback %}
 {{     bgpcfg.bgp_network(af,loopback[af]) }}

--- a/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
+++ b/netsim/ansible/templates/bgp/sros.gnmi.macro.j2
@@ -31,8 +31,9 @@
           name: [ bgp ]
       action:
         action-type: accept
+{% if vrf_bgp.import is defined %}
 {{  import_protocols(vrf_bgp.import|default([])) | indent(4,first=True) }}
-
+{% endif %}
 {% for af in ['ipv4','ipv6'] if af in vrf_context.af and vrf_context.af[af] %}
 {% if loopback[af] is defined and vrf=="default" and bgp.advertise_loopback %}
 {{ bgp_export_prefix(vrf,loopback[af]|ipaddr('address')|ipaddr('host')) }}

--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -46,11 +46,13 @@ router isis {{ isis.instance }}
 {% for l in interfaces|default([]) if 'isis' in l and l.isis.passive %}
   passive-interface {{ l.ifname }}
 {% endfor %}
-{% if 'ipv4' in isis.af %}
+{% if 'ipv4' in isis.af and isis.import is defined %}
 {{   redistribute.config(isis,af='ipv4',ospf_pid=ospf.process|default(1))|indent(1,first=True) }}
 {% endif %}
 {% if isis.af.ipv6 is defined %}
   address-family ipv6
     multi-topology
-{{   redistribute.config(isis,af='ipv6',ospf_pid=ospf.process|default(1))|indent(3,first=True) }}
+{%   if isis.import is defined %}
+{{     redistribute.config(isis,af='ipv6',ospf_pid=ospf.process|default(1))|indent(3,first=True) }}
+{%   endif %}
 {% endif %}

--- a/netsim/ansible/templates/isis/junos.j2
+++ b/netsim/ansible/templates/isis/junos.j2
@@ -23,7 +23,9 @@ protocols {
 {%   if l.isis.network_type is defined %}
       {{ l.isis.network_type }};
 {%   endif %}
-{{   disable_level(l.isis.type)|indent(2,first=True) }}
+{%   if '1-2' not in l.isis.type|default('1-2') %}
+{{     disable_level(l.isis.type)|indent(2,first=True) }}
+{%   endif %}
 {%   if l.isis.passive %}
       passive;
 {%   endif %}

--- a/netsim/ansible/templates/ospf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/ospf/cumulus_nvue.j2
@@ -16,7 +16,9 @@
             enable: on
             area: 
               {{ _ospf.area|default(ospf.area) }}: {}
-{{     redistribute.config(_ospf,af='ipv4')|indent(12,first=True) }}
+{%     if _ospf.import is defined %}
+{{       redistribute.config(_ospf,af='ipv4')|indent(12,first=True) }}
+{%     endif %}
 {%     if _ospf.reference_bandwidth is defined %}
             reference-bandwidth: {{ _ospf.reference_bandwidth }}
 {%     endif %}

--- a/netsim/ansible/templates/ospf/ios.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/ios.ospfv2.j2
@@ -17,7 +17,9 @@ router ospf {{ ospf_pid }}
  passive-interface {{ l.ifname }}
 {% endfor %}
 {{ ospf_default.config(ospf_data,'ipv4') }}
-{{ redistribute.config(ospf_data,af='ipv4',t_proto='ospf',vrf=ospf_vrf) }}
+{% if ospf.import is defined %}
+{{   redistribute.config(ospf_data,af='ipv4',t_proto='ospf',vrf=ospf_vrf) }}
+{% endif %}
 !
 {% for l in intf_data if 'ospf' in l and ('ipv4' in l or 'ipv4' in l.dhcp.client|default({})) %}
 interface {{ l.ifname }}

--- a/netsim/ansible/templates/ospf/ios.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/ios.ospfv3.j2
@@ -15,8 +15,12 @@ router ospfv3 {{ ospf_pid }}
 {% for l in intf_data if l.ospf.passive|default(False) %}
   passive-interface {{ l.ifname }}
 {% endfor %}
-{{ ospf_default.config(ospf_data,'ipv6')|indent(1,first=True) }}
-{{ redistribute.config(ospf_data,af='ipv6',vrf=ospf_vrf)|indent(1,first=True) }}
+{% if ospf.default is defined %}
+{{   ospf_default.config(ospf_data,'ipv6')|indent(1,first=True) }}
+{% endif %}
+{% if ospf.import is defined %}
+{{   redistribute.config(ospf_data,af='ipv6',vrf=ospf_vrf)|indent(1,first=True) }}
+{% endif %}
 !
 {% for l in intf_data if 'ospf' in l and ('ipv6' in l or 'ipv6' in l.dhcp.client|default({})) %}
 interface {{ l.ifname }}

--- a/netsim/ansible/templates/ripv2/ios.macro.j2
+++ b/netsim/ansible/templates/ripv2/ios.macro.j2
@@ -15,7 +15,9 @@ router rip
 {%     if 'timers' in ripv2 %}
   timers basic {{ ripv2.timers['update'] }} {{ ripv2.timers.timeout }} {{ ripv2.timers.garbage }} 1
 {%     endif %}
-{{     redistribute.config(ripv2,af='ipv4',ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%     if ripv2.import is defined %}
+{{       redistribute.config(ripv2,af='ipv4',ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%     endif %}
 {%     for intf in ripv2.interfaces|default(netlab_interfaces) %}
 {%       if 'ripv2' in intf and intf.ipv4|default(False) is string %}
   network {{ intf.ipv4|ipaddr('address') }}
@@ -36,7 +38,9 @@ ipv6 router rip default
 {%     if 'timers' in ripv2 %}
   timers {{ ripv2.timers['update'] }} {{ ripv2.timers.timeout }} {{ ripv2.timers.garbage }} 1
 {%     endif %}
-{{     redistribute.config(ripv2,af='ipv6',ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%     if ripv2.import is defined %}
+{{       redistribute.config(ripv2,af='ipv6',ospf_pid=ospf_pid)|indent(1,first=True) }}
+{%     endif %}
 !
 {%     for intf in ripv2.interfaces|default(netlab_interfaces) if 'ripv2' in intf and 'ipv6' in intf %}
 !

--- a/netsim/ansible/templates/routing/_redistribute.ios.j2
+++ b/netsim/ansible/templates/routing/_redistribute.ios.j2
@@ -2,20 +2,18 @@
   {% if 'policy' in sp_data %} route-map {{ sp_data.policy }}-{{ af }}{% endif +%}
 {%- endmacro %}
 {% macro config(pdata,af='ipv4',t_proto='',ospf_pid=1,vrf='default') -%}
-{%   if pdata.import is defined %}
-{%     set r_append = ' subnets' if t_proto == 'ospf' else '' %}
-{%     for s_proto,s_data in pdata.import.items() %}
-{%       set sp_config = s_proto %}
-{%       if s_proto == 'bgp' %}
-{%         set sp_config = sp_config + ' ' + bgp.as|string %}
-{%       elif s_proto == 'isis' %}
-{%         set sp_config = sp_config + ' ' + isis.instance + ' level-1-2' %}
-{%       elif s_proto == 'ospf' %}
-{%         set sp_config = sp_config + ' ' + ospf_pid|string + ' match internal external' %}
-{%       elif s_proto == 'rip' and af == 'ipv6' %}
-{%         set sp_config = sp_config + ' default' %}
-{%       endif %}
+{%   set r_append = ' subnets' if t_proto == 'ospf' else '' %}
+{%   for s_proto,s_data in pdata.import.items() %}
+{%     set sp_config = s_proto %}
+{%     if s_proto == 'bgp' %}
+{%       set sp_config = sp_config + ' ' + bgp.as|string %}
+{%     elif s_proto == 'isis' %}
+{%       set sp_config = sp_config + ' ' + isis.instance + ' level-1-2' %}
+{%     elif s_proto == 'ospf' %}
+{%       set sp_config = sp_config + ' ' + ospf_pid|string + ' match internal external' %}
+{%     elif s_proto == 'rip' and af == 'ipv6' %}
+{%       set sp_config = sp_config + ' default' %}
+{%     endif %}
  redistribute {{ sp_config }}{{ policy(s_data,af) }}
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
 {%- endmacro %}

--- a/netsim/ansible/templates/vrf/eos.bgp.j2
+++ b/netsim/ansible/templates/vrf/eos.bgp.j2
@@ -27,7 +27,9 @@ router bgp {{ bgp.as }}
 {%   for af in ['ipv4','ipv6'] if af in vdata.af|default({}) %}
 !
   address-family {{ af }}
-{{     redistribute.config(vdata.bgp,af=af)|indent(2,first=True) }}
+{%     if vdata.bgp.import is defined %}
+{{       redistribute.config(vdata.bgp,af=af)|indent(2,first=True) }}
+{%     endif %}
 {%     for n in vdata.networks|default([]) if af in n %}
     network {{ n[af]|ipaddr('0') }}
 {%     endfor %}

--- a/netsim/ansible/templates/vrf/frr.bgp.j2
+++ b/netsim/ansible/templates/vrf/frr.bgp.j2
@@ -20,7 +20,9 @@ router bgp {{ vdata.as|default(bgp.as) }} vrf {{ vname }}
 {% endfor %}
 {% for af in ['ipv4','ipv6'] if vdata.af[af]|default(False) %}
  address-family {{ af }} unicast
-{{   redistribute.config(vdata.bgp,af=af)|indent(1,first=True) }}
+{%   if vdata.bgp.import is defined %}
+{{     redistribute.config(vdata.bgp,af=af)|indent(1,first=True) }}
+{%   endif %}
   label vpn export auto
   export vpn
   import vpn

--- a/netsim/ansible/templates/vrf/ios.bgp.j2
+++ b/netsim/ansible/templates/vrf/ios.bgp.j2
@@ -6,7 +6,9 @@ router bgp {{ bgp.as }}
 {%   for af in ('ipv4','ipv6') if af in vdata.af|default({}) %}
  address-family {{ af }} vrf {{ vname }}
   bgp router-id {{ vdata.bgp.router_id|default(bgp.router_id) }}
-{{     redistribute.config(vdata.bgp,af=af,ospf_pid=vdata.vrfidx,vrf=vname)|indent(1,first=True) }}
+{%     if vdata.bgp.import is defined %}
+{{       redistribute.config(vdata.bgp,af=af,ospf_pid=vdata.vrfidx,vrf=vname)|indent(1,first=True) }}
+{%     endif %}
 !
 {%     for n in vdata.networks|default([]) if af in n %}
 {{       bgpcfg.bgp_network(af,n[af]) }}


### PR DESCRIPTION
I have no idea why a Jinja2 macro that generates no text returns 'None' when used in Ansible 12.x, but the 'None' value crashes the standard Jinja2 indent filter (but then, nothing Ansible-related surprises me anymore).

Anyway, the sane workaround seems to be to add a condition around every '{{ some_macro()|indent }}' expressions to ensure 'some_macro' is called (and the result piped through indent) only when it returns something.