### PR TITLE
Generalize vjunos/vptx device-specific readiness script

### DIFF
--- a/netsim/ansible/tasks/readiness-check/junos.yml
+++ b/netsim/ansible/tasks/readiness-check/junos.yml
@@ -1,0 +1,10 @@
+---
+- name: Wait for first interface ({{ interfaces[0].junos_interface }})
+  junos_command:
+    commands:
+    - show interfaces terse
+    wait_for:
+    - result[0] contains {{ interfaces[0].junos_interface }}
+    interval: 5
+    retries: 60
+  when: interfaces

--- a/netsim/ansible/tasks/readiness-check/vjunos-router.yml
+++ b/netsim/ansible/tasks/readiness-check/vjunos-router.yml
@@ -1,1 +1,0 @@
-vjunos-switch.yml

--- a/netsim/ansible/tasks/readiness-check/vjunos-switch.yml
+++ b/netsim/ansible/tasks/readiness-check/vjunos-switch.yml
@@ -1,9 +1,0 @@
----
-- name: Wait for ge-0/0/0 to appear
-  junos_command:
-    commands:
-    - show interfaces terse
-    wait_for:
-    - result[0] contains ge-0/0/0
-    interval: 5
-    retries: 30

--- a/netsim/ansible/tasks/readiness-check/vptx.yml
+++ b/netsim/ansible/tasks/readiness-check/vptx.yml
@@ -1,9 +1,0 @@
----
-- name: Wait for et-0/0/0 to appear
-  junos_command:
-    commands:
-    - show interfaces terse
-    wait_for:
-    - result[0] contains et-0/0/0
-    interval: 5
-    retries: 60


### PR DESCRIPTION
This change replaces a device-specific readiness script testing the presence of a specific interface on vjunos-router, vjunos-switch, and vptx, with a generic Junos script testing for the presence of first interface used in netlab topology.