### PR TITLE
Enable MPLS transport for EVPN on Juniper cRPD

### DIFF
--- a/netsim/devices/crpd.yml
+++ b/netsim/devices/crpd.yml
@@ -23,7 +23,7 @@ features:
   vlan: false
   vxlan: false
   evpn:
-    irb: true
+    transport: [ mpls ]
   gateway:
     protocol: [ vrrp ]
 


### PR DESCRIPTION
After updating to 26.03, I found that I was unable to create a cRPD EVPN route reflector. 

This PR adds `features.evpn.transport: [ mpls ]` to the Juniper cRPD device type.  

Only tested with EVPN route reflector.  Replaces `features.evpn.irb: true` as I only added that in #3141 to enable EVPN support and IRB was never tested.