### PR TITLE
Cisco IOS XRd management VRF

### DIFF
--- a/netsim/devices/iosxr.yml
+++ b/netsim/devices/iosxr.yml
@@ -28,6 +28,8 @@ libvirt:
 clab:
   node:
     kind: cisco_xrd
+    env:
+      CLAB_MGMT_VRF: management
     runtime: docker
     config_templates:
       netlab-config: /config/netlab/netlab-config.sh:sh


### PR DESCRIPTION
Enables a management VRF on Cisco IOS XRd nodes with `clab.node.env.CLAB_MGMT_VRF` variable to be used in [ContainerLab's startup config](https://github.com/srl-labs/containerlab/blob/main/nodes/xrd/xrd.cfg)