### PR TITLE
FOS: disable password policy enforcement

### DIFF
--- a/netsim/install/libvirt/fortios/openstack/latest/user_data
+++ b/netsim/install/libvirt/fortios/openstack/latest/user_data
@@ -9,6 +9,10 @@ config system global
     set timezone "UTC"
 end
 
+config system password-policy
+    set status disable
+end
+
 config system fortiguard
     set auto-firmware-upgrade disable
 end


### PR DESCRIPTION
Disable the password policy enforcement feature introduced in FortiOS 7.6.5 in a cloud-init configuration supplied for vagrant box.
https://docs.fortinet.com/document/fortigate/7.6.6/fortios-release-notes/799879/password-policy-enforcement