### PR TITLE
FRR: Fix MPLS kernel module loading for libvirt VMs

### DIFF
--- a/netsim/ansible/templates/mpls/frr.j2
+++ b/netsim/ansible/templates/mpls/frr.j2
@@ -3,6 +3,20 @@
 set -e
 
 {% if ldp is defined %}
+
+#
+# Make sure MPLS kernel modules are loaded
+# For clab containers, modules are loaded on the host by load_kmods()
+# For libvirt VMs, modules need to be loaded inside the VM
+#
+{% if node_provider|default('') != 'clab' %}
+for module in mpls-router mpls-iptunnel; do
+  if [ ! -e /sys/module/$module ]; then
+    modprobe $module >/dev/null 2>&1
+  fi
+done
+{% endif %}
+
 sysctl -w net.mpls.platform_labels=1048575
 {%   for l in interfaces if ('ldp' in l) and not l.ldp.passive %}
 sysctl -w net.mpls.conf.{{ l.ifname }}.input=1


### PR DESCRIPTION
- Skip modprobe for clab containers (modules loaded on host by load_kmods)
- Load modules inside libvirt VMs (modules need to be in VM kernel)