### PR TITLE
Fix: Control Linux IP forwarding with netlab_ip_forwarding variable

### DIFF
--- a/docs/labs/linux.md
+++ b/docs/labs/linux.md
@@ -62,6 +62,8 @@ IPv4 and IPv6 packet forwarding on Linux devices is controlled with the **role**
 * **gateway**: a Linux device does not perform packet forwarding but acts as the default gateway for other hosts. You will have to install a proxy (or a similar solution) for inter-subnet packet forwarding.
 * **router**: A Linux device performs packet forwarding but does not run routing protocols. Use the **frr** device if you want to run routing protocols on a Linux server.
 
+You can also enable the IPv4/IPv6 packet forwarding on a Linux device with the **netlab_ip_forwarding** node attribute/group variable set to *True*.
+
 (linux-loopback)=
 ## Loopback Interface
 

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -185,7 +185,12 @@ netplan apply
 # Sysctl settings: IPv4/IPv6 forwarding, IPv6 LLA
 # Do this after 'netplan apply', e.g. bond devices won't exist before that
 #
-{% set pkt_fwd = "1" if role|default("host") == "router" else "0" %}
+{#
+   IP forwarding is controlled with the 'netlab_ip_forwarding' group variable. If that
+   variable is not set, the IP forwarding is controlled by the node 'role' (which is
+   assumed to be 'host' when missing
+#}
+{% set pkt_fwd = "1" if netlab_ip_forwarding|default(role|default("host") == "router") else "0" %}
 cat <<SCRIPT > /etc/sysctl.d/10-netsim.conf
 net.ipv4.conf.all.arp_announce=2
 net.ipv4.ip_forward={{ pkt_fwd }}

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -7,9 +7,14 @@
 sysctl -w net.ipv4.conf.all.arp_announce=2
 
 #
-# Disable IPv4 and IPv6 forwarding
+# Enable or disable IPv4 and IPv6 forwarding
 #
-{% set pkt_fwd = "1" if role|default("host") == "router" else "0" %}
+{#
+   IP forwarding is controlled with the 'netlab_ip_forwarding' group variable. If that
+   variable is not set, the IP forwarding is controlled by the node 'role' (which is
+   assumed to be 'host' when missing
+#}
+{% set pkt_fwd = "1" if netlab_ip_forwarding|default(role|default("host") == "router") else "0" %}
 sysctl -w net.ipv4.ip_forward={{ pkt_fwd }}
 sysctl -w net.ipv6.conf.all.forwarding={{ pkt_fwd }}
 {% if loopback is defined %}


### PR DESCRIPTION
The Linux initial configuration enabled IP forwarding when the node 'role' was set to 'router'. Nodes in KinD clusters have to forward traffic between "external" interfaces and K8S pods, but cannot use 'role' set to 'router' because they rely on static routes to get to external destinations.

This commit adds a more explicit way of configuring Linux IP forwarding with a node/group variable. The role-based forwarding is used as a fallback mechanism.