### PR TITLE
Add custom actions to integration tests

### DIFF
--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -17,7 +17,7 @@ from box import Box
 
 from netsim import __version__
 from netsim.cli import external_commands, parser_add_verbose
-from netsim.data import get_box, get_empty_box
+from netsim.data import get_a_list, get_box, get_empty_box
 from netsim.utils import files as _files
 from netsim.utils import log
 from netsim.utils import read as _read
@@ -288,7 +288,7 @@ def run_test(test: str, args: argparse.Namespace,first: bool) -> None:
     return
 
   test_def = topology.defaults.netlab.integration
-  test_skip = test_def.get("skip",[])
+  test_skip = get_a_list(test_def.get("skip",[]))
   test_exec = []
 
   up_cmd = test_def.get("up",f"netlab up --snapshot --no-config")
@@ -309,8 +309,8 @@ def run_test(test: str, args: argparse.Namespace,first: bool) -> None:
     return
   else:
     os.environ['ANSIBLE_ANY_ERRORS_FATAL'] = 'True'
-    cmd  = "netlab initial" if 'up' in args.steps else "netlab initial -o config"
-    stat = "config(ok)" if 'up' in args.steps else "config(files)"
+    cmd  = "netlab initial" if 'up' in test_exec else "netlab initial -o config"
+    stat = "config(ok)" if 'up' in test_exec else "config(files)"
     cmd  = test_def.get("initial",cmd)
     if execute(cmd,args,test=test,log="initial",err="initial").returncode == 0:
       print(stat,end=" ",flush=True)


### PR DESCRIPTION
This commit allows lab topologies to specify what actions should be performed in the up/initial/validate stages of an integration test by setting the 'defaults.netlab.integration' parameters. They can also specify which tests to skip with the 'skip' list in the same defaults dictionary.

Implements #2918