### PR TITLE
Fix EOS RIPv2 template

### DIFF
--- a/netsim/ansible/templates/ripv2/eos.j2
+++ b/netsim/ansible/templates/ripv2/eos.j2
@@ -5,7 +5,7 @@ router rip
 {%     if 'timers' in ripv2 %}
   timers {{ ripv2.timers['update'] }} {{ ripv2.timers.timeout }} {{ ripv2.timers.garbage }}
 {%     endif %}
-{%   for intf in netlab_interfaces if 'ripv2' in intf and intf.ipv4|default('')|ansible.utils.ipaddr() %}
+{%   for intf in netlab_interfaces if 'ripv2' in intf and intf.ipv4|default(False) is string %}
   network {{ intf.ipv4|ansible.utils.ipaddr(0) }}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
EOS RIPv2 template could pass True to ipaddr filter. Rewrote the test to check only if intf.ipv4 is a string (because we know it's a valid address)

Resolves #2930