### PR TITLE
Fix: Adjust validation plugins to enable VRF prefix checks

### DIFF
--- a/netsim/validate/_common.py
+++ b/netsim/validate/_common.py
@@ -32,9 +32,10 @@ def check_for_prefix(
       lookup: typing.Callable,
       data: typing.Union[Box,list],
       table: str = 'routing table',
-      state: str = 'present') -> typing.Union[Box,BoxList]:
+      state: str = 'present',
+      **rest: typing.Any) -> typing.Union[Box,BoxList]:
 
-  result = lookup(pfx,data)
+  result = lookup(pfx,data,**rest)
   if result is None:
     report_state(
       exit_msg=f'The prefix {pfx} is not in the {table}',
@@ -57,7 +58,7 @@ def run_prefix_checks(
       **rest: typing.Any) -> str:
   
   pfx = _rp_utils.get_prefix(pfx)
-  data = check_for_prefix(pfx=pfx,lookup=lookup,data=data,table=table,state=state)
+  data = check_for_prefix(pfx=pfx,lookup=lookup,data=data,table=table,state=state,**rest)
 
   keys = list(checks.keys())
   for k in kwargs:

--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -237,9 +237,9 @@ BGP prefix validation function:
 * Use single-prefix show command
 * Use the run_prefix_checks framework for validation
 """
-def show_bgp_prefix(pfx: str, af: str = 'ipv4', **kwargs: typing.Any) -> str:
+def show_bgp_prefix(pfx: str, af: str = 'ipv4', vrf: str = 'default', **kwargs: typing.Any) -> str:
   pfx = _rp_utils.get_prefix(pfx)
-  return f"bgp {af} unicast {pfx} | json"
+  return f"bgp {af} unicast {pfx} vrf {vrf} | json"
 
 def valid_bgp_prefix(
       pfx: str,*,

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -105,7 +105,7 @@ def valid_bgp_neighbor_details(
 """
 BGP prefix checks, starting with 'get a BGP prefix from JSON results'
 """
-def get_bgp_prefix(pfx: str, data: Box) -> typing.Optional[typing.Union[Box,BoxList]]:
+def get_bgp_prefix(pfx: str, data: Box, **kwargs: typing.Any) -> typing.Optional[typing.Union[Box,BoxList]]:
   if 'prefix' not in data:
     return None
 

--- a/netsim/validate/ospf/eos.py
+++ b/netsim/validate/ospf/eos.py
@@ -71,7 +71,7 @@ def valid_ospf6_neighbor(id: str, present: bool = True,vrf: str = 'default') -> 
 def show_ospf_prefix(pfx: str, vrf: str = 'default', **kwargs: typing.Any) -> str:
   return f'ip route vrf {vrf} ospf detail | json'
 
-def get_ospf_prefix(pfx: str, data: Box) -> typing.Optional[Box]:
+def get_ospf_prefix(pfx: str, data: Box, **kwargs: typing.Any) -> typing.Optional[Box]:
   for v in data.get('vrfs',{}).values():
     return v.get('routes',{}).get(pfx,None)
   

--- a/netsim/validate/ospf/frr.py
+++ b/netsim/validate/ospf/frr.py
@@ -75,7 +75,7 @@ def valid_ospf6_neighbor(id: str, present: bool = True) -> bool:
 def show_ospf_prefix(pfx: str, **kwargs: typing.Any) -> str:
   return f'ip ospf route json'
 
-def get_ospf_prefix(pfx: str, data: Box) -> typing.Optional[Box]:
+def get_ospf_prefix(pfx: str, data: Box, **kwargs: typing.Any) -> typing.Optional[Box]:
   return data.get(pfx,None)
 
 def check_ospf_cost(data: list, value: typing.Any, **kwargs: typing.Any) -> list:


### PR DESCRIPTION
The validation plugins were unable to perform checks of VRF prefixes because the VRF parameter was not propagated by the common validation function to device-specific functions. This change passes the 'rest' of parameters (which include the VRF name) to the callback 'get me prefixes' device-specific functions.

Currently tested: check BGP VRF prefixes on Arista EOS