### PR TITLE
Fix: Remove MAC address change from IOSvL2 normalize template

### DIFF
--- a/netsim/ansible/templates/normalize/iosvl2.j2
+++ b/netsim/ansible/templates/normalize/iosvl2.j2
@@ -3,7 +3,4 @@
 interface {{ intf.ifname }}
 {# 'no switchport' allocates an internal VLAN in range 1006-, causing issues when overlapping with topology vlans #}
  shutdown
-{% if l.mac_address is defined %}
- mac-address {{ l.mac_address }}
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
Due to an incorrect variable name (and Ansible-style 'is defined' Jinja2 tests), the MAC address was never set by the IOSvL2 normalize template. However, setting the MAC address effectively removed it from the router config due to a weird interaction between IOS and Ansible. The solution was to remove the MAC address change from the normalize template.

Identified by Copilot while commenting on #3055