### PR TITLE
Fix: Set explicit evpn.transport feature on VXLAN-only devices

### DIFF
--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -60,6 +60,7 @@ features:
     asymmetrical_irb: true
     irb: true
     bundle: [ vlan_aware ]
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/crpd.yml
+++ b/netsim/devices/crpd.yml
@@ -23,6 +23,7 @@ features:
   vlan: false
   vxlan: false
   evpn:
+    transport: []
     irb: true
   gateway:
     protocol: [ vrrp ]

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -95,6 +95,7 @@ features:
   evpn:
     irb: True
     asymmetrical_irb: True
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -50,6 +50,7 @@ features:
   evpn:
     irb: True
     asymmetrical_irb: True
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -34,6 +34,7 @@ features:
   evpn:
     asymmetrical_irb: true
     irb: true
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -120,6 +120,7 @@ features:
     irb: true
     asymmetrical_irb: True
     multi_rt: True
+    transport: [ vxlan ]
   gateway:
     protocol: [ vrrp, anycast ]
   isis:

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -50,6 +50,7 @@ features:
   eigrp: true
   evpn:
     irb: true
+    transport: [ vxlan ]
   gateway:
     protocol: [ vrrp ]
   isis:

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -67,6 +67,7 @@ features:
   evpn:
     irb: True
     asymmetrical_irb: True
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast ]
   isis:

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -55,6 +55,7 @@ features:
   evpn:
     irb: True
     asymmetrical_irb: True
+    transport: [ vxlan ]
   isis:
     circuit_type: true
     unnumbered:

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -12,6 +12,7 @@ features:
     irb: true
     multi_rt: true
     bundle: [ vlan_aware ]
+    transport: [ vxlan ]
   vlan:
     model: router
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -11,6 +11,7 @@ features:
     irb: true
     multi_rt: true
     bundle: [ vlan_aware ]
+    transport: [ vxlan ]
   lag:
     passive: True
   vlan:

--- a/netsim/devices/vptx.yml
+++ b/netsim/devices/vptx.yml
@@ -12,6 +12,7 @@ features:
     irb: true
     multi_rt: true
     bundle: [ vlan_aware ]
+    transport: [ vxlan ]
   gateway:
     protocol: [ anycast, vrrp ]
   lag:

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -33,6 +33,7 @@ features:
   evpn:
     asymmetrical_irb: true
     irb: true
+    transport: [ vxlan ]
   gateway:
     protocol: [ vrrp ]
   isis:

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -551,8 +551,8 @@ Check whether the node supports the evpn.transport setting used in lab topology
 """
 def check_node_transport(node: Box, topology: Box) -> bool:
   features = devices.get_device_features(node,topology.defaults)
-  transport = node.get('evpn.transport','vxlan')
-  s_trans  = features.get('evpn.transport',['vxlan'])       # Missing feature means VXLAN only
+  transport = node.get('evpn.transport','vxlan')            # Get configured VXLAN transport
+  s_trans  = features.get('evpn.transport',[])              # Get supported transports
   if transport not in s_trans:                              # Is the requested transport supported by the device?
     log.error(
       f'Device {node.device} (node {node.name}) does not support EVPN transport {transport}',


### PR DESCRIPTION
The EVPN module assumed that the devices that have no evpn.transport feature support VXLAN transport. Let's make that assumption explicit ;)