### PR TITLE
Set bgp.advertise on main loopback to simplify BGP config templates

### DIFF
--- a/netsim/ansible/templates/bgp/eos.j2
+++ b/netsim/ansible/templates/bgp/eos.j2
@@ -65,15 +65,22 @@ router bgp {{ bgp.as }}
 !
  address-family {{ af }}
 {{     redistribute.config(bgp,af=af) }}
-{%     if loopback[af] is defined and bgp.advertise_loopback %}
-  network {{ loopback[af]|ipaddr('0') }}
-{%     endif %}
 !
-{%     for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+{%     for l in netlab_interfaces if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+{%     if loop.first %}
+!
+! Originate networks from connected subnets
+!
+{%     endif %}
   network {{ l[af]|ipaddr('0') }}
 {%     endfor %}
 !
 {%     for pfx in bgp.originate|default([]) if af == 'ipv4' %}
+{%     if loop.first %}
+!
+! Originate networks from static routes
+!
+{%     endif %}
   network {{ pfx|ipaddr('0') }}
 {%     endfor %}
 !

--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -46,16 +46,20 @@ router bgp {{ bgp.as }}
  address-family {{ af }} unicast
 !
 {{   redistribute.config(bgp,af=af) }}
-{%   if loopback[af] is defined and bgp.advertise_loopback %}
+{%   for l in netlab_interfaces if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+{%     if loop.first %}
 !
-  network {{ loopback[af]|ipaddr(0) }}
-{%   endif %}
+! Originate networks from connected subnets
 !
-{%   for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+{%     endif %}
   network {{ l[af]|ipaddr(0) }}
 {%   endfor %}
-!
 {%   for pfx in bgp.originate|default([]) if af == 'ipv4' %}
+{%     if loop.first %}
+!
+! Originate networks from static routes
+!
+{%     endif %}
   network {{ pfx|ipaddr('0') }}
 {%   endfor %}
 !

--- a/netsim/ansible/templates/bgp/ios.j2
+++ b/netsim/ansible/templates/bgp/ios.j2
@@ -34,14 +34,20 @@ router bgp {{ bgp.as }}
   bgp scan-time 5
 {{   redistribute.config(bgp,af=af,ospf_pid=ospf_pid)|indent(1,first=True) }}
 !
-{%   if loopback[af] is defined and bgp.advertise_loopback %}
-{{     bgpcfg.bgp_network(af,loopback[af]) }}
-{%   endif %}
+{%   for l in netlab_interfaces if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+{%     if loop.first %}
 !
-{%   for l in interfaces|default([]) if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
+! Originate networks from connected subnets
+!
+{%     endif %}
 {{     bgpcfg.bgp_network(af,l[af]) }}
 {%   endfor %}
 {%   for pfx in bgp.originate|default([]) if af == 'ipv4' %}
+{%     if loop.first %}
+!
+! Originate networks from static routes
+!
+{%     endif %}
 {{     bgpcfg.bgp_network(af,pfx) }}
 {%   endfor %}
 !

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -534,7 +534,9 @@ bgp_set_advertise: set bgp.advertise flag on stub links and on loopback interfac
 def bgp_set_advertise(node: Box, topology: Box) -> None:
   stub_roles = data.get_global_parameter(topology,"bgp.advertise_roles") or []
 
-  for l in node.get("interfaces",[]):
+  # Process regular interfaces and the loopback interface (if it exists)
+  #
+  for l in node.get("interfaces",[]) + ([ node.loopback ] if 'loopback' in node else []):
     if "bgp" in l:
       if l.bgp is False:                    # Skip interfaces on which we don't want to run BGP
         continue

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -175,6 +175,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -238,6 +240,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32
@@ -417,6 +421,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.1
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -533,6 +539,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -245,6 +245,8 @@ nodes:
       system_id: 0000.0000.0007
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:7::1/64
@@ -400,6 +402,8 @@ nodes:
       system_id: 0000.0000.0021
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:15::1/64
@@ -533,6 +537,8 @@ nodes:
       system_id: 0000.0000.0042
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:2a::1/64
@@ -650,6 +656,8 @@ nodes:
       system_id: 0000.0000.0001
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8:0:1::1/64

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -190,6 +190,8 @@ nodes:
       system_id: 0000.0000.0007
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::7/128
@@ -330,6 +332,8 @@ nodes:
       system_id: 0000.0000.0021
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::15/128
@@ -457,6 +461,8 @@ nodes:
       system_id: 0000.0000.0042
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::2a/128
@@ -541,6 +547,8 @@ nodes:
     id: 1
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv6: 2001:db8::1/128

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -89,6 +89,8 @@ nodes:
     id: 1
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -147,6 +149,8 @@ nodes:
       role: stub
       type: stub
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -92,6 +92,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -171,6 +173,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -448,6 +448,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -563,6 +565,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -660,6 +664,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -805,6 +811,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -125,6 +125,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -213,6 +215,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -324,6 +328,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/bgp-confederation.yml
+++ b/tests/topology/expected/bgp-confederation.yml
@@ -228,6 +228,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -337,6 +339,8 @@ nodes:
         passive: false
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -455,6 +459,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -537,6 +543,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -609,6 +617,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32

--- a/tests/topology/expected/bgp-ibgp-localas.yml
+++ b/tests/topology/expected/bgp-ibgp-localas.yml
@@ -249,6 +249,8 @@ nodes:
         mode: irb
         name: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -334,6 +336,8 @@ nodes:
           name: red
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 172.42.1.1/24
@@ -424,6 +428,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 172.42.2.1/24
@@ -502,6 +508,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -578,6 +586,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 172.42.4.1/24

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -170,6 +170,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: loopback0
       ipv4: 10.0.0.1/32
@@ -289,6 +291,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -419,6 +423,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: loopback0
       ipv4: 10.0.0.3/32
@@ -548,6 +554,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -140,6 +140,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -227,6 +229,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -175,6 +175,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32
@@ -231,6 +233,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.6/32
@@ -337,6 +341,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -443,6 +449,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -548,6 +556,8 @@ nodes:
         node: pe2
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -653,6 +663,8 @@ nodes:
         node: pe2
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/bgp-rs-2as.yml
+++ b/tests/topology/expected/bgp-rs-2as.yml
@@ -118,6 +118,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -196,6 +198,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -275,6 +279,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -355,6 +361,8 @@ nodes:
       role: external
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -163,6 +163,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -260,6 +262,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -348,6 +352,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -306,6 +306,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -397,6 +399,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -464,6 +468,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -523,6 +529,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -612,6 +620,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -121,6 +121,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -207,6 +209,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -268,6 +272,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -195,6 +195,8 @@ nodes:
         routed_link: true
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -456,6 +458,8 @@ nodes:
         routed_link: true
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -662,6 +666,8 @@ nodes:
         routed_link: true
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -249,6 +249,8 @@ nodes:
       role: stub
       type: stub
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32
@@ -361,6 +363,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.6/32
@@ -533,6 +537,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -670,6 +676,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -809,6 +817,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -948,6 +958,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -411,6 +411,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -499,6 +501,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -634,6 +638,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32
@@ -838,6 +844,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.6/32
@@ -1042,6 +1050,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.7/32
@@ -1186,6 +1196,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.8/32
@@ -1330,6 +1342,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.10/32
@@ -1534,6 +1548,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.12/32
@@ -1738,6 +1754,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.13/32
@@ -1882,6 +1900,8 @@ nodes:
         passive: false
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.14/32

--- a/tests/topology/expected/device-module-defaults.yml
+++ b/tests/topology/expected/device-module-defaults.yml
@@ -92,6 +92,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.1/32
@@ -150,6 +152,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -278,6 +278,8 @@ nodes:
       type: p2p
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -368,6 +370,8 @@ nodes:
           keepalive: 3
         type: ebgp
       - _source_intf:
+          bgp:
+            advertise: true
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.2/32
@@ -433,6 +437,8 @@ nodes:
       type: p2p
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -523,6 +529,8 @@ nodes:
           keepalive: 3
         type: ebgp
       - _source_intf:
+          bgp:
+            advertise: true
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.3/32
@@ -573,6 +581,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -663,6 +673,8 @@ nodes:
         node: r1
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -556,6 +556,8 @@ nodes:
         name: blue
       vrf: tenant
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -901,6 +903,8 @@ nodes:
         name: red
       vrf: tenant
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -104,6 +104,8 @@ nodes:
       type: p2p
       vrf: hub
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -200,6 +202,8 @@ nodes:
       type: p2p
       vrf: spoke
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -146,6 +146,8 @@ nodes:
       type: stub
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -273,6 +275,8 @@ nodes:
       type: stub
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -106,6 +106,8 @@ nodes:
         name: red
       vrf: tenant
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -99,6 +99,8 @@ nodes:
         mode: irb
         name: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -563,6 +563,8 @@ nodes:
         mode: irb
         name: blue
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -761,6 +763,8 @@ nodes:
         mode: irb
         name: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -907,6 +911,8 @@ nodes:
         mode: irb
         name: blue
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -338,6 +338,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.5/32
@@ -466,6 +468,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.6/32
@@ -668,6 +672,8 @@ nodes:
       role: stub
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -768,6 +774,8 @@ nodes:
       role: stub
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -853,6 +861,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -938,6 +948,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -262,6 +262,8 @@ nodes:
         passive: false
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -108,6 +108,8 @@ nodes:
     id: 1
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -177,6 +179,8 @@ nodes:
     id: 2
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.2/32
@@ -246,6 +250,8 @@ nodes:
     id: 3
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.3/32
@@ -315,6 +321,8 @@ nodes:
     id: 4
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.4/32
@@ -384,6 +392,8 @@ nodes:
     id: 5
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.5/32
@@ -453,6 +463,8 @@ nodes:
     id: 6
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: lo
       ipv4: 10.0.0.6/32

--- a/tests/topology/expected/module-node-global-params.yml
+++ b/tests/topology/expected/module-node-global-params.yml
@@ -114,6 +114,8 @@ nodes:
         node: r1
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/module-node-global.yml
+++ b/tests/topology/expected/module-node-global.yml
@@ -64,6 +64,8 @@ nodes:
     id: 2
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/module-node-only.yml
+++ b/tests/topology/expected/module-node-only.yml
@@ -71,6 +71,8 @@ nodes:
     id: 2
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/module-node-params.yml
+++ b/tests/topology/expected/module-node-params.yml
@@ -105,6 +105,8 @@ nodes:
     id: 2
     interfaces: []
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/module-reorder.yml
+++ b/tests/topology/expected/module-reorder.yml
@@ -174,6 +174,8 @@ nodes:
       system_id: 0000.0000.0001
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -342,6 +344,8 @@ nodes:
       system_id: 0000.0000.0003
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32
@@ -462,6 +466,8 @@ nodes:
       system_id: 0000.0000.0004
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -164,6 +164,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.1
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -299,6 +301,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -177,6 +177,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.5/32
@@ -251,6 +253,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.6/32
@@ -475,6 +479,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.1
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -616,6 +622,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -734,6 +742,8 @@ nodes:
         ipv4: true
       router_id: 10.0.0.4
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.4/32

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -97,6 +97,8 @@ nodes:
       type: p2p
       vrf: node
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -184,6 +186,8 @@ nodes:
         vrf: node
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/removed-attr-inheritance.yml
+++ b/tests/topology/expected/removed-attr-inheritance.yml
@@ -200,6 +200,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -296,6 +298,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -363,6 +367,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -103,6 +103,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -192,6 +194,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -128,6 +128,8 @@ nodes:
           name: red
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -207,6 +209,8 @@ nodes:
           name: red
       type: lan
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -240,6 +240,8 @@ nodes:
       system_id: 0000.0000.0001
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -505,6 +507,8 @@ nodes:
       system_id: 0000.0000.0002
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -733,6 +737,8 @@ nodes:
       role: external
       type: p2p
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -204,6 +204,8 @@ nodes:
       type: p2p
       vrf: blue
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -430,6 +432,8 @@ nodes:
       type: p2p
       vrf: red
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -624,6 +628,8 @@ nodes:
       virtual_interface: true
       vrf: blue
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -377,6 +377,8 @@ nodes:
       system_id: 0000.0000.0001
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -802,6 +804,8 @@ nodes:
       system_id: 0000.0000.0002
       type: level-2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
@@ -1081,6 +1085,8 @@ nodes:
       type: p2p
       vrf: b_2
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.3/32

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -162,6 +162,8 @@ nodes:
       virtual_interface: true
       vrf: blue
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
@@ -345,6 +347,8 @@ nodes:
       virtual_interface: true
       vrf: black
     loopback:
+      bgp:
+        advertise: true
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32


### PR DESCRIPTION
This change makes it simpler to write BGP configuration templates. It includes a simple fix
to the BGP module, proof-of-concept templates (EOS, FRR, IOS), and tons of changes in
transformation test results.

There's no need to adapt any other configuration template at this moment; this just makes
it easier to create new templates.