### PR TITLE
Fix: Replace underscores with hyphens in multilab lab names

### DIFF
--- a/docs/plugins/multilab.md
+++ b/docs/plugins/multilab.md
@@ -74,8 +74,8 @@ $ export NETLAB_MULTILAB_ID=17
 
 ```
 change:
-  name: 'ml_{id}'
-  defaults.name: 'ml_{id}'
+  name: 'ml-{id}'
+  defaults.name: 'ml-{id}'
   defaults.providers.libvirt.tunnel_id: '{id}'
   defaults.providers.libvirt.vifprefix: 'vif_{id}'
   addressing.mgmt:

--- a/docs/release/26.01.md
+++ b/docs/release/26.01.md
@@ -59,6 +59,10 @@ You can use the undocumented `--generate ansible` parameter in the **‌netlab i
 
 * _netlab_ now automatically uses **paramiko** for `network_cli` connections to Cisco IOS/IOS-XE devices when `ansible-pylibssh` version 1.3.0 or higher is installed. This change addresses compatibility issues between newer versions of ansible-pylibssh and Cisco IOS devices. You can override this behavior by setting the `ansible_network_cli_ssh_type` variable at the device or node level.
 
+### Other Breaking Changes
+
+* Default multilab lab names start with `ml-` (previously: `ml_`) to reduce the underscore-induced problems in some Linux distros and newer versions of the OpenSSH library. Set `multilab.change.name` and `multilab.change.defaults.name` [default values](topo-defaults) to `ml_{id}` to revert to the old behavior.
+
 (bug-fixes-26.01)=
 ## Bug Fixes
 

--- a/netsim/defaults/multilab.yml
+++ b/netsim/defaults/multilab.yml
@@ -4,8 +4,8 @@
 # multilab.id must be set with a CLI parameter or topology/user default
 #
 change:
-  name: 'ml_{id}'
-  defaults.name: 'ml_{id}'
+  name: 'ml-{id}'
+  defaults.name: 'ml-{id}'
   defaults.providers.libvirt.tunnel_id: '{id}'
   defaults.providers.libvirt.vifprefix: 'vgif_{id}'
   addressing.mgmt:


### PR DESCRIPTION
Resolves #2917