### PR TITLE
Fix: Start Ansible from 'netlab initial -o' only when needed

### DIFF
--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -73,7 +73,7 @@ def create_from_config_templates(topology: Box, nodeset: list, abs_path: Path, a
     node_configs = set(n_data.get('module',[]) + ['initial']) | set(n_data.get('config',[]))
     ansible_config = node_configs - set(n_data.get('netlab_ansible_skip_module',[]))
     if not ansible_config:
-      ansible_skip_nodes.extend(n_name)
+      ansible_skip_nodes.append(n_name)
 
     # And now back to the regular programming...
     #


### PR DESCRIPTION
Some devices (for example, Bird) are not provisioned through Ansible. It makes no sense to start Ansible playbook from 'netlab initial -o' if none of the lab devices (or a subset specified with --limit argument) need Ansible.