### PR TITLE
Implement _default values in data validation

### DIFF
--- a/docs/dev/validation.md
+++ b/docs/dev/validation.md
@@ -122,6 +122,7 @@ All attributes defined with a dictionary (**mode** in the above example, but not
 * **true_value** -- value to use when the parameter is set to *True*
 * **_requires** -- a list of modules that must be enabled in global- or node context to allow the use of this attribute. See `vrfs` in `modules/vrf.yml` and `vlans` in `modules/vlan.yml` for more details.
 * **_required** (bool) -- the attribute must be present in the parent dictionary[^CRQ]
+* **_default** -- the default value of the attribute. Added to the data structure when the attribute is not specified in the lab topology
 * **_valid_with** -- a list or dictionary of attributes that can be used with this attribute ([example](inter-attribute-examples)).
 * **_invalid_with** -- specifies attributes that cannot be used together with this attribute. Can be:
 

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -132,13 +132,18 @@ def validate_module_can_be_false(
   return bool(intersect)
 
 """
-check_required_keys -- checks that the required keys are present in the data structure
+check_required_keys -- checks that the required keys are present in the data structure and sets the default
+values for missing keys with _default attribute
 """
 
 def check_required_keys(data: Box, attributes: Box, path: str,module: str) -> bool:
   result = True
   for k,v in attributes.items():
-    if isinstance(v,Box) and '_required' in v and v._required:
+    if not isinstance(v,Box):
+      continue
+    if '_default' in v and k not in data:
+      data[k] = v._default
+    if '_required' in v and v._required:
       if k in data:
         continue
       log.error(

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -41,7 +41,11 @@ attributes:
       _subtype:
         type: dict
         _keys:
-          type: { type: str, valid_values: [ standard, extended, large ]}
+          type:
+            type: str
+            valid_values: [ standard, extended, large ]
+            _required: True
+            _default: standard
           value:
             type: list
             make_list: True

--- a/netsim/modules/routing/clist.py
+++ b/netsim/modules/routing/clist.py
@@ -89,8 +89,6 @@ whether they use regular expressions or not
 """
 def expand_community_list(p_name: str,o_name: str,node: Box,topology: Box) -> typing.Optional[list]:
   p_clist = node.routing[o_name][p_name]                    # Shortcut pointer to current community list
-  if 'type' not in p_clist:
-    p_clist.type = 'standard'                               # Assume the clist filter for standard communities
   regexp = False                                            # Figure out whether we need expanded clist
   for (p_idx,p_entry) in enumerate(p_clist.value):
     try:

--- a/tests/topology/expected/rp-clist-expansion.yml
+++ b/tests/topology/expected/rp-clist-expansion.yml
@@ -6,6 +6,7 @@ groups:
       routing:
         community:
           cg1:
+            type: standard
             value:
             - action: permit
               path:
@@ -136,18 +137,21 @@ provider: libvirt
 routing:
   community:
     cl4:
+      type: standard
       value:
       - action: permit
         path:
         - 65000:104
         sequence: 10
     cl5:
+      type: standard
       value:
       - action: permit
         path:
         - 65000:100
         sequence: 100
     cl7:
+      type: standard
       value:
       - _value: 65000:106
         action: permit


### PR DESCRIPTION
You can use the '_default' type attribute to specify the default value of a missing attribute.

Used to implement the default 'type' for community lists. Replaces the hardcoded value in 'expand_community_list'