### PR TITLE
Fix: Accept '.j2' suffix in custom config template name

### DIFF
--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -47,6 +47,7 @@ def create_config_file(
       provider_path: str,
       output_path: Path,
       template_path: typing.Optional[str] = None,
+      flatten_output_fname: bool = False,
       config_mode: str = '') -> bool:
 
   o_suffix = '' if config_mode == 'none' else '.sh' if (config_mode in ('ns','sh')) else '.cfg'
@@ -70,6 +71,10 @@ def create_config_file(
       module='configs',
       more_hints=["Use the '--debug template' option if you're troubleshooting custom configuration templates"])
     return False
+
+  if flatten_output_fname:                              # When used in "netlab initial --output"
+    o_fname = o_fname.replace('/','.')                  # ... create all output files in the same directory
+    o_fname = o_fname.replace('.j2.','.')               # ... and remove the .j2 suffix when present
 
   OK = u_templates.render_config_template(              # ... node.template.cfg/sh file in the output directory
           node=node,
@@ -97,7 +102,8 @@ def create_node_configs(
       no_refresh: bool = False,
       skip_extra_config: bool = False,
       node_directory: bool = False,
-      default_suffix: typing.Optional[str] = None) -> None:
+      default_suffix: typing.Optional[str] = None,
+      flatten_output_fname: bool = False) -> None:
   all_configs = utils.deploy_all_configs(args)
   for n_name in nodeset:
     n_data = topology.nodes[n_name]
@@ -156,7 +162,8 @@ def create_node_configs(
             module=module,
             provider_path=provider_path,
             output_path=abs_path / n_data.name if node_directory else abs_path,
-            config_mode=default_suffix or template_mode.get(module,'cfg')):
+            config_mode=default_suffix or template_mode.get(module,'cfg'),
+            flatten_output_fname=flatten_output_fname):
         created_list.append(module)
 
     if not log.VERBOSE and created_list:
@@ -201,7 +208,7 @@ def run(topology: Box, args: argparse.Namespace, cwd: str) -> None:
   if args.generate != 'ansible':                            # Did the user ask for Ansible-generated configs?
     if args.generate == 'compare':                          # Do we have to adjust the output to be directly
       remove_extra_templates(topology,nodeset)              # ... comparable with Ansible?
-    create_node_configs(topology,nodeset,abs_path,args)
+    create_node_configs(topology,nodeset,abs_path,args,flatten_output_fname=True)
   else:
     ansible.check_version()
     rest = utils.ansible_args(args)

--- a/netsim/cli/initial/deploy.py
+++ b/netsim/cli/initial/deploy.py
@@ -108,9 +108,12 @@ def ansible_extra_vars(topology: Box) -> Box:
   ev = get_empty_box()
   ev.node_files = str(Path("./node_files").resolve().absolute())
 
-  ev.paths_t_files.files = "{{ config_module }}"  # Change the name of the module configuration snippet
-  ev.paths_custom.files = "{{ custom_config }}"   # Change the name of the custom configuration snippet
-  for p in ['templates','custom']:                # Change the search paths of the configuration snippets
+  # Change the search names of the module/custom configuration snippet, get rid of config paths
+  # and limit the search to per-node node_files
+  #
+  ev.paths_t_files.files = "{{ config_module }}"
+  ev.paths_custom.files = "{{ custom_config }}"
+  for p in ['templates','custom']:
     ev[f'paths_{p}'].dirs = "{{ node_files }}/{{ inventory_hostname }}"
 
   # Retain the custom configuration task name(s)

--- a/netsim/utils/templates.py
+++ b/netsim/utils/templates.py
@@ -185,7 +185,10 @@ def find_provider_template(
       print(f'- {p}')
 
   if fname in node.get('config',[]):                    # Are we dealing with extra-config template?
-    n_list = topology.defaults.paths.custom.f_files
+    if fname.endswith('.j2'):                           # If the user specified a Jinja2 filename
+      n_list = [ fname ]                                # ... stop guessing and just use it
+    else:                                               # Otherwise, iterate through the whole list
+      n_list = topology.defaults.paths.custom.f_files   # ... of potential file names
   else:
     n_list = [ fname + '.j2'] + topology.defaults.paths.t_files.f_files
 

--- a/tests/platform-integration/config/03-custom.yml
+++ b/tests/platform-integration/config/03-custom.yml
@@ -1,0 +1,81 @@
+message: |
+  This topology tests various custom configuration mechanisms for non-daemon devices
+
+defaults.sources.extra: [ ../../integration/wait_times.yml ]
+
+provider: clab
+
+plugin: [ files, ospf.areas ]
+ospf.area: 1
+
+nodes:
+  r1:
+    device: frr
+    module: [ ospf ]
+    ospf.areas:
+    - area: 0.0.0.1
+      kind: stub
+  r2:
+    device: eos
+    module: [ ospf ]
+    ospf.areas:
+    - area: 0.0.0.1
+      kind: stub
+  r3:
+    device: frr
+    frr.daemons: [ ospfd ]
+    config: [ ospf_cfg, cfglet/o_areas, rid.j2 ]
+  r4:
+    device: eos
+    config: [ ospf_cfg, cfglet/o_areas/eos.j2, rid ]
+  h1:
+    device: linux
+    config: [ cfglet/ipaddr/h1.j2 ]
+
+configlets:
+  ospf_cfg:
+    eos-clab: |
+      router ospf 1
+      !
+      {% for intf in netlab_interfaces %}
+      interface {{ intf.ifname }}
+       ip ospf area 0.0.0.1
+      {% endfor %}
+    eos: |
+      no router ospf 1
+    frr: |
+      router ospf
+      !
+      {% for intf in netlab_interfaces %}
+      interface {{ intf.ifname }}
+       ip ospf area 0.0.0.1
+      {% endfor %}
+
+files:
+  rid.j2: |
+    router ospf {{'1' if netlab_device_type == 'eos' else ''}}
+      router-id {{ loopback.ipv4|ipaddr('address') }}
+  cfglet/o_areas/eos.j2: &c_stub |
+    router ospf {{'1' if netlab_device_type == 'eos' else ''}}
+      area 0.0.0.1 stub
+  cfglet/o_areas/frr.j2: *c_stub
+  cfglet/ipaddr/h1.j2: |
+    #!/bin/bash
+    #
+    ip addr
+
+links:
+- r1-r2
+- r2-r3
+- r3-r4
+- r4-r1
+
+validate:
+  o_r2:
+    nodes: [ r1, r3 ]
+    plugin: ospf_neighbor('10.0.0.2')
+    wait: ospfv2_adj_lan
+  o_r4:
+    nodes: [ r1, r3 ]
+    plugin: ospf_neighbor('10.0.0.4')
+    wait: ospfv2_adj_lan


### PR DESCRIPTION
@sdargoeuves -- this should fix #2973. Could you please verify whether it works for you?

I tried to break it in as many ways as I could creatively think of (see the integration test that's part of this PR), but I might still be missing something.