### PR TITLE
Fix VyOS RIP template

### DIFF
--- a/netsim/ansible/templates/ripv2/vyos.j2
+++ b/netsim/ansible/templates/ripv2/vyos.j2
@@ -13,7 +13,7 @@ configure
 
 set protocols rip version 2
 
-{%   for intf in netlab_interfaces if 'ipv4' in intf and not 'vrf' in intf %}
+{%   for intf in netlab_interfaces if intf.ipv4|default(False) is string and 'vrf' not in intf %}
 set protocols rip network {{ intf.ipv4|ansible.utils.ipaddr(0) }}
 {%     if intf.ripv2.passive|default(False) or not 'ripv2' in intf %}
 set protocols rip passive-interface {{ intf.ifname }}


### PR DESCRIPTION
The VyOS RIP template could crash with interface IPv4 address set to True. The changed test checks whether IPv4 address is a string.

Resolves #2931