### PR TITLE
Refactor the containerlab configuration template

### DIFF
--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -4,7 +4,7 @@
 description: containerlab with Docker
 config: clab.yml
 lab_prefix: "clab" # Containerlab default, set to "" to remove prefix
-node_config_attributes: [ type, cmd, dns, env, exec, license, ports, startup-delay, restart-policy ]
+node_config_special: [ binds, config_templates, image, kind, startup-config, srl-agents, runtime ]
 template: clab.j2
 version: 0.69.3
 # Preserve env to allow user to configure PATH

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -17,9 +17,6 @@ topology:
 {% for name,n in nodes.items() if not (n.unmanaged|default(False)) %}
 {%   set clab = n.clab|default({}) %}
     {{ name }}:
-{%   if 'network-mode' in clab %}
-      network-mode: {{ clab['network-mode'] }}
-{%   endif %}
 {%   if 'network-mode' not in clab or clab['network-mode'] != 'none' %}
 {%     if n.mgmt.ipv4 is defined %}
       mgmt-ipv4: {{ n.mgmt.ipv4 }}
@@ -33,7 +30,8 @@ topology:
 {%   if kind == 'linux' and 'restart-policy' not in clab %}
       restart-policy: 'no'
 {%   endif %}
-{%   for cset in defaults.providers.clab.node_config_attributes if clab[cset] is defined %}
+{%   for cset in defaults.providers.clab.attributes.node._keys
+         if clab[cset] is defined and cset not in defaults.providers.clab.node_config_special %}
 {%     if clab[cset] is string %}
       {{ cset }}: '{{ clab[cset] }}'
 {%     else %}
@@ -43,8 +41,7 @@ topology:
       image: {{ clab.image|default(n.box) }}
       runtime: {{ clab.runtime|default(defaults.providers.clab.runtime) }}
 {%   if groups is defined %}
-      group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor %}
-
+      group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor +%}
 {%   endif %}
 {%   if 'srl-agents' in clab %}
       extras:


### PR DESCRIPTION
The containerlab configuration template used a list of "extra" clab attributes that would be copied into the template.

The new template reverses that logic; all clab attributes apart from the "special" attributes defined in node_config_special are copied verbatim, the special attributes are handled by the template.

This allows the users to add clab attributes that get copied into the template without changing the template or replacing the "node_config_attributes" list.

Resolves #2836