### PR TITLE
Fix: Use SCP to copy replacement configuration to SR Linux

### DIFF
--- a/netsim/ansible/tasks/reload-config/srlinux.yml
+++ b/netsim/ansible/tasks/reload-config/srlinux.yml
@@ -1,6 +1,7 @@
 - name: Copy replacement configuration to SR Linux container
-  shell: docker cp {{ config_template }} {{ ansible_host }}:/tmp/replace-config
-  delegate_to: localhost
+  include_tasks: _copy_config.yml
+  vars:
+    netlab_device_disk: "/tmp/"
 
 - name: Load SR Linux configuration file
   vars:


### PR DESCRIPTION
The SR Linux 'reload config' used 'docker cp' which broke after #2913. Using 'scp' instead of that seems to work like a charm.

Closes #3067