### PR TITLE
Fix: Consistently quote node/group names in DOT graph descriptions

### DIFF
--- a/netsim/outputs/graph.py
+++ b/netsim/outputs/graph.py
@@ -88,7 +88,7 @@ def gv_start(f : typing.TextIO, graph: Box, topology: Box, settings: Box) -> Non
   if rank:
     f.write ('  newrank=true;\n')
     for r_val in sorted(list(rank)):
-      r_nodes = [ node.name +"; "
+      r_nodes = [ f'"{node.name}"; '
                     for node in graph.nodes.values()
                       if node.get('graph.rank',None) == r_val and node.device != 'link' ]
       f.write(f'  {{ rank=same; {"".join(r_nodes)}}}\n')
@@ -128,7 +128,7 @@ def gv_network(f : typing.TextIO, n: Box, settings: Box, indent: int = 0) -> Non
 
 def gv_clusters(f : typing.TextIO, graph: Box, topology: Box, settings: Box) -> None:
   for c_name,c_data in graph.clusters.items():
-    f.write(f'  subgraph cluster_{c_name} {{\n')
+    f.write(f'  subgraph "cluster_{c_name}" {{\n')
 
     get_gv_attr(c_data,'as',settings)
     label = c_data.get('name',None)

--- a/tests/platform-integration/graph/topo.yml
+++ b/tests/platform-integration/graph/topo.yml
@@ -6,18 +6,18 @@ groups:
   _auto_create: True
   switch:
     device: frr
-    members: [ fabric ]
-  fabric:
+    members: [ dc-fabric ]
+  dc-fabric:
     graph.color: '#ff8080'
     graph.width: 3
     graph.fill: '#ffc0c0'
     bgp.as: 65000
-    members: [ s1, s2, l1, l2 ]
+    members: [ s-1, s-b-2, l1, l2 ]
   host:
     members: [ h1, h2, h3, h4 ]
     device: linux
   spine:
-    members: [ s1, s2 ]
+    members: [ s-1, s-b-2 ]
     graph.rank: 1
     graph.format.width: 2
     d2.format:
@@ -35,10 +35,10 @@ groups:
 module: [ ospf, bgp ]
 
 links:
-- s1-l1
-- s1-l2
-- s2-l1
-- s2:
+- interfaces: [ s-1, l1 ]
+- interfaces: [ s-1, l2 ]
+- interfaces: [ s-b-2, l1 ]
+- s-b-2:
   l2:
   graph.format.style: dashed
   d2.format.style.stroke-dash: 5
@@ -62,7 +62,7 @@ files:
       netlab graph --title "Topology graph, no AS clusters" dot-topo-no-clusters.svg
     NETLAB_OUTPUTS_GRAPH_INTERFACE__LABELS=True \
       netlab graph --title "Topology graph, interface labels" dot-topo-intf-labels.svg
-    NETLAB_OUTPUTS_GRAPH_GROUPS=[fabric,host] \
+    NETLAB_OUTPUTS_GRAPH_GROUPS=[dc-fabric,host] \
       netlab graph --title "Topology graph, custom groups" dot-topo-groups.svg
   make_d2.sh: |
     unset D2_LAYOUT
@@ -81,5 +81,5 @@ files:
       netlab graph -e d2 --title "Topology graph, no AS clusters" d2-topo-no-clusters.svg
     NETLAB_OUTPUTS_D2_INTERFACE__LABELS=True \
       netlab graph -e d2 --title "Topology graph, interface labels" d2-topo-intf-labels.svg
-    NETLAB_OUTPUTS_D2_GROUPS=[fabric,host] \
+    NETLAB_OUTPUTS_D2_GROUPS=[dc-fabric,host] \
       netlab graph -e d2 --title "Topology graph, custom groups" d2-topo-groups.svg


### PR DESCRIPTION
Resolves #3006