### PR TITLE
Fix: FRR (sometimes) needs metric on route redistribution into RIP

### DIFF
--- a/netsim/ansible/templates/ripv2/frr.macro.j2
+++ b/netsim/ansible/templates/ripv2/frr.macro.j2
@@ -7,7 +7,7 @@ router rip{% if vrf %} vrf {{ vrf }}{% endif +%}
 {%     if 'timers' in ripv2 %}
  timers basic {{ ripv2.timers['update'] }} {{ ripv2.timers.timeout }} {{ ripv2.timers.garbage }}
 {%     endif %}
-{{     redistribute.config(ripv2,af='ipv4') }}
+{{     redistribute.config(ripv2,af='ipv4',metric=8) }}
 {%     for intf in ripv2.interfaces|default(netlab_interfaces) if 'ripv2' in intf and 'ipv4' in intf %}
  network {{ intf.ifname }}
 {%       if intf.ripv2.passive|default(False) %}
@@ -21,7 +21,7 @@ router ripng{% if vrf %} vrf {{ vrf }}{% endif +%}
 {%     if 'timers' in ripv2 %}
  timers basic {{ ripv2.timers['update'] }} {{ ripv2.timers.timeout }} {{ ripv2.timers.garbage }}
 {%     endif %}
-{{     redistribute.config(ripv2,af='ipv6') }}
+{{     redistribute.config(ripv2,af='ipv6',metric=8) }}
 {%     for intf in ripv2.interfaces|default(netlab_interfaces) if 'ripv2' in intf and 'ipv6' in intf %}
  network {{ intf.ifname }}
 {%       if intf.ripv2.passive|default(False) %}

--- a/netsim/ansible/templates/routing/_redistribute.frr.j2
+++ b/netsim/ansible/templates/routing/_redistribute.frr.j2
@@ -1,7 +1,9 @@
-{% macro policy(sp_data,af) -%}
-  {% if 'policy' in sp_data %} route-map {{ sp_data.policy }}-{{ af }}{% endif +%}
+{% macro policy(sp_data,af,metric) -%}
+  {% if 'policy' in sp_data %} route-map {{ sp_data.policy }}-{{ af }}{% 
+     elif metric %} metric {{ metric }}{%
+     endif +%}
 {%- endmacro %}
-{% macro config(pdata,af,af_redistribute=False,isis_level='') -%}
+{% macro config(pdata,af,af_redistribute=False,isis_level='',metric='') -%}
 {%   if pdata.import is defined %}
 {%     for s_proto,s_data in pdata.import.items() %}
 {%       if s_proto == 'ospf' and af == 'ipv6' %}
@@ -16,7 +18,7 @@
 {#         ISIS wants to know into which database it should redistribute #}
 {%         set s_proto = s_proto + ' ' + isis_level %}
 {%       endif %}
- redistribute {{ s_proto }}{{ policy(s_data,af) }}
+ redistribute {{ s_proto }}{{ policy(s_data,af,metric) }}
 {%     endfor %}
 {%   endif %}
 {%- endmacro %}


### PR DESCRIPTION
For whatever weird reason, redistributing routes into RIP started to fail when (fast)configuring FRR with bash scripts. Specifying an explicit metric on 'redistribute' command makes the problem go away.