### PR TITLE
Fix Bird BGP connect/retry/hold timers

### DIFF
--- a/netsim/daemons/bird/bgp.j2
+++ b/netsim/daemons/bird/bgp.j2
@@ -79,8 +79,9 @@ protocol bgp bgp_{{ n.name }}_{{ af }} {
 {%     set local_ip = loopback[af]|default('') %}
   local {{ local_ip.split('/')[0] if n.type == 'ibgp' else '' }} as {{ n.local_as|default(bgp.as) }};
   neighbor {{ n[af] }} as {{ n['as'] }};
-  connect retry time 10;
-  startup hold time 30;
+  connect retry time 5;
+  error wait time 5,10;
+  startup hold time 10;
 {% if n.local_if is defined %}
   interface "{{ n.local_if }}";
 {% endif %}


### PR DESCRIPTION
Some Bird BGP integration tests started to fail because FRR started so much faster than previously expected. Tweaking the timers results in faster retries, completing tests within the alloted retry interval.

Closes #3075