### PR TITLE
ArubaCX: Check for static route nexthop data before using it

### DIFF
--- a/netsim/ansible/templates/routing/arubacx.j2
+++ b/netsim/ansible/templates/routing/arubacx.j2
@@ -40,7 +40,10 @@ ip route {{
 {%   endif %}
 {%   if 'ipv6' in sr_data %}
 {%   set nh_ipv6 = 'nullroute' if 'discard' in sr_data.nexthop else sr_data.nexthop.ipv6 %}
-{%   set cmd_nh_v6 = sr_data.nexthop.intf if 'vrf' in sr_data.nexthop else nh_ipv6 %}
+{%   set cmd_nh_v6 = sr_data.nexthop.intf 
+                        if 'vrf' in sr_data.nexthop
+                          and 'intf' in sr_data.nexthop
+                        else nh_ipv6 %}
 ipv6 route {{ sr_data.ipv6 }} {{ cmd_nh_v6 }} {{ cmd_vrf }}
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
The static routing configuration template on ArubaCX assumed the next-hop-interface is set for VRF routes. In some cases, that resulted in Jinja2 errors. This change checks the presence of next-hop interface before using it.