### PR TITLE
Fix: Remove obscure Ansible J2 filters from CL NVUE templates

### DIFF
--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -48,7 +48,11 @@
       # dad                    Duplicate Address Detection (DAD) configuration parameters
       # mac-vrf-soo            EVPN MAC VRF Site-of-Origin VPN extended community in ASN:NN or IP-ADDRESS:NN format.
 {% if vxlan._shared_vtep is defined %}
-      mac-vrf-soo: {{ vxlan.vtep }}:{{ interfaces|json_query('[*].lag.mlag.peergroup')|first }}
+{%   for intf in interfaces if intf.lag.mlag.peergroup is defined %}
+{%     if loop.first %}
+      mac-vrf-soo: {{ vxlan.vtep }}:{{ intf.lag.mlag.peergroup }}
+{%     endif %}
+{%   endfor %}
 {% endif %}
       # multihoming            Multihoming global configuration parameters
       # route-advertise        Route advertising

--- a/netsim/ansible/templates/lag/cumulus_nvue.j2
+++ b/netsim/ansible/templates/lag/cumulus_nvue.j2
@@ -22,9 +22,9 @@
     mlag:
       init-delay: 10
       backup:
-{% if pools.mgmt.ipv4 | ansible.netcommon.network_in_usable(lag.mlag.peer_backup_ip) %}
+{% if lag.mlag.peer_backup_vrf is defined %}
         {{ lag.mlag.peer_backup_ip }}:
-          vrf: mgmt
+          vrf: {{ lag.mlag.peer_backup_vrf }}
 {% else %}
         {{ lag.mlag.peer_backup_ip }}: {}
 {% endif %}

--- a/netsim/ansible/templates/vrf/cumulus_nvue.j2
+++ b/netsim/ansible/templates/vrf/cumulus_nvue.j2
@@ -25,7 +25,10 @@
 {# Workaround for lack of NVUE support for VRF route leaking - note can only create 1 snippet for frr.conf globally #}
 {% set import_lengths = vrfs.values()|map(attribute='import',default=[])|map('length')|list %}
 {# Workaround for lack of control over VRF loopbacks and OSPF area config #}
-{% set ospf_loopbacks = vrfs.values()|map(attribute='ospf.interfaces',default=[])|flatten|selectattr('type','eq','loopback')|list %}
+{% set ospf_loopbacks = vrfs.values()|
+              map(attribute='ospf.interfaces',default=[])|
+              flatten|
+              selectattr('type','eq','loopback')|list %}
 {% if import_lengths|max > 1 or ospf_loopbacks %}
 - set:
     system:

--- a/netsim/modules/lag.py
+++ b/netsim/modules/lag.py
@@ -343,6 +343,8 @@ def populate_mlag_peer(node: Box, intf: Box, topology: Box) -> None:
     bk_ip = peer.get(mlag_peer.backup_ip,None)
     if bk_ip:
       _target.mlag.peer_backup_ip = str(netaddr.IPNetwork(bk_ip).ip)
+      if mlag_peer.backup_ip.startswith('mgmt.'):
+        _target.mlag.peer_backup_vrf = 'mgmt'
     else:
       log.error(f'Node {peer.name} must have "{mlag_peer.backup_ip}" defined to support backup MLAG peerlink',
                 category=log.IncorrectValue,


### PR DESCRIPTION
Cumulus NVUE templates used Ansible-specific Jinja2 filters that were not used anywyere else. Most of those filters have been removed, and the LAG module got a new flag -- the peer backup IP VRF name.