### PR TITLE
[bugfix] Accept default route and any prefix in bgp.originate

### DIFF
--- a/netsim/extra/bgp.originate/defaults.yml
+++ b/netsim/extra/bgp.originate/defaults.yml
@@ -7,6 +7,6 @@ bgp:
       originate:
         type: list
         _subtype:
-          ipv4: { type: ipv4, use: subnet_prefix }
-          ipv6: { type: ipv6, use: subnet_prefix }
+          ipv4: { type: ipv4, use: prefix }
+          ipv6: { type: ipv6, use: prefix }
           _alt_types: [ prefix_str ]

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -83,7 +83,7 @@ attributes:
     rr_mesh: { copy: global }
     originate:
       type: list
-      _subtype: { type: ipv4, use: subnet_prefix, named: True }
+      _subtype: { type: ipv4, use: prefix, named: True }
     advertise_loopback: { copy: global }
     sessions: { copy: global }
     activate: { copy: global }


### PR DESCRIPTION
Use prefix validation instead of subnet_prefix so 0.0.0.0/0 and ::/0 are allowed (reserved-range checks apply only to subnet_prefix).

- bgp.originate plugin defaults: ipv4/ipv6 use prefix
- core bgp module node originate attribute: same for named-prefix lists

I am not sure if the bgp.yml ```originate``` defaults are strictly needed, it confusingly overlaps with the plugin.

Fixes #3214 

Cursor analysis:
```
Core BGP does touch bgp.originate, but only in one place
In netsim/modules/bgp.py, node_post_transform calls bgp_set_originate_af, which:

Sets node.bgp.ipv4 = True if bgp.originate is a non-empty list.
Walks the list and replaces named prefixes (keys in topology.prefix) with their IPv4 string.

bgp.py Lines 568-583 [...]

check_bgp_parameters does not validate originate; schema comes from netsim/modules/bgp.yml via the generic attribute machinery.

Order relative to the bgp.originate plugin
Transform order is plugin post_node_transform first, then module post-transform:

main.py
Lines 89-90
  augment.plugin.execute('post_node_transform',topology)
  modules.post_node_transform(topology)
The plugin turns originate entries into loopback links and removes originate from the node:

plugin.py Lines 21-42 [...]

So with the plugin enabled, by the time bgp_set_originate_af runs, bgp.originate is usually already gone: core’s originate handling is effectively a no-op for that path. The important work is loopbacks + bgp.advertise on those links; bgp_set_advertise / session build then drive IPv4 as usual.

Without the plugin
originate stays on the node, bgp_set_originate_af runs as above, and many BGP Jinja templates still iterate bgp.originate (e.g. FRR, Junos, NX-OS, VyOS, …) — so the no-plugin path relies on that list remaining on the node and on core only doing named-prefix expansion + ipv4 flag.

Bottom line: core BGP does process originate, but only that small bgp_set_originate_af step; it does not create originate loopbacks. With bgp.originate loaded, that core step normally sees an empty originate after the plugin’s pop. Keeping originate in core bgp.yml still matters for validation and for topologies that use bgp.originate without the plugin.
```