### PR TITLE
Fix: Display build instructions for internally-built containers

### DIFF
--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -22,7 +22,7 @@ clab:
     netlab_show_command: [ birdc, 'show $@' ]
     docker_shell: bash -il
   image: netlab/bird:latest
-  build: 'https://netlab.tools/netlab/clab/#netlab-clab-build'
+  build: True
   features:
     initial:
       roles: [ host, router ]

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -11,7 +11,7 @@ clab:
   group_vars:
     docker_shell: bash -il
   image: netlab/dnsmasq:latest
-  build: 'https://netlab.tools/netlab/clab/#netlab-clab-build'
+  build: True
   features:
     initial:
       roles: [ host ]

--- a/netsim/devices/netscaler.yml
+++ b/netsim/devices/netscaler.yml
@@ -13,6 +13,7 @@ features:
     ipv4:
 mtu: 1500
 clab:
+  build: True
   image: netlab/netscaler
   node:
     kind: linux # kind not yet available in Containerlab

--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -331,15 +331,23 @@ class Containerlab(_Provider):
     if 'build' not in dp_data:                              # We have no build recipe, let's hope it's downloadable
       return
 
+    if dp_data.build is True:
+      hints = [
+        f"This container image is not available online and has to be installed locally.",
+        f"You can build the container image with the 'netlab clab build {node.device}' command",
+        f"See https://netlab.tools/netlab/clab/#netlab-clab-build for more details" ]
+    else:
+      hints = [
+        f"This container image is not available online and has to be installed locally.",
+        f"If you're using a private Docker repository, use the 'docker image pull {node.box}'",
+        f"command to pull the image from it or build/install it using this recipe:",
+        dp_data.build ]
+
     log.error(
       f'Container {node.box} used by node {node.name} is not installed',
       category=log.IncorrectValue,
       module='clab',
-      more_hints=[ 
-        f"This container image is not available on Docker Hub and has to be installed locally.",
-        f"If you're using a private Docker repository, use the 'docker image pull {node.box}'",
-        f"command to pull the image from it or build/install it using this recipe:",
-        dp_data.build ])
+      more_hints=hints)
 
   def deploy_node_config(self, node: Box, topology: Box, deploy_list: list) -> None:
     cfg_files = node.get('clab.config_templates',[])


### PR DESCRIPTION
Instead of displaying just the pointer to the build recipe, display the 'netlab clab' command + the pointer when a container that can be built locally is not available