### PR TITLE
Fix ROS7: Set VLAN interface MTU/description

### DIFF
--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -26,18 +26,19 @@
 {% endif %}
 
 {% for l in interfaces|default([]) %}
+{%   set intf_type = 'vlan' if l.type == 'svi' else 'ethernet' %}
 
 {% if l.name is defined %}
-/interface ethernet set comment="{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}" {{ l.ifname }}
+/interface {{ intf_type }} set comment="{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}" {{ l.ifname }}
 {% elif l.type|default("") == "stub" %}
-/interface ethernet set comment="Stub interface" {{ l.ifname }}
+/interface {{ intf_type }} set comment="Stub interface" {{ l.ifname }}
 {% endif %}
 
 {% if l.mtu is defined %}
-/interface ethernet set mtu={{ l.mtu }} {{ l.ifname }}
+/interface {{ intf_type }} set mtu={{ l.mtu }} {{ l.ifname }}
 {% endif %}
 {% if l.shutdown|default(False) %}
-/interface ethernet set disabled=yes {{ l.ifname }}
+/interface {{ intf_type }} set disabled=yes {{ l.ifname }}
 {% endif %}
 {#
 # Add same interface comment also to the IP Address, for better troubleshooting


### PR DESCRIPTION
The initial configuration template incorrectly used /interface/ethernet command on VLAN interfaces. Now, we first find the correct keyword (ethernet or vlan) and then use that keyword when configuring interface parameters