### PR TITLE
Fix: Move callback and YAML messages from 'verbose' to 'debug' class

### DIFF
--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -31,7 +31,7 @@ def parser_add_debug(parser: argparse.ArgumentParser, add_test: bool = True) -> 
                   choices=sorted([
                     'all','addr','cli','links','libvirt','clab','modules','plugin','template',
                     'vlan','vrf','quirks','validate','addressing','groups','status','paths',
-                    'external','defaults','lag']),
+                    'external','defaults','loadable','lag']),
                   help=argparse.SUPPRESS)
   if add_test:
     parser.add_argument('--test', dest='test', action='store',nargs='*',

--- a/netsim/utils/callback.py
+++ b/netsim/utils/callback.py
@@ -9,7 +9,6 @@ The Callback class defines two methods:
 
 import importlib
 import inspect
-import sys
 import typing
 
 from . import log
@@ -19,22 +18,22 @@ class Callback():
 
   @classmethod
   def find_class(self, module_name: str, abort: bool = False) -> typing.Optional[typing.Any]:
-    if log.VERBOSE:
+    if log.debug_active('loadable'):
       print("loading %s..." % module_name)
     try:
       module = importlib.import_module(module_name)
       for name,obj in inspect.getmembers(module):
         if inspect.isclass(obj) and issubclass(obj,Callback):
-          if log.VERBOSE:
+          if log.debug_active('loadable'):
             print("... found %s " % obj)
           return obj
       return None
 
-    except (ImportError, AttributeError):
+    except (ImportError, AttributeError) as ex:
       if abort:
-        log.fatal(f"Failed to load specific module: {sys.exc_info()[1]}")
+        log.fatal(f"Failed to load specific module: {str(ex)}")
       else:
-        print(f"Failed to load specific module: {sys.exc_info()[1]}")
+        print(f"Failed to load specific module: {str(ex)}")
       return None
 
   def call(self, name: str, *args: typing.Any, **kwargs: typing.Any) -> typing.Any:

--- a/netsim/utils/log.py
+++ b/netsim/utils/log.py
@@ -18,6 +18,7 @@ LOGGING : bool = False
 VERBOSE : int = 0
 DEBUG : typing.Optional[typing.List[str]] = None
 QUIET : bool = False
+NO_WARNING: bool = False                # Do not display warnings (used in CI tests)
 
 RAISE_ON_ERROR : bool = False
 WARNING : bool = False
@@ -211,7 +212,8 @@ def error(
       skip_header: typing.Optional[bool] = None,
       exit_on_error: bool = False) -> None:
 
-  global _ERROR_LOG,err_class_map,_WARNING_LOG,_HINTS_CACHE,QUIET,err_color_map,_error_header_printed
+  global _ERROR_LOG,_WARNING_LOG,_HINTS_CACHE,QUIET,NO_WARNING
+  global err_class_map,err_color_map,_error_header_printed
 
   module = '' if module == '-' else get_calling_module(module)
   err_name = category.__name__
@@ -221,7 +223,7 @@ def error(
     _error_header_printed = skip_header
 
   if category is Warning:
-    if QUIET:
+    if QUIET or NO_WARNING:
       return
     _WARNING_LOG.extend(f'{module}: {text}'.split("\n"))            # Warnings are collected in a separate list
   else:
@@ -463,7 +465,7 @@ def print_verbose(t: typing.Any) -> None:
 # Internal debugging flags (RAISE_ON_ERROR, WARNING) cannot be set with this function
 #
 def set_logging_flags(args: typing.Union[argparse.Namespace,Box]) -> None:
-  global VERBOSE, LOGGING, DEBUG, QUIET, WARNING, RAISE_ON_ERROR
+  global VERBOSE, LOGGING, DEBUG, QUIET, WARNING, RAISE_ON_ERROR, NO_WARNING
   global _error_header_printed
   
   if 'verbose' in args and args.verbose:
@@ -471,9 +473,6 @@ def set_logging_flags(args: typing.Union[argparse.Namespace,Box]) -> None:
 
   if 'logging' in args and args.logging:
     LOGGING = True
-
-  if 'test' in args and args.test and 'errors' in args.test:
-    QUIET = True
 
   if 'debug' in args:
     if args.debug is None:
@@ -484,6 +483,7 @@ def set_logging_flags(args: typing.Union[argparse.Namespace,Box]) -> None:
 
   if 'test' in args and args.test and 'errors' in args.test:
     _error_header_printed = True
+    NO_WARNING = True
 
   if 'quiet' in args and args.quiet:
     QUIET = True

--- a/netsim/utils/read.py
+++ b/netsim/utils/read.py
@@ -231,17 +231,14 @@ def read_yaml(filename: typing.Optional[str] = None, string: typing.Optional[str
   else:
     if not os.path.isfile(filename):
       if log.LOGGING or log.VERBOSE:
-        print("YAML file %s does not exist" % filename) # pragma: no cover -- too hard to test to bother
+        print(f"YAML file {filename} does not exist") # pragma: no cover -- too hard to test to bother
       return None
     try:
       yaml_data = Box().from_yaml(filename=filename,default_box=True,box_dots=True,default_box_none_transform=False,Loader=UniqueKeyLoader)
       include_yaml(yaml_data,filename)
       read_cache[filename] = Box(yaml_data)
-    except:
-      log.fatal("Cannot read YAML from %s: %s " % (filename,str(sys.exc_info()[1])))
-
-  if log.LOGGING or log.VERBOSE:
-    print("Read YAML data from %s" % (filename or "string"))
+    except Exception as ex:
+      log.fatal(f"Cannot read YAML from {filename}: {str(ex)}")
 
   return yaml_data
 

--- a/tests/coverage/errors/duplicate-yaml-section.log
+++ b/tests/coverage/errors/duplicate-yaml-section.log
@@ -1,3 +1,3 @@
 IncorrectType in yaml: Duplicate section in YAML file: nodes
 Fatal error in netlab: Cannot read YAML from coverage/errors/duplicate-yaml-section.yml: Duplicate section nodes
-  in "coverage/errors/duplicate-yaml-section.yml", line 2, column 1 
+  in "coverage/errors/duplicate-yaml-section.yml", line 2, column 1

--- a/tests/errors/invalid-yaml.log
+++ b/tests/errors/invalid-yaml.log
@@ -1,2 +1,2 @@
 Fatal error in netlab: Cannot read YAML from errors/invalid-yaml.yml: mapping values are not allowed here
-  in "errors/invalid-yaml.yml", line 2, column 14 
+  in "errors/invalid-yaml.yml", line 2, column 14


### PR DESCRIPTION
'netlab create --verbose' generated tons of messages that were really debugging messages. Now they're printed only if the corresponding 'debug' flag is active.

Also: fix 'test errors => QUIET => no warnings' problem introduced in f92490e that broke the error tests.