### PR TITLE
[Doc] Clean up duplicate ToC entries

### DIFF
--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -1,3 +1,4 @@
+(dev-plugins)=
 # Developing Plugins
 
 Plugins are either Python files or directories containing Python code plus configuration templates. *netlab* tries to locate them in the *plugin search path* (specified in the **defaults.paths.plugin** setting), which usually includes the user search path and the `netsim/extra` _networklab_ package directory.

--- a/docs/dev/transform.md
+++ b/docs/dev/transform.md
@@ -1,3 +1,4 @@
+(dev-transform)=
 # Topology File Transformation
 
 *netlab* performs a complex data transformation of the lab topology file to get device-level data that is then used to [create output files](../outputs/index.md) (Ansible inventory, Vagranfile...).

--- a/docs/example/addressing-tutorial.md
+++ b/docs/example/addressing-tutorial.md
@@ -1,3 +1,4 @@
+(addressing-example)=
 # Addressing Tutorial
 
 IP Address Management (IPAM) is one of the most interesting *netlab* features -- it allows you to create full-blown fully configured networking labs without spending a millisecond  on IP addressing scheme, assigning IP addresses to nodes and interfaces, or configuring them on network devices.

--- a/docs/example/link-definition.md
+++ b/docs/example/link-definition.md
@@ -1,3 +1,4 @@
+(link-example)=
 # Link Definition Examples
 
 This document contains way too many link definition examples, ranging from simple links to complex topologies emulating bridging loops.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,11 +81,8 @@ Before shutting down your lab with the **[netlab down](netlab/down.md)** command
 
    netlab/cli.md
    topology-reference.md
-   modules.md
    module-reference.md
-   providers.md
    plugins.md
-   defaults.md
    outputs/index.md
    customize.md
 ..

--- a/docs/install.md
+++ b/docs/install.md
@@ -74,15 +74,11 @@ If you want to get the latest development code or if you want to participate in 
    install/ubuntu.md
    install/linux.md
    install/cloud.md
-   labs/libvirt.md
-   labs/clab.md
    install/clone.md
 ```
-```eval_rst
-.. toctree::
-   :caption: Deprecated
-   :maxdepth: 1
-   :hidden:
 
-   labs/virtualbox.md
-```
+## Installing Virtualization Providers
+
+* [](lab-clab)
+* [](lab-libvirt)
+* [](lab-virtualbox) (no longer supported or maintained)

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -96,13 +96,7 @@ The easiest way to work around that problem is to turn off your distribution's f
 * Execute `nixos-rebuild switch` command to reach the new desired configuration state
 * Reboot into the new configuration
 
+## Installing Virtualization Providers
 
-```eval_rst
-.. toctree::
-   :caption: Next Steps
-   :maxdepth: 1
-   :titlesonly:
-
-   ../labs/libvirt.md
-   ../labs/clab.md
-```
+* [](lab-clab)
+* [](lab-libvirt)

--- a/docs/install/ubuntu-vm.md
+++ b/docs/install/ubuntu-vm.md
@@ -108,12 +108,7 @@ netlab install -y ubuntu ansible libvirt containerlab
 
 * After completing the software installation, log out from the VM, log back in, and test your installation with the **[netlab test](netlab-test)** command. If those tests fail, you might have to use **usermod** to add your user to the *libvirt* and *docker* groups.
 
-```eval_rst
-.. toctree::
-   :caption: Next Steps
-   :maxdepth: 1
-   :titlesonly:
+## Installing Virtualization Providers
 
-   ../labs/libvirt.md
-   ../labs/clab.md
-```
+* [](lab-clab)
+* [](lab-libvirt)

--- a/docs/install/ubuntu.md
+++ b/docs/install/ubuntu.md
@@ -73,12 +73,7 @@ $ source mylab/bin/activate
 * Use the **groups** command to check that your user belongs **vagrant** and **libvirt** groups when using *libvirt*, or **docker** and **clab_admins** groups when using *containerlab*.
 * Test your installation with **netlab test libvirt** or **netlab test clab**.
 
-```eval_rst
-.. toctree::
-   :caption: Next Steps
-   :maxdepth: 1
-   :titlesonly:
+## Installing Virtualization Providers
 
-   ../labs/libvirt.md
-   ../labs/clab.md
-```
+* [](lab-clab)
+* [](lab-libvirt)

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -311,7 +311,6 @@ providers.libvirt.probe: []
    dellos10.md
    vsrx.md
    vptx.md
-   linux.md
    openbsd.md
    routeros7.md
    sonic.md

--- a/docs/links.md
+++ b/docs/links.md
@@ -786,11 +786,7 @@ r1:
 ...
 ```
 
-```eval_rst
-.. toctree::
-   :caption: Detailed Examples
-   :maxdepth: 1
+## Detailed Examples
 
-   example/link-definition.md
-   example/addressing-tutorial.md
-```
+* [](link-example)
+* [](addressing-example)

--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -481,16 +481,11 @@ The current _netlab_ implementation of BGP confederations does not support[^CWP]
 
 ## Related Plugins
 
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-
-   ../plugins/bgp.domain.md
-   ../plugins/bgp.originate.md
-   ../plugins/bgp.policy.md
-   ../plugins/bgp.session.md
-   ../plugins/ebgp.multihop.md
-```
+* [](plugin-bgp-domain)
+* [](plugin-bgp-originate)
+* [](plugin-bgp-policy)
+* [](plugin-bgp-session)
+* [](plugin-ebgp-multihop)
 
 ## More Examples
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -58,11 +58,7 @@ links:
 
 Plugins providing support for additional networking features usually rely on Jinja2 templates to configure those features, limiting their use to a subset of supported platforms. Please check the plugin documentation for more details.
 
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-   :caption: More information
+## More Information
 
-   dev/plugins.md
-   dev/transform.md
-```
+* [](dev-plugins)
+* [](dev-transform)

--- a/docs/plugins/bgp.originate.md
+++ b/docs/plugins/bgp.originate.md
@@ -1,3 +1,4 @@
+(plugin-bgp-originate)=
 # BGP Network Origination Plugin
 
 The **bgp.originate** modifies the way _netlab_ configures BGP network origination. The [](../module/bgp.md) configures static routes to the Null interface to originate additional IPv4 prefixes and does not support IPv6 prefixes.

--- a/docs/topology-reference.md
+++ b/docs/topology-reference.md
@@ -53,12 +53,10 @@ You'll find sample topology files in the [tutorials](tutorials.md).
    modules.md
    custom-config-templates.md
    extools.md
-   plugins.md
    prefix.md
    providers.md
    components.md
    defaults.md
    topology/hierarchy.md
    topology/validate.md
-   customize.md
 ```

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -24,8 +24,8 @@ These instructions and tutorials cover some of the usual early hurdles:
 
 Once you want to know more, check out these lab topology tutorials:
 
-* [Link definitions](example/link-definition.md)
-* [](example/addressing-tutorial.md)
+* [](link-example)
+* [](addressing-example)
 * [netlab Custom Groups and Deployment Templates](https://blog.ipspace.net/2021/11/netsim-groups-deployment-templates/)
 * [Simplify netlab Topologies with Link Groups](https://blog.ipspace.net/2023/05/netlab-link-groups/)
 * [Mix Containers and VMs in the Same Lab Topology](https://blog.ipspace.net/2023/02/netlab-vm-containers/)
@@ -108,6 +108,7 @@ Documentation of individual configuration modules includes sample lab topology f
 
    example/github.md
    example/release.md
+   example/link-definition.md
    example/linux.md
    example/bridge.md
    example/vlan-addressing.md


### PR DESCRIPTION
Having the same file in multiple ToC entries makes some versions of Sphinx nervous as it doesn't know where in the left-hand sidebar to put the header entry.

This commit removes all duplicate ToC entries, usually leaving them where Sphinx selected the primary entry anyway (so it's just decluttering the build process)