### PR TITLE
Fix custom task paths in custom config deployment

### DIFF
--- a/netsim/ansible/tasks/deploy-custom-config.yml
+++ b/netsim/ansible/tasks/deploy-custom-config.yml
@@ -42,11 +42,20 @@
     verbosity: 1
   tags: [ test, custom ]
 
-# Find deployment task list. It could be a config-specific tasklist (somewhere in paths_custom directories with
-# file name from paths_custom.tasks list) or a generic deployment tasklist from deployment directories and
-# using generic deployment task names (a combination of ansible_network_os and netlab_provider). missing.yml
-# in the deployment directory is the catch-all of last resort.
+# Find deployment task list. It could be a config-specific tasklist (somewhere
+# in paths_custom directories with file name from paths_custom.tasks list) or a
+# generic deployment tasklist from deployment directories and using generic
+# deployment task names (a combination of ansible_network_os and
+# netlab_provider). missing.yml in the deployment directory is the catch-all of
+# last resort.
 #
+# Please note that the 'paths_custom.dirs' is changed by netlab initial/config.
+# 'paths_custom.task_dirs' is a copy of the original 'paths_custom.dirs'
+#
+- block:
+  - debug: var=paths_custom.task_dirs
+  - debug: var=paths_custom.tasks
+  when: ansible_verbosity > 1
 - name: Find custom configuration deployment script
   set_fact:
     deploy_task:
@@ -55,7 +64,7 @@
   vars:
     node_provider: "{{ provider|default(netlab_provider) }}"
     c_params:
-      paths: "{{ paths_custom.dirs }}"
+      paths: "{{ paths_custom.task_dirs }}"
       files: "{{ paths_custom.tasks }}"
     d_params:
       paths: "{{ paths_deploy.dirs }}"

--- a/netsim/cli/config.py
+++ b/netsim/cli/config.py
@@ -84,8 +84,9 @@ def ansible_extra_vars(topology: Box, reload: bool = False, extra_vars: dict = {
   for p in ['templates','custom']:                            # Change the search paths to node_files
     ev[f'paths_{p}'].dirs = "{{ node_files }}/{{ inventory_hostname }}"
 
-  # Retain the custom configuration task name(s)
+  # Retain the custom configuration task name(s) and directories
   ev.paths_custom.tasks = topology.defaults.paths.custom.tasks
+  ev.paths_custom.task_dirs = topology.defaults.paths.custom.dirs
   return ev
 
 def get_ansible_args(ans_vars: Box,nodeset: list,cfg_name: str) -> list:

--- a/netsim/cli/initial/deploy.py
+++ b/netsim/cli/initial/deploy.py
@@ -88,8 +88,9 @@ def ansible_extra_vars(topology: Box) -> Box:
   for p in ["templates", "custom"]:
     ev[f"paths_{p}"].dirs = "{{ node_files }}/{{ inventory_hostname }}"
 
-  # Retain the custom configuration task name(s)
+  # Retain the custom configuration task name(s) and directories
   ev.paths_custom.tasks = topology.defaults.paths.custom.tasks
+  ev.paths_custom.task_dirs = topology.defaults.paths.custom.dirs
   return ev
 
 


### PR DESCRIPTION
The custom config deployment (in netlab initial/config) had to change the paths_custom.dirs variable to point to node_files where the rendered template is waiting. This broke the use of custom deployment tasks that relied on the same path variable.

This fix adds 'paths_custom.task_dirs' Ansible variable that is a copy of the original 'paths.custom.dirs' value and uses it in the 'deploy-custom-config' task list.

Please note that the same change must be made in netlab initial and netlab config because they in the end use the same task list.