### PR TITLE
Cat8000v: use the new VLAN config model with 'premier' license

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -100,10 +100,21 @@ nodes:
 (caveats-cat8000v)=
 ## Cisco Catalyst 8000v
 
-* Apart from the VLAN configuration, Catalyst 8000v implementation uses the same configuration templates as CSR 1000v.
+Licensing:
+
+* Catalyst 8000v uses a boot-level license to enable additional features. The _netlab_-built Vagrant box configures the **premier** license, while the _vrnetlab_-built container has no add-on license. You can specify the license available to your Catalyst 8000v nodes using the node **cat8000v.license** attribute (set by default to **premier** for Vagrant VMs).
+* The **premier** license is required for new-style VLAN configuration (see below), MPLS, SR-MPLS, and SRv6.
+
+VLAN caveats:
+
 * You cannot use reserved VLANs (1002..1005) on Catalyst 8000v
+* _netlab_ uses new-style VLAN configuration (service instance configured as a **member** of the **bridge-domain**) on Catalyst 8000v nodes with the **premier** license, and old-style VLAN configuration (**bridge-domain** configured under **service instance**) on other Catalyst 8000v nodes.
+* Recent _vrnetlab_ code uses **virtio** NICs for Catalyst 8000v VMs ([GitHub issue](https://github.com/srl-labs/vrnetlab/issues/414)). Ethernet subinterfaces on Catalyst 8000v [do not work with **virtio** NICs](https://developer.cisco.com/docs/modeling-labs/cat-8000v/#limitations); scenarios such as router-on-a-stick thus fail when using recent _vrnetlab_-built Catalyst 8000v containers.
+
+Other caveats:
+
+* Apart from the VLAN configuration, Catalyst 8000v implementation uses the same configuration templates as CSR 1000v or Cisco IOL.
 * Catalyst 8000v accepts CSR 1000v-based VXLAN configuration, but the validation tests fail. You cannot configure VXLAN on Catalyst 8000v with the current _netlab_ release.
-* MPLS and SR-MPLS require a license that enables the advanced functionality after a reboot. That license is automatically enabled in recent _netlab_ and _vrnetlab_ releases, but you cannot apply it to a running lab; you have to rebuild the Catalyst 8000v Vagrant box or container.
 
 See also [CSR 1000v](caveats-csr) and [Cisco IOSv](caveats-iosv) caveats.
 

--- a/docs/release/25.x.md
+++ b/docs/release/25.x.md
@@ -1,0 +1,44 @@
+# Changes in Release 25.xx
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+```
+
+(release-25.xx)=
+## New Functionality
+
+* Something new
+
+**Minor improvements**
+
+* Something new
+
+(release-25.xx-device-features)=
+## New Device Features
+
+Cisco Catalyst 8000v:
+* _netlab_ tracks the state of the Catalyst 8000v license applied to the nodes with the **cat8000v.license** node attribute. This parameter is set to **premier** on Catalyst 8000v VMs and left empty on Catalyst 8000v vrnetlab containers.
+* The VLAN configuration template has been changed to use the new bridge-domain configuration model (service instances are defined as members of **bridge-domain**) when the **cat8000v.license** node attribute is set to **premier**. 
+
+(release-25.xx-device-fixes)=
+## Fixes in Configuration Templates
+
+Arista EOS:
+* Something new
+
+(release-25.xx-breaking)=
+## Breaking changes
+
+Something is broken
+
+(bug-fixes-25.xx)=
+## Bug Fixes
+
+* Bugs were fixed
+
+(doc-fixes-25.xx)=
+## Documentation Fixes
+
+* Docs were fixed

--- a/netsim/ansible/templates/vlan/cat8000v.essentials.j2
+++ b/netsim/ansible/templates/vlan/cat8000v.essentials.j2
@@ -1,0 +1,32 @@
+{% if vlans is defined %}
+{%   for vname,vdata in vlans.items() %}
+!
+bridge-domain {{ vdata.id }}
+{%   endfor %}
+{% endif %}
+{% for ifdata in interfaces if ifdata.vlan.access_id is defined or ifdata.vlan.trunk_id is defined %}
+!
+interface {{ ifdata.ifname }}
+{%   if ifdata.vlan.trunk_id is defined %}
+{%     for vlan_id in ifdata.vlan.trunk_id if vlan_id != ifdata.vlan.access_id|default(0) %}
+ service instance {{ vlan_id }} ethernet
+  encapsulation dot1q {{ vlan_id }}
+  bridge-domain {{ vlan_id }}
+  rewrite ingress tag pop 1
+  rewrite egress tag push dot1q {{ vlan_id }}
+{%     endfor %}
+{%     if ifdata.vlan.native is defined %}
+ service instance {{ ifdata.vlan.access_id }} ethernet
+  encapsulation untagged
+  bridge-domain {{ ifdata.vlan.access_id }}
+{%     endif %}
+{%   elif ifdata.vlan.access_id is defined %}
+{%     if ifdata.type == 'vlan_member' %}
+ encapsulation dot1Q {{ ifdata.vlan.access_id }}
+{%     else %}
+ service instance {{ ifdata.vlan.access_id }} ethernet
+  encapsulation untagged
+  bridge-domain {{ ifdata.vlan.access_id }}
+{%     endif %}
+{%   endif %}
+{% endfor +%}

--- a/netsim/ansible/templates/vlan/cat8000v.j2
+++ b/netsim/ansible/templates/vlan/cat8000v.j2
@@ -1,32 +1,5 @@
-{% if vlans is defined %}
-{%   for vname,vdata in vlans.items() %}
-!
-bridge-domain {{ vdata.id }}
-{%   endfor %}
+{% if cat8000v.license|default('') == 'premier' %}
+{%   include 'iol.j2' %}
+{% else %}
+{%   include 'cat8000v.essentials.j2' %}
 {% endif %}
-{% for ifdata in interfaces if ifdata.vlan.access_id is defined or ifdata.vlan.trunk_id is defined %}
-!
-interface {{ ifdata.ifname }}
-{%   if ifdata.vlan.trunk_id is defined %}
-{%     for vlan_id in ifdata.vlan.trunk_id if vlan_id != ifdata.vlan.access_id|default(0) %}
- service instance {{ vlan_id }} ethernet
-  encapsulation dot1q {{ vlan_id }}
-  bridge-domain {{ vlan_id }}
-  rewrite ingress tag pop 1
-  rewrite egress tag push dot1q {{ vlan_id }}
-{%     endfor %}
-{%     if ifdata.vlan.native is defined %}
- service instance {{ ifdata.vlan.access_id }} ethernet
-  encapsulation untagged
-  bridge-domain {{ ifdata.vlan.access_id }}
-{%     endif %}
-{%   elif ifdata.vlan.access_id is defined %}
-{%     if ifdata.type == 'vlan_member' %}
- encapsulation dot1Q {{ ifdata.vlan.access_id }}
-{%     else %}
- service instance {{ ifdata.vlan.access_id }} ethernet
-  encapsulation untagged
-  bridge-domain {{ ifdata.vlan.access_id }}
-{%     endif %}
-{%   endif %}
-{% endfor +%}

--- a/netsim/devices/cat8000v.yml
+++ b/netsim/devices/cat8000v.yml
@@ -1,6 +1,9 @@
 ---
 description: Cisco Catalyst 8000v
 parent: csr
+attributes:
+  node:
+    cat8000v.license: { type: str, valid_values: [ essential, advantage, premier ] }
 virtualbox:
   image:
 clab:
@@ -9,6 +12,12 @@ clab:
     kind: cisco_c8000v
   interface.name: eth{ifindex-1}
   build: https://containerlab.dev/manual/kinds/vr-c8000v/
+libvirt:
+  cat8000v.license: premier
+  image: cisco/cat8000v
+  build: https://netlab.tools/labs/cat8000v/
+  create_template: cat8000v.xml.j2
+  create_iso: cat8000v
 group_vars:
   netlab_device_type: cat8000v
 node:
@@ -22,8 +31,3 @@ features:
   vlan:
     model: l3-switch
     subif_name: "{ifname}.{subif_index}"
-libvirt:
-  image: cisco/cat8000v
-  build: https://netlab.tools/labs/cat8000v/
-  create_template: cat8000v.xml.j2
-  create_iso: cat8000v


### PR DESCRIPTION
This change introduces 'cat8000v.license' node attribute that is automatically set to 'premier' on Vagrant boxes but can be set by the user in system default or on individual nodes.

The initial impact of the 'cat8000v.license' attribute is the selection of VLAN configuration mode. With the 'premier' license, netlab configures Ethernet services as members of bridge domains. Without it, the old-style configuration (bridge-domain configured under 'service ethernet' is used).

The 'premier' license is also required for MPLS, SR-MPLS, and SRv6. These requirements are not yet checked (coming in a separate PR).