### PR TITLE
Fix: Remove artifacts similar to netlab files from Ansible inventory

### DIFF
--- a/docs/outputs/ansible.md
+++ b/docs/outputs/ansible.md
@@ -10,6 +10,12 @@ A single formatting modifier can be used to modify the distribution of informati
 * **dirs** (default) -- Ansible inventory file contains minimal amount of information[^3]. Host- and group directories are created under *host_vars* and *group_vars*. Each host- or group directory within *host_vars* or *group_vars* contain *topology* file in JSON or YAML format (see below) with host- or group variables. This format allows you to add Ansible inventory information (create additional files within host- or group subdirectories) without interfering with *ansible* output module.
 * **files** -- Ansible inventory file contains a minimal amount of information. Per-host or per-group files are created in *host_vars* and *group_vars*. Do not modify those files; they will be overwritten the next time you run **netlab create** command.
 
+```{tip}
+You can add custom inventory files to *‌host_vars* or *‌group_vars* directories as long as their names do not start with `topology` (those files are removed by the Ansible output module).
+
+Do keep in mind, though, that the whole Ansible inventory is removed by the **‌netlab down --cleanup** command. Adding information to the lab topology (nodes or group variables) is thus a better approach.
+```
+
 The same parameter can be set using the **defaults.outputs.ansible.hostvars** [topology default](topo-defaults).
 
 The Ansible inventory files (apart from `hosts.yml`) are created in JSON format by default. If you need YAML-formatted inventory files, set the **defaults.outputs.ansible.filetype** [topology default](topo-defaults) to `yaml` or `yml` (depending on the desired file type).

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -132,17 +132,20 @@ def write_inventory_file(data: Box, fname: str, header: str, filetype: typing.Op
     fname += '.' + filetype
 
   dirname = os.path.dirname(fname)
-  if dirname and not os.path.exists(dirname):
+  if dirname and not os.path.exists(dirname):               # Make an empty directory if needed
     os.makedirs(dirname)
-  else:
-    similar_names = os.path.splitext(fname)[0] + ".*"
+  elif dirname:                                             # Otherwise, delete similar files (different extension)
+    similar_names = os.path.splitext(fname)[0] + ".*"       # ... from the existing directories
     for similar in glob.glob(similar_names):
       try:
+        if log.VERBOSE:
+          print(f'Removing existing inventory file {similar}')
         os.remove(similar)
-      except Exception as ex:
-        log.warning(
+      except Exception as ex:                               # A failure to remove a similar file is not catastrophic
+        log.warning(                                        # ... but deserves a warning
           text=f'Tried to remove inventory file {similar} but failed: {str(ex)}',
           module='ansible')
+
   if filetype in ['yaml','yml']:
     contents = header+"\n"+strings.get_yaml_string(data)
   else:


### PR DESCRIPTION
With the switch from YAML to JSON inventory files, it's possible to have old inventory files still present in host_vars or group_vars, resulting in weird behavior as the two inventory files are merged by Ansible playbooks.

This fix removes all similar inventory files from host_vars or group_vars subdirectories. An alternative would be to remove the whole directory structure and recreate it with every 'netlab create', but that might break setups that use extra inventory files in long-running projects.

Inspired by #3136