### PR TITLE
SRv6 implementation on IOS-XE (IOL, IOLL2, Cat8000v)

### DIFF
--- a/docs/module/srv6.md
+++ b/docs/module/srv6.md
@@ -14,20 +14,24 @@ The module currently depends on IS-IS and will trigger a configuration error if 
 ## Platform Support
 The following table describes the per-platform support of individual router-level SRv6 features:
 
-| Operating system         | IS-IS | OSPFv3 | BGP v4/v6 | Transit only |
-| ------------------------ |:-----:|:------:|:---------:|:-------------:
-| FRR                      |   ✅  |   ❌   |    ❌     |      ❌      | 
-| Nokia SR OS[^SROS]       |   ✅  |   ❌   |    ✅     |      ✅      |
+| Operating system   | IS-IS | OSPFv3 | BGP v4/v6 | Transit only |
+|--------------------|:--:|:-:|:-:|:-:|
+| Cisco IOS/XE[^XE]  | ✅ | ❌ | ❌ | ❌ |
+| FRR                | ✅ | ❌ | ❌ | ❌ | 
+| Nokia SR OS[^SROS] | ✅ | ❌ | ✅ | ✅ |
 
 [^SROS]: Includes the Nokia SR-SIM container and the Virtualized 7750 SR and 7950 XRS Simulator (vSIM) virtual machine
+
+[^XE]: Includes Catalyst 8000v, Cisco IOL, and Cisco IOL layer-2 image. The minimum Cisco IOS/XE release with working SRv6 is release 17.16.01a.
 
 (srv6-l3vpn-supported-platforms)=
 ### BGP/SRv6 L3VPN
 
 | Operating system      | VPNv4 | VPNv6 |
 | ----------------------| :---: | :---: |
-| FRR                   |   ✅  |   ✅ [❗️](caveats-frr)  |
-| Nokia SR OS[^SROS]    |   ❌  |   ❌  |
+| Cisco IOS/XE[^XE]     |   ✅  |  ✅  |
+| FRR                   |   ✅  |  ✅ [❗️](caveats-frr)  |
+| Nokia SR OS[^SROS]    |   ❌   |   ❌  |
 
 **Notes**
 * VPNv4 and VPNv6 address families are enabled on IPv6 IBGP sessions
@@ -35,7 +39,7 @@ The following table describes the per-platform support of individual router-leve
 ## Configurable Global and Node Parameters
 
 * **addressing.srv6_locator** -- global address pool[^poolname] for allocation of SRv6 locator prefixes, the default prefix is defined in `topology.defaults.srv6.locator_pool` (5F00::/16, the IANA reserved range defined by [RFC9602](https://datatracker.ietf.org/doc/rfc9602/)
-* **srv6.allocate_loopback** -- global flag (default: `True`) to replace the IPv6 loopback address of each SRv6-enabled node with an IP allocated from the locator range
+* **srv6.allocate_loopback** -- global flag (default: `False`) to replace the IPv6 loopback address of each SRv6-enabled node with an IPv6 address allocated from the locator range
 * **srv6.bgp** -- enable BGP with IPv4 and IPv6 address families over SRv6, default IPv4 + IPv6 over iBGP.
 * **srv6.vpn** -- enable BGP with VPNv4 and VPNv6 address families over SRv6. BGP/SRv6 L3VPN is disabled by default.
 * **srv6.igp** -- list of IGP protocols for which to enable SRv6, default `[isis]`

--- a/netsim/ansible/templates/srv6/ios.bgp.j2
+++ b/netsim/ansible/templates/srv6/ios.bgp.j2
@@ -1,0 +1,13 @@
+router bgp {{ bgp.as }}
+!
+{% for af in srv6.vpn %}
+ address-family {{ af.replace('ip','vpn') }}
+  segment-routing srv6
+   locator {{ inventory_hostname }}
+   alloc-mode per-vrf
+  exit-srv6
+{%   for n in bgp.neighbors|default([]) if n.ipv6 is defined and n.type in srv6.vpn[af] %}
+  neighbor {{ n.ipv6 }} activate
+  neighbor {{ n.ipv6 }} send-community both
+{%   endfor %}
+{% endfor %}

--- a/netsim/ansible/templates/srv6/ios.j2
+++ b/netsim/ansible/templates/srv6/ios.j2
@@ -1,0 +1,19 @@
+!
+segment-routing srv6
+ encapsulation
+  source-address {{ loopback.ipv6|ipaddr('address') }}
+ locators
+  locator {{ inventory_hostname }}
+   prefix {{ srv6.locator }}
+   format usid-f3216
+!
+{% if 'isis' in srv6.igp|default([]) and isis.instance is defined %}
+router isis {{ isis.instance }}
+ address-family ipv6 unicast
+ segment-routing srv6
+  locator {{ inventory_hostname }}
+{% endif %}
+
+{% if srv6.vpn is defined and bgp.as is defined %}
+{%   include "ios.bgp.j2" %}
+{% endif %}

--- a/netsim/devices/cat8000v.yml
+++ b/netsim/devices/cat8000v.yml
@@ -14,6 +14,10 @@ group_vars:
 node:
   min_mtu: 1500
 features:
+  srv6:
+    bgp: false
+    isis: true
+    vpn: true
   vxlan: false
   vlan:
     model: l3-switch

--- a/netsim/devices/iol.py
+++ b/netsim/devices/iol.py
@@ -3,11 +3,22 @@
 #
 from box import Box
 
-from . import _Quirks
+from ..utils import log
+from . import _Quirks, report_quirk
 from .iosv import check_ripng_passive
 
+
+def check_srv6_sid(node: Box, topology: Box) -> None:
+  if node.get('srv6.allocate_loopback',False):
+    report_quirk(
+      f'SRv6 SID on Cisco IOS-XE cannot overlap with the loopback address',
+      node,
+      quirk='srv6.sid',
+      more_hints=['Set the srv6.allocate_loopback parameter to False'],
+      category=log.IncorrectValue)
 
 class IOSXE(_Quirks):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     check_ripng_passive(node,topology)
+    check_srv6_sid(node,topology)

--- a/netsim/devices/iol.yml
+++ b/netsim/devices/iol.yml
@@ -21,6 +21,10 @@ features:
     ipv4:
       unnumbered: true
   sr: true
+  srv6:
+    bgp: false
+    isis: true
+    vpn: true
   vlan:
     model: l3-switch
     svi_interface_name: BDI{vlan}

--- a/netsim/modules/srv6.yml
+++ b/netsim/modules/srv6.yml
@@ -6,7 +6,7 @@ config_after: [ vlan, isis, ospf, bgp ]
 transform_after: [ vlan, bgp, vrf ]
 no_propagate: [ locator_pool ]
 
-allocate_loopback: True     # Replace the IPv6 loopback address with an IP from locator pool range, for each SRv6 node
+allocate_loopback: False    # Replace the IPv6 loopback address with an IP from locator pool range, for each SRv6 node
 locator_pool: 5F00::/16     # Default address pool for locators based on the IANA reserved range in RFC9602
                             # See https://datatracker.ietf.org/doc/html/rfc9602
 igp: [ isis ]               # By default, enable SRv6 over IS-IS

--- a/tests/integration/srv6/02-isis-ipv4-bgp-vpn.yml
+++ b/tests/integration/srv6/02-isis-ipv4-bgp-vpn.yml
@@ -9,14 +9,14 @@ defaults.sources.extra: [ ../wait_times.yml ]
 addressing:
   core:
     ipv4: False                      # ipv6-only
-    ipv6: 2001:1::/48                # SRv6 requires ipv6 addresses on interfaces
+    ipv6: 2001:db8:1::/48            # SRv6 requires ipv6 addresses on interfaces
 
   p2p:
     ipv6: False
 
   loopback:
     ipv4: False                      # No need for ipv4 loopbacks, this avoids creating ipv4 ibgp sessions too
-    ipv6: 5F00::/16                  # Using loopbacks within the SRv6 locator range
+    ipv6: 2001:db8::/48
 
   lb_ce:
     ipv4: 192.168.0.0/24
@@ -25,7 +25,7 @@ addressing:
   lan:
     ipv6: False
 
-srv6.allocate_loopback: True         # Override the ipv6 loopback address
+srv6.allocate_loopback: False        # Keep loopback interface outside of SRv6 SID
 
 srv6.bgp: False                      # No plain IPv4/6 in the overlay
 srv6.vpn:

--- a/tests/integration/srv6/12-isis-ipv6-bgp-vpn.yml
+++ b/tests/integration/srv6/12-isis-ipv6-bgp-vpn.yml
@@ -8,26 +8,22 @@ defaults.sources.extra: [ ../wait_times.yml ]
 
 addressing:
   core:
-    ipv4: False                      # ipv6-only
-    ipv6: 2001:1::/48                # SRv6 requires ipv6 addresses on interfaces
+    ipv4: False                      # ipv6-only core
+    ipv6: 2001:db8:1::/48
 
   p2p:
     ipv4: False
-    ipv6: 2001:db8:1::/48
+    ipv6: 2001:db8:2::/48
 
   loopback:
     ipv4: False                      # No need for ipv4 loopbacks, this avoids creating ipv4 ibgp sessions too
-    ipv6: 5F00::/16                  # Using loopbacks within the SRv6 locator range
-
-  lb_ce:
     ipv6: 2001:db8::/48
-    prefix: 32
 
   lan:
     ipv4: False
-    ipv6: 2001:db8:2::/48
+    ipv6: 2001:db8:3::/48
 
-srv6.allocate_loopback: True         # Override the ipv6 loopback address
+srv6.allocate_loopback: False        # Override the ipv6 loopback address
 
 srv6.bgp: False                      # No plain IPv4/6 in the overlay
 srv6.vpn:
@@ -53,7 +49,6 @@ groups:
   ce:
     members: [ ce1, ce2 ]
     module: [ bgp ]
-    loopback.pool: lb_ce
   x_switches:
     members: [ p, pe2, ce1, ce2 ]
     device: frr


### PR DESCRIPTION
Implemented features:

* SRv6 with IS-IS
* L3VPN (IPv4 and IPv6) over SRv6

Other changes:

* srv6.allocate_loopback default value is changed to 'False' It makes no sense to use a default value that a majority of supported devices cannot work with.
* Integration tests were adjusted to use a loopback pool that is outside of SRv6 SID