### PR TITLE
Large BGP community lists on Junos

### DIFF
--- a/docs/module/routing-clist.txt
+++ b/docs/module/routing-clist.txt
@@ -43,7 +43,7 @@ You can define BGP community filters on these platforms:
 | Cumulus Linux      | ✅ | ❌  | ❌  |
 | Dell OS10          | ✅ | ❌  | ❌  |
 | FRR                | ✅ | ✅ | ❌  |
-| Junos              | ✅ | ❌  | ❌  |
+| Junos              | ✅ | ✅ | ❌  |
 | VyOS               | ✅ | ❌  | ❌  |
 
 ### Shortcut BGP Community Filter Definitions

--- a/docs/module/routing-policy.txt
+++ b/docs/module/routing-policy.txt
@@ -71,10 +71,10 @@ You can use these routing policy **match** parameters on devices supported by th
 | Cisco IOS/XE[^18v]  | ✅ | ❌  | ✅ | ✅ | ❌  |
 | Cumulus Linux       | ✅ | ❌  | ✅ | ✅ | ❌  |
 | Dell OS10           | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Junos               | ✅ | ❌  | [✅](caveats-junos) | ✅ |❓ |
+| Junos               | ✅ | ❌  | [✅](caveats-junos) | ✅ | ✅ |
 | FRR                 | ✅ | ❌  | ✅ | ✅ | ✅ |
 | Nokia SR Linux      | ✅ | ❌  | ❌  | ❌  | ❌  |
-| VyOS                | ✅ | ❌  | ✅ | ✅ | ❓ |
+| VyOS                | ✅ | ❌  | ✅ | ✅ | ❌  |
 
 You can use these routing policy **set** parameters on devices supported by the **routing** module:
 
@@ -113,9 +113,9 @@ In addition to setting BGP communities on BGP routes, these devices can perform 
 | Cisco IOS/XE[^18v]  | ✅ | ✅❗️| ✅ | ❌  |
 | Cumulus Linux       | ✅ | ❌  | ❌  | ❌  |
 | Dell OS10           | ✅ | ❌  | ❌  | ❌  |
-| Junos               | ✅ | ✅ | ✅ | ❓ |
+| Junos               | ✅ | ✅ | ✅ | ✅ |
 | FRR                 | ✅ | ✅❗️ | ✅ | ✅ |
-| VyOS                | ✅ | ❌  | ❌  | ❓ |
+| VyOS                | ✅ | ❌  | ❌  | ❌  |
 
 **Notes:**
 * _netlab_ is creating an internal BGP community list on FRR and Cisco IOS/XE to delete BGP communities specified with the **delete.community** routing policy parameter.

--- a/netsim/ansible/templates/routing/_route_policy_junos.j2
+++ b/netsim/ansible/templates/routing/_route_policy_junos.j2
@@ -32,7 +32,7 @@
 {%       set cset = p_entry.set.community %}
 {%       for kw in ('standard','extended','large') if kw in cset %}
 {%         for cur_com in cset[kw] %}
-{{           community_set(cur_com,c_append=cset.append|default(False)) }}
+{{           community_set(cur_com,c_append=cset.append|default(not loop.first)) }}
 {%         endfor %}
 {%       endfor %}
 {%     endif %}
@@ -48,8 +48,10 @@
 {{         community_set(cur_com,c_delete=True) }}
 {%       endfor %}
 {%     endfor %}
-{%     if dset.list.standard is defined %}
-      then community delete {{ dset.list.standard }};
+{%     if dset.list is defined %}
+{%       for kw in ('standard','extended','large') if kw in dset.list %}
+      then community delete {{ dset.list[kw] }};
+{%       endfor %}
 {%     endif %}
 {%   endif %}
 {# - MATCH entries #}

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -40,13 +40,8 @@ policy-options {
 delete: policy-options policy-statement x_comm_match_{{ c_name }};
 {%     for c_line in c_value.value %}
 {# we need to create both indexed communities, required for permit/deny matching, and "full" communities for set #}
-{%       if c_value.type|default('') == 'large' %}
-policy-options community {{ c_name }} members [ "large:{{ c_line._value }}" ];
-policy-options community {{ c_name }}_idx{{ loop.index }} members [ "large:{{ c_line._value }}" ];
-{%       else %}
 policy-options community {{ c_name }} members [ "{{ c_line._value }}" ];
 policy-options community {{ c_name }}_idx{{ loop.index }} members [ "{{ c_line._value }}" ];
-{%       endif %}
 
 {# we need to create a subroutine for community matching if we want to use permit/deny, and use the community name defined above #}
 policy-options {

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -45,6 +45,7 @@ features:
         aspath: True
         community:
           standard: True
+          large: True
       set:
         locpref: True
         med: True
@@ -63,6 +64,7 @@ features:
     aspath: True
     community:
       standard: True
+      large: True
   sr: true
   vrf:
     ospfv2: True

--- a/tests/integration/routing/13-match-community-large.yml
+++ b/tests/integration/routing/13-match-community-large.yml
@@ -33,7 +33,7 @@ nodes:
           - action: permit
         cd:
           type: large
-          value: [ '65101:101:42 ']
+          value: [ '65101:101:42' ]
       policy:
         set_med:
         - match.community.large: c1


### PR DESCRIPTION
* Recalculate the community values to include the 'large:' keyword in a Junos quirk
* Simplify the configuration template as it no longer needs the 'large:' keyword juggling (which didn't work for regexes anyway)

Also:

* Fix a bug where a Junos policy would set only the last community in the set.community list
* Fix a typo in the integration test large community value