### PR TITLE
Fix: Auto-generate node RD when its value is empty

### DIFF
--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -240,9 +240,10 @@ def set_vrf_ids(obj: Box, topology: Box) -> None:
       vdata.id = topology.vrfs[vname].id                    # We cannot merge global-to-node before post-transform
       if 'rd' not in vdata:                                 # No local RD, copy it from global VRF definition
         vdata.rd = topology.vrfs[vname].rd
-      elif not vdata.rd:                                    # Local RD is empty value, create it
-        vdata.rd = f'{asn}:{vdata.id}'
-      continue                                              # And move on, we're all set
+        continue
+      elif asn and not vdata.rd:                            # Local RD is empty value, create it
+        vdata.rd = f'{asn}:{vdata.id}'                      # ... if we can
+        continue                                            # Move on, we're all set
 
     if not asn:
       log.error(f'Need a usable vrf.as or bgp.as to create auto-generated VRF RD for {vname} in {obj_name}',

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -181,7 +181,7 @@ def normalize_vrf_ids(topology: Box) -> None:
     normalize_vrf_dict(n,topology)
 
 def vrf_needs_id(vrf: Box) -> bool:
-  if 'rd' in vrf and 'id' in vrf:
+  if vrf.get('rd',None) and vrf.get('id',None):
     return False
   return True
 
@@ -236,8 +236,9 @@ def set_vrf_ids(obj: Box, topology: Box) -> None:
       continue
     asn = asn or get_rd_as_number(obj,topology)
 
-    if not is_global and vname in topology.get('vrfs',{}):  # Can we copy the global values?
-      vdata.id = topology.vrfs[vname].id                    # We cannot merge global-to-node before post-transform
+    if not is_global and vname in topology.get('vrfs',{}):  # Can we copy the global values (can't do merge yet)
+      if not vdata.get('id',None):                          # Do we need VRF ID?
+        vdata.id = topology.vrfs[vname].id                  # Copy it from the global data
       if 'rd' not in vdata:                                 # No local RD, copy it from global VRF definition
         vdata.rd = topology.vrfs[vname].rd
         continue

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -234,13 +234,16 @@ def set_vrf_ids(obj: Box, topology: Box) -> None:
   for vname,vdata in obj.vrfs.items():                      # Iterate over object VRFs
     if not vrf_needs_id(vdata):                             # Skip if the ID/RD is set
       continue
+    asn = asn or get_rd_as_number(obj,topology)
 
     if not is_global and vname in topology.get('vrfs',{}):  # Can we copy the global values?
-      vdata.id = topology.vrfs[vname].id                    # ... we have to copy individual values because
-      vdata.rd = topology.vrfs[vname].rd                    # ... we cannot simply merge global into node data
-      continue                                              # ... before post-transform
+      vdata.id = topology.vrfs[vname].id                    # We cannot merge global-to-node before post-transform
+      if 'rd' not in vdata:                                 # No local RD, copy it from global VRF definition
+        vdata.rd = topology.vrfs[vname].rd
+      elif not vdata.rd:                                    # Local RD is empty value, create it
+        vdata.rd = f'{asn}:{vdata.id}'
+      continue                                              # And move on, we're all set
 
-    asn = asn or get_rd_as_number(obj,topology)
     if not asn:
       log.error(f'Need a usable vrf.as or bgp.as to create auto-generated VRF RD for {vname} in {obj_name}',
         log.MissingValue,
@@ -305,24 +308,28 @@ def set_import_export_rt(obj : Box, topology: Box) -> None:
 #
 # VRF route leaking is usually implemented through BGP VPNv4 address families
 # Check whether we have BGP AS configured on all nodes that use VRFs with route leaking
-# (identified as import or export RT not equal to [ RD ])
+# (identified as import or export RT not equal to [ RD ]). We cannot simply compare
+# import and export RT as we might have two VRFs with different RDs but equal RT values.
 #
 
 def validate_vrf_route_leaking(node : Box) -> None:
   for vname,vdata in node.vrfs.items():
     simple_rt = [ vdata.rd ]
-    leaked_routes = vdata['import'] and vdata['import'] != simple_rt
-    leaked_routes = leaked_routes or (vdata['export'] and vdata['export'] != simple_rt)
-    if leaked_routes:
-      vdata._leaked_routes = True
-      if not node.get('bgp.as',None):
-        if node.get('vrf.as',None):
-          node.bgp['as'] = node.vrf['as']
-        else:
-          log.error(
-            f"VRF {vname} on {node.name} uses inter-VRF route leaking, but there's no BGP AS configured on the node",
-            log.MissingValue,
-            'vrf')
+    leaked_routes = vdata.get('import',[]) != simple_rt or vdata.get('export',[]) != simple_rt
+    if not leaked_routes:                         # Simple setup, no extra work
+      continue                                    # ... move on
+
+    vdata._leaked_routes = True                   # Set the flag for VRF configuration templates
+    if node.get('bgp.as',None):                   # If we already have a valid node BGP ASN, move on
+      continue
+
+    if node.get('vrf.as',None):                   # Many devices need BGP ASN for inter-VRF route leaking
+      node.bgp['as'] = node.vrf['as']             # ... even if it's a fake one
+    else:
+      log.error(
+        f"VRF {vname} on {node.name} uses inter-VRF route leaking, but there's no BGP AS configured on the node",
+        log.MissingValue,
+        'vrf')
 
 # If we have an in-VRF loopback, fix parent interface for VRF IPv4 unnumbered interfaces
 #

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -406,6 +406,7 @@ nodes:
         rd: '65001:4'
         vrfidx: 101
       red:
+        _leaked_routes: true
         bgp:
           import:
             connected:
@@ -416,12 +417,15 @@ nodes:
         id: 2
         import:
         - '65000:2'
-        rd: '65000:2'
+        rd: '65001:2'
         vrfidx: 100
   r3:
     af:
       ipv4: true
       vpnv4: true
+    bgp:
+      as: 65000
+      router_id: 10.0.0.3
     box: none
     device: none
     hostname: clab-input-r3
@@ -483,6 +487,11 @@ nodes:
       as: 65000
     vrfs:
       orange:
+        _leaked_routes: true
+        bgp:
+          import:
+            connected:
+              auto: true
         export: []
         id: 7
         import:
@@ -493,6 +502,10 @@ nodes:
       yellow:
         af:
           ipv4: true
+        bgp:
+          import:
+            connected:
+              auto: true
         export:
         - '65000:1'
         id: 6


### PR DESCRIPTION
The VRF documentation claims the node VRF RD can be set to an empty value and will get a value from node bgp.as. The actual code blindly copied global RD value into node RD value.

This fix carefully copies global VRF ID into the node VRF data (to have consistent VRF ID across the lab topology) and either copies (missing), creates (empty), or leaves alone (non-empty) node vrf.rd attribute.

The fixed behavior triggered a '_leaked_route' flag in a transformation test as the VRF RT != [ VRF RD ], so I cleaned up that code as well. The logic hasn't changed, but the code is cleaner and catches another leaked route scenario that was not caught by the previous code.

Fixes #3225