### PR TITLE
Fix: Add node-level router_id

### DIFF
--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -117,6 +117,7 @@ node:
   skip_config: list
   group: list
   role: { type: str, valid_values: [ router, host, bridge, gateway ] }
+  router_id: { type: ipv4, use: id }
   mgmt:
     ipv4: { type: ipv4, use: interface }
     ipv6: { type: ipv6, use: interface }

--- a/tests/errors/rid-pool-overflow.log
+++ b/tests/errors/rid-pool-overflow.log
@@ -1,5 +1,5 @@
 IncorrectValue in bgp: attribute 'nodes.r1.bgp.router_id' must be IPv4 address (Expected 4 octets in 'error')
 ... use 'netlab show attributes --module bgp node' to display valid attributes
-IncorrectAttr in nodes: Invalid node attribute 'router_id' found in nodes.r4
+IncorrectValue in nodes: attribute 'nodes.r4.router_id' must be IPv4 address (Expected 4 octets in 'error')
 ... use 'netlab show attributes node' to display valid attributes
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/topology/expected/bgp-ibgp-localas.yml
+++ b/tests/topology/expected/bgp-ibgp-localas.yml
@@ -163,7 +163,7 @@ nodes:
       next_hop_self: true
       originate:
       - 172.42.42.0/24
-      router_id: 10.0.0.1
+      router_id: 10.0.0.42
     box: none
     device: none
     id: 1
@@ -259,7 +259,8 @@ nodes:
       - _area_int: 0
         area: 0.0.0.0
         kind: regular
-      router_id: 10.0.0.1
+      router_id: 10.0.0.42
+    router_id: 10.0.0.42
     vlan:
       max_bridge_group: 1
     vlans:

--- a/tests/topology/input/bgp-ibgp-localas.yml
+++ b/tests/topology/input/bgp-ibgp-localas.yml
@@ -18,6 +18,7 @@ vlans:
 nodes:
   dut:
     bgp.originate: 172.42.42.0/24
+    router_id: 10.0.0.42                # Regression test for #3211
     module: [ bgp, ospf, vlan ]
     vlans.red.bgp.local_as: 65002       # Regression test for #2615
   x1:


### PR DESCRIPTION
The attribute was in the documentation 'forever' but I obviously forgot it when implementing stricter attribute checks.

Fixes #3211