### PR TITLE
Use Ansible file search lists for daemon/node config files

### DIFF
--- a/netsim/ansible/templates/initial/bird-clab.j2
+++ b/netsim/ansible/templates/initial/bird-clab.j2
@@ -2,6 +2,6 @@ set -x
 {% include 'linux-clab.j2' +%}
 #
 set -e
-{% if loopback.ipv6 is defined %}
+{% if loopback is defined and loopback.ipv6 is defined %}
 ip addr add fe80::1/64 dev lo scope link
 {% endif %}

--- a/netsim/ansible/templates/vlan/linux-clab.j2
+++ b/netsim/ansible/templates/vlan/linux-clab.j2
@@ -1,5 +1,7 @@
 {% include 'frr.j2' +%}
 {% from "initial/linux/vanilla-ifconfig.j2" import ifconfig %}
-{% for intf in interfaces if intf.type == 'svi' or intf.vlan.mode|default('') == 'route' %}
+{% for intf in interfaces 
+     if intf.type == 'svi' or 
+        intf.vlan is defined and intf.vlan.mode|default('') == 'route' %}
 {{   ifconfig(intf) }}
 {% endfor %}

--- a/netsim/augment/config.py
+++ b/netsim/augment/config.py
@@ -185,6 +185,7 @@ def make_paths_absolute(p_top: Box, parents: str = 'defaults.paths') -> None:
   for k in list(p_top.keys()):
     if k.startswith('files') or k.startswith('tasks'):
       p_top[k] = [ fn.replace('\n','') for fn in p_top[k] ]
+      p_top[f'f_{k}'] = [ fn.replace('{{','{').replace('}}','}') for fn in p_top[k] ]
       continue
     v = p_top[k]
     if isinstance(v,str):

--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -14,7 +14,6 @@ from ...augment import devices
 from ...outputs.ansible import get_host_addresses
 from ...outputs.common import adjust_inventory_host
 from ...providers import _Provider
-from ...utils import files as _files
 from ...utils import log, templates
 from .. import _nodeset, ansible, error_and_exit
 
@@ -93,11 +92,11 @@ def create_from_config_templates(topology: Box, nodeset: list, abs_path: Path, a
         skip = skip or args.custom and b_template not in n_data.get('config',[])
         if skip:                                            # ... or custom configs not in 'config' list
           continue
-      b_path = _files.find_provider_template(
-                        node=n_data,
-                        fname=b_template,
-                        topology=topology,
-                        provider_path=p.get_full_template_path())
+      b_path = templates.find_provider_template(
+                  node=n_data,
+                  fname=b_template,
+                  topology=topology,
+                  provider_path=p.get_full_template_path())
       if not b_path:                                        # Try to find the configuration template
         log.warning(                                        # Houston, we have a problem...
           text=f'Cannot find template {b_template} for node {n_name}/device {n_data.device}',
@@ -105,11 +104,11 @@ def create_from_config_templates(topology: Box, nodeset: list, abs_path: Path, a
         continue
 
       try:
-        node_paths = _files.config_template_paths(
-                              node=n_data,
-                              fname=b_template,
-                              topology=topology,
-                              provider_path=p.get_full_template_path())
+        node_paths = templates.config_template_paths(
+                        node=n_data,
+                        fname=b_template,
+                        topology=topology,
+                        provider_path=p.get_full_template_path())
         o_fname = f'{n_name}.{b_template}.cfg'              # Try to render the template into
         templates.write_template(                           # ... node.template.cfg file in the output directory
           in_folder=os.path.dirname(b_path),

--- a/netsim/daemons/bird/initial.j2
+++ b/netsim/daemons/bird/initial.j2
@@ -1,1 +1,0 @@
-{% include 'initial/linux/vanilla.j2' %}

--- a/netsim/daemons/bird/lag.j2
+++ b/netsim/daemons/bird/lag.j2
@@ -1,1 +1,0 @@
-{% include 'lag/linux.j2' %}

--- a/netsim/daemons/bird/vlan.j2
+++ b/netsim/daemons/bird/vlan.j2
@@ -1,7 +1,0 @@
-{% include 'vlan/frr.j2' +%}
-{% from "initial/linux/vanilla-ifconfig.j2" import ifconfig %}
-{% for intf in interfaces 
-     if intf.type == 'svi' or 
-        intf.vlan is defined and intf.vlan.mode|default('') == 'route' %}
-{{   ifconfig(intf) }}
-{% endfor %}

--- a/netsim/outputs/common.py
+++ b/netsim/outputs/common.py
@@ -3,9 +3,11 @@
 #
 
 import typing
+
 from box import Box
+
 from ..augment import devices
-from ..data import get_empty_box,get_box
+from ..data import get_box, get_empty_box
 
 topo_to_host = { 'mgmt.ipv4': 'ansible_host', 'hostname': 'ansible_host', 'id': 'id' }
 topo_to_host_skip = [ 'name','device' ]
@@ -32,7 +34,8 @@ def add_group_vars(
   group_vars = devices.get_device_attribute(node,'group_vars',defaults)
   if isinstance(group_vars,dict):
     for (k,v) in group_vars.items():
-      host[k] = v
+      if k not in host:
+        host[k] = v
 
 def adjust_inventory_host(
       node: Box,

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -129,7 +129,7 @@ class _Provider(Callback):
       if out_key in bind_dict:
         continue
 
-      template_path = _files.find_provider_template(node,file,topology,self.get_full_template_path())
+      template_path = templates.find_provider_template(node,file,topology,self.get_full_template_path())
       if not template_path:
         log.error(
           f"Cannot find template {file}.j2 for extra file {self.provider}.{inkey}.{file} on node {node.name}",
@@ -141,6 +141,10 @@ class _Provider(Callback):
       append_to_list(node[self.provider],'_template_cache',{ 'fname': file, 'fpath': template_path})
 
     node[self.provider][outkey] = filemaps.dict_to_mapping(bind_dict)
+
+    # Finally, remove the cached data we used to generate template file names. We won't need it any longer
+    #
+    node.pop('_template_vars',None)
 
   def create_extra_files(
       self,
@@ -221,7 +225,7 @@ class _Provider(Callback):
         continue
 
       try:
-        node_paths = _files.config_template_paths(
+        node_paths = templates.config_template_paths(
                         node=node,
                         fname=template_fname,
                         topology=topology,

--- a/netsim/utils/files.py
+++ b/netsim/utils/files.py
@@ -10,8 +10,6 @@ import sys
 import textwrap
 import typing
 
-from box import Box
-
 from ..data import global_vars
 from . import log
 
@@ -133,55 +131,6 @@ def find_file(path: str, search_path: typing.List[str]) -> typing.Optional[str]:
     log.info(f'Failed to find {path} in:',more_data=textwrap.indent('\n'.join(search_path),'  - '))
 
   return None
-
-"""
-Build a list of potential directories in which we might find a configuration template
-
-The function uses default search paths for custom- or configuration templates and augments
-them with provider- and device-specific information
-"""
-def config_template_paths(
-      node: Box,
-      fname: str,
-      topology: Box,
-      provider_path: typing.Optional[str] = None) -> list:
-  if fname in node.get('config',[]):                    # Are we dealing with extra-config template?
-    path_prefix = topology.defaults.paths.custom.dirs
-    path_suffix = [ fname ]
-  else:
-    path_suffix = [ node.device ]
-    path_prefix = [ provider_path ] if provider_path else []
-    path_prefix += topology.defaults.paths.templates.dirs
-
-    if node.get('_daemon',False):
-      if '_daemon_parent' in node:
-        path_suffix.append(node._daemon_parent)
-
-  return [ os.path.join(pf, sf) for pf in path_prefix for sf in path_suffix ] + path_prefix
-
-"""
-Find a provider/daemon configuration template
-"""
-def find_provider_template(
-      node: Box,
-      fname: str,
-      topology: Box,
-      provider_path: typing.Optional[str] = None) -> typing.Optional[str]:
-
-  path = config_template_paths(node,fname,topology,provider_path=provider_path)
-  if log.debug_active('template'):
-    print(f'Searching for {fname} template for {node.name}/{node.device} in:')
-    for p in path:
-      print(f'- {p}')
-
-  if fname in node.get('config',[]):                    # Are we dealing with extra-config template?
-    fname = node.device
-
-  found_file = find_file(f'{fname}.j2', path)
-  if log.debug_active('template'):
-    print(f'Found file: {found_file}')
-
-  return found_file
 
 #
 # Get a list of files matching a glob pattern


### PR DESCRIPTION
This change unifies the way internal code (creating daemon/node config files/scripts) and Ansible playbooks search for template files.

* The 'defaults.paths.X.files' list is transformed into 'f_files' version of the list which contains f-strings
* The list of potential file names is used to find the configuration template in the list of directories.
* Per-node data used to generate file names is cached to reduce the overhead
* Bird Initial/VLAN/LAG configuration scripts are used as a proof-of-concept (they are generated from Bird and Linux Ansible templates)

Other fixes:

* Linux and Bird Ansible templates were fixed to carefully check for existence of multi-level dictionaries
* The template-searching functions have been moved from utils.files to utils.templates
* The add_group_vars function has been fixed to copy group var into node data only if the node does not have the same attribute