### PR TITLE
Use updated SuzieQ image

### DIFF
--- a/netsim/tools/suzieq.yml
+++ b/netsim/tools/suzieq.yml
@@ -8,7 +8,7 @@ docker:
       {sys.docker_net}
       -v '{name}_suzieq_data':/parquet
       -v './suzieq':/suzieq
-      netenglabs/suzieq-demo -c 'sq-poller -I /suzieq/suzieq-inventory.yml'
+      netenglabs/suzieq -c 'sq-poller -I /suzieq/suzieq-inventory.yml'
   message:
     Use 'netlab connect suzieq' to start SuzieQ CLI
   connect:


### PR DESCRIPTION
Netlab uses the [SuzieQ demo image](https://hub.docker.com/r/netenglabs/suzieq-demo) which has not been updated in 4 years.  This PR changes it to a more recent image https://hub.docker.com/r/netenglabs/suzieq