### PR TITLE
MPLS/VPN BGP RR fixes (IOS, FRR, VyOS)

### DIFF
--- a/netsim/ansible/templates/mpls/frr.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/frr.mplsvpn.j2
@@ -10,5 +10,8 @@ router bgp {{ bgp.as }}
 {%     if n.type == 'ibgp' %}
   neighbor {{ n[vpnaf] }} next-hop-self
 {%     endif %}
+{%     if n.rr_client|default(False) %}
+  neighbor {{ n[vpnaf] }} route-reflector-client
+{%     endif %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/ansible/templates/mpls/ios.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/ios.mplsvpn.j2
@@ -1,3 +1,7 @@
+{% if mpls.vpn.ipv6|default(False) %}
+!
+ipv6 unicast-routing
+{% endif %}
 !
 router bgp {{ bgp.as }}
 {% for af in ['ipv4','ipv6'] if mpls.vpn[af] is defined %}

--- a/netsim/ansible/templates/mpls/vyos.mplsvpn.j2
+++ b/netsim/ansible/templates/mpls/vyos.mplsvpn.j2
@@ -7,7 +7,7 @@ set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn
 {%     if bgp.next_hop_self is defined and bgp.next_hop_self %}
 set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn nexthop-self
 {%     endif %}
-{%     if bgp.rr|default('') and not n.rr|default('') %}
+{%     if n.rr_client|default(False) %}
 set protocols bgp neighbor {{ n[vpnaf] }} address-family {{ af }}-vpn route-reflector-client
 {%     endif %}
 

--- a/tests/integration/mpls/15-vpnv4-rr.yml
+++ b/tests/integration/mpls/15-vpnv4-rr.yml
@@ -33,7 +33,7 @@ groups:
     members: [ dut ]
     module: [ ospf, bgp, mpls ]
     mpls.ldp: True
-    mpls.vpn: True
+    mpls.vpn.ipv4: [ ibgp ]
     bgp.rr: True
 
 vrfs:

--- a/tests/integration/mpls/25-vpnv6-rr.yml
+++ b/tests/integration/mpls/25-vpnv6-rr.yml
@@ -67,13 +67,17 @@ validate:
     nodes: [ pe1, pe2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
     stop_on_error: true
-  pe_vpnv4:
-    description: Check VPNv4 AF on IBGP session between PE-routers
+  pe_vpnv6:
+    description: Check VPNv6 AF on IBGP session between PE-routers
+    wait: bgp_scan_time
+    wait_msg: Waiting for VPNv6 AF negotiation
     nodes: [ pe1, pe2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',activate='vpnv6')
     stop_on_error: true
   pfx_tenant:
     description: Check for tenant PE1 prefix on PE2
+    wait: bgp_scan_long
+    wait_msg: Waiting for VPNv6 prefix propagation
     nodes: [ pe2 ]
     plugin: bgp_prefix(prefix.ce1.ipv6,af='ipv6',vrf='tenant')
   vrf_ping:


### PR DESCRIPTION
* IOS and FRR did not configure RR clients in VPNv4/VPNv6 AFs
* VyOS configured RR clients but used the old logic (bgp.rr flag)

Also:
* VPNv4 integration test needed limited mpls.vpn AFs, otherwise it wouldn't work for FRR and VyOS
* VPNv6 integration test needed a few "wait" commands