### PR TITLE
Fix: Use clab.name as node container name

### DIFF
--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -288,6 +288,10 @@ class Containerlab(_Provider):
   through "defaults.providers.clab.lab_prefix"
   """
   def get_node_name(self, node: str, topology: Box) -> str:
+    n_data = topology.nodes[node]
+    if 'clab.name' in n_data:
+      return n_data.clab.name
+
     lab_prefix = topology.get("defaults.providers.clab.lab_prefix")
     return f'{ lab_prefix }-{ topology.name }-{ node }' if lab_prefix else node
 


### PR DESCRIPTION
In some rare cases ('kind' cluster), the container name does not follow the standard clab naming convention. The new 'clab.name' attribute enables connectivity to such containers. This is, however, a rare edge case; the 'clab.name' attribute is thus not a valid node attribute (it can only be set in a plugin) and is not documented