### PR TITLE
Fix: Add a unique timestamp to topology data structure

### DIFF
--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -9,6 +9,7 @@ import importlib
 import os
 import shutil
 import sys
+import time
 import typing
 from pathlib import Path
 
@@ -276,6 +277,7 @@ def load_snapshot(
   if not ghosts:
     topology = augment.nodes.ghost_buster(topology)
 
+  topology.defaults._cache.timestamp = time.time()
   global_vars.init(topology)
   check_modified_source(snapshot,topology,warn_modified)
   return topology

--- a/netsim/utils/read.py
+++ b/netsim/utils/read.py
@@ -383,6 +383,7 @@ def load(
   if user_defaults or user_defaults is None:                # User defaults missing or specified?
     include_environment_defaults(topology)                  # ... we care about user defaults, add environment vars
 
+  topology.defaults._cache.timestamp = time.time()          # Add a unique topology timestamp
   return topology
 
 #


### PR DESCRIPTION
During the integration tests we use the same data structures with multiple topologies. The timestamp added to the topology data should help the singleton-like functions that don't want to use 'global_vars' to track changes in topology data