### PR TITLE
Fix: Prune search paths after the plugin output hooks

### DIFF
--- a/netsim/augment/config.py
+++ b/netsim/augment/config.py
@@ -151,7 +151,7 @@ paths: adjust system paths, replacing package: and topology: prefixes
 '''
 def paths(topology: Box) -> None:
   adjust_paths(topology.defaults.paths)
-  make_paths_absolute(topology.defaults.paths)
+  make_paths_absolute(topology.defaults.paths,limit=['plugin'])
 
 '''
 adjust_paths: prepend or append path elements to default paths
@@ -181,8 +181,10 @@ Recursive function that traverses the 'paths' tree and converts every list into
 a list of absolute paths... unless the key starts with 'files' or 'tasks' in
 which case the list is a list of potential file names and should not be changed.
 '''
-def make_paths_absolute(p_top: Box, parents: str = 'defaults.paths') -> None:
+def make_paths_absolute(p_top: Box, parents: str = 'defaults.paths', limit: list = []) -> None:
   for k in list(p_top.keys()):
+    if limit and k not in limit:
+      continue
     if k.startswith('files') or k.startswith('tasks'):
       p_top[k] = [ fn.replace('\n','') for fn in p_top[k] ]
       p_top[f'f_{k}'] = [ fn.replace('{{','{').replace('}}','}') for fn in p_top[k] ]

--- a/netsim/cli/create.py
+++ b/netsim/cli/create.py
@@ -188,6 +188,11 @@ def run(cli_args: typing.List[str],
     if plugin:
       augment.plugin.execute_plugin_hook('output',plugin,topology)
 
+  # Adjust search paths before creating output files. This step cannot be done
+  # earlier in the process because the plugins might create directories that
+  # are used in search paths
+  augment.config.make_paths_absolute(topology.defaults.paths)
+
   for output_format in args.output:
     output_param = get_output_parameter(output_format,args.output)
     if not output_param:


### PR DESCRIPTION
Plugins might create paths that are used in search paths (config templates). The pruning of search paths (apart from the 'plugin' search path which is used in data transformation) has to be done after the plugins created whatever they wanted to create.

This commit moves the generic path resolution/pruning code to 'netlab create' (where it's executed after the plugin output hook). The early path pruning is limited to the 'plugin' key.

Please note that we don't want plugins creating stuff even if the topology transformation fails, so we cannot do pruning any earlier than what we do now.