### PR TITLE
docs: Add configuration template developer documentation for SRv6 module

### DIFF
--- a/docs/dev/config/index.md
+++ b/docs/dev/config/index.md
@@ -18,6 +18,7 @@ The following implementation notes for configuration deployment, initial device 
    ospf.areas.md
    rip.md
    routing.md
+   srv6.md
    vlan.md
    vrf.md
 ```

--- a/docs/dev/config/srv6.md
+++ b/docs/dev/config/srv6.md
@@ -1,7 +1,7 @@
 (dev-config-srv6)=
 # Configuring SRv6
 
-This document describes the device data model parameters one should consider when creating an SRv6 device configuration template. For a wider picture, please see the [contributing new devices](../devices.md) document.
+This document describes the device data model parameters one should consider when creating an [SRv6](module-srv6) device configuration template. For a wider picture, please see the [contributing new devices](../devices.md) document.
 
 The configuration template (in Jinja2 format) should be stored in the `netsim/ansible/templates/srv6/` directory. The template file name is derived from the `netlab_device_type` or `ansible_network_os` variable (see [](dev-config-bgp) for details on how the platform name is used).
 
@@ -22,7 +22,7 @@ Add the following **features.srv6** entries to a device YAML file (`netsim/devic
 
 * **isis** -- device supports SRv6 with IS-IS
 * **ospf** -- device supports SRv6 with OSPFv3
-* **bgp** -- device supports BGP v4/v6 overlay over SRv6 (end.dt4 / end.dt6)
+* **bgp** -- device supports BGP v4/v6 overlay over SRv6 (end.dt4/end.dt6)
 * **vpn** -- device supports BGP L3VPN v4/v6 over SRv6
 
 ## Node Attributes
@@ -31,9 +31,7 @@ The `srv6` node dictionary is always present on nodes that have the `srv6` modul
 
 ### srv6.locator
 
-An IPv6 prefix in CIDR notation (e.g., `5f00:0:1::/48`), automatically allocated per-node from the `srv6_locator` address pool (default `5F00::/16`, based on the IANA-reserved range in [RFC 9602](https://datatracker.ietf.org/doc/html/rfc9602)).
-
-The user may override the locator with a static value in the topology file; the module uses it as-is in that case.
+An IPv6 prefix in CIDR notation (e.g., `5f00:0:1::/48`), specified in lab topology or automatically allocated per-node from the SRv6 locator address pool (default `5F00::/16`, based on the IANA-reserved range in [RFC 9602](https://datatracker.ietf.org/doc/html/rfc9602)).
 
 Templates typically use `srv6.locator` to configure the SRv6 locator prefix:
 
@@ -58,15 +56,15 @@ router isis {{ isis.instance }}
 
 ### srv6.bgp
 
-A dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types that should use SRv6 as the transport for the plain IPv4 or IPv6 unicast address family (end.dt4 / end.dt6, *not* VPN).
+An optional dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types that should use SRv6 as the transport for the plain IPv4 or IPv6 unicast address family (end.dt4/end.dt6, *not* VPN).
 
-`srv6.bgp` is absent (evaluates to `{}`) when the feature is disabled. It is set to `{'ipv4': ['ibgp'], 'ipv6': ['ibgp']}` when enabled with `True`. The module performs a boolean-to-dictionary expansion (`True` → default dict, `False` → empty dict) before templates are rendered.
+`srv6.bgp` is absent when the feature is disabled.
 
 Example:
 
 ```
 {% if srv6.bgp is defined %}
-{%   for af in ['ipv4','ipv6'] if srv6.bgp.get(af) %}
+{%   for af in ['ipv4','ipv6'] if af in srv6.bgp %}
   family {{ af }}
     locator {{ inventory_hostname }}
 {%   endfor %}
@@ -75,7 +73,7 @@ Example:
 
 ### srv6.vpn
 
-A dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types for which BGP L3VPN routes should be carried over SRv6 (end.dt4-vrf / end.dt6-vrf).
+A dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types for which BGP L3VPN routes should be carried over SRv6 (end.dt4-vrf/end.dt6-vrf).
 
 The structure and boolean-expansion rules are identical to `srv6.bgp`. `srv6.vpn` is absent when L3VPN is disabled.
 
@@ -89,35 +87,29 @@ A boolean flag (`True`/`False`). When `True`, the node acts as a transit-only SR
 {% endif %}
 ```
 
-### srv6.allocate_loopback
-
-A boolean flag that is **not** present in the rendered template data — it is consumed during the `node_pre_transform` phase to auto-assign `loopback.ipv6` from within the node's SRv6 locator range. After transformation this attribute is no longer useful to templates; use `loopback.ipv6` directly.
-
 ## Loopback IPv6 Address
 
-`loopback.ipv6` is always present on SRv6 nodes (enforced by `node_post_transform`). It may be:
-
-* a user-defined loopback address from the topology `loopback` pool, or
-* automatically assigned as the first host address within `srv6.locator` (when `srv6.allocate_loopback: True`).
+`loopback.ipv6` is always present on SRv6 nodes (enforced by `node_post_transform`). It may be user-defined, assigned from the `loopback` topology pool, or automatically assigned as the first host address in `srv6.locator` (when `srv6.allocate_loopback: True`).
 
 Templates must use `loopback.ipv6` as the SRv6 source address:
 
 ```
-source-address {{ loopback.ipv6 | ipaddr('address') }}
+source-address {{ loopback.ipv6 | ansible.utils.ipaddr('address') }}
 ```
 
 ## BGP Neighbor Attributes
 
-The `srv6` module modifies the `bgp.neighbors` list during `node_post_transform`. For each neighbor that:
+The `srv6` module modifies the `bgp.neighbors` list during `node_post_transform`. For each BGP neighbor that...
 
-* has an `ipv6` address (IPv6 transport), **and**
+* has an `ipv6` transport address
+* has no `ipv4` transport address,
 * is listed in `srv6.bgp.ipv4` or `srv6.vpn.ipv4` (i.e., IPv4 AF is carried over an IPv6 session)
 
-the module adds:
+...the module adds:
 
 * **extended_nexthop** (`True`) — signals that the BGP session requires extended next-hop encoding (RFC 8950) to carry IPv4 prefixes over an IPv6 transport session.
 
-Templates should check for this attribute to conditionally enable extended next-hop negotiation:
+Templates could check for this attribute to conditionally enable extended next-hop negotiation:
 
 ```
 {% for n in bgp.neighbors|default([]) if n.ipv6 is defined %}
@@ -137,7 +129,7 @@ The `srv6` module does not add any per-interface attributes. Templates that need
 
 ## Template Architecture
 
-Complex platforms may split SRv6 configuration into a main template and a BGP sub-template, included conditionally. The main template handles locator declaration and IGP integration; the BGP sub-template handles the BGP overlay and VPN configuration.
+Complex platforms may split SRv6 configuration into a main template and a conditionally-included BGP sub-template. The main template handles locator declaration and IGP integration; the BGP sub-template handles the BGP overlay and VPN configuration.
 
 **Example** (`frr.j2` main template, simplified):
 
@@ -210,7 +202,7 @@ updates:
 
 The integration tests for the SRv6 module are in the `tests/integration/srv6/` directory:
 
-* `x-01-isis-ipv4-bgp.yml` — PE router running IS-IS + BGP (`srv6.bgp.ipv4: True`) with `allocate_loopback: True`, carrying IPv4 over an IPv6-only SRv6 core (4PE scenario).
-* `x-11-isis-ipv6-bgp.yml` — Similar scenario with IPv6 BGP overlay.
 * `02-isis-ipv4-bgp-vpn.yml` — PE router running IS-IS + BGP L3VPN (`srv6.vpn.ipv4: True`) over an IPv6-only SRv6 core, with VRFs attached; validates end-to-end L3VPN reachability.
 * `12-isis-ipv6-bgp-vpn.yml` — Similar scenario with IPv6 L3VPN overlay.
+* `x-01-isis-ipv4-bgp.yml` — PE router running IS-IS + BGP (`srv6.bgp.ipv4: True`) with `allocate_loopback: True`, carrying IPv4 over an IPv6-only SRv6 core (4PE scenario).
+* `x-11-isis-ipv6-bgp.yml` — Similar scenario with IPv6 BGP overlay.

--- a/docs/dev/config/srv6.md
+++ b/docs/dev/config/srv6.md
@@ -1,0 +1,216 @@
+(dev-config-srv6)=
+# Configuring SRv6
+
+This document describes the device data model parameters one should consider when creating an SRv6 device configuration template. For a wider picture, please see the [contributing new devices](../devices.md) document.
+
+The configuration template (in Jinja2 format) should be stored in the `netsim/ansible/templates/srv6/` directory. The template file name is derived from the `netlab_device_type` or `ansible_network_os` variable (see [](dev-config-bgp) for details on how the platform name is used).
+
+```{tip}
+The `<platform>` is the value of the `netlab_device_type` or `ansible_network_os` variable.
+```
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+   :backlinks: none
+```
+
+## Device Features
+
+Add the following **features.srv6** entries to a device YAML file (`netsim/devices/<device>.yml`) to indicate which SRv6 features the platform supports:
+
+* **isis** -- device supports SRv6 with IS-IS
+* **ospf** -- device supports SRv6 with OSPFv3
+* **bgp** -- device supports BGP v4/v6 overlay over SRv6 (end.dt4 / end.dt6)
+* **vpn** -- device supports BGP L3VPN v4/v6 over SRv6
+
+## Node Attributes
+
+The `srv6` node dictionary is always present on nodes that have the `srv6` module enabled. It contains the following attributes after transformation:
+
+### srv6.locator
+
+An IPv6 prefix in CIDR notation (e.g., `5f00:0:1::/48`), automatically allocated per-node from the `srv6_locator` address pool (default `5F00::/16`, based on the IANA-reserved range in [RFC 9602](https://datatracker.ietf.org/doc/html/rfc9602)).
+
+The user may override the locator with a static value in the topology file; the module uses it as-is in that case.
+
+Templates typically use `srv6.locator` to configure the SRv6 locator prefix:
+
+```
+locator {{ inventory_hostname }}
+  prefix {{ srv6.locator }}
+```
+
+### srv6.igp
+
+A list of IGP protocol names (e.g., `['isis']`) over which SRv6 should be signalled. The default is `['isis']`. Valid values are `isis` and `ospf`.
+
+Use `if 'isis' in srv6.igp` (or `'ospf' in srv6.igp`) to conditionally enable SRv6 under an IGP:
+
+```
+{% if 'isis' in srv6.igp %}
+router isis {{ isis.instance }}
+  segment-routing srv6
+    locator {{ inventory_hostname }}
+{% endif %}
+```
+
+### srv6.bgp
+
+A dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types that should use SRv6 as the transport for the plain IPv4 or IPv6 unicast address family (end.dt4 / end.dt6, *not* VPN).
+
+`srv6.bgp` is absent (evaluates to `{}`) when the feature is disabled. It is set to `{'ipv4': ['ibgp'], 'ipv6': ['ibgp']}` when enabled with `True`. The module performs a boolean-to-dictionary expansion (`True` → default dict, `False` → empty dict) before templates are rendered.
+
+Example:
+
+```
+{% if srv6.bgp is defined %}
+{%   for af in ['ipv4','ipv6'] if srv6.bgp.get(af) %}
+  family {{ af }}
+    locator {{ inventory_hostname }}
+{%   endfor %}
+{% endif %}
+```
+
+### srv6.vpn
+
+A dictionary with keys `ipv4` and/or `ipv6`, each containing a list of BGP neighbor types for which BGP L3VPN routes should be carried over SRv6 (end.dt4-vrf / end.dt6-vrf).
+
+The structure and boolean-expansion rules are identical to `srv6.bgp`. `srv6.vpn` is absent when L3VPN is disabled.
+
+### srv6.transit_only
+
+A boolean flag (`True`/`False`). When `True`, the node acts as a transit-only SRv6 node — it forwards SRv6 traffic but does not need to allocate FPE resources or end.dt SIDs for originating/terminating traffic. Default is `False`.
+
+```
+{% if not srv6.transit_only|default(False) %}
+  termination-fpe: [2]
+{% endif %}
+```
+
+### srv6.allocate_loopback
+
+A boolean flag that is **not** present in the rendered template data — it is consumed during the `node_pre_transform` phase to auto-assign `loopback.ipv6` from within the node's SRv6 locator range. After transformation this attribute is no longer useful to templates; use `loopback.ipv6` directly.
+
+## Loopback IPv6 Address
+
+`loopback.ipv6` is always present on SRv6 nodes (enforced by `node_post_transform`). It may be:
+
+* a user-defined loopback address from the topology `loopback` pool, or
+* automatically assigned as the first host address within `srv6.locator` (when `srv6.allocate_loopback: True`).
+
+Templates must use `loopback.ipv6` as the SRv6 source address:
+
+```
+source-address {{ loopback.ipv6 | ipaddr('address') }}
+```
+
+## BGP Neighbor Attributes
+
+The `srv6` module modifies the `bgp.neighbors` list during `node_post_transform`. For each neighbor that:
+
+* has an `ipv6` address (IPv6 transport), **and**
+* is listed in `srv6.bgp.ipv4` or `srv6.vpn.ipv4` (i.e., IPv4 AF is carried over an IPv6 session)
+
+the module adds:
+
+* **extended_nexthop** (`True`) — signals that the BGP session requires extended next-hop encoding (RFC 8950) to carry IPv4 prefixes over an IPv6 transport session.
+
+Templates should check for this attribute to conditionally enable extended next-hop negotiation:
+
+```
+{% for n in bgp.neighbors|default([]) if n.ipv6 is defined %}
+{%   if n.extended_nexthop is defined %}
+  neighbor {{ n.ipv6 }} capability extended-nexthop
+{%   endif %}
+{% endfor %}
+```
+
+## Interface Attributes
+
+The `srv6` module does not add any per-interface attributes. Templates that need SRv6 interface-level configuration (e.g., end.x SIDs) typically iterate over interfaces that have IS-IS or OSPF enabled:
+
+```
+{% set srv6_interfaces = interfaces | selectattr('isis','defined') | list %}
+```
+
+## Template Architecture
+
+Complex platforms may split SRv6 configuration into a main template and a BGP sub-template, included conditionally. The main template handles locator declaration and IGP integration; the BGP sub-template handles the BGP overlay and VPN configuration.
+
+**Example** (`frr.j2` main template, simplified):
+
+```
+segment-routing
+ srv6
+  encapsulation
+   source-address {{ loopback.ipv6 | ansible.utils.ipaddr('address') }}
+  locators
+   locator {{ inventory_hostname }}
+    prefix {{ srv6.locator }}
+
+{% if 'isis' in srv6.igp|default([]) and isis.instance is defined %}
+router isis {{ isis.instance }}
+ segment-routing srv6
+   locator {{ inventory_hostname }}
+{% endif %}
+
+{% if srv6.vpn is defined and bgp.as is defined %}
+{%   include "frr.bgp.j2" %}
+{% endif %}
+```
+
+**Example** (`frr.bgp.j2` BGP sub-template, simplified):
+
+```
+router bgp {{ bgp.as }}
+ segment-routing srv6
+  locator {{ inventory_hostname }}
+
+{% if srv6.vpn is defined %}
+{%   for n in bgp.neighbors|default([]) if n.ipv6 is defined %}
+{%     if n.extended_nexthop is defined %}
+ neighbor {{ n.ipv6 }} capability extended-nexthop
+{%     endif %}
+{%     for af in ['ipv4','ipv6'] if n.type in srv6.vpn.get(af,[]) %}
+ address-family {{ af }} vpn
+  neighbor {{ n.ipv6 }} activate
+{%     endfor %}
+{%   endfor %}
+{% endif %}
+```
+
+**Example** (`sros.j2`, Nokia SR-OS — gNMI/YANG path style):
+
+```
+{% set srv6_interfaces = interfaces | selectattr('isis','defined') | list %}
+updates:
+- path: configure/router[router-name=Base]/segment-routing/segment-routing-v6
+  val:
+   locator:
+   - locator-name: JvB
+     prefix:
+      ip-prefix: {{ srv6.locator }}
+{%   if not srv6.transit_only|default(False) %}
+     termination-fpe: [2]
+{%   endif %}
+
+{% if 'isis' in srv6.igp %}
+- path: configure/router[router-name=Base]/isis[isis-instance=0]
+  val:
+   segment-routing-v6:
+    admin-state: enable
+    locator:
+    - locator-name: JvB
+{% endif %}
+```
+
+## Integration Tests
+
+The integration tests for the SRv6 module are in the `tests/integration/srv6/` directory:
+
+* `x-01-isis-ipv4-bgp.yml` — PE router running IS-IS + BGP (`srv6.bgp.ipv4: True`) with `allocate_loopback: True`, carrying IPv4 over an IPv6-only SRv6 core (4PE scenario).
+* `x-11-isis-ipv6-bgp.yml` — Similar scenario with IPv6 BGP overlay.
+* `02-isis-ipv4-bgp-vpn.yml` — PE router running IS-IS + BGP L3VPN (`srv6.vpn.ipv4: True`) over an IPv6-only SRv6 core, with VRFs attached; validates end-to-end L3VPN reachability.
+* `12-isis-ipv6-bgp-vpn.yml` — Similar scenario with IPv6 L3VPN overlay.


### PR DESCRIPTION
## Summary

Adds `docs/dev/config/srv6.md` — a configuration template developer reference for the **SRv6** module, following the same structure as the existing MPLS and BGP documentation.

## What's documented

- **Device features** — the four `features.srv6` flags (`isis`, `ospf`, `bgp`, `vpn`) to declare in device YAML files
- **Node attributes** after transformation: `srv6.locator`, `srv6.igp`, `srv6.bgp`, `srv6.vpn`, `srv6.transit_only` — including the boolean→dictionary expansion applied to `bgp` and `vpn`
- **Loopback IPv6** — always required, may be auto-allocated from the locator range when `allocate_loopback: True`
- **BGP neighbor attribute** — `extended_nexthop` injected by the module for IPv4-AF-over-IPv6-transport sessions
- **Interface attributes** — none are added by the module; shows how to select IS-IS interfaces for end.x SID allocation
- **Template architecture** — concrete examples using FRR (main + BGP sub-template) and SR-OS (gNMI/YANG path style)
- **Integration tests** — the four test topologies in `tests/integration/srv6/`

## Changes

- `docs/dev/config/srv6.md` — new file
- `docs/dev/config/index.md` — add `srv6.md` to the ToC