### PR TITLE
Fix: Cleanup RouterOS 6 templates

### DIFF
--- a/netsim/ansible/templates/bgp/routeros.macro.j2
+++ b/netsim/ansible/templates/bgp/routeros.macro.j2
@@ -6,10 +6,10 @@
 {%   set neigh_id = ip|replace('.', '_')|replace(':', '_') %}
 {%   set afi_list = [] %}
 {%   if n['ipv4'] is defined %}
-{{ afi_list.append('ip') }}
-{%  endif %}
+{%     set _ = afi_list.append('ip') %}
+{%   endif %}
 {%   if n['ipv6'] is defined %}
-{{ afi_list.append('ipv6') }}
+{%     set _ = afi_list.append('ipv6') %}
 {%   endif %}
 
 /routing bgp peer add name={{ neigh_id }} remote-address={{ ip }} remote-as={{ n.as }} \

--- a/netsim/ansible/templates/initial/routeros.vrf.j2
+++ b/netsim/ansible/templates/initial/routeros.vrf.j2
@@ -6,7 +6,7 @@
 {% set vrf_if_list = [] %}
 {% for l in interfaces|default([]) %}
 {%   if l.vrf is defined and l.vrf == vname %}
-{{ vrf_if_list.append(l.ifname) }}
+{%     set _ = vrf_if_list.append(l.ifname) %}
 {%   endif %}
 {% endfor %}
 

--- a/netsim/ansible/templates/ospf/routeros.j2
+++ b/netsim/ansible/templates/ospf/routeros.j2
@@ -10,14 +10,14 @@
 #}
 {% set area_list = [] %}
 {% if area != '0.0.0.0' %}
-{{ area_list.append(area) }}
+{%   set _ = area_list.append(area) %}
 {% endif %}
 {#
   For each link, check defined area. If != 0.0.0.0, add to area list
 #}
 {% for l in interfaces|default([]) if l.ospf.area is defined %}
 {% if l.ospf.area != '0.0.0.0' %}
-{{ area_list.append(l.ospf.area) }}
+{%   set _ = area_list.append(l.ospf.area) %}
 {% endif %}
 {% endfor %}
 
@@ -44,18 +44,18 @@
 
 /routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }} and instance=default] network={{ l.ipv4 | ipaddr('subnet') }}
 
-{% set ospf_intf_params=[] %}
+{%     set ospf_intf_params=[] %}
 
 {%     if l.ospf.network_type is defined %}
-{{ ospf_intf_params.append('network-type='+KW_NETWORK_TYPE[l.ospf.network_type]) }}
+{%       set _ = ospf_intf_params.append('network-type='+KW_NETWORK_TYPE[l.ospf.network_type]) %}
 {%     endif %}
 
 {%     if l.ospf.cost is defined %}
-{{ ospf_intf_params.append('cost='+l.ospf.cost|string) }}
+{%       set _ = ospf_intf_params.append('cost='+l.ospf.cost|string) %}
 {%     endif %}
 
 {%     if l.ospf.bfd|default(False) %}
-{{ ospf_intf_params.append('use-bfd=yes') }}
+{%       set _ = ospf_intf_params.append('use-bfd=yes') %}
 {%     endif %}
 
 {%     if ospf_intf_params|length > 0 %}

--- a/netsim/ansible/templates/vrf/routeros.bgp.j2
+++ b/netsim/ansible/templates/vrf/routeros.bgp.j2
@@ -16,8 +16,8 @@
     For that reason, as instance Router ID, the IP of the last interface in that VRF is used (can't easily use break in Jinja loops).
 #}
 {% set vrf_router_ids = [ '0.0.0.0' ] %}
-{% for l in interfaces|default([]) if l.vrf is defined and l.vrf == vname %}
-{{ vrf_router_ids.append(l.ipv4|ansible.utils.ipaddr('address')) }}
+{% for l in interfaces|default([]) if l.vrf is defined and l.vrf == vname and l.ipv4 is string %}
+{%   set _ = vrf_router_ids.append(l.ipv4|ansible.utils.ipaddr('address')) %}
 {% endfor %}
 {% set vrf_router_id = vrf_router_ids|last %}
 

--- a/netsim/ansible/templates/vrf/routeros.ospfv2-vrf.j2
+++ b/netsim/ansible/templates/vrf/routeros.ospfv2-vrf.j2
@@ -11,7 +11,7 @@
 #}
 {% set area_list = [] %}
 {% for l in vdata.ospf.interfaces|default([]) if 'ospf' in l and 'ipv4' in l %}
-{{ area_list.append(l.ospf.area) }}
+{%   set _ = area_list.append(l.ospf.area) %}
 {% endfor %}
 
 {#
@@ -29,18 +29,18 @@
 
 /routing ospf network add area=[/routing ospf area find area-id={{ l.ospf.area|default(area) }} and instance={{ vname }}] network={{ l.ipv4 | ipaddr('subnet') }}
 
-{% set ospf_intf_params=[] %}
+{%     set ospf_intf_params=[] %}
 
 {%     if l.ospf.network_type is defined %}
-{{ ospf_intf_params.append('network-type='+KW_NETWORK_TYPE[l.ospf.network_type]) }}
+{%       set _ = ospf_intf_params.append('network-type='+KW_NETWORK_TYPE[l.ospf.network_type]) %}
 {%     endif %}
 
 {%     if l.ospf.cost is defined %}
-{{ ospf_intf_params.append('cost='+l.ospf.cost|string) }}
+{%       set _ = ospf_intf_params.append('cost='+l.ospf.cost|string) %}
 {%     endif %}
 
 {%     if l.ospf.bfd|default(False) %}
-{{ ospf_intf_params.append('use-bfd=yes') }}
+{%       set _ = ospf_intf_params.append('use-bfd=yes') %}
 {%     endif %}
 
 {%     if ospf_intf_params|length > 0 %}


### PR DESCRIPTION
Several templates used 'append within an expression' pattern that was replaced by 'assign the append result to a throwaway variable'.

The VRF BGP template also lacked a check for presence of IPv4 interface address (which caused a bit of a problem in IPv6-only environment)