### PR TITLE
NVUE: use rr_client flag to configure RR clients in EVPN AF

### DIFF
--- a/netsim/ansible/templates/evpn/cumulus_nvue.j2
+++ b/netsim/ansible/templates/evpn/cumulus_nvue.j2
@@ -24,7 +24,7 @@
                   l2vpn-evpn:
                     enable: on
                     soft-reconfiguration: on
-{%     if bgp.rr|default('') and not n.rr|default('') %}
+{%     if n.rr_client|default(False) %}
                     route-reflector-client: on
 {%     endif %}
 {%   endfor %}


### PR DESCRIPTION
The NVUE EVPN template configured all BGP neighbors as RR clients if the bgp.rr flag was set. NVUE didn't like the idea of having EBGP neighbors as RR clients