### PR TITLE
Fix: Use 'subnet_of' instead of 'overlaps' for reserved IP range check

### DIFF
--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -724,7 +724,8 @@ RESERVED_PREFIXES: typing.Dict[str,dict] = {
   'IPv4': {
     'local':     ipaddress.IPv4Network('0.0.0.0/8'),
     'loopback':  ipaddress.IPv4Network('127.0.0.0/8'),
-    'multicast': ipaddress.IPv4Network('224.0.0.0/4')
+    'multicast': ipaddress.IPv4Network('224.0.0.0/4'),
+    'class_e':   ipaddress.IPv4Network('240.0.0.0/4'),
   },
   'IPv6': {
     'loopback':  ipaddress.IPv6Network('::1/128'),
@@ -757,7 +758,7 @@ def common_addr_parse(
         ranges: dict,
         p_addr: typing.Any) -> typing.Optional[str]:
     for k,v in ranges.items():
-      if v.overlaps(p_addr):
+      if p_addr.subnet_of(v):
         return k
 
     return None

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -725,7 +725,7 @@ RESERVED_PREFIXES: typing.Dict[str,dict] = {
     'local':     ipaddress.IPv4Network('0.0.0.0/8'),
     'loopback':  ipaddress.IPv4Network('127.0.0.0/8'),
     'multicast': ipaddress.IPv4Network('224.0.0.0/4'),
-    'class_e':   ipaddress.IPv4Network('240.0.0.0/4'),
+    'class E':   ipaddress.IPv4Network('240.0.0.0/4'),
   },
   'IPv6': {
     'loopback':  ipaddress.IPv6Network('::1/128'),

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -193,6 +193,7 @@ nodes:
       next_hop_self: true
       originate:
       - 10.1.0.0/24
+      - 0.0.0.0/0
       router_id: 10.0.0.3
     box: arista/veos
     device: eos

--- a/tests/topology/input/bgp-af-rt-929.yml
+++ b/tests/topology/input/bgp-af-rt-929.yml
@@ -22,7 +22,7 @@ nodes:
   nl1:
     bgp.as: 65002
     bgp.advertise_loopback: false
-    bgp.originate: [10.1.0.0/24]
+    bgp.originate: [ 10.1.0.0/24, 0.0.0.0/0 ]     # Regression test for #3214
   nl2:
     bgp.advertise_loopback: false
     bgp.as: 65003


### PR DESCRIPTION
The checks of reserved IP ranges used 'overlaps' function which triggered an error even when '0.0.0.0/0' was compared to '0.0.0.0/8'

Fixes #3214