### PR TITLE
Integration tests for the graph output module

### DIFF
--- a/tests/platform-integration/graph/01-topo.yml
+++ b/tests/platform-integration/graph/01-topo.yml
@@ -56,6 +56,7 @@ links:
 
 files:
   make_dot.sh: |
+    set -e
     NETLAB_OUTPUTS_GRAPH_NODE__ADDRESS__LABEL=False \
       netlab graph --title "Topology graph, no labels" dot-topo-no-labels.svg
     NETLAB_OUTPUTS_GRAPH_AS__CLUSTERS=False \
@@ -65,6 +66,7 @@ files:
     NETLAB_OUTPUTS_GRAPH_GROUPS=[dc-fabric,host] \
       netlab graph --title "Topology graph, custom groups" dot-topo-groups.svg
   make_d2.sh: |
+    set -e
     unset D2_LAYOUT
     unset D2_SKETCH
     if [[ "$*" == *"elk"* ]]; then

--- a/tests/platform-integration/graph/02-bgp.yml
+++ b/tests/platform-integration/graph/02-bgp.yml
@@ -49,11 +49,13 @@ links:
 
 files:
   make_dot.sh: |
+    set -e
     netlab graph -t bgp -f rr --title "BGP route reflector sessions" dot-bgp-rr.svg
     netlab graph -t bgp -f vrf --title "Dashed VRF BGP sessions" dot-bgp-vrf.svg
     netlab graph -t bgp -f novrf --title "Global BGP sessions (no VRF sessions)" dot-bgp-novrf.svg
     netlab graph -t bgp -f evpn,rr --title "EVPN BGP sessions" dot-bgp-evpn.svg
   make_d2.sh: |
+    set -e
     unset D2_LAYOUT
     unset D2_SKETCH
     if [[ "$*" == *"elk"* ]]; then

--- a/tests/platform-integration/graph/03-isis.yml
+++ b/tests/platform-integration/graph/03-isis.yml
@@ -36,6 +36,9 @@ links:
 - c2
 
 files:
-  make.sh: |
+  make_dot.sh: |
+    set -e
     netlab graph -t isis dot-isis.svg
+  make_d2.sh: |
+    set -e
     netlab graph -t isis -e d2 d2-isis.svg

--- a/tests/platform-integration/graph/04-vlan.yml
+++ b/tests/platform-integration/graph/04-vlan.yml
@@ -27,6 +27,9 @@ links:
   vlan.trunk: [ red, blue ]
 
 files:
-  make.sh: |
+  make_dot.sh: |
+    set -e
     netlab graph -t topology -f vlan dot-vlan.svg
+  make_d2.sh: |
+    set -e
     netlab graph -t topology -f vlan -e d2 d2-vlan.svg

--- a/tests/platform-integration/graph/topology-defaults.yml
+++ b/tests/platform-integration/graph/topology-defaults.yml
@@ -1,0 +1,4 @@
+netlab.integration:
+  up: bash make_dot.sh
+  initial: bash make_d2.sh
+  skip: [ validate ]


### PR DESCRIPTION
Using the functionality from #3060 (and fixes from #3059), the sample topologies demonstrating the graphing features can be turned into true integration tests with error reporting.