### PR TITLE
fix (bgp.policy): avoid default_box creating empty node.module

### DIFF
--- a/netsim/extra/bgp.policy/plugin.py
+++ b/netsim/extra/bgp.policy/plugin.py
@@ -249,7 +249,7 @@ def apply_bgp_routing_policy(ndata: Box,ngb: Box,intf: Box,topology: Box) -> Non
     if f'bgp.policy.{direction}' not in intf:               # No policies applied in this direction, move on
       continue
 
-    if 'routing' not in ndata.module:
+    if 'routing' not in ndata.get('module', []):
       log.error(
         f"You cannot use 'bgp.policy' interface attribute on a node that does not use 'routing' module",
         category=log.IncorrectType,
@@ -309,7 +309,7 @@ def post_transform(topology: Box) -> None:
   _attr_list = _direct + list(_compound.keys())
 
   for n, ndata in topology.nodes.items():
-    if 'bgp' not in ndata.module:                           # Skip nodes not running BGP
+    if 'bgp' not in ndata.get('module',[]):                 # Skip nodes not running BGP
       continue
 
     route_aggregation(ndata,topology)

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -42,11 +42,60 @@ links:
     ipv4: 10.1.0.0/30
   role: external
   type: p2p
+- _linkname: links[2]
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 10.1.0.6/30
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.5/30
+    node: h
+  linkindex: 2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.4/30
+  type: p2p
 module:
 - routing
 - bgp
 name: input
 nodes:
+  h:
+    af:
+      ipv4: true
+      ipv6: true
+    box: debian/bookworm64
+    device: frr
+    id: 3
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.5/30
+      linkindex: 2
+      mtu: 1500
+      name: h -> r1
+      neighbors:
+      - ifname: eth2
+        ipv4: 10.1.0.6/30
+        node: r1
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.3/32
+      ipv6: 2001:db8:cafe:3::1/64
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: ca:fe:00:03:00:00
+    mtu: 1500
+    name: h
+    role: router
   r1:
     af:
       ipv4: true
@@ -101,6 +150,16 @@ nodes:
         ipv4: 10.1.0.2/30
         node: r2
       role: external
+      type: p2p
+    - ifindex: 2
+      ifname: eth2
+      ipv4: 10.1.0.6/30
+      linkindex: 2
+      name: r1 -> h
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.5/30
+        node: h
       type: p2p
     loopback:
       bgp:

--- a/tests/topology/input/rp-aspath-numbers.yml
+++ b/tests/topology/input/rp-aspath-numbers.yml
@@ -4,7 +4,6 @@
 addressing.loopback.ipv6: 2001:db8:cafe::/48
 defaults.device: none
 
-module: [bgp, routing]
 plugin: [bgp.policy]
 
 routing:
@@ -23,8 +22,10 @@ routing:
 nodes:
   r1:
     bgp.as: 65000
+    module: [bgp, routing]
   r2:
     bgp.as: 65001
+    module: [bgp, routing]
     routing:
       aspath:
         ap4: 65000 .*
@@ -34,9 +35,13 @@ nodes:
           set.locpref: 100
         - match.aspath: ap4
           set.locpref: 200
+  h:                                          # Regression test for #3213
+    device: frr
 
 links:
 - r1:
     bgp.policy.in: rp1
   r2:
     bgp.policy.in: px
+- r1:
+  h:


### PR DESCRIPTION
Use ndata.get('module', []) for membership checks instead of ndata.module so nodes without a module list do not get an auto-created Box({}).

Fixes #3213 