### PR TITLE
Fix: Add 'get_node_group_var' to augment.devices

### DIFF
--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -91,7 +91,7 @@ def get_consolidated_device_data(node: Box, defaults: Box) -> Box:
   provider = get_provider(node,defaults)
 
   if not devtype in defaults.devices:
-    log.fatal(f'Internal error: call to get_provider_data with unknown device {devtype}')
+    log.fatal(f'Internal error: call to get_consolidated_device_data with unknown device {devtype}')
 
   data = defaults.devices[devtype] + defaults.devices[devtype].get(provider,{})
   for p in defaults.providers.keys():


### PR DESCRIPTION
The new function makes it simpler to get a value that could be defined within a node or as a device group variable.

Also: various 'get something' functions were rearranged in a more logical order to make the code easier to read.