### PR TITLE
Fix IOS OSPF template when bgp is undefined

### DIFF
--- a/netsim/ansible/templates/ospf/ios.j2
+++ b/netsim/ansible/templates/ospf/ios.j2
@@ -2,8 +2,8 @@
 {% import "ios.ospfv3.j2" as ospfv3 with context %}
 {% set ospf_pid = ospf.process|default(1) %}
 {% if ospf.af.ipv4 is defined %}
-{{   ospfv2.config(ospf_pid,False,ospf,netlab_interfaces,bgp) }}
+{{   ospfv2.config(ospf_pid,False,ospf,netlab_interfaces,bgp|default({})) }}
 {% endif %}
 {% if ospf.af.ipv6 is defined %}
-{{   ospfv3.config(ospf_pid,False,ospf,netlab_interfaces,bgp) }}
+{{   ospfv3.config(ospf_pid,False,ospf,netlab_interfaces,bgp|default({})) }}
 {% endif %}


### PR DESCRIPTION
Problem: IOS OSPF template fails on OSPF-only nodes with `'bgp' is undefined`.

Cause: `netsim/ansible/templates/ospf/ios.j2` passes `bgp` to OSPFv2/OSPFv3 macros without a default.

Fix: use `bgp|default({})` in both macro calls.

Impact: no behavior change when BGP exists; prevents failure when BGP is absent.

Testing done:

Validation run (local):
- ./tests/run-tests.sh ci
- pytest: 2 passed, 3 deselected
- mypy: success
- yamllint: no errors