### PR TITLE
FRR: Use 'rr_client' neighbor attribute to configure EVPN RR client

### DIFF
--- a/netsim/ansible/templates/evpn/frr.evpn-config.j2
+++ b/netsim/ansible/templates/evpn/frr.evpn-config.j2
@@ -23,7 +23,7 @@ router bgp {{ bgp.as }}
 {%   set peer = n[af] if n[af] is string else n.local_if|default('?') %}
   neighbor {{ peer }} activate
 #  neighbor {{ peer }} soft-reconfiguration inbound
-{%   if bgp.rr|default('') and not n.rr|default('') %}
+{%   if n.rr_client|default(False) %}
   neighbor {{ peer }} route-reflector-client
 {%   endif %}
 {%  endfor %}


### PR DESCRIPTION
FRR EVPN template configured neighbors as RR clients whenever the bgp.rr attribute was set, and tried to do that on EBGP neighbors. FRR BGP daemon was not amused.