### PR TITLE
Create daemon config files in 'netlab initial' Python code

### DIFF
--- a/docs/netlab/initial.md
+++ b/docs/netlab/initial.md
@@ -34,8 +34,8 @@ Jinja2 templates are used together with **_device_\_config** Ansible modules to 
 
 ```text
 $ netlab initial -h
-usage: netlab initial [-h] [--log] [-v] [-q] [-i] [-m [MODULE]] [-c] [--ready] [--fast]
-                      [-o [OUTPUT]] [--instance INSTANCE]
+usage: netlab initial [-h] [--log] [-v] [-q] [-i] [-m [MODULE]] [-l LIMIT] [-c]
+                      [--ready] [--fast] [-o [OUTPUT]] [--clean] [--instance INSTANCE]
 
 Initial device configurations
 
@@ -45,17 +45,20 @@ options:
   -v, --verbose         Verbose logging (add multiple flags for increased verbosity)
   -q, --quiet           Report only major errors
   -i, --initial         Deploy just the initial configuration
-  -m [MODULE], --module [MODULE]
+  -m, --module [MODULE]
                         Deploy module-specific configuration (optionally including a
                         list of modules separated by commas)
+  -l, --limit LIMIT     Limit the operation to a subset of nodes
   -c, --custom          Deploy custom configuration templates (specified in "config"
                         group or node attribute)
   --ready               Wait for devices to become ready
   --fast                Use "free" strategy in Ansible playbook for faster configuration
                         deployment
-  -o [OUTPUT], --output [OUTPUT]
+  -o, --output [OUTPUT]
                         Create a directory with initial configurations instead of
                         deploying them (default output directory: config)
+  --clean               Clean up the output directory before creating the initial
+                        configuration
   --instance INSTANCE   Specify lab instance to configure
 
 All other arguments are passed directly to ansible-playbook
@@ -119,10 +122,10 @@ You'll find more details in _[](custom-config)_ and _[](dev-find-custom)_ docume
 
 The **netlab initial** command deploys all initial device configurations when started without additional parameters. To control the deployment of initial configurations:
 
-* use the `-i` flag to deploy initial device configurations. 
-* use the `-m` flag to deploy module-specific configurations. 
-* use the `-m` flag followed by a module name (example: `-m ospf -m bgp`) to deploy device configuration for specific modules. You can use the `-m` flag multiple times.
-* use the `-c` flag to deploy custom configuration templates. 
+* Use the `-i` flag to deploy initial device configurations.
+* Use the `-m` flag to deploy all module-specific configurations.
+* Use the `-m` flag followed by a module name (example: `-m ospf`) or a comma-separated list of module names (example: `-m ospf,bgp`) to deploy device configuration for specific module(s).
+* Use the `-c` flag to deploy custom configuration templates.
 
 All unrecognized parameters are passed to the internal `initial-config.ansible` Ansible playbook. You can use **ansible-playbook** CLI parameters to modify the configuration deployment, for example:
 

--- a/netsim/ansible/create-config.ansible
+++ b/netsim/ansible/create-config.ansible
@@ -7,19 +7,11 @@
     config_dir: "{{ lookup('env','PWD') }}/config"
     node_provider: "{{ provider|default(netlab_provider) }}"
   tasks:
-  - block:
-    - name: Set variables that cannot be set with vars
-      set_fact:
-        netlab_device_type: "{{ netlab_device_type|default(ansible_network_os) }}"
-        netlab_interfaces: "{{ ([ loopback ] if loopback is defined else []) + interfaces|default([]) }}"
-
-    - name: Create config directory in {{ config_dir }}
-      file:
-        path: "{{ config_dir }}"
-        state: directory
-      run_once: true
-
-    delegate_to: localhost
+  - name: Set variables that cannot be set with vars
+    set_fact:
+      netlab_device_type: "{{ netlab_device_type|default(ansible_network_os) }}"
+      netlab_interfaces: "{{ ([ loopback ] if loopback is defined else []) + interfaces|default([]) }}"
+    tags: [ always ]
 
   - name: Create initial device configuration
     include_tasks: "tasks/create-config.yml"
@@ -28,6 +20,8 @@
         vars:
           config_item: initial
           paths: "{{ paths_templates.dirs }}"
+        tags: [ always ]
+    tags: [ initial ]
 
 - name: Create module-specific configurations
   hosts: modules
@@ -50,9 +44,11 @@
         loop_var: config_item
       args:
         apply:
+          tags: [ always ]
           vars:
             paths: "{{ paths_templates.dirs }}"
 
+    tags: [ module ]
     delegate_to: localhost
 
 - name: Create custom deployment templates
@@ -68,27 +64,7 @@
       loop_var: custom_config
     args:
       apply:
+        tags: [ always ]
         vars:
           paths: "{{ paths_custom.dirs }}"
-
-- name: Create daemon configuration files
-  hosts: daemons
-  serial: 1
-  vars:
-    node_provider: "{{ provider|default(netlab_provider) }}"
-    extra_config: >
-      {{ _daemon_config|default({})
-            |list
-            |difference(modules|default([]))
-            |difference(config|default([])) }}
-  tasks:
-  - name: Create daemon configurations
-    include_tasks: "tasks/create-config.yml"
-    loop: "{{ extra_config }}"
-    when: "'@' not in config_item"
-    loop_control:
-      loop_var: config_item
-    args:
-      apply:
-        vars:
-          paths: "{{ paths_templates.dirs }}"
+    tags: [ custom ]

--- a/netsim/cli/initial.py
+++ b/netsim/cli/initial.py
@@ -3,8 +3,6 @@
 #
 # Deploys initial device configurations
 #
-import argparse
-import os
 import typing
 
 from .. import devices
@@ -12,97 +10,27 @@ from ..utils import log
 from ..utils import status as _status
 from . import (
   ansible,
-  common_parse_args,
   external_commands,
   get_message,
+  initial_actions,
   lab_status_change,
   load_snapshot,
-  parser_lab_location,
 )
 
 
-#
-# CLI parser for 'netlab initial' command
-#
-def initial_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
-  parser = argparse.ArgumentParser(
-    parents=[ common_parse_args() ],
-    prog="netlab initial",
-    description='Initial device configurations',
-    epilog='All other arguments are passed directly to ansible-playbook')
-
-  parser.add_argument(
-    '-i','--initial',
-    dest='initial', action='store_true',
-    help='Deploy just the initial configuration')
-  parser.add_argument(
-    '-m','--module',
-    dest='module', action='store',nargs='?',const='*',
-    help='Deploy module-specific configuration (optionally including a list of modules separated by commas)')
-  parser.add_argument(
-    '-c','--custom',
-    dest='custom', action='store_true',
-    help='Deploy custom configuration templates (specified in "config" group or node attribute)')
-  parser.add_argument(
-    '--ready',
-    dest='ready', action='store_true',
-    help='Wait for devices to become ready')
-  parser.add_argument(
-    '--fast',
-    dest='fast', action='store_true',
-    help='Use "free" strategy in Ansible playbook for faster configuration deployment')
-  parser.add_argument(
-    '-o','--output',
-    dest='output', action='store',nargs='?',const='config',
-    help='Create a directory with initial configurations instead of deploying them (default output directory: config)')
-  parser.add_argument(
-    '--no-message',
-    dest='no_message', action='store_true',
-    help=argparse.SUPPRESS)
-  parser_lab_location(parser,instance=True,i_used=True,action='configure')
-
-  return parser.parse_known_args(args)
-
 def run_initial(cli_args: typing.List[str]) -> None:
-  (args,rest) = initial_config_parse(cli_args)
-  if args.output:
-    rest = ['-e',f'config_dir="{os.path.abspath(args.output)}"' ] + rest
-
+  (args,rest) = initial_actions.initial_config_parse(cli_args)
   topology = load_snapshot(args)
 
-  deploy_parts = []
-  if args.verbose:
-    rest = ['-' + 'v' * args.verbose] + rest
-
-  if args.initial:
-    rest = ['-t','initial'] + rest
-    deploy_parts.append("initial configuration")
-
-  if args.quiet:
-    os.environ["ANSIBLE_STDOUT_CALLBACK"] = "selective"
-
-  if args.module:
-    if args.module != "*":
-      deploy_parts.append("module(s): " + args.module)
-      rest = ['-e','modlist='+args.module] + rest
-    else:
-      deploy_parts.append("modules")
-    rest = ['-t','module'] + rest
-  
-  if args.custom:
-    deploy_parts.append("custom")
-    rest = ['-t','custom'] + rest
-
-  if args.fast or os.environ.get('NETLAB_FAST_CONFIG',None):
-    rest = ['-e','netlab_strategy=free'] + rest
+  rest = rest + initial_actions.ansible_args(args)
+  deploy_parts = initial_actions.get_deploy_parts(args)
 
   if args.logging or args.verbose:
     print("Ansible playbook args: %s" % rest)
 
   ansible.check_version()
   if args.output:
-    ansible.playbook('create-config.ansible',rest)
-    print("\nInitial configurations have been created in the %s directory" % args.output)
+    initial_actions.configs.run(topology,args,rest)
     return
   elif args.ready:
     ansible.playbook('device-ready.ansible',rest)

--- a/netsim/cli/initial_actions/__init__.py
+++ b/netsim/cli/initial_actions/__init__.py
@@ -1,0 +1,107 @@
+"""
+Common functions for the "netlab initial" actions
+"""
+
+import argparse
+import os
+import typing
+
+from .. import common_parse_args, parser_lab_location
+from . import configs
+
+
+#
+# CLI parser for 'netlab initial' command
+#
+def initial_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
+  parser = argparse.ArgumentParser(
+    parents=[ common_parse_args() ],
+    prog="netlab initial",
+    description='Initial device configurations',
+    epilog='All other arguments are passed directly to ansible-playbook')
+
+  parser.add_argument(
+    '-i','--initial',
+    dest='initial', action='store_true',
+    help='Deploy just the initial configuration')
+  parser.add_argument(
+    '-m','--module',
+    dest='module', action='store',nargs='?',const='*',
+    help='Deploy module-specific configuration (optionally including a list of modules separated by commas)')
+  parser.add_argument(
+    '-l','--limit',
+    dest='limit', action='store',
+    help='Limit the operation to a subset of nodes')
+  parser.add_argument(
+    '-c','--custom',
+    dest='custom', action='store_true',
+    help='Deploy custom configuration templates (specified in "config" group or node attribute)')
+  parser.add_argument(
+    '--ready',
+    dest='ready', action='store_true',
+    help='Wait for devices to become ready')
+  parser.add_argument(
+    '--fast',
+    dest='fast', action='store_true',
+    help='Use "free" strategy in Ansible playbook for faster configuration deployment')
+  parser.add_argument(
+    '-o','--output',
+    dest='output', action='store',nargs='?',const='config',
+    help='Create a directory with initial configurations instead of deploying them (default output directory: config)')
+  parser.add_argument(
+    '--clean',
+    dest='clean', action='store_true',
+    help='Clean up the output directory before creating the initial configuration')
+  parser.add_argument(
+    '--no-message',
+    dest='no_message', action='store_true',
+    help=argparse.SUPPRESS)
+  parser_lab_location(parser,instance=True,i_used=True,action='configure')
+
+  return parser.parse_known_args(args)
+
+"""
+Build Ansible arguments based on 'netlab initial' parameters
+"""
+def ansible_args(args: argparse.Namespace) -> list:
+  rest: typing.List[str] = []
+  if args.verbose:
+    rest = ['-' + 'v' * args.verbose] + rest
+
+  if args.limit:
+    rest = ['--limit',args.limit] + rest
+
+  if args.initial:
+    rest = ['-t','initial'] + rest
+
+  if args.quiet:
+    os.environ["ANSIBLE_STDOUT_CALLBACK"] = "selective"
+
+  if args.module:
+    if args.module != "*":
+      rest = ['-e','modlist='+args.module] + rest
+    rest = ['-t','module'] + rest
+
+  if args.custom:
+    rest = ['-t','custom'] + rest
+
+  if args.fast or os.environ.get('NETLAB_FAST_CONFIG',None):
+    rest = ['-e','netlab_strategy=free'] + rest
+
+  return rest
+
+def get_deploy_parts(args: argparse.Namespace) -> list:
+  deploy_parts = []
+  if args.initial:
+    deploy_parts.append("initial configuration")
+
+  if args.module:
+    if args.module != "*":
+      deploy_parts.append("module(s): " + args.module)
+    else:
+      deploy_parts.append("modules")
+
+  if args.custom:
+    deploy_parts.append("custom")
+
+  return deploy_parts

--- a/netsim/cli/initial_actions/configs.py
+++ b/netsim/cli/initial_actions/configs.py
@@ -1,0 +1,127 @@
+"""
+Building device configurations in the specified output directory
+"""
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+from box import Box
+
+from ... import data
+from ...augment import devices
+from ...outputs.ansible import get_host_addresses
+from ...outputs.common import adjust_inventory_host
+from ...providers import _Provider
+from ...utils import log, templates
+from .. import _nodeset, ansible, error_and_exit
+
+
+def cleanup_config_dir(output_path: Path, args: argparse.Namespace) -> None:
+  if not output_path.exists():                      # Doesn't exist? No problem, no cleanup
+    return
+
+  cur_dir = Path('.').resolve()                     # Check if the output path is within current directory
+  if output_path == cur_dir:
+    error_and_exit('Cannot cleanup current directory')
+
+  try:
+    output_path.relative_to(cur_dir)                # Is it relative to .?
+    log.info(f"Cleaning up the '{args.output}' directory")
+    try:
+      shutil.rmtree(output_path)
+    except Exception as ex:
+      log.error(f"Failed to remove directory '{args.output}'",more_data=[ str(ex) ])
+  except ValueError:
+    log.info(f'Cannot clean a directory outside of the current directory')
+
+"""
+Create files that are usually created for clab.binds from clab.config_templates
+in the config directory to have everything in one place
+"""
+def create_from_config_templates(topology: Box, nodeset: list, abs_path: Path, args: argparse.Namespace) -> None:
+  shared_data = {                                           # Create the shared data we need for config templates
+    'hostvars': topology.nodes.to_dict(),
+    'hosts': get_host_addresses(topology),
+    'addressing': topology.addressing.to_dict()
+  }
+
+  output_path = str(abs_path)
+  all_configs = not args.module and not args.initial and not args.custom
+
+  # Get the (optional) list of modules for which we're rendering the configs
+  #
+  mod_list = topology.get('module',[]) if args.module == '*' or not args.module else args.module.split(',')
+  if args.initial:
+    mod_list = mod_list + [ 'initial' ]
+
+  for n_name in nodeset:
+    n_data = topology.nodes[n_name]
+    p = _Provider(provider=devices.get_provider(n_data,topology.defaults),data=data.get_empty_box())
+    if 'clab.config_templates' not in n_data:               # The node is not using config templates
+      continue                                              # Move on
+
+    node_data = adjust_inventory_host(                      # Add group variables to node data
+                              node=n_data,
+                              defaults=topology.defaults,
+                              group_vars=True).to_dict()
+    for k,v in shared_data.items():                         # And copy shared data
+      node_data[k] = v
+
+    for b_item in n_data.clab.config_templates:             # Now iterate over all config templates the node is using
+      b_template = b_item.split(':')[0]                     # Extract template name
+      if not all_configs:                                   # Check whether the user wants us to generate this file
+        skip = mod_list and b_template not in mod_list      # Skip modules that are not in mod_list
+        skip = skip or args.custom and b_template not in n_data.get('config',[])
+        if skip:                                            # ... or custom configs not in 'config' list
+          continue
+      b_path = p.find_extra_template(n_data,b_template,topology)
+      if not b_path:                                        # Try to find the configuration template
+        log.warning(                                        # Houston, we have a problem...
+          text=f'Cannot find template {b_template} for node {n_name}/device {n_data.device}',
+          module='initial')
+        continue
+
+      try:
+        o_fname = f'{n_name}.{b_template}.cfg'              # Try to render the template into
+        templates.write_template(                           # ... node.template.cfg file in the output directory
+          in_folder=os.path.dirname(b_path),
+          j2=os.path.basename(b_path),
+          data=node_data,
+          out_folder=output_path,
+          filename=o_fname)
+        log.info(f"Rendered {b_template} template for {n_name} into {o_fname}")
+      except Exception as ex:                               # Gee, we failed
+        log.error(                                          # Report an error and move on
+          text=f"Error rendering template {b_template} for node {n_name}/device {n_data.device}",
+          more_data=[f'Template source: {b_path}',f'error: {str(ex)}'],
+          module='initial',
+          category=log.IncorrectValue)
+
+"""
+Create node configurations
+
+The Ansible parameters are already parsed/augmented and received in the 'rest' list
+"""
+def run(topology: Box, args: argparse.Namespace, rest: list) -> None:
+  # Find the subset of nodes we should work on
+  #
+  nodeset = _nodeset.parse_nodeset(args.limit,topology) if args.limit else list(topology.nodes.keys())
+
+  abs_path = Path(args.output).resolve()                    # Output directory could be outside lab directory
+  if args.clean:                                            # Try to clean it up if asked to do so
+    cleanup_config_dir(abs_path, args)
+
+  if not abs_path.exists():                                 # Create the output directory if needed
+    log.info(f'Creating directory: {args.output}')
+    abs_path.mkdir(parents=True,exist_ok=True)
+
+  rest = ['-e',f'config_dir="{abs_path}"' ] + rest          # Add output directory path to Ansible variables
+
+  # Create files specified in clab.config_templates directly in the Python code (so they use our
+  # internal versions of Jinja2 filters), and run an Ansible playbook to create the rest
+  #
+  create_from_config_templates(topology,nodeset,abs_path,args)
+  ansible.playbook('create-config.ansible',rest)
+  log.info(f"Initial configurations have been created in the '{args.output}' directory")


### PR DESCRIPTION
The daemon config files and other container configuration templates are no longer rendered in an Ansible playbook, ensuring the created configurations match the actual daemon configurations mapped into containers.

Also:
* Add '--clean' parameter to cleanup the output directory
* Handle the output directory cleanup/creation in Python code
* Add tags to 'create-config' playbook to correctly handle the '-m', '-i' and '-c' parameters
* Define '-l' parameter as a valid 'netlab initial' parameter (previously it was just passed to Ansible) and use it to limit the nodes for which the container config templates are rendered.