### PR TITLE
Fix integration tests affected by change in line wraps in Box 7.3.3

### DIFF
--- a/tests/topology/expected/bgp-ibgp-localas.yml
+++ b/tests/topology/expected/bgp-ibgp-localas.yml
@@ -105,25 +105,6 @@ links:
   prefix:
     ipv4: 10.1.0.8/30
   type: p2p
-message: 'Use this topology to test the ''local_as'' functionality on IBGP sessions.
-  The
-
-  device under test uses local AS which is identical to remote AS, effectively
-
-  turning an EBGP session into an IBGP session. It should establish the BGP
-
-  sessions with X1 and X2, and propagate BGP prefixes between them.
-
-
-  The test also checks (as a warning) whether DUT propagates "real" IBGP routes
-
-  over local-as IBGP session. Failure to do that indicates that the next hop is
-
-  not set correctly, or that DUT is not working as a route reflector toward
-
-  local-as IBGP neighbor.
-
-  '
 module:
 - vlan
 - ospf

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -220,22 +220,6 @@ links:
   type: lan
   vlan:
     access: green
-message: 'The devices under test form a server cluster connected to a pair of ToR
-  switches.
-
-  Host facing ports are automatically configured as ''edge'' ports, the inter-switch
-  port is
-
-  manually configured as ''network''
-
-
-  * h1 and h2 should be able to ping each other
-
-  * h3 and h4 should be able to ping each other
-
-  * h1 should not be able to reach h3
-
-  '
 module:
 - vlan
 - stp

--- a/tests/topology/input/bgp-ibgp-localas.yml
+++ b/tests/topology/input/bgp-ibgp-localas.yml
@@ -1,15 +1,4 @@
 ---
-message: |
-  Use this topology to test the 'local_as' functionality on IBGP sessions. The
-  device under test uses local AS which is identical to remote AS, effectively
-  turning an EBGP session into an IBGP session. It should establish the BGP
-  sessions with X1 and X2, and propagate BGP prefixes between them.
-
-  The test also checks (as a warning) whether DUT propagates "real" IBGP routes
-  over local-as IBGP session. Failure to do that indicates that the next hop is
-  not set correctly, or that DUT is not working as a route reflector toward
-  local-as IBGP neighbor.
-
 module: [ bgp, ospf ]
 defaults.device: none
 

--- a/tests/topology/input/stp-port-type.yml
+++ b/tests/topology/input/stp-port-type.yml
@@ -1,13 +1,4 @@
 ---
-message: |
-  The devices under test form a server cluster connected to a pair of ToR switches.
-  Host facing ports are automatically configured as 'edge' ports, the inter-switch port is
-  manually configured as 'network'
-
-  * h1 and h2 should be able to ping each other
-  * h3 and h4 should be able to ping each other
-  * h1 should not be able to reach h3
-
 defaults.device: eos
 
 stp:


### PR DESCRIPTION
For some reason, python-box 7.3.3 generates slightly different YAML text representations for long (multiline) strings, resulting in failed transformation tests (which compare YAML-to-YAML).

The workaround: remove 'message' attributes for tests that produce different results under the latest Box version.