### PR TITLE
Fix: Reorder the search paths for the device provisioning templates

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -25,9 +25,9 @@ If you want to change the provisioning or device configuration templates, you ca
 
 ```{tip}
 * Use the `netlab create --debug paths` command to display the components of individual search paths and the directories _netlab_ uses when searching those paths (non-existent directories are removed from the search paths).
-* Use the `‌netlab create --debug template` command to troubleshoot template errors; the debugging printouts display every template file _netlab_ searched for and the search path it used for the search.
-* Use the `‌netlab create --output provider` with one of the `--debug` options to reduce the amount of debugging output when troubleshooting the provider configuration files.
-* The `‌--debug` option must be the last option in the command line.
+* Use the `netlab create --debug template` command to troubleshoot template errors; the debugging printouts display every template file _netlab_ searched for and the search path it used for the search.
+* Use the `netlab create --output provider` with one of the `--debug` options to reduce the amount of debugging output when troubleshooting the provider configuration files.
+* The `--debug` option must be the last option in the command line.
 ```
 
 ```{warning}

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -109,8 +109,7 @@ class _Provider(Callback):
     fname = self.get_output_name(fname,topology)
     tname = self.get_root_template()
     try:
-      search_path = _files.get_search_path(self.provider)
-      search_path.append(self.get_full_template_path())
+      search_path = _files.get_search_path(self.provider,pkg_path_component=self.get_template_path())
       r_text = templates.render_template(
         data=topology.to_dict(),
         j2_file=tname,


### PR DESCRIPTION
* The default provider template directory is placed at the end of the search path (previously, it was the first entry)
* The documentation mentioned in the issue was updated to reflect the new debugging behavior

Closes #3182