### PR TITLE
Fix CL NVUE OSPFv2 area parameter config template

### DIFF
--- a/netsim/extra/ospf.areas/cumulus_nvue.j2
+++ b/netsim/extra/ospf.areas/cumulus_nvue.j2
@@ -2,7 +2,7 @@
 {% macro area_config(adata,af,abr) %}
 {%   set kind = 'normal' if adata.kind == 'regular' else adata.kind %}
               {{ adata.area }}:
-                type: {{ 'totally-' if not adata.inter_area else '' }}{{ kind }}
+                type: {{ 'totally-' if not adata.inter_area|default(True) else '' }}{{ kind }}
 {%   if adata.kind in ['stub','nssa'] and adata.default.cost is defined and af == 'ipv4' %}
                 default-lsa-cost: {{ adata.default.cost }}
 {%   endif %}


### PR DESCRIPTION
The error in template logic resulted in 'totally-normal' area type upsetting nvued

Closes #3073