### PR TITLE
OpenBSD: Add BGP support

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -111,6 +111,7 @@ These devices support BGP local-AS functionality to build EBGP or IBGP sessions:
 | JunOS                    |  ✅ |  ✅ |
 | Nokia SR Linux           |  ✅ |  ✅ |
 | Nokia SR OS[^SROS]       |  ✅ |  ✅ |
+| OpenBSD                  |  ✅ |  ❌  |
 | Sonic                    |  ✅ |  ✅ |
 | VyOS                     |  ✅ |  ❌  |
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -377,7 +377,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌  | ✅  |   ❌  |
 | Nokia SR Linux        | ✅   |  ✅   |   ❌  | ✅  |   ❌  |
 | Nokia SR OS[^SROS]    | ✅   |  ✅   |   ❌  | ✅  | ✅  |
-| OpenBSD               | ✅   |   ❌   |   ❌  |  ❌  | ✅   |
+| OpenBSD               | ✅   |   ❌   |   ❌  | ✅   | ✅   |
 | Sonic                 |  ❌   |   ❌   |   ❌  | ✅  |   ❌  |
 | VyOS                  | ✅   |  ✅   |   ❌  | ✅  |   ❌  |
 
@@ -502,6 +502,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Mikrotik RouterOS 7   | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Nokia SR Linux        | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Nokia SR OS[^SROS]    | ✅ | ✅ | ❌ | ✅ | ✅ |
+| OpenBSD               | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Sonic                 |  ❌ | ❌ | ❌ | ✅ | ❌ |
 | VyOS                  | ✅ | ✅ | ❌ | ✅ | ❌ |
 

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -67,6 +67,7 @@ The plugin implements generic BGP session features for the following platforms:
 | Mikrotik RouterOS 7 |  ✅  |   ❌  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |  ✅  |
 | Nokia SR OS         |  ✅  |   ❌  |   ❌  |   ❌  |
+| OpenBSD             |  ✅  |  ✅  |   ❌  |  ✅  |
 | VyOS                |  ✅  |   ❌  |   ❌  |   ❌  |
 
 [^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
@@ -100,6 +101,7 @@ BGP session security features are available on these platforms:
 | Mikrotik RouterOS 7 |    ✅    | ❌  |  ❌  |
 | Nokia SR Linux      |    ✅    | ❌  |  ❌  |
 | Nokia SR OS         |    ✅    | ❌  |  ✅  |
+| OpenBSD             |    ✅    | ✅  |  ❌  |
 
 BGP session security features are also available on these daemons:
 
@@ -126,6 +128,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | Mikrotik RouterOS 7 |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
 | Nokia SR Linux      |  ✅  |  ✅  |  ✅  |   ❌  |  ✅  |
 | Nokia SR OS         |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
+| OpenBSD.            |  ✅  |  ✅  |   ❌  |  ✅  |  ✅  |
 | VyOS                |  ✅  |  ✅  |   ❌  |   ❌  |   ❌  |
 
 (bgp-session-apply)=

--- a/netsim/ansible/templates/bgp/openbsd.j2
+++ b/netsim/ansible/templates/bgp/openbsd.j2
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+cat <<BGPD_CONF >/etc/bgpd.conf
+AS {{ bgp.as }}
+{% if bgp.router_id|ipv4 %}
+router-id {{ bgp.router_id }}
+{% endif %}
+log updates
+
+## network announcements
+
+{% for pfx in bgp.originate|default([]) %}
+network {{ pfx|ansible.utils.ipaddr('0') }}
+{% endfor %}
+{% for intf in netlab_interfaces %}
+{%   if intf.bgp.advertise|default(False) %}
+{%     if intf.ipv4|default(False) %}
+network {{ intf.ipv4|ansible.utils.ipaddr('0') }}
+{%     endif %}
+{%     if intf.ipv6|default(False) %}
+network {{ intf.ipv6|ansible.utils.ipaddr('0') }}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+
+## neighbors and groups
+
+{% for n in bgp.neighbors %}
+{%   for af in ['ipv4', 'ipv6'] %}
+{%     if n[af]|default(False) %}
+neighbor {{ n[af] }} {
+    remote-as {{ n.as }}
+    descr "{{ n.name }}"
+{%       if n.local_as|default(False) %}
+    local-as {{ n.local_as }}
+{%       endif %}
+{%       if n.allowas_in|default(False) %}
+    enforce local-as no
+{%       endif %}
+{%       if n.as_override|default(False) %}
+    as-override yes
+{%       endif %}
+{%       if n._source_intf|default(False) %}
+    local-address {{ n._source_intf[af]|ipaddr('address') }}
+{%       endif %}
+{%       if n.rr_client|default(False) %}
+    route-reflector{% if bgp.rr_cluster_id|default(False) %} {{ bgp.rr_cluster_id }}{% endif +%}
+{%       endif %}
+{%       if n.default_originate|default(False) %}
+    export default-route
+{%       endif %}
+{%       if n.gtsm|default(False) %}
+    ttl-security yes
+{%       endif %}
+{%       if n.passive|default(False) %}
+    passive
+{%       endif %}
+{%       if n.password|default(False) %}
+    tcp md5sig password {{ n.password }}
+{%       endif %}
+{%       if n.timers|default(False) %}
+    holdtime {{ n.timers.hold|default(180) }}
+    holdtime min {{ n.timers.min_hold|default(3) }}
+{%       endif %}
+{%       if n.rs_client|default(False) %}
+    enforce neighbor-as no
+{%       endif %}
+{%       if n.rs|default(False) %}
+    transparent-as yes
+{%       endif %}
+}
+{%     endif %}
+{%   endfor %}
+{% endfor %}
+
+## rules
+
+{% if bgp.next_hop_self|default(False) %}
+match from ebgp set { nexthop self }
+{% endif %}
+{# delete communities that should not be advertised #}
+{% set c_types = ['standard', 'large', 'extended'] %}
+{% for key, values in bgp.community.items() %}
+{%   if key in ['ebgp', 'ibgp'] %}
+{%     for ct in c_types %}
+{%       if ct not in values %}
+match to {{ key }} set
+{%-        if ct == 'standard' %}
+ { community delete *:* }
+{%         elif ct == 'large' %}
+ { large-community delete *:*:* }
+{%         elif ct == 'extended' %}
+ { ext-community delete * * }
+{%         endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+
+allow from any
+allow to any
+
+BGPD_CONF
+
+chmod 640 /etc/bgpd.conf
+rcctl enable bgpd
+rcctl restart bgpd
+
+{% for pfx in bgp.originate|default([]) %}
+route add -blackhole {{ pfx|ipaddr('0') }} -priority 63 localhost
+{% endfor %}

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -27,6 +27,23 @@ features:
     ipv6: true
     passive: false
     import: [ connected, static ]
+  bgp:
+    local_as: true
+    community:
+      standard: [ standard, large ]
+      large: [ large ]
+      extended: [ extended ]
+      2octet: [ standard ]
+    allowas_in: True
+    as_override: True
+    default_originate: True
+    description: True
+    gtsm: True
+    passive: True
+    password: True
+    rs: True
+    rs_client: True
+    timers: True
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd

--- a/netsim/extra/bgp.session/openbsd.j2
+++ b/netsim/extra/bgp.session/openbsd.j2
@@ -1,0 +1,1 @@
+# Empty file, all configuration is done in bgp/openbsd.j2


### PR DESCRIPTION
This is a start for supporting OpenBSD's BGP daemon with netlab.

I'm not sure I understood features.bgp.community right. By default OpenBSD sends all communities. I implemented filters that drop communities if required.

I did not yet look into policies and redistribution.

Because vrnetlab currently uses 10.0.0.2 for the management interface (hidden) I was running tests like this:
"netlab up -s addressing.loopback.ipv4=10.100.0.0/24 test.yml"
--> https://github.com/srl-labs/vrnetlab/tree/master?tab=readme-ov-file#management-interface

### BGP integration tests passed

**tests/integration/bgp:**

01-ebgp-session.yml
02-ibgp-ebgp-session.yml
03-ibgp-rr.yml
--> one fail and one warning because of hardcoded 10.0.0.10 in test
04-originate.yml
--> three failis because of hardcoded 10.0.0.2 (loopback dut2) in test
05-community.yml
07-ebgp-localas.yml
11-ipv6-ebgp.yml
12-ipv6-ibgp-ebgp.yml
13-ipv6-ibgp-rr.yml
14-ipv6-originate.yml

**tests/integration/bgp.session:**

01-allowas-in.yml
02-as-override.yml
04-default-originate.yml
--> VRF-specific tests skipped
05-gtsm.yml
--> 10.0.0.17/32 hardcoded in tests. with the options I started the topology the prefix is 10.100.0.17/32.
--> somehow it takes rather long untile the session are established.
06-passive.yml
07-password.yml
10-timers.yml
--> tests succeed but are unreliable.
--> keepalive can not be configured explicitely. openbgpd uses holdtime / 3.
11-rs-client.yml
12-rs.yml