### PR TITLE
Fix SR OS OSPF router ID fallback in VRF context

### DIFF
--- a/netsim/ansible/templates/ospf/sros.j2
+++ b/netsim/ansible/templates/ospf/sros.j2
@@ -32,7 +32,7 @@
 {%  endif %}
 {% endmacro %}
 
-{% macro ospf_config(af,ospf,vrf_interfaces,vrf_name='') %}
+{% macro ospf_config(af,ospf,vrf_interfaces,vrf_name='',global_router_id=None) %}
 {%   set vname = vrf_name or 'default' %}
 {%   set pid = ospf.process|default(0) %}
 {%   set ospfv = 'ospf3' if af=='ipv6' else 'ospf' %}
@@ -51,7 +51,7 @@
     reference-bandwidth: {{ ospf.reference_bandwidth * 1000 }} # in kbps
 {%   endif %}
     admin-state: enable
-    router-id: {{ ospf.router_id }}
+    router-id: {{ ospf.router_id|default(global_router_id) }}
 {#
    SR OS configures interfaces within areas, so we need a list of areas. netlab
    does not provide that directly, so we're reverse-engineering it from the

--- a/netsim/ansible/templates/vrf/sros.j2
+++ b/netsim/ansible/templates/vrf/sros.j2
@@ -24,7 +24,7 @@ updates:
 {%   if 'ospf' in vdata and 'af' in vdata %}
 {%     for rtg_af in ['ipv4','ipv6'] %}
 {%       if vdata.ospf.af[rtg_af]|default(False) %}
-{{         ospf_config(rtg_af,vdata.ospf,vdata.ospf.interfaces,vname) }}
+{{         ospf_config(rtg_af,vdata.ospf,vdata.ospf.interfaces,vname,global_router_id=ospf.router_id) }}
 {%       endif %}
 {%     endfor %}
 {%   endif %}


### PR DESCRIPTION
- Modified ospf_config() macro to accept global_router_id parameter
- Updated macro to use global router ID as fallback when VRF-specific router ID is not set
- Updated VRF template to pass global OSPF router ID to the macro

This ensures OSPF router ID in VRF contexts correctly falls back to global OSPF router ID, consistent with BGP router ID handling in the same template.

Fixes: #2943

Note: We may want to consider having the Python code in the OSPF module fill out the router_id in each VRF, such that the templates can simply take it from there. That way, inconsistencies like this are less likely by structure