### PR TITLE
Use paramiko for network_cli on Cisco IOS with new ansible-pylibssh

### DIFF
--- a/netsim/devices/cat8000v.py
+++ b/netsim/devices/cat8000v.py
@@ -6,6 +6,7 @@ from box import Box
 from ..utils import log
 from . import report_quirk
 from .iol import IOSXE as _IOSXE
+from .iosv import use_paramiko
 from .iosvl2 import check_reserved_vlans
 
 
@@ -23,9 +24,10 @@ def check_premier_license(node: Box) -> None:
         quirk='license',
         category=log.MissingDependency)
 
-class IOSL2(_IOSXE):
+class C8KV(_IOSXE):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     super().device_quirks(node,topology)
     check_reserved_vlans(node,topology)
     check_premier_license(node)
+    use_paramiko(node,topology)

--- a/netsim/devices/csr.py
+++ b/netsim/devices/csr.py
@@ -2,8 +2,15 @@
 # Cisco IOS-XE quirks
 #
 
+from box import Box
+
 from .iol import IOSXE as _IOSXE
+from .iosv import use_paramiko
 
 
 class CSR(_IOSXE):
-  pass
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    super().device_quirks(node,topology)
+    use_paramiko(node,topology)

--- a/netsim/devices/iosv.py
+++ b/netsim/devices/iosv.py
@@ -1,6 +1,8 @@
 #
 # Cisco IOSv quirks
 #
+import typing
+
 from box import Box
 
 from ..modules import _routing
@@ -51,6 +53,29 @@ def vlan_1_subinterface(node: Box, topology: Box) -> None:
       quirk='vlan.trunk_1',
       category=log.IncorrectValue)
 
+ANSIBLE_USE_PARAMIKO: typing.Optional[bool] = None
+
+def use_paramiko(node: Box, topology: Box) -> None:
+  global ANSIBLE_USE_PARAMIKO
+  if ANSIBLE_USE_PARAMIKO is None:
+    try:
+      import pylibsshext  # type: ignore
+      ANSIBLE_USE_PARAMIKO = pylibsshext.__version__ >= '1.3.0'
+    except:
+      ANSIBLE_USE_PARAMIKO = False
+
+  if ANSIBLE_USE_PARAMIKO:
+    device = node.device
+    dev_vars = topology.defaults.devices[device].group_vars
+    if 'ansible_network_cli_ssh_type' not in dev_vars:
+      dev_vars.ansible_network_cli_ssh_type = 'paramiko'    # Force Paramiko connection
+      report_quirk(
+        f"Changing Ansible network_cli connection SSH type to 'paramiko'",
+        node,
+        quirk='paramiko',
+        category=Warning,
+        more_hints=[ 'The installed version of ansible-pylibssh might not work with Cisco IOS devices' ])
+
 def common_ios_quirks(node: Box, topology: Box) -> None:
   mods = node.get('module',[])
   if 'ospf' in mods:
@@ -58,6 +83,8 @@ def common_ios_quirks(node: Box, topology: Box) -> None:
 
   if 'ripv2' in mods:
     check_ripng_passive(node,topology)
+
+  use_paramiko(node,topology)
 
 class IOS(_Quirks):
 

--- a/netsim/templates/ansible.cfg.j2
+++ b/netsim/templates/ansible.cfg.j2
@@ -14,3 +14,7 @@ deprecation_warnings=False
 
 [persistent_connection]
 command_timeout=60
+
+[paramiko_connection]
+look_for_keys = false
+record_host_keys = false

--- a/tests/integration/warnings.yml
+++ b/tests/integration/warnings.yml
@@ -3,6 +3,7 @@
 devices:
   eos.warnings.ospf_stub: False
   sros.warnings.loopback_ipv6: False
+  ios.warnings.paramiko: False
 
 warnings:
   providers.change: False


### PR DESCRIPTION
This commit uses the device quirks to check the version of the 'ansible-pylibssh' library, decide whether to use paramiko as network_cli connection with Cisco IOS/IOS-XE devices, and modifies the device group vars, allowing users to override this behavior on device-, device+provider, or node level.

Resolves #2966