### PR TITLE
Fix: Do not try to apply empty IOS XRd config snippet

### DIFF
--- a/netsim/templates/provider/clab/iosxr/netlab-config.j2
+++ b/netsim/templates/provider/clab/iosxr/netlab-config.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 source /pkg/bin/ztp_helper.sh
 tail -n +2 $1 > /tmp/config.conf # strip first line since config is rejected when shebang is present
-if grep -v -e '^!' /tmp/config.conf >/dev/null; then
+if grep -vE '^\s*(!|$)' /tmp/config.conf >/dev/null; then
   xrapply /tmp/config.conf
 else
   echo "No configuration to apply"


### PR DESCRIPTION
The xrapply script hangs when given a config snippet with no config commands (just comments). This fix checks whether there's a valid config command (something not starting with '!') in the config file before trying to apply it