### PR TITLE
Enable use of clab k8s-kind

### DIFF
--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -16,6 +16,41 @@ topology:
   nodes:
 {% for name,n in nodes.items() if not (n.unmanaged|default(False)) %}
 {%   set clab = n.clab|default({}) %}
+{%   set kind = clab.kind | default(n.device) %}
+{%   if kind == 'k8s-control-plane' %}
+{%     set cluster_name = name.rsplit('-control-plane', 1)[0] %}
+    {{ cluster_name }}:
+      kind: k8s-kind
+{%    if clab.image %}
+      image: {{ clab.image }}
+{%    endif %}
+      startup-config: {{ cluster_name }}-config.yml
+      extras:
+        k8s_kind:
+          deploy:
+            wait: 0s
+    {{ name }}:
+      kind: ext-container
+{%     for cset in defaults.providers.clab.attributes.node._keys
+         if clab[cset] is defined and cset not in defaults.providers.clab.node_config_special %}
+{%       if clab[cset] is string %}
+      {{ cset }}: '{{ clab[cset] }}'
+{%       else %}
+      {{ cset }}: {{ clab[cset] }}
+{%       endif %}
+{%     endfor %}
+{%   elif kind == 'k8s-worker' %}
+    {{ name }}:
+      kind: ext-container
+{%     for cset in defaults.providers.clab.attributes.node._keys
+         if clab[cset] is defined and cset not in defaults.providers.clab.node_config_special %}
+{%       if clab[cset] is string %}
+      {{ cset }}: '{{ clab[cset] }}'
+{%       else %}
+      {{ cset }}: {{ clab[cset] }}
+{%       endif %}
+{%     endfor %}
+{%   else %}
     {{ name }}:
 {%   if 'network-mode' not in clab or clab['network-mode'] != 'none' %}
 {%     if n.mgmt.ipv4 is defined %}
@@ -25,37 +60,37 @@ topology:
       mgmt-ipv6: {{ n.mgmt.ipv6 }}
 {%     endif %}
 {%   endif %}
-{%   set kind = clab.kind | default(n.device) %}
       kind: {{ kind }}
-{%   if kind == 'linux' and 'restart-policy' not in clab %}
+{%     if kind == 'linux' and 'restart-policy' not in clab %}
       restart-policy: 'no'
-{%   endif %}
-{%   for cset in defaults.providers.clab.attributes.node._keys
-         if clab[cset] is defined and cset not in defaults.providers.clab.node_config_special %}
-{%     if clab[cset] is string %}
-      {{ cset }}: '{{ clab[cset] }}'
-{%     else %}
-      {{ cset }}: {{ clab[cset] }}
 {%     endif %}
-{%   endfor %}
+{%     for cset in defaults.providers.clab.attributes.node._keys
+         if clab[cset] is defined and cset not in defaults.providers.clab.node_config_special %}
+{%       if clab[cset] is string %}
+      {{ cset }}: '{{ clab[cset] }}'
+{%       else %}
+      {{ cset }}: {{ clab[cset] }}
+{%       endif %}
+{%     endfor %}
       image: {{ clab.image|default(n.box) }}
       runtime: {{ clab.runtime|default(defaults.providers.clab.runtime) }}
-{%   if groups is defined %}
+{%     if groups is defined %}
       group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor +%}
-{%   endif %}
-{%   if 'srl-agents' in clab %}
+{%     endif %}
+{%     if 'srl-agents' in clab %}
       extras:
         srl-agents: {{ clab['srl-agents'] }}
-{%   endif %}
-{%   if 'binds' in clab %}
+{%     endif %}
+{%     if 'binds' in clab %}
       binds:
-{%     for bind_item in clab.binds %}
+{%       for bind_item in clab.binds %}
       - {{ bind_item }}
-{%     endfor %}
-{%   endif %}
-{%   if 'startup-config' in clab %}
-{%     set cfg = clab['startup-config'] %}
+{%       endfor %}
+{%     endif %}
+{%     if 'startup-config' in clab %}
+{%       set cfg = clab['startup-config'] %}
       startup-config: {{ ("|\n" + cfg) | indent(8) if '\n' in cfg else cfg }}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 


### PR DESCRIPTION
I've started this work to allow for the use of K8S (Kubernetes) nodes in topologies.

Containerlab does have [support](https://containerlab.dev/manual/kinds/k8s-kind/) for it but it does pose some challenges on how to add it here.

The main challenge I have come across is that you cannot influence the naming of nodes. It does look like this is [by design](https://github.com/kubernetes-sigs/kind/issues/1401) and won't change any time soon. It means that a certain naming pattern has to be followed for this to work.

For now topology configs based on this PR would look like this:
```
groups:
  unprovisioned:
    members: [ k01-control-plane, k01-worker, k01-worker2 ]
    module: []
    device: linux

nodes:
  k01-control-plane:
    clab:
      kind: k8s-control-plane
  k01-worker:
    clab:
      kind: k8s-worker
  k01-worker2:
    clab:
      kind: k8s-worker
```

Along with this a `k01-config.yml` would be needed:
```
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
nodes:
  - role: control-plane
  - role: worker
  - role: worker
```

I am sure there is probably better ways to do this, but I am not familiar enough with the concepts here to suggest. Feel free to criticise or change as you see fit.