### PR TITLE
Fix: Always check EVPN transport module

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -244,10 +244,10 @@ def check_evpn_transport(topology: Box) -> str:
       valid_values=topology.defaults.evpn.attributes.transport.valid_values,
       module='evpn')
   if not setting:
-    return VALID_TRANSPORTS[0]                 # Default to VXLAN
-  if setting not in topology.get('module',[]): # Warn if user sets it without adding the module
+    setting = VALID_TRANSPORTS[0]                 # Default to VXLAN
+  if setting not in topology.get('module',[]):    # Warn if user sets it without adding the module
     log.error(
-      f"Selected EVPN transport module evpn.transport='{setting}' not active in topology",
+      f"Selected EVPN transport module (evpn.transport='{setting}') not active in topology",
       log.MissingDependency,
       'evpn')
   return setting

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -237,11 +237,12 @@ def register_static_transit_vni(topology: Box) -> None:
 Check evpn.transport from user, default to VXLAN if not provided
 """
 def check_evpn_transport(topology: Box) -> str:
+  global VALID_TRANSPORTS
   setting = must_be_string(
       parent=topology,
       key='evpn.transport',
       path='topology',
-      valid_values=topology.defaults.evpn.attributes.transport.valid_values,
+      valid_values=VALID_TRANSPORTS,
       module='evpn')
   if not setting:
     setting = VALID_TRANSPORTS[0]                 # Default to VXLAN

--- a/tests/errors/addr-link-prefix-invalid-af.yml
+++ b/tests/errors/addr-link-prefix-invalid-af.yml
@@ -6,7 +6,7 @@ addressing:
     ipv4:
     ipv6: 2001:db8:1::/48
 
-module: [ evpn, bgp ]
+module: [ evpn, bgp, vxlan, vlan ]
 bgp.as: 65000
 
 nodes:

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -41,8 +41,10 @@ links:
     ipv4: 10.1.0.0/30
   type: p2p
 module:
+- vlan
 - bgp
 - vrf
+- vxlan
 - evpn
 name: input
 nodes:
@@ -118,8 +120,10 @@ nodes:
       ipv4: 192.168.121.101
       mac: ca:fe:00:01:00:00
     module:
+    - vlan
     - bgp
     - vrf
+    - vxlan
     - evpn
     name: r1
     vrf:
@@ -145,6 +149,13 @@ nodes:
         - '65000:2'
         rd: '65000:1'
         vrfidx: 100
+    vxlan:
+      domain: global
+      flooding: evpn
+      l3vnis:
+      - hub
+      vtep: 10.0.0.1
+      vtep_interface: Loopback0
   r2:
     af:
       ipv4: true
@@ -217,8 +228,10 @@ nodes:
       ipv4: 192.168.121.102
       mac: ca:fe:00:02:00:00
     module:
+    - vlan
     - bgp
     - vrf
+    - vxlan
     - evpn
     name: r2
     vrf:
@@ -244,6 +257,13 @@ nodes:
         - '65000:1'
         rd: '65000:2'
         vrfidx: 100
+    vxlan:
+      domain: global
+      flooding: evpn
+      l3vnis:
+      - spoke
+      vtep: 10.0.0.2
+      vtep_interface: Loopback0
 provider: clab
 vrf:
   as: 65000
@@ -268,3 +288,7 @@ vrfs:
     import:
     - '65000:1'
     rd: '65000:2'
+vxlan:
+  domain: global
+  flooding: evpn
+  use_v6_vtep: false

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -11,6 +11,8 @@ bgp:
 evpn:
   session:
   - ibgp
+  vlans:
+  - red
   vrfs:
   - tenant
 groups:
@@ -38,6 +40,7 @@ module:
 - vlan
 - bgp
 - vrf
+- vxlan
 - evpn
 name: input
 nodes:
@@ -75,6 +78,8 @@ nodes:
       session:
       - ibgp
       transport: vxlan
+      vlans:
+      - red
       vrfs:
       - tenant
     id: 1
@@ -123,6 +128,7 @@ nodes:
     - vlan
     - bgp
     - vrf
+    - vxlan
     - evpn
     name: a
     role: router
@@ -131,11 +137,19 @@ nodes:
     vlans:
       red:
         bridge_group: 1
+        evpn:
+          evi: 1000
+          export:
+          - 65000:1000
+          import:
+          - 65000:1000
+          rd: 10.0.0.1:1000
         id: 1000
         mode: irb
         prefix:
           allocation: id_based
           ipv4: 172.16.0.0/24
+        vni: 101000
         vrf: tenant
     vrf:
       as: 65000
@@ -159,9 +173,24 @@ nodes:
         - '65000:1'
         rd: '65000:1'
         vrfidx: 100
+    vxlan:
+      domain: global
+      flooding: evpn
+      l3vnis:
+      - tenant
+      vlans:
+      - red
+      vtep: 10.0.0.1
+      vtep_interface: Loopback0
 provider: libvirt
 vlans:
   red:
+    evpn:
+      evi: 1000
+      export:
+      - 65000:1000
+      import:
+      - 65000:1000
     host_count: 0
     id: 1000
     neighbors:
@@ -175,6 +204,7 @@ vlans:
     prefix:
       allocation: id_based
       ipv4: 172.16.0.0/24
+    vni: 101000
     vrf: tenant
 vrf:
   as: 65000
@@ -189,3 +219,9 @@ vrfs:
     import:
     - '65000:1'
     rd: '65000:1'
+vxlan:
+  domain: global
+  flooding: evpn
+  use_v6_vtep: false
+  vlans:
+  - red

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -11,6 +11,8 @@ bgp:
 evpn:
   session:
   - ibgp
+  vlans:
+  - red
 groups:
   as65000:
     members:
@@ -35,6 +37,7 @@ links:
 module:
 - vlan
 - bgp
+- vxlan
 - evpn
 name: input
 nodes:
@@ -71,6 +74,8 @@ nodes:
       session:
       - ibgp
       transport: vxlan
+      vlans:
+      - red
     id: 1
     interfaces:
     - bgp:
@@ -115,6 +120,7 @@ nodes:
     module:
     - vlan
     - bgp
+    - vxlan
     - evpn
     name: a
     role: router
@@ -125,17 +131,33 @@ nodes:
         bridge_group: 1
         evpn:
           evi: 10
+          export:
+          - '65000:10'
+          import:
+          - '65000:10'
           rd: 10.0.0.1:10
         id: 1000
         mode: irb
         prefix:
           allocation: id_based
           ipv4: 172.16.0.0/24
+        vni: 101000
+    vxlan:
+      domain: global
+      flooding: evpn
+      vlans:
+      - red
+      vtep: 10.0.0.1
+      vtep_interface: Loopback0
 provider: libvirt
 vlans:
   red:
     evpn:
       evi: 10
+      export:
+      - '65000:10'
+      import:
+      - '65000:10'
     host_count: 0
     id: 1000
     neighbors:
@@ -148,3 +170,10 @@ vlans:
     prefix:
       allocation: id_based
       ipv4: 172.16.0.0/24
+    vni: 101000
+vxlan:
+  domain: global
+  flooding: evpn
+  use_v6_vtep: false
+  vlans:
+  - red

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -37,8 +37,10 @@ links:
     ipv4: 10.1.0.0/30
   type: p2p
 module:
+- vlan
 - bgp
 - vrf
+- vxlan
 - evpn
 name: input
 nodes:
@@ -111,6 +113,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: ca:fe:00:01:00:00
     module:
+    - vlan
     - bgp
     - vrf
     - evpn
@@ -201,9 +204,14 @@ nodes:
       ipv4: 192.168.121.102
       mac: ca:fe:00:02:00:00
     module:
+    - vlan
     - bgp
     - evpn
     name: n2
 provider: clab
 vrf:
   as: 65000
+vxlan:
+  domain: global
+  flooding: evpn
+  use_v6_vtep: false

--- a/tests/topology/input/evpn-hub-spoke.yml
+++ b/tests/topology/input/evpn-hub-spoke.yml
@@ -14,7 +14,7 @@ vrfs:
     import: [hub]
     export: [spoke]
 
-module: [vrf, bgp, evpn] # Note: no vlan module included
+module: [vrf, bgp, evpn, vxlan, vlan]
 
 bgp.as: 65000
 

--- a/tests/topology/input/evpn-node-vrf.yml
+++ b/tests/topology/input/evpn-node-vrf.yml
@@ -1,5 +1,5 @@
 defaults.device: eos
-module: [vlan, bgp, evpn, vrf]
+module: [vlan, bgp, evpn, vrf, vxlan]
 
 vrfs:
   tenant:

--- a/tests/topology/input/evpn-vlan-attr.yml
+++ b/tests/topology/input/evpn-vlan-attr.yml
@@ -1,5 +1,5 @@
 defaults.device: eos
-module: [vlan, bgp, evpn]
+module: [vlan, bgp, evpn, vxlan]
 
 vlans:
   red:

--- a/tests/topology/input/null-vrfs.yml
+++ b/tests/topology/input/null-vrfs.yml
@@ -1,7 +1,7 @@
 #
 # Regression test for issue with topology containing only node local vrfs
 #
-module: [vrf, bgp, evpn]
+module: [vrf, bgp, evpn, vxlan, vlan]
 
 defaults.device: none
 defaults.provider: clab


### PR DESCRIPTION
The check_evpn_transport did not check the presence of data-plane module when using the default value (vxlan).

Also: Had to update transformation and error tests that used EVPN without VXLAN.