### PR TITLE
Clarify delete.community.list attributes in routing policy

### DIFF
--- a/docs/module/routing-policy.txt
+++ b/docs/module/routing-policy.txt
@@ -36,13 +36,13 @@ You can delete these route parameters:
 
 * **community**: A dictionary that can be used to delete standard, large, or extended communities. The dictionary can also contain **list** element to delete all communities matching a BGP [community filter](generic-routing-community).
 
-You can specify a standard community as the value of the **delete.community.list**, or use attributes **delete.community.list.standard**, **delete.community.list.extended**, **delete.community.list.large** to delete standard, extended, or large communities matching a community list. You can use multiple delete lists (one per BGP community type) within a single routing policy entry.
+You can specify a standard BGP community list as the value of the **delete.community.list**, or use attributes **delete.community.list.standard**, **delete.community.list.extended**, or **delete.community.list.large** to delete standard, extended, or large communities matching a community list. You can use multiple delete lists (one per BGP community type) within a single routing policy entry.
 
 Routing policies are specified in the global- or node-level **routing.policy** dictionary (see [](routing-object-import) and  [](routing-object-merge) for more details).
 
 The dictionary keys in the **routing.policy** dictionary are policy names (route map names), and the dictionary values are routing policies (lists of routing policy entries).
 
-The following example specifies three routing policies: two global routing policies setting BGP local preference to different values and a node routing policy setting MED.
+The following example specifies three routing policies: two global routing policies that set BGP local preference to different values, and a node routing policy that sets MED.
 
 ```
 module: [ routing ]


### PR DESCRIPTION
Minor nitpick.

Make the attribute listing similar to the match how attributes are described elsewhere in the documentation.
