### PR TITLE
Fix addr for link-local addressed interfaces

### DIFF
--- a/netsim/outputs/_graph.py
+++ b/netsim/outputs/_graph.py
@@ -134,6 +134,8 @@ def append_edge(graph: Box, if_a: Box, if_b: Box, g_type: str) -> None:
   e_attr = get_empty_box()
   for intf in (if_a, if_b):
     addr = intf.ipv4 or intf.ipv6
+    if addr is True:
+      addr = "auto"
     if addr and 'prefix' not in intf:
       addr = addr.split('/')[0]
     intf_attr = get_graph_attributes(intf,g_type)


### PR DESCRIPTION
On a link [addressed using only IPv6 link-local](https://netlab.tools/example/addressing-tutorial/#link-local-addresses) the following error occurs when running `netlab graph`:
```
File "/usr/local/lib/python3.12/dist-packages/netsim/outputs/_graph.py", line 140, in append_edge
  addr = addr.split('/')[0]
         ^^^^^^^^^^
```