### PR TITLE
Fix: Sort routing policy objects by sequence numbers

### DIFF
--- a/netsim/modules/routing/__init__.py
+++ b/netsim/modules/routing/__init__.py
@@ -101,13 +101,14 @@ expand the prefixes/pools in prefix list.
 """
 transform_dispatch: typing.Dict[str,dict] = {
   'policy': {
-    'import': policy.adjust_routing_policy
+    'import': policy.adjust_routing_policy,
+    'sort': True
   },
   'prefix': {
-    'import': prefix.expand_prefix_list
+    'import': prefix.expand_prefix_list,
   },
   'aspath': {
-    'import': aspath.number_aspath_acl
+    'import': aspath.number_aspath_acl,
   },
   'community': {
     'import' : clist.expand_community_list,

--- a/netsim/modules/routing/aspath.py
+++ b/netsim/modules/routing/aspath.py
@@ -34,6 +34,7 @@ Number AS path ACLs (some platforms refer to them by numbers)
 
 def number_aspath_acl(p_name: str,o_name: str,node: Box,topology: Box) -> None:
   numacl = node.routing._numobj[o_name]
+  node.routing[o_name][p_name] = sorted(node.routing[o_name][p_name],key=lambda O: O.get('sequence',10))
   if p_name not in numacl:
     maxacl = max([ 0 ] + [ acl for acl in numacl.values() ])
     numacl[p_name] = maxacl + 1

--- a/netsim/modules/routing/clist.py
+++ b/netsim/modules/routing/clist.py
@@ -90,6 +90,7 @@ whether they use regular expressions or not
 def expand_community_list(p_name: str,o_name: str,node: Box,topology: Box) -> typing.Optional[list]:
   p_clist = node.routing[o_name][p_name]                    # Shortcut pointer to current community list
   regexp = False                                            # Figure out whether we need expanded clist
+  p_clist.value = sorted(p_clist.value,key=lambda O: O.get('sequence',10))
   for (p_idx,p_entry) in enumerate(p_clist.value):
     try:
       fix_clist_entry(p_clist.value[p_idx],topology)

--- a/netsim/modules/routing/normalize.py
+++ b/netsim/modules/routing/normalize.py
@@ -170,6 +170,8 @@ def process_routing_data(node: Box,o_type: str, topology: Box, dispatch: dict, a
         dispatch[o_type]['check'](p_name,o_type,node,topology)
     if 'related' in dispatch[o_type]:
       dispatch[o_type]['related'](p_name,o_type,node,topology)
+    if 'sort' in dispatch[o_type] and p_name in node.routing[o_type]:
+      node.routing[o_type][p_name] = sorted(node.routing[o_type][p_name],key=lambda O: O.get('sequence',10))
 
   if o_type not in dispatch:                         # pragma: no cover
     log.fatal(f'Invalid routing object {o_type} passed to process_routing_data')

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -94,6 +94,7 @@ def expand_prefix_list(p_name: str,o_name: str,node: Box,topology: Box) -> typin
   for (p_idx,p_entry) in enumerate(node.routing[o_name][p_name]):
     node.routing[o_name][p_name][p_idx] = expand_prefix_entry(node.routing[o_name][p_name][p_idx],topology)
 
+  node.routing[o_name][p_name] = sorted(node.routing[o_name][p_name],key=lambda O: O.get('sequence',10))
   af_prefix: dict = {}                                      # Prepare dictionary of per-AF prefix lists
   for af in ('ipv4','ipv6'):                                # Iterate over address families (sorry, no CLNS or IPX)
     af_prefix[af] = []                                      # Start with an emtpy per-AF list

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -128,10 +128,10 @@ nodes:
         ap3:
         - action: deny
           path: 65000 65001
-          sequence: 10
+          sequence: 5
         - action: permit
           path: '6510.'
-          sequence: 20
+          sequence: 10
       policy:
         rp1:
         - action: permit
@@ -257,12 +257,12 @@ routing:
       path: 65000
       sequence: 10
     ap3:
-    - action: deny
-      path: 65000 65001
-      sequence: 10
     - action: permit
       path: '6510.'
-      sequence: 20
+      sequence: 10
+    - action: deny
+      path: 65000 65001
+      sequence: 5
   policy:
     rp1:
     - action: permit

--- a/tests/topology/expected/rp-clist-expansion.yml
+++ b/tests/topology/expected/rp-clist-expansion.yml
@@ -116,9 +116,12 @@ nodes:
           regexp: ''
           type: standard
           value:
-          - _value: 65000:106
+          - _value: 65000:110
             action: permit
             sequence: 10
+          - _value: 65000:120
+            action: permit
+            sequence: 20
       policy:
         m_clist:
         - action: permit
@@ -155,6 +158,9 @@ routing:
     cl7:
       type: standard
       value:
-      - _value: 65000:106
-        action: permit
+      - action: permit
+        path: 65000:120
+        sequence: 20
+      - action: permit
+        path: 65000:110
         sequence: 10

--- a/tests/topology/expected/rp-normalize-merge.yml
+++ b/tests/topology/expected/rp-normalize-merge.yml
@@ -100,13 +100,13 @@ routing:
   policy:
     p1:
     - action: permit
-      sequence: 10
-      set:
-        locpref: 10
-    - action: permit
       sequence: 20
       set:
         med: 100
+    - action: permit
+      sequence: 10
+      set:
+        locpref: 10
     p2:
     - action: permit
       sequence: 10

--- a/tests/topology/expected/rp-prefix-expansion.yml
+++ b/tests/topology/expected/rp-prefix-expansion.yml
@@ -183,12 +183,12 @@ routing:
   prefix:
     p1:
     - action: permit
-      ipv4: 172.16.0.0/16
-      sequence: 10
-    - action: permit
       ipv4: 192.168.43.0/24
       ipv6: 2001:db8:dead:beef::/64
       sequence: 20
+    - action: permit
+      ipv4: 172.16.0.0/16
+      sequence: 10
     p2:
     - action: deny
       ipv4: 192.168.44.32/28

--- a/tests/topology/input/rp-aspath-numbers.yml
+++ b/tests/topology/input/rp-aspath-numbers.yml
@@ -12,9 +12,10 @@ routing:
     ap1: 65000                                # AS-path ACL as int => single-entry ACL
     ap2: [65000]                              # Single-entry AS-path ACL
     ap3:                                      # AS-path ACL
+    - '6510.'                                 # the second entry is a regexp
     - action: deny
       path: [65000, 65001]                    # first entry is a list of ASNs
-    - '6510.'                                 # the second entry is a regexp
+      sequence: 5
   policy:
     rp1:
       match.aspath: ap3

--- a/tests/topology/input/rp-clist-expansion.yml
+++ b/tests/topology/input/rp-clist-expansion.yml
@@ -19,8 +19,12 @@ routing:
       action: permit
       path: 65000:100
     cl7:
-      action: permit
-      path: 65000:106
+    - action: permit
+      path: 65000:120
+      sequence: 20
+    - action: permit
+      path: 65000:110
+      sequence: 10
 
 nodes:
   r1:
@@ -37,11 +41,11 @@ nodes:
         cl3: _65000:10[1-2]_                      # Regular expression
         cl4:                                      # More complex standard ACL
         - action: permit                          # Used to implement or-of-ands condition
-          path: [65000:100, 65001:100]
-          sequence: 20
-        - action: permit
           path: [65000:103, 65001:103]
           sequence: 30
+        - action: permit
+          path: [65000:100, 65001:100]
+          sequence: 20
         cl5:                                      # A mix standard and extended conditions ==> extended
           type: standard
           value:

--- a/tests/topology/input/rp-normalize-merge.yml
+++ b/tests/topology/input/rp-normalize-merge.yml
@@ -6,8 +6,10 @@ defaults.device: none
 
 routing.policy:
   p1:
-  - locpref: 10
   - set.med: 100
+    sequence: 20
+  - locpref: 10
+    sequence: 10
   p2:
   - locpref: 20
   - set.med: 200

--- a/tests/topology/input/rp-prefix-expansion.yml
+++ b/tests/topology/input/rp-prefix-expansion.yml
@@ -14,8 +14,10 @@ prefix:
 
 routing.prefix:
   p1:
-  - pool: lan
   - prefix: pf2
+    sequence: 20
+  - pool: lan
+    sequence: 10
   p2:
   - action: deny
     ipv4: 192.168.44.32/28


### PR DESCRIPTION
Most implementations use sequence numbers when defining routing policy objects and thus implicitely sort the entries while configuring the device.

Implementations that do not contain an embedded sorting mechanism (for example, IOS XR RPL) need sorted entries. Instead of doing the sorting in Jinja2 templates, this fix sorts policy, prefix, aspath and community routing objects using their sequence numbers