### PR TITLE
FortiOS: static routing with discard support

### DIFF
--- a/docs/module/routing-static.txt
+++ b/docs/module/routing-static.txt
@@ -15,6 +15,7 @@ _netlab_ supports static routes on these platforms:
 | Cisco IOS XR[^XR]   | ✅ | ✅ | ✅ | ✅ |
 | Cumulus Linux 4.x   | ✅ |  ❌ | ✅ | ✅ |
 | Dell OS10           | ✅ | ✅ | ✅ | ✅ |
+| Fortinet FortiOS    | ✅ | ✅ |  ❌ |  ❌ |
 | Junos               | ✅ | ✅ | ✅ | ❌ |
 | FRR                 | ✅ | ✅ | ✅ | ✅ |
 | Linux               | ✅ |  ❌ |  ❌ |  ❌ |

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -30,6 +30,7 @@ The following table describes high-level per-platform support of generic routing
 | Cumulus Linux      | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Cumulus NVUE 5.x   | ❌  | ❌  | ❌  | ❌  | ✅ |
 | Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fortinet FortiOS   | ❌  | ❌  | ❌  | ❌  | ✅ |
 | FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |
 | Junos              | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/netsim/ansible/templates/routing/fortios.j2
+++ b/netsim/ansible/templates/routing/fortios.j2
@@ -1,0 +1,36 @@
+{% macro render_routes(routes, family) %}
+{% for route in routes if family in route %}
+{% set nh = route.nexthop %}
+    edit {{ loop.index }}
+        set dst {{ route[family] }}
+{% if 'discard' in nh %}
+        set blackhole enable
+{% else %}
+        set gateway {{ nh[family] }}
+        set device {{ nh['intf'] }}
+{% endif %}
+    next
+{% endfor %}
+{% endmacro %}
+
+{% set vdom_traffic = netlab_vdom|default(vdom) %}
+{% set multi_vdom = vdom_traffic != vdom %}
+
+{% if multi_vdom %}
+config vdom
+    edit {{ vdom_traffic }}
+{% endif %}
+
+{% set static_routes = routing.static | default([]) %}
+
+config router static
+{{ render_routes(static_routes, 'ipv4') }}
+end
+
+config router static6
+{{ render_routes(static_routes, 'ipv6') }}
+end
+
+{% if multi_vdom %}
+end
+{% endif %}

--- a/netsim/ansible/templates/routing/fortios.j2
+++ b/netsim/ansible/templates/routing/fortios.j2
@@ -7,7 +7,7 @@
         set blackhole enable
 {% else %}
         set gateway {{ nh[family] }}
-        set device {{ nh['intf'] }}
+        set device "{{ nh['intf'] }}"
 {% endif %}
     next
 {% endfor %}

--- a/netsim/devices/fortios.py
+++ b/netsim/devices/fortios.py
@@ -1,0 +1,13 @@
+#
+# FortiOS quirks
+#
+from box import Box
+
+from . import _Quirks
+from ._common import check_indirect_static_routes
+
+class FortiOS(_Quirks):
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    check_indirect_static_routes(node)

--- a/netsim/devices/fortios.py
+++ b/netsim/devices/fortios.py
@@ -6,6 +6,7 @@ from box import Box
 from . import _Quirks
 from ._common import check_indirect_static_routes
 
+
 class FortiOS(_Quirks):
 
   @classmethod

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -33,6 +33,7 @@ group_vars:
   ansible_httpapi_port: 80
   netlab_console_connection: ssh
   netlab_ready: [ ansible ]
+  netlab_device_type: fortios
 external:
   image: none
 features:
@@ -40,4 +41,7 @@ features:
     password: true
     priority: true
     timers: true
+  routing:
+    static:
+      discard: true
 graphite.icon: firewall


### PR DESCRIPTION
Static routing support for FortiOS.

I added netlab_device_type to name it consistently with other devices.
Other devices seems to use short name in ansible_network_os which is probably not ideal.
On the other hand using FQCN as a file name for templates is weird.