### PR TITLE
Fix: Restore the IOL interface state after system restart

### DIFF
--- a/netsim/ansible/templates/initial/iol.j2
+++ b/netsim/ansible/templates/initial/iol.j2
@@ -1,0 +1,9 @@
+{% include "ios.j2" %}
+{% if netlab_config_mode == "startup" %}
+!
+event manager applet ReloadIfstate
+ event syslog occurs 1 pattern "%SYS-5-RESTART: System restarted"
+ action 1.0 cli command "enable"
+ action 2.0 cli command "copy unix:ifstate.cfg running-config" pattern "running"
+ action 2.1 cli command ""
+{% endif %}

--- a/netsim/devices/iol.yml
+++ b/netsim/devices/iol.yml
@@ -12,6 +12,8 @@ clab:
   image: vrnetlab/cisco_iol:17.16.01a
   node:
     kind: cisco_iol
+    config_templates:
+      ifstate: /iol/ifstate.cfg
 
 features:
   initial:

--- a/netsim/templates/provider/clab/iol/ifstate.j2
+++ b/netsim/templates/provider/clab/iol/ifstate.j2
@@ -1,0 +1,8 @@
+{% for ifdata in interfaces %}
+!
+interface {{ ifdata.ifname }}
+{%   if not ifdata.shutdown|default(False) %}
+ no shutdown
+{%   endif %}
+{% endfor %}
+end


### PR DESCRIPTION
For whatever stupid reason, one of the final steps in IOL system restart shuts down bridge interfaces. This QDS triggers an EEM applet after the system restart and uses a config snippet mapped into IOL container to restore the interface state to "no shutdown"

Fixes #3095