### PR TITLE
Fix: Clean up SR-OS EVPN template

### DIFF
--- a/netsim/ansible/templates/evpn/sros.j2
+++ b/netsim/ansible/templates/evpn/sros.j2
@@ -74,27 +74,6 @@ updates:
 {% endif %}
 {% endmacro %}
 
-{% macro evpn_vprn() %}
-{# Add it to the VPRN, enable evpn-tunnel and configure RT #}
-- path: configure/service/vprn[service-name={{ vname }}]
-  val:
-   interface:
-   - interface-name: l3vni-{{ vname }}
-     vpls:
-     - vpls-name: l3vni-{{ vname }}
-       evpn-tunnel: { }   # Applicable when there are no hosts connected to this backhaul R-VPLS, avoids requiring IP on interface
-   bgp-ipvpn:
-    mpls:
-     admin-state: enable
-     route-distinguisher: {{ vdata.evpn.id }}
-     vrf-target:
-      export-community: target:{{ vdata.export[0] }}
-      import-community: target:{{ vdata.import[0] }}
-     auto-bind-tunnel:
-      resolution: any
-      ecmp: {{ 1 if 'ixr' in clab.type else 8 }}
-{% endmacro %}
-
 {# Configure EVPN parameters for simple MAC-VRF (VLAN) services #}
 {% if vlans is defined %}
 {%   for vname,vdata in vlans.items() if vdata.evpn.evi is defined %}


### PR DESCRIPTION
Remove the evpn_vprn macro that is not used anywhere

Resolves #2967