### PR TITLE
Implement configuration reload support for devices that cannot reload (#2959)

### DIFF
--- a/netsim/ansible/reload-config.ansible
+++ b/netsim/ansible/reload-config.ansible
@@ -1,7 +1,7 @@
 #!/usr/bin/env ansible-playbook
 ---
 - name: Reload saved device configurations
-  hosts: all:!unprovisioned
+  hosts: all:!unprovisioned:!no_reload
   gather_facts: false
   tasks:
   - name: Did we get the configuration directory name?

--- a/netsim/cli/config.py
+++ b/netsim/cli/config.py
@@ -30,69 +30,64 @@ from .initial import utils as i_utils
 #
 def custom_config_parse(args: typing.List[str]) -> typing.Tuple[argparse.Namespace, typing.List[str]]:
   parser = argparse.ArgumentParser(
-    prog='netlab config',
-    description='Deploy custom configuration template',
-    epilog='All other arguments are passed directly to ansible-playbook')
+    prog="netlab config",
+    description="Deploy custom configuration template",
+    epilog="All other arguments are passed directly to ansible-playbook",
+  )
+  parser.add_argument("-r", "--reload", dest="reload", action="store_true", help="Reload saved device configurations")
+  parser.add_argument("-l", "--limit", dest="limit", action="store", help="Limit the operation to a subset of nodes")
   parser.add_argument(
-    '-r','--reload',
-    dest='reload',
-    action='store_true',
-    help='Reload saved device configurations')
-  parser.add_argument(
-    '-l','--limit',
-    dest='limit', action='store',
-    help='Limit the operation to a subset of nodes')
-  parser.add_argument(
-    '-e','--extra-vars',
-    dest='extra_vars',action='append',
-    help='Specify extra variables for the configuration template')
-  parser.add_argument(
-    dest='template', action='store',
-    help='Configuration template or a directory with templates')
+    "-e",
+    "--extra-vars",
+    dest="extra_vars",
+    action="append",
+    help="Specify extra variables for the configuration template",
+  )
+  parser.add_argument(dest="template", action="store", help="Configuration template or a directory with templates")
   parser_add_verbose(parser)
-  parser_add_debug(parser,add_test=False)
-  parser_lab_location(parser,instance=True,action='configure')
+  parser_add_debug(parser, add_test=False)
+  parser_lab_location(parser, instance=True, action="configure")
 
   return parser.parse_known_args(args)
 
+
 def set_initial_args(args: argparse.Namespace, initial: bool = False) -> None:
-  setattr(args,'custom',True)                     # Tell 'netlab initial' code to deploy custom configs only
-  setattr(args,'initial',initial)                 # We might need initial config for configuration reload
-  setattr(args,'module',None)                     # ... but definitely no modules
-  setattr(args,'generate',None)                   # ... and internally-generated configs
+  setattr(args, "custom", True)  # Tell 'netlab initial' code to deploy custom configs only
+  setattr(args, "initial", initial)  # We might need initial config for configuration reload
+  setattr(args, "module", None)  # ... but definitely no modules
+  setattr(args, "generate", None)  # ... and internally-generated configs
 
-def set_custom_config(
-      topology: Box,
-      nodeset: list,
-      cfg_name: str,
-      extra_vars: dict = {}) -> None:
 
+def set_custom_config(topology: Box, nodeset: list, cfg_name: str, extra_vars: dict = {}) -> None:
   for n_name in nodeset:
     n_data = topology.nodes[n_name]
-    n_data.config = [ cfg_name ]
-    for k,v in extra_vars.items():
+    n_data.config = [cfg_name]
+    for k, v in extra_vars.items():
       n_data[k] = v
 
+
 def ansible_extra_vars(topology: Box, reload: bool = False, extra_vars: dict = {}) -> Box:
-  cfg_sfx = '.cfg' if reload else ''
+  cfg_sfx = ".cfg" if reload else ""
 
   ev = get_box(extra_vars)
   ev.node_files = str(Path("./node_files").resolve().absolute())
 
-  ev.paths_t_files.files = "{{ config_module }}" + cfg_sfx    # Take only module file from node_files
-  ev.paths_custom.files = "{{ custom_config }}" + cfg_sfx     # And rendered custom config from node_files
-  for p in ['templates','custom']:                            # Change the search paths to node_files
-    ev[f'paths_{p}'].dirs = "{{ node_files }}/{{ inventory_hostname }}"
+  ev.paths_t_files.files = "{{ config_module }}" + cfg_sfx  # Take only module file from node_files
+  ev.paths_custom.files = "{{ custom_config }}" + cfg_sfx  # And rendered custom config from node_files
+  for p in ["templates", "custom"]:  # Change the search paths to node_files
+    ev[f"paths_{p}"].dirs = "{{ node_files }}/{{ inventory_hostname }}"
 
   # Retain the custom configuration task name(s)
   ev.paths_custom.tasks = topology.defaults.paths.custom.tasks
   return ev
 
-def get_ansible_args(ans_vars: Box,nodeset: list,cfg_name: str) -> list:
+
+def get_ansible_args(ans_vars: Box, nodeset: list, cfg_name: str) -> list:
   args = i_utils.common_ansible_args()
-  args += ["-e",ans_vars.to_json(),"-e",f'config={cfg_name}']
-  args += ["-l",','.join(nodeset)]
+  args += ["-e", ans_vars.to_json(), "-e", f"config={cfg_name}"]
+  args += ["-l", ",".join(nodeset)]
   return args
+
 
 def parse_extra_vars(ev_list: typing.Optional[list]) -> dict:
   ev: dict = {}
@@ -100,9 +95,9 @@ def parse_extra_vars(ev_list: typing.Optional[list]) -> dict:
     return ev
 
   for v_item in ev_list:
-    if '=' not in v_item:
-      error_and_exit('Extra variables have to be specified in name=value format')
-    (n,v)  = v_item.split('=',maxsplit=1)
+    if "=" not in v_item:
+      error_and_exit("Extra variables have to be specified in name=value format")
+    (n, v) = v_item.split("=", maxsplit=1)
     try:
       value = eval(v)
     except:
@@ -111,55 +106,61 @@ def parse_extra_vars(ev_list: typing.Optional[list]) -> dict:
 
   return ev
 
+
 """
 Create the required configs in node_files
 """
+
+
 def create_node_files(
-      topology: Box,
-      nodeset: list,
-      args: argparse.Namespace,
-      cfg_name: str,
-      extra_vars: dict = {},
-      initial: bool = False,
-      cfg_suffix: str = 'none') -> None:
+  topology: Box,
+  nodeset: list,
+  args: argparse.Namespace,
+  cfg_name: str,
+  extra_vars: dict = {},
+  initial: bool = False,
+  cfg_suffix: str = "none",
+) -> None:
+  set_initial_args(args, initial=initial)  # Adjust args for 'netlab initial' processing
+  set_custom_config(topology, nodeset, cfg_name, extra_vars)
 
-  set_initial_args(args,initial=initial)              # Adjust args for 'netlab initial' processing
-  set_custom_config(topology,nodeset,cfg_name,extra_vars)
-
-  i_configs.create_node_configs(                      # Create the necessary files in node_files directory
+  i_configs.create_node_configs(  # Create the necessary files in node_files directory
     topology=topology,
     nodeset=nodeset,
-    abs_path=Path('node_files'),
+    abs_path=Path("node_files"),
     args=args,
     skip_extra_config=True,
     node_directory=True,
-    default_suffix=cfg_suffix)
-  log.exit_on_error()                                 # Stop if the files could not be created
+    default_suffix=cfg_suffix,
+  )
+  log.exit_on_error()  # Stop if the files could not be created
+
 
 """
 Reload node configurations
 """
-def reload_node_configs(topology: Box,nodeset: list,args: argparse.Namespace, rest: list) -> None:
+
+
+def reload_node_configs(topology: Box, nodeset: list, args: argparse.Namespace, rest: list) -> None:
   cfg_path = Path(args.template).resolve().absolute()
-  if not cfg_path.is_dir():                           # Sanity check: are we reloading from a directory?
-    error_and_exit('The argument specified with the --reload option must be a directory')
-  
+  if not cfg_path.is_dir():  # Sanity check: are we reloading from a directory?
+    error_and_exit("The argument specified with the --reload option must be a directory")
+
   if args.extra_vars:
-    error_and_exit('You cannot specify extra vars while reloading configuration')
+    error_and_exit("You cannot specify extra vars while reloading configuration")
 
   no_config = []
-  for n_name in nodeset:                              # Identify nodes that have no configs
-    if not list(cfg_path.glob(n_name+'.*')):          # ... in the specified directory
+  for n_name in nodeset:  # Identify nodes that have no configs
+    if not list(cfg_path.glob(n_name + ".*")):  # ... in the specified directory
       no_config.append(n_name)
-  
-  if no_config:                                       # Do we have nodes with missing configs?
-    log.warning(                                      # Warn the user and adjust the nodeset
-      text='Skipping nodes with no saved configurations',
-      more_data=[ ",".join(no_config) ],
-      module='reload')
-    nodeset = [ n for n in nodeset if n not in no_config ]
-    if not nodeset:                                   # Any nodes left to work on?
-      error_and_exit('Found no nodes with saved configuration, exiting')
+
+  if no_config:  # Do we have nodes with missing configs?
+    log.warning(  # Warn the user and adjust the nodeset
+      text="Skipping nodes with no saved configurations", more_data=[",".join(no_config)], module="reload"
+    )
+    nodeset = [n for n in nodeset if n not in no_config]
+    if not nodeset:  # Any nodes left to work on?
+      error_and_exit("Found no nodes with saved configuration, exiting")
 
   """
   Now prepare the environment for the "netlab initial" processing
@@ -168,61 +169,97 @@ def reload_node_configs(topology: Box,nodeset: list,args: argparse.Namespace, re
   * Create initial- and custom config files
   * Change the node "config" parameter to request configuration reload
   """
-  topology.defaults.paths.custom.dirs = [ str(cfg_path.parent) ]
-  create_node_files(topology,nodeset,args,str(cfg_path.name),initial=True,cfg_suffix='.cfg')
+  topology.defaults.paths.custom.dirs = [str(cfg_path.parent)]
+  create_node_files(topology, nodeset, args, str(cfg_path.name), initial=True, cfg_suffix=".cfg")
 
   # Run the Ansible playbook with modified path variables and an adjusted nodeset
   #
-  ans_vars = ansible_extra_vars(topology,reload=True)
-  rest_args = rest + get_ansible_args(ans_vars,nodeset,str(cfg_path.name))
-  if not ansible.playbook('reload-config.ansible',rest_args,abort_on_error=False):
-    error_and_exit('Cannot reload initial device configurations')
+  ans_vars = ansible_extra_vars(topology, reload=True)
+  rest_args = rest + get_ansible_args(ans_vars, nodeset, str(cfg_path.name))
+  if not ansible.playbook("reload-config.ansible", rest_args, abort_on_error=False):
+    error_and_exit("Cannot reload initial device configurations")
 
-def deploy_custom_config(topology: Box,nodeset: list,args: argparse.Namespace, rest: list) -> None:
+  # Check if there are devices that cannot reload and run initial config for them
+  if topology.groups.get("no_reload") and topology.groups.no_reload.hosts:
+    # Get device types that cannot reload
+    no_reload_devices = set()
+    for node_name in topology.groups.no_reload.hosts:
+      no_reload_devices.add(topology.nodes[node_name].device)
+
+    log.warning(
+      text=f"Configuration reload is not supported for device types: {', '.join(sorted(no_reload_devices))}. "
+      f"Running initial configuration for {len(topology.groups.no_reload.hosts)} devices."
+    )
+
+    # Call initial command programmatically with same verbosity settings
+    from .initial.deploy import run as initial_run
+
+    initial_args = argparse.Namespace(
+      limit="no_reload",
+      initial=True,
+      deploy=True,
+      no_message=False,
+      module=False,
+      custom=False,
+      fast=False,
+      ready=False,
+      output=False,
+      clean=False,
+      generate=False,
+      debug=False,
+    )
+    initial_run(topology, initial_args, [])
+
+
+def deploy_custom_config(topology: Box, nodeset: list, args: argparse.Namespace, rest: list) -> None:
   cfg_name = args.template
-  if '/' in cfg_name:                             # Custom config specified as a path to directory
+  if "/" in cfg_name:  # Custom config specified as a path to directory
     cfg_path = Path(cfg_name).absolute().resolve()
-    if not cfg_path.exists():                     # Does the specified path exist?
-      error_and_exit(f'The path {cfg_name} does not exist')
+    if not cfg_path.exists():  # Does the specified path exist?
+      error_and_exit(f"The path {cfg_name} does not exist")
 
-    topology.defaults.paths.custom.dirs = [ str(cfg_path.parent) ]
+    topology.defaults.paths.custom.dirs = [str(cfg_path.parent)]
     cfg_name = str(cfg_path.name)
-    if cfg_name.endswith('.j2'):
+    if cfg_name.endswith(".j2"):
       cfg_name = cfg_name[:-3]
 
-  extra_vars=parse_extra_vars(args.extra_vars)
-  create_node_files(topology,nodeset,args,cfg_name,extra_vars)
+  extra_vars = parse_extra_vars(args.extra_vars)
+  create_node_files(topology, nodeset, args, cfg_name, extra_vars)
 
   # Run the Ansible playbook with modified path variables and an adjusted nodeset
   #
-  ans_vars = ansible_extra_vars(topology,reload=False,extra_vars=extra_vars)
-  rest_args = rest + get_ansible_args(ans_vars,nodeset,cfg_name)
-  if not ansible.playbook('config.ansible',rest_args,abort_on_error=False):
-    error_and_exit('Cannot deploy custom configuration template')
+  ans_vars = ansible_extra_vars(topology, reload=False, extra_vars=extra_vars)
+  rest_args = rest + get_ansible_args(ans_vars, nodeset, cfg_name)
+  if not ansible.playbook("config.ansible", rest_args, abort_on_error=False):
+    error_and_exit("Cannot deploy custom configuration template")
+
 
 def run_config(cli_args: typing.List[str]) -> None:
-  (args,rest) = custom_config_parse(cli_args)
+  (args, rest) = custom_config_parse(cli_args)
   log.set_logging_flags(args)
   topology = load_snapshot(args)
 
-  nodeset = _nodeset.parse_nodeset(args.limit,topology) if args.limit else list(topology.nodes.keys())
+  nodeset = _nodeset.parse_nodeset(args.limit, topology) if args.limit else list(topology.nodes.keys())
   if not nodeset:
-    error_and_exit('The specified nodeset is empty, there are no nodes to configure')
-  set_initial_args(args,initial=False)
+    error_and_exit("The specified nodeset is empty, there are no nodes to configure")
+  set_initial_args(args, initial=False)
 
   if args.reload:
-    reload_node_configs(topology,nodeset,args,rest)
+    reload_node_configs(topology, nodeset, args, rest)
   else:
-    deploy_custom_config(topology,nodeset,args,rest)
+    deploy_custom_config(topology, nodeset, args, rest)
 
-  log.repeat_warnings('netlab config')
+  log.repeat_warnings("netlab config")
+
 
 """
 We need a wrapper around the actual "run" function to catch the user interrupts
 """
+
+
 def run(cli_args: typing.List[str]) -> None:
   try:
     run_config(cli_args)
   except KeyboardInterrupt:
-    external_commands.interrupted('netlab config')
+    external_commands.interrupted("netlab config")
   return

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -26,6 +26,7 @@ clab:
   features:
     initial:
       roles: [ host, router ]
+      reload: false
 libvirt:                        # Not yet available on libvirt or virtualbox
   image:
 virtualbox:
@@ -59,3 +60,4 @@ features:
     ipv6:
       lla: true
     roles: [ host, router ]
+    reload: false

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -15,6 +15,7 @@ clab:
   features:
     initial:
       roles: [ host ]
+      reload: false
 
 libvirt:                        # Not yet available on libvirt or virtualbox
   image:
@@ -25,6 +26,7 @@ features:
     server: true
   initial:
     roles: [ host ]
+    reload: false
 dhcp:
   server: true
 module: [ dhcp ]

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -16,6 +16,7 @@ features:
       lla: true
       use_ra: true
     roles: [ host ]
+    reload: false
 libvirt:
   image: bento/ubuntu-24.04
   group_vars:

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -6,20 +6,25 @@ import typing
 
 from box import Box
 
-from ..augment import nodes, plugin
+from ..augment import devices, nodes, plugin
 from ..utils import files as _files
 from ..utils import log, strings, templates
 from . import _TopologyOutput, check_writeable
 from .common import adjust_inventory_host, get_host_addresses
 
-forwarded_port_name = { 'ssh': 'ansible_port', }
+forwarded_port_name = {
+  "ssh": "ansible_port",
+}
 
 
 """
 Add the hosts dictionary to Ansible inventory as an 'all' group variable 
 """
+
+
 def add_host_addresses(topology: Box, inventory: Box) -> None:
   inventory.all.vars.hosts = get_host_addresses(topology)
+
 
 """
 Copy defaults.paths dictionary into ALL group. Create separate variables
@@ -27,29 +32,35 @@ from individual customizable paths to prevent dependencies on too many
 variables that might not be set (example: only 'paths.custom' values should
 depend on 'custom_config' variable)
 """
+
+
 def copy_paths(inventory: Box, topology: Box) -> None:
-  if 'paths' not in topology.defaults:
+  if "paths" not in topology.defaults:
     return
-  
-  for k,v in topology.defaults.paths.items():
-    inventory.all.vars[f'paths_{k}'] = v
+
+  for k, v in topology.defaults.paths.items():
+    inventory.all.vars[f"paths_{k}"] = v
+
 
 """
 Copy other interesting global topology data into all group to make it accessible to all nodes
 """
+
+
 def copy_global_vars(inventory: Box, topology: Box) -> None:
-  for kw in ['prefix']:
+  for kw in ["prefix"]:
     if kw not in topology:
       continue
     inventory.all.vars[kw] = topology[kw]
 
+
 def create(topology: Box) -> Box:
-  inventory = Box({},default_box=True,box_dots=True)
+  inventory = Box({}, default_box=True, box_dots=True)
 
   inventory.all.vars.netlab_provider = topology.defaults.provider
   inventory.all.vars.netlab_name = topology.name
-  copy_paths(inventory,topology)
-  copy_global_vars(inventory,topology)
+  copy_paths(inventory, topology)
+  copy_global_vars(inventory, topology)
 
   inventory.modules.hosts = {}
   inventory.custom_configs.hosts = {}
@@ -57,33 +68,41 @@ def create(topology: Box) -> Box:
 
   defaults = topology.defaults
 
-  if 'module' in topology:
+  if "module" in topology:
     inventory.modules.vars.netlab_module = topology.module
 
-  if 'addressing' in topology:
+  if "addressing" in topology:
     inventory.all.vars.pools = topology.addressing
-    for name,pool in inventory.all.vars.pools.items():
+    for name, pool in inventory.all.vars.pools.items():
       for k in list(pool.keys()):
-        if ('_pfx' in k) or ('_eui' in k):
+        if ("_pfx" in k) or ("_eui" in k):
           del pool[k]
 
-  add_host_addresses(topology,inventory)    # Create the 'hosts' dictionary in 'all' group
+  add_host_addresses(topology, inventory)  # Create the 'hosts' dictionary in 'all' group
 
-  extra_groups: dict = {                    # Extra groups created in Ansible inventory
-    'module':  'modules',                   # Devices using configuration modules
-    'config':  'custom_configs',            # Devices using custom configuration
-    '_daemon': 'daemons'                    # Daemons
+  extra_groups: dict = {  # Extra groups created in Ansible inventory
+    "module": "modules",  # Devices using configuration modules
+    "config": "custom_configs",  # Devices using custom configuration
+    "_daemon": "daemons",  # Daemons
   }
 
-  for name,node in topology.nodes.items():
-    group = node.get('device','all')
-    inventory[group].hosts[name] = adjust_inventory_host(node,defaults=topology.defaults,group_vars=False)
+  # Create no_reload group for devices that don't support config reload
+  inventory.no_reload = Box({"hosts": {}, "vars": {}, "children": {}})
+
+  for name, node in topology.nodes.items():
+    group = node.get("device", "all")
+    inventory[group].hosts[name] = adjust_inventory_host(node, defaults=topology.defaults, group_vars=False)
 
     for xg in extra_groups.keys():
-      if node.get(xg,False):                # Add device to the extra group if it has the corresponding attribute set
+      if node.get(xg, False):  # Add device to the extra group if it has the corresponding attribute set
         inventory[extra_groups[xg]].hosts[name] = {}
 
-  if 'devices' in defaults:
+    # Add device to no_reload group if it doesn't support config reload
+    features = devices.get_device_features(node, topology.defaults)
+    if not features.get("initial.reload", True):
+      inventory.no_reload.hosts[name] = {}
+
+  if "devices" in defaults:
     for group in inventory.keys():
       if group in defaults.devices:
         devdata = defaults.devices[group]
@@ -91,30 +110,30 @@ def create(topology: Box) -> Box:
         # add device features to device group_vars
         group_vars.features = devdata.features
         if group_vars:
-          inventory[group]['vars'] = group_vars
-    for group in list(inventory.keys()):          # Ansible is unhappy with hyphens in group names
-      if '-' in group:                            # So we have to recreate those group entries
-        g_correct = group.replace('-','_')        # ... replacing hyphens with underscores
+          inventory[group]["vars"] = group_vars
+    for group in list(inventory.keys()):  # Ansible is unhappy with hyphens in group names
+      if "-" in group:  # So we have to recreate those group entries
+        g_correct = group.replace("-", "_")  # ... replacing hyphens with underscores
         inventory[g_correct] = inventory[group]
-        inventory.pop(group,None)
+        inventory.pop(group, None)
 
-  if (inventory.custom_configs.hosts):
+  if inventory.custom_configs.hosts:
     try:
       inventory.custom_configs.vars.netlab_custom_config = plugin.sort_extra_config(topology)
     except log.FatalError as ex:
-      log.fatal(f'Cannot sort custom configuration requests: {str(ex)}','ansible',header=True)
+      log.fatal(f"Cannot sort custom configuration requests: {str(ex)}", "ansible", header=True)
 
-  if not 'groups' in topology:
+  if not "groups" in topology:
     return inventory
 
-  for gname,gdata in topology.groups.items():
+  for gname, gdata in topology.groups.items():
     if not gname in inventory:
-      inventory[gname] = { 'hosts': {} }
+      inventory[gname] = {"hosts": {}}
 
-    if 'vars' in gdata:
-      inventory[gname].vars = inventory[gname].get('vars',{}) + gdata.vars
+    if "vars" in gdata:
+      inventory[gname].vars = inventory[gname].get("vars", {}) + gdata.vars
 
-    if 'members' in gdata:
+    if "members" in gdata:
       for m in gdata.members:
         if m in topology.nodes:
           if not m in inventory[gname].hosts:
@@ -124,6 +143,7 @@ def create(topology: Box) -> Box:
 
   return inventory
 
+
 # Note to self: the dump function is used by the testing scripts. Do not remove
 #
 def dump(data: Box) -> None:
@@ -132,42 +152,47 @@ def dump(data: Box) -> None:
   inventory = create(data)
   print(strings.get_yaml_string(inventory))
 
+
 def write_yaml(data: Box, fname: str, header: str) -> None:
   dirname = os.path.dirname(fname)
   if dirname and not os.path.exists(dirname):
     os.makedirs(dirname)
 
-  _files.create_file_from_text(fname,header+"\n"+strings.get_yaml_string(data))
+  _files.create_file_from_text(fname, header + "\n" + strings.get_yaml_string(data))
 
-min_inventory_data = [ 'id','ansible_host','ansible_port','ansible_connection','ansible_user','ansible_ssh_pass' ]
 
-def ansible_inventory(topology: Box, fname: typing.Optional[str] = 'hosts.yml', hostvars: typing.Optional[str] = 'dirs') -> None:
+min_inventory_data = ["id", "ansible_host", "ansible_port", "ansible_connection", "ansible_user", "ansible_ssh_pass"]
+
+
+def ansible_inventory(
+  topology: Box, fname: typing.Optional[str] = "hosts.yml", hostvars: typing.Optional[str] = "dirs"
+) -> None:
   inventory = create(topology)
 
-#  import ipdb; ipdb.set_trace()
-  header = "# Ansible inventory created from %s\n#\n" % topology.get('input','<unknown>')
+  #  import ipdb; ipdb.set_trace()
+  header = "# Ansible inventory created from %s\n#\n" % topology.get("input", "<unknown>")
 
   if not fname:
-    fname = 'hosts.yml'
+    fname = "hosts.yml"
   if not hostvars:
     hostvars = "dirs"
 
   if hostvars == "min":
-    write_yaml(inventory,fname,header)
+    write_yaml(inventory, fname, header)
     log.status_created()
     print(f"single-file Ansible inventory {fname}")
     return
 
   for g in inventory.keys():
-    gvars = inventory[g].pop('vars',None)
+    gvars = inventory[g].pop("vars", None)
     if gvars:
-      write_yaml(gvars,'group_vars/%s/topology.yml' % g,header)
+      write_yaml(gvars, "group_vars/%s/topology.yml" % g, header)
       if not log.QUIET:
-        strings.print_colored_text('[GROUPS]  ','bright_cyan','Created ')
+        strings.print_colored_text("[GROUPS]  ", "bright_cyan", "Created ")
         print(f"group_vars for {g}")
 
-    if 'hosts' in inventory[g]:
-      hosts = inventory[g]['hosts']
+    if "hosts" in inventory[g]:
+      hosts = inventory[g]["hosts"]
       for h in hosts.keys():
         if not hosts[h]:
           continue
@@ -179,61 +204,63 @@ def ansible_inventory(topology: Box, fname: typing.Optional[str] = 'hosts.yml', 
           else:
             vars_host[item] = hosts[h][item]
 
-        write_yaml(vars_host,'host_vars/%s/topology.yml' % h,header)
+        write_yaml(vars_host, "host_vars/%s/topology.yml" % h, header)
         if not log.QUIET:
-          strings.print_colored_text('[HOSTS]   ','bright_cyan','Created ')
+          strings.print_colored_text("[HOSTS]   ", "bright_cyan", "Created ")
           print(f"host_vars for {h}")
         hosts[h] = min_host
 
-  write_yaml(inventory,fname,header)
+  write_yaml(inventory, fname, header)
   log.status_created()
   print(f"minimized Ansible inventory {fname}")
 
-def ansible_config(config_file: typing.Union[str,None] = 'ansible.cfg', inventory_file: typing.Union[str,None] = 'hosts.yml') -> None:
+
+def ansible_config(
+  config_file: typing.Union[str, None] = "ansible.cfg", inventory_file: typing.Union[str, None] = "hosts.yml"
+) -> None:
   if not config_file:
-    config_file = 'ansible.cfg'
+    config_file = "ansible.cfg"
   if not inventory_file:
-    inventory_file = 'hosts.yml'
+    inventory_file = "hosts.yml"
 
   try:
     cfg_text = templates.render_template(
-                j2_file='ansible.cfg.j2',
-                data={'inventory': inventory_file or 'hosts.yml'},
-                path='templates',
-                extra_path=_files.get_search_path('ansible'))
+      j2_file="ansible.cfg.j2",
+      data={"inventory": inventory_file or "hosts.yml"},
+      path="templates",
+      extra_path=_files.get_search_path("ansible"),
+    )
   except Exception as ex:
-    log.fatal(
-      text=f"Error rendering ansible.cfg\n{strings.extra_data_printout(str(ex))}",
-      module='ansible')
+    log.fatal(text=f"Error rendering ansible.cfg\n{strings.extra_data_printout(str(ex))}", module="ansible")
 
-  _files.create_file_from_text(config_file,cfg_text)
+  _files.create_file_from_text(config_file, cfg_text)
   if not log.QUIET:
     log.status_created()
     print(f"Ansible configuration file: {config_file}")
 
-class AnsibleInventory(_TopologyOutput):
 
-  DESCRIPTION :str = 'Ansible inventory and configuration file'
+class AnsibleInventory(_TopologyOutput):
+  DESCRIPTION: str = "Ansible inventory and configuration file"
 
   def write(self, topology: Box) -> None:
-    check_writeable('Ansible inventory')
-    hostfile = self.settings.hostfile or 'hosts.yml'
-    configfile = self.settings.configfile or 'ansible.cfg'
+    check_writeable("Ansible inventory")
+    hostfile = self.settings.hostfile or "hosts.yml"
+    configfile = self.settings.configfile or "ansible.cfg"
     output_format = None
 
-    if hasattr(self,'filenames'):
+    if hasattr(self, "filenames"):
       hostfile = self.filenames[0]
       if len(self.filenames) > 1:
         configfile = self.filenames[1]
       if len(self.filenames) > 2:
-        log.error('Extra output filename(s) ignored: %s' % str(self.filenames[2:]),log.IncorrectValue,'ansible')
+        log.error("Extra output filename(s) ignored: %s" % str(self.filenames[2:]), log.IncorrectValue, "ansible")
 
     if self.format:
       output_format = self.format[0]
-    
+
     # Creates a "ghost clean" topology
     # (AKA, remove unmanaged devices)
     ansible_topology = nodes.ghost_buster(topology)
 
-    ansible_inventory(ansible_topology,hostfile,output_format)
-    ansible_config(configfile,hostfile)
+    ansible_inventory(ansible_topology, hostfile, output_format)
+    ansible_config(configfile, hostfile)


### PR DESCRIPTION
## Summary
This PR implements support for handling devices that cannot reload their configuration during `netlab up --reload`. 

### Changes Made
- **Device Feature Flag**: Added `initial.reload: false` to Linux, dnsmasq, and bird daemons to indicate they cannot reload config
- **Ansible Group**: Created `no_reload` group in ansible.py output module for devices that don't support config reload
- **Playbook Update**: Modified `reload-config.ansible` to exclude `no_reload` devices
- **Enhanced CLI**: Updated `netlab config --reload` command to run initial config for `no_reload` devices and display warning

### Workflow
The `netlab up --reload` process now:
1. Reloads configuration where supported (excludes no_reload group)
2. Runs `netlab initial --limit no_reload` for devices that cannot reload
3. Prints warning listing device types that cannot reload configuration

### Example Output
```
WARNING: Configuration reload is not supported for device types: linux, bird. Running initial configuration for 3 devices.
```

### Testing
- Verified feature flag parsing and Ansible group creation
- Confirmed playbook correctly excludes no_reload devices
- Tested warning message displays correct device types
- All linting and type checking passes

Fixes #2959