### PR TITLE
Recreate node config files in netlab initial if templates changed

### DIFF
--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -187,7 +187,7 @@ def start_lab(settings: Box, provider: str, step: int = 2, cli_command: str = "t
     log.fatal(f"{exec_command} failed, aborting...",cli_command)
 
 def deploy_configs(command: str = "test", fast: typing.Optional[bool] = False) -> None:
-  cmd = ["netlab","initial","--no-message"]
+  cmd = ["netlab","initial","--no-message","--no-refresh"]
   if log.VERBOSE:
     cmd.append("-" + "v" * log.VERBOSE)
 

--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -3,19 +3,16 @@ Building device configurations in the specified output directory
 """
 
 import argparse
-import os
 import shutil
 from pathlib import Path
 
 from box import Box
 
-from ... import data
 from ...augment import devices
-from ...outputs.ansible import get_host_addresses
-from ...outputs.common import adjust_inventory_host
-from ...providers import _Provider
-from ...utils import log, templates
+from ...providers import get_provider_module
+from ...utils import log
 from .. import _nodeset, ansible, error_and_exit
+from . import templates as i_templates
 from . import utils
 
 
@@ -42,67 +39,50 @@ Create files that are usually created for clab.binds from clab.config_templates
 in the config directory to have everything in one place
 """
 def create_from_config_templates(topology: Box, nodeset: list, abs_path: Path, args: argparse.Namespace) -> int:
-  shared_data = {                                           # Create the shared data we need for config templates
-    'hostvars': topology.nodes.to_dict(),
-    'hosts': get_host_addresses(topology),
-    'addressing': topology.addressing.to_dict()
-  }
-
-  output_path = str(abs_path)
   output_count = 0
   for n_name in nodeset:
     n_data = topology.nodes[n_name]
     n_provider = devices.get_provider(n_data,topology.defaults)
-    n_deploy = utils.node_deploy_list(n_data,args)
-    if f'{n_provider}.config_templates' not in n_data:      # The node is not using config templates
+    if f'{n_provider}._template_cache' not in n_data:       # The node is not using config templates
       continue                                              # Move on
 
-    p = _Provider(provider=n_provider,data=data.get_empty_box())
-    node_data = adjust_inventory_host(                      # Add group variables to node data
-                              node=n_data,
-                              defaults=topology.defaults,
-                              group_vars=True).to_dict()
-    for k,v in shared_data.items():                         # And copy shared data
-      node_data[k] = v
+    p = get_provider_module(topology,n_provider)
+    provider_path = p.get_full_template_path()
 
-    node_data['node_provider'] = n_provider
-    for b_item in n_data[n_provider].config_templates:      # Now iterate over all config templates the node is using
-      b_template = b_item.split(':')[0].replace('@','.')    # Extract template name
-      if b_template not in n_deploy:                        # Was this requested by the user?
+    # Next, update template cache and iterate over it
+    i_templates.update_template_cache(n_data,n_provider,provider_path,topology)
+    node_dict = None
+    node_deploy = utils.node_deploy_list(n_data,args)
+    node_module = n_data.get('module',[])
+    node_config = n_data.get('config',[])
+    for t_item in n_data[n_provider].get('_template_cache',[]):
+      if not t_item.fpath:
         continue
-      b_path = templates.find_provider_template(
-                        node=n_data,
-                        fname=b_template,
-                        topology=topology,
-                        provider_path=p.get_full_template_path())
-      if not b_path:                                        # Try to find the configuration template
-        log.warning(                                        # Houston, we have a problem...
-          text=f'Cannot find template {b_template} for node {n_name}/device {n_data.device}',
-          module='initial')
+
+      module = t_item.fname
+
+      OK = module in node_deploy
+      OK |= module not in node_module and module not in node_config and 'initial' in node_deploy
+      if not OK:
         continue
+
+      if node_dict is None:                                 # Create node data in template-friendly format if needed
+        node_dict = i_templates.template_node_data(n_data,topology)
+
+      f_mode = t_item.get('mode','')                        # Figure out the output file name
+      o_suffix = '.sh' if f_mode in ('ns','sh') else '.cfg'
+      o_fname = f'{n_name}.{t_item.fname}{o_suffix}'        # Try to render the template into
+      if i_templates.render_config_template(                # ... node.template.cfg/sh file in the output directory
+            node=n_data,
+            node_dict=node_dict,
+            template_id=module,
+            template_path=t_item.fpath,
+            output_file=str(abs_path / o_fname),
+            provider_path=provider_path,
+            topology=topology):
+        log.info(f"Rendered {t_item.fname} template for {n_data.name} into {o_fname}")
 
       output_count += 1
-      try:
-        node_paths = templates.config_template_paths(
-                        node=n_data,
-                        fname=b_template,
-                        topology=topology,
-                        provider_path=p.get_full_template_path())
-        o_fname = f'{n_name}.{b_template}.cfg'              # Try to render the template into
-        templates.write_template(                           # ... node.template.cfg file in the output directory
-          in_folder=os.path.dirname(b_path),
-          j2=os.path.basename(b_path),
-          data=node_data,
-          out_folder=output_path,
-          filename=o_fname,
-          extra_path=node_paths)
-        log.info(f"Rendered {b_template} template for {n_name} into {o_fname}")
-      except Exception as ex:                               # Gee, we failed
-        log.error(                                          # Report an error and move on
-          text=f"Error rendering template {b_template} for node {n_name}/device {n_data.device}",
-          more_data=[f'Template source: {b_path}',f'error: {str(ex)}'],
-          module='initial',
-          category=log.IncorrectValue)
 
   return output_count
 

--- a/netsim/cli/initial/deploy.py
+++ b/netsim/cli/initial/deploy.py
@@ -9,17 +9,52 @@ import typing
 from box import Box
 
 from ... import devices
-from ...providers import execute_node
+from ...augment import devices as a_devices
+from ...providers import execute_node, get_provider_module
 from ...utils import log, strings
 from .. import _nodeset, ansible, error_and_exit, external_commands, get_message, lab_status_change
+from . import templates as i_templates
 from . import utils
 
+
+def update_config_files(n_data: Box, topology: Box, args: argparse.Namespace) -> None:
+  if args.no_refresh:
+    return
+  n_provider = a_devices.get_provider(n_data,topology.defaults)
+  p = get_provider_module(topology,n_provider)
+  provider_path = p.get_full_template_path()
+
+  # Next, update template cache and iterate over it
+  i_templates.update_template_cache(n_data,n_provider,provider_path,topology)
+  node_dict = None
+
+  for t_item in n_data[n_provider].get('_template_cache',[]):
+    if not t_item.get('modified',False):
+      continue
+    if not t_item.fpath:
+      log.warning(
+        text=f'Cannot find {t_item.fname} configuration template for node {n_data.name}/device {n_data.device}',
+        module='initial')
+      continue
+    if node_dict is None:                                 # Create node data in template-friendly format if needed
+      node_dict = i_templates.template_node_data(n_data,topology)
+    if i_templates.render_config_template(                # Recreate configuration file
+          node=n_data,
+          node_dict=node_dict,
+          template_id=t_item.fname,
+          template_path=t_item.fpath,
+          output_file=t_item.output,
+          provider_path=provider_path,
+          topology=topology):
+      log.warning(
+        text=f"{t_item.fname} template for node {n_data.name} changed. Recreated the configuration file")
 
 def deploy_provider_config(nodeset: list, topology: Box, args: argparse.Namespace) -> typing.Tuple[bool,bool]:
   OK = True
   Used = False
   for n_name in nodeset:
     n_data = topology.nodes[n_name]
+    update_config_files(n_data,topology,args)
     n_deploy = utils.node_deploy_list(n_data,args)
     execute_node('deploy_node_config',n_data,topology,deploy_list=n_deploy)
     Used = Used or '_deploy' in n_data

--- a/netsim/cli/initial/templates.py
+++ b/netsim/cli/initial/templates.py
@@ -1,0 +1,117 @@
+"""
+The template-handling utility functions shared across 'netlab initial' modules
+"""
+
+import os
+import typing
+
+from box import Box
+
+from ...augment import devices
+from ...outputs.ansible import get_host_addresses
+from ...outputs.common import adjust_inventory_host
+from ...utils import files as _files
+from ...utils import log, templates
+
+"""
+template_shared_data: create or retrieve shared data used by all configuration templates
+"""
+TEMPLATE_SHARED_DATA: typing.Optional[dict] = None
+
+def template_shared_data(topology: Box) -> dict:
+  global TEMPLATE_SHARED_DATA
+  if TEMPLATE_SHARED_DATA is None:
+    TEMPLATE_SHARED_DATA = {                      # Create the shared data we need for config templates
+      'hostvars': topology.nodes.to_dict(),
+      'hosts': get_host_addresses(topology),
+      'addressing': topology.addressing.to_dict()
+    }
+
+  return TEMPLATE_SHARED_DATA
+
+"""
+template_node_data: node data with extra Ansible-like attributes used in config templates or template paths
+"""
+def template_node_data(n_data: Box, topology: Box) -> dict:
+  node_data = adjust_inventory_host(                        # Add group variables to node data
+                            node=n_data,
+                            defaults=topology.defaults,
+                            group_vars=True).to_dict()
+  shared_data = template_shared_data(topology)
+  for k,v in shared_data.items():                           # ...copy shared data
+    node_data[k] = v
+
+  # ... and add provider info
+  node_data['node_provider'] = devices.get_provider(n_data,topology.defaults)
+  return node_data
+
+"""
+update_template_cache: refresh the node template and check the timestamps on input and output files
+"""
+def update_template_cache(node: Box, n_provider: str, provider_path: str, topology: Box) -> None:
+  t_cache = node.get(f'{n_provider}._template_cache')
+  if not t_cache:
+    return
+  for t_item in t_cache:
+    t_path = templates.find_provider_template(
+                        node=node,
+                        fname=t_item.fname,
+                        topology=topology,
+                        provider_path=provider_path)
+    if not t_path:                                        # Try to find the configuration template
+      log.warning(                                        # Houston, we have a problem...
+        text=f'Cannot find {t_item.fname} template for node {node.name}/device {node.device}',
+        module='initial')
+      t_item.fpath = None
+      continue
+
+    if t_path != t_item.fpath:                            # Change in configuration template path?
+      t_item.fpath = t_path                               # Store the new one and mark the file as modified
+      t_item.modified = True
+      continue
+
+    if not os.path.exists(t_item.output):                 # Output file missing?
+      t_item.modified = True                              # We need to recreate it
+      continue
+
+    # Template modified later than the output file? Recreate the output file!
+    #
+    if os.path.getmtime(t_item.output) < os.path.getmtime(t_item.fpath):
+      t_item.modified = True
+
+"""
+render_config_template: create an output file from the specified config template
+"""
+def render_config_template(
+      node: Box,
+      node_dict: typing.Optional[dict],
+      template_id: str,
+      template_path: str,
+      output_file: str,
+      provider_path: str,
+      topology: Box) -> bool:
+
+  if node_dict is None:
+    node_dict = template_node_data(node,topology)
+  try:
+    node_paths = templates.config_template_paths(
+                    node=node,
+                    fname=template_id,
+                    topology=topology,
+                    provider_path=provider_path)
+    templates.write_template(
+      in_folder=os.path.dirname(template_path),
+      j2=os.path.basename(template_path),
+      data=node_dict,
+      out_folder=os.path.dirname(output_file),
+      filename=os.path.basename(output_file),
+      extra_path=node_paths)
+    return True
+  except Exception as ex:                               # Gee, we failed
+    short_path = template_path.replace(str(_files.get_moddir()),'package:')
+    log.error(                                          # Report an error and move on
+      text=f"Error rendering template {template_id} for node {node.name}/device {node.device}",
+      more_data=[f'Template source: {short_path}',f'error: {str(ex)}'] + templates.template_error_location(ex),
+      module='initial',
+      category=log.IncorrectValue)
+    return False

--- a/netsim/cli/initial/utils.py
+++ b/netsim/cli/initial/utils.py
@@ -57,6 +57,10 @@ def initial_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namesp
     '--no-message',
     dest='no_message', action='store_true',
     help=argparse.SUPPRESS)
+  parser.add_argument(
+    '--no-refresh',
+    dest='no_refresh', action='store_true',
+    help=argparse.SUPPRESS)
   parser_lab_location(parser,instance=True,i_used=True,action='configure')
 
   return parser.parse_known_args(args)


### PR DESCRIPTION
This commit resolves #2905 and adds automatic check-and-recreate functionality to 'netlab initial'. Before creating configuration files or deploying them, the templates are searched again (in case the user added/removed a custom template) and the output files are recreated if the underlying templates changed.

This functionality is controlled by the '--no-refresh' flag to allow 'netlab up' to run 'netlab initial' without checking files that were created milliseconds ago.

Other changes:

* Template functions were moved from netsim.cli.initial.config to netsim.cli.initial.template
* 'netlab config' uses _template_cache instead of config_templates to create configuration files