### PR TITLE
fix netlab status to use netlab.snapshot.pickle

### DIFF
--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -163,9 +163,9 @@ def show_lab(args: argparse.Namespace,lab_states: Box) -> None:
   lab_state = lab_states[iid]
   show_lab_instance(iid,lab_state)
   wdir = lab_state.dir
-  snapshot = f'{wdir}/netlab.snapshot.yml'
+  snapshot = f'{wdir}/netlab.snapshot.pickle'
 
-  topology = _read.read_yaml(filename=snapshot)
+  topology = _read.load_pickled_data(snapshot)
   if topology is None:
     log.fatal(f'Cannot read topology snapshot file {snapshot}')
 


### PR DESCRIPTION
I have an issue where I can't run `netlab status` on the version 26.01, as the code is looking for the netlab.snapshot.yml, but it no longer exists.

```
╰─❯ netlab status
Lab 3 in /home/sa/code/quick-netlab-lab/cisco-sdwan-lab
  status: started
  provider(s): clab

[FATAL]   Cannot read topology snapshot file /home/sa/code/quick-netlab-lab/cisco-sdwan-lab/netlab.snapshot.yml
```

This is a suggestion that works when I did my quick test.