### PR TITLE
Clean up router_id tests in templates

### DIFF
--- a/netsim/ansible/templates/bgp/arubacx.j2
+++ b/netsim/ansible/templates/bgp/arubacx.j2
@@ -4,7 +4,7 @@
 router bgp {{ bgp.as }}
   bgp log-neighbor-changes
   timers bgp connect-retry 10
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/asa.j2
+++ b/netsim/ansible/templates/bgp/asa.j2
@@ -1,7 +1,7 @@
 {% import "asa.macro.j2" as bgpcfg %}
 !
 router bgp {{ bgp.as }}
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/bgp/cumulus_nvue.j2
+++ b/netsim/ansible/templates/bgp/cumulus_nvue.j2
@@ -4,7 +4,7 @@
       bgp:
         enable: on
         autonomous-system: {{ bgp.as }}
-{%   if bgp.router_id|ipv4 %}
+{%   if bgp.router_id is defined %}
         router-id: {{ bgp.router_id }}
 {%   endif %}
 {{ bgp_in_vrf('default', { 'bgp': bgp, 'loopback': loopback, 'af': af } ) }}

--- a/netsim/ansible/templates/bgp/dellos10.j2
+++ b/netsim/ansible/templates/bgp/dellos10.j2
@@ -12,7 +12,7 @@ router bgp {{ bgp.as }}
     link-local-only-nexthop
     exit
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.confederation is defined %}

--- a/netsim/ansible/templates/bgp/eos.j2
+++ b/netsim/ansible/templates/bgp/eos.j2
@@ -47,7 +47,7 @@ router bgp {{ bgp.as }}
   bgp confederation identifier {{ bgp.confederation.as }}
   bgp confederation peers {{ bgp.confederation.peers|join(' ') }}
 {% endif %}
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -12,7 +12,7 @@ router bgp {{ bgp.as }}
   ! Consider AS paths of same length but with different AS as ECMP candidates
   bgp bestpath as-path multipath-relax
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   bgp router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/ios.j2
+++ b/netsim/ansible/templates/bgp/ios.j2
@@ -13,7 +13,7 @@ router bgp {{ bgp.as }}
  bgp confederation identifier {{ bgp.confederation.as }}
  bgp confederation peers {{ bgp.confederation.peers|join(' ') }}
 {% endif %}
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
  bgp router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/junos.j2
+++ b/netsim/ansible/templates/bgp/junos.j2
@@ -3,7 +3,7 @@
 
 routing-options {
   autonomous-system {{ bgp.as }};
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.originate is defined %}

--- a/netsim/ansible/templates/bgp/nxos.j2
+++ b/netsim/ansible/templates/bgp/nxos.j2
@@ -5,7 +5,7 @@
 feature bgp
 !
 router bgp {{ bgp.as }}
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/routeros.j2
+++ b/netsim/ansible/templates/bgp/routeros.j2
@@ -2,7 +2,7 @@
 
 /routing bgp instance set 0 as={{ bgp.as }}
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
   /routing bgp instance set 0 router-id={{ bgp.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/bgp/routeros7.j2
+++ b/netsim/ansible/templates/bgp/routeros7.j2
@@ -2,7 +2,7 @@
 
 /routing/bgp/template add name=main as={{ bgp.as }} output.network=bgp-networks
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
 /routing/bgp/template set main router-id={{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -2,7 +2,7 @@
 
 set protocols bgp system-as {{ bgp.as }}
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
 set protocols bgp parameters router-id {{ bgp.router_id }}
 {% endif %}
 {% if bgp.rr|default(False) and bgp.rr_cluster_id|default(False) %}

--- a/netsim/ansible/templates/eigrp/ios.j2
+++ b/netsim/ansible/templates/eigrp/ios.j2
@@ -5,7 +5,7 @@ Configure IPv4 EIGRP
 #}
 {% if eigrp.af.ipv4 is defined %}
 router eigrp {{ eigrp.as }}
-{% if eigrp.router_id|ipv4 %}
+{% if eigrp.router_id is defined %}
  eigrp router-id {{ eigrp.router_id }}
 {% endif %}
 {% for l in netlab_interfaces|default([]) if 'eigrp' in l and 'ipv4' in l  and l.ipv4 is string %}
@@ -26,7 +26,7 @@ Configure IPv6 EIGRP - totally separate configuration
 #}
 {% if eigrp.af.ipv6 is defined %}
 ipv6 router eigrp {{ eigrp.as }}
-{% if eigrp.router_id|ipv4 %}
+{% if eigrp.router_id is defined %}
  eigrp router-id {{ eigrp.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/eigrp/nxos.j2
+++ b/netsim/ansible/templates/eigrp/nxos.j2
@@ -1,7 +1,7 @@
 feature eigrp
 !
 router eigrp {{ eigrp.as }}
-{% if eigrp.router_id|ipv4 %}
+{% if eigrp.router_id is defined %}
  router-id {{ eigrp.router_id }}
 {% endif %}
 {% if 'ipv6' in eigrp.af %}

--- a/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/arubacx.ospfv2.j2
@@ -1,7 +1,7 @@
 {% import "templates/routing/_default.ios.j2" as ospf_default %}
 !
 router ospf {{ pid }}
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
     router-id {{ ospf.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/ospf/asa.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/asa.ospfv2.j2
@@ -7,7 +7,7 @@
 !
 {% macro config(ospf_pid,ospf_vrf,ospf_data,intf_data,bgp={}) %}
 router ospf {{ ospf_pid }}
-{% if ospf_data.router_id|ipv4 %}
+{% if ospf_data.router_id is defined %}
   router-id {{ ospf_data.router_id }}
 {% endif %}
 {% if ospf_data.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/cumulus.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/cumulus.ospfv2.j2
@@ -2,7 +2,7 @@
 {% import "templates/routing/_redistribute.frr.j2" as redistribute with context %}
 !
 router ospf
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
  ospf router-id {{ ospf.router_id }}
 {% endif %}
 {% for l in interfaces|default([]) if l.ospf.passive|default(False) %}

--- a/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/dellos10.ospfv2.j2
@@ -2,7 +2,7 @@
 {% import "templates/routing/_redistribute.dellos10.j2" as redistribute with context %}
 
 router ospf {{ pid }}
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
  router-id {{ ospf.router_id }}
 {% endif %}
 {% if ospf.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/eos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/eos.ospfv2.j2
@@ -13,7 +13,7 @@ router ospf {{ ospf_pid }}
 {#
   Get local- or global OSPF router ID. Global is always set
 #}
-{% if ospf_data.router_id|ipv4 %}
+{% if ospf_data.router_id is defined %}
  router-id {{ ospf_data.router_id }}
 {% endif %}
  interface unnumbered hello mask tx 0.0.0.0

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -9,7 +9,7 @@ router ospf vrf {{ ospf_vrf }}
 {% else %}
 router ospf
 {% endif %}
-{% if ospf_data.router_id|ipv4 %}
+{% if ospf_data.router_id is defined %}
  ospf router-id {{ ospf_data.router_id }}
 {% endif %}
 {% if ospf_data.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/ios.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/ios.ospfv2.j2
@@ -7,7 +7,7 @@ router ospf {{ ospf_pid }} vrf {{ ospf_vrf }}
 {% else %}
 router ospf {{ ospf_pid }}
 {% endif %}
-{% if ospf_data.router_id|ipv4 %}
+{% if ospf_data.router_id is defined %}
  router-id {{ ospf_data.router_id }}
 {% endif %}
 {% if ospf_data.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/iosxr.j2
+++ b/netsim/ansible/templates/ospf/iosxr.j2
@@ -14,7 +14,7 @@ router ospf{{ 'v3' if igp_af == 'ipv6' else '' }} {{ pid }}{% if vrf %} vrf {{ v
 !
  timers throttle spf 10 20 100
  timers throttle lsa all 10 20 100
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
  router-id {{ ospf.router_id }}
 {% endif %}
 {{ ospf_default.config(ospf,igp_af) }}

--- a/netsim/ansible/templates/ospf/junos.j2
+++ b/netsim/ansible/templates/ospf/junos.j2
@@ -1,5 +1,5 @@
 {% import "junos.macro.j2" as ospf_cfg %}
-{% if ospf.router_id is defined and ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
 routing-options {
   router-id {{ ospf.router_id }}
 }

--- a/netsim/ansible/templates/ospf/nxos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/nxos.ospfv2.j2
@@ -5,7 +5,7 @@ feature bfd
 {% endif %}
 !
 router ospf {{ pid }}
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
  router-id {{ ospf.router_id }}
  timers throttle spf 100 200 500
  timers throttle lsa 0 100 500

--- a/netsim/ansible/templates/ospf/nxos.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/nxos.ospfv3.j2
@@ -5,7 +5,7 @@ feature bfd
 {% endif %}
 !
 router ospfv3 {{ pid }}
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
  router-id {{ ospf.router_id }}
 {% endif %}
 {% if ospf.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/openbsd.ospfv2.j2
@@ -1,7 +1,7 @@
 {% macro config(ospf_vrf,ospf_data,intf_data) %}
 {%- set areas = intf_data|selectattr('ipv4', 'defined')|map(attribute='ospf.area', default='')|reject('eq', '')|sort|unique %}
 cat <<OSPFD_CONF >/etc/ospfd.conf
-{% if ospf_data.router_id|ipv4 %}
+{% if ospf_data.router_id is defined %}
 router-id {{ ospf_data.router_id }}
 {% endif %}
 spf-delay msec 100

--- a/netsim/ansible/templates/ospf/routeros.j2
+++ b/netsim/ansible/templates/ospf/routeros.j2
@@ -1,7 +1,7 @@
 {% set KW_NETWORK_TYPE = {'point-to-point': 'point-to-point','point-to-multipoint': 'ptmp', 'non-broadcast': 'nbma','broadcast': 'broadcast' } %}
 {% set area = ospf.area|default("0.0.0.0") %}
 
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
   /routing ospf instance set 0 router-id={{ ospf.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/ospf/routeros7.ospf-include.j2
+++ b/netsim/ansible/templates/ospf/routeros7.ospf-include.j2
@@ -2,7 +2,7 @@
 
 {% set area = (ospf.area|default("0.0.0.0"))|string|ansible.utils.ipaddr('address') %}
 
-{% if ospf_router_id|ipv4 %}
+{% if ospf_router_id is defined %}
 /routing/ospf/instance add name={{instance}} version={{ospf_version}} router-id={{ ospf_router_id }} vrf={{ospf_vrf|default('main')}}
 {% endif %}
 

--- a/netsim/ansible/templates/ospf/vyos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv2.j2
@@ -1,6 +1,6 @@
 {% import "vyos.default.j2" as ospf_default %}
 
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
 set protocols ospf parameters router-id {{ ospf.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/ospf/vyos.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/vyos.ospfv3.j2
@@ -1,6 +1,6 @@
 {% import "vyos.default.j2" as ospf_default %}
 
-{% if ospf.router_id|ipv4 %}
+{% if ospf.router_id is defined %}
 set protocols ospfv3 parameters router-id {{ ospf.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/vrf/junos.bgp.j2
+++ b/netsim/ansible/templates/vrf/junos.bgp.j2
@@ -58,7 +58,7 @@ routing-instances {
   {{vname}} {
     routing-options {
       autonomous-system {{ bgp.as }};
-{%   if bgp.router_id|ipv4 %}
+{%   if bgp.router_id is defined %}
       router-id {{ vdata.bgp.router_id|default(bgp.router_id) }}
 {%   endif %}
     }

--- a/netsim/ansible/templates/vrf/junos.j2
+++ b/netsim/ansible/templates/vrf/junos.j2
@@ -7,7 +7,7 @@
 {# 
    generic policy to redistribute bgp + leaked(imported) into ospf
 #}
-{% if vdata.ospf.router_id is defined and vdata.ospf.router_id|ipv4 %}
+{% if vdata.ospf.router_id is defined %}
 routing-instances {
   {{ vname }} {
     routing-options {

--- a/netsim/ansible/templates/vrf/nxos.bgp.j2
+++ b/netsim/ansible/templates/vrf/nxos.bgp.j2
@@ -7,7 +7,7 @@ route-map all
 router bgp {{ bgp.as }}
 {% for vname, vdata in vrfs.items() %}
   vrf {{ vname }}
-{%   if bgp.router_id|ipv4 %}
+{%   if bgp.router_id is defined %}
     router-id {{ bgp.router_id }}
 {%   endif %}
 {%   for af in ['ipv4','ipv6'] if vdata.af|default({}) %}

--- a/netsim/ansible/templates/vrf/nxos.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/nxos.ospfv2-vrf.j2
@@ -17,7 +17,7 @@ router ospf {{ pid }}
  vrf {{ vname }}
   timers throttle spf 100 200 500
   timers throttle lsa 0 100 500
-{% if vdata.ospf.router_id|ipv4 %}
+{% if vdata.ospf.router_id is defined %}
   router-id {{ vdata.ospf.router_id }}
 {% endif %}
 {% if ospf.reference_bandwidth is defined %}

--- a/netsim/ansible/templates/vrf/routeros7.bgp.j2
+++ b/netsim/ansible/templates/vrf/routeros7.bgp.j2
@@ -11,7 +11,7 @@
 #}
 /routing/bgp/template add name=vrf_{{ vname }} as={{ bgp.as }} output.network=bgp-networks-{{ vname }} vrf={{ vname }} routing-table={{ vname }} output.redistribute=connected,bgp,bgp-mpls-vpn,vpn
 
-{% if bgp.router_id|ipv4 %}
+{% if bgp.router_id is defined %}
 /routing/bgp/template set vrf_{{ vname }} router-id={{ bgp.router_id }}
 {% endif %}
 

--- a/netsim/ansible/templates/vrf/vyos.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/vyos.ospfv2-vrf.j2
@@ -1,6 +1,6 @@
 {% import "templates/ospf/vyos.default.j2" as ospf_default %}
 
-{% if vdata.ospf.router_id|ipv4 or ospf.router_id|ipv4 %}
+{% if vdata.ospf.router_id is defined or ospf.router_id is defined %}
 set protocols ospf parameters router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
 {% endif %}
 

--- a/netsim/ansible/templates/vrf/vyos.ospfv3-vrf.j2
+++ b/netsim/ansible/templates/vrf/vyos.ospfv3-vrf.j2
@@ -1,6 +1,6 @@
 {% import "templates/ospf/vyos.default.j2" as ospf_default %}
 
-{% if vdata.ospf.router_id|ipv4 or ospf.router_id|ipv4 %}
+{% if vdata.ospf.router_id is defined or ospf.router_id is defined %}
 set protocols ospfv3 parameters router-id {{ vdata.ospf.router_id|default(ospf.router_id) }}
 {% endif %}
 


### PR DESCRIPTION
Replace meaningless router_id|ipv4 tests with router_id is defined checks. If router_id is calculated or configured, it will always be an IPv4 address, so testing for ipv4 format is redundant. The proper test is whether router_id is defined.

Fixes #2929