### PR TITLE
Implement EVPN control-plane-only nodes

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -553,6 +553,10 @@ def check_node_transport(node: Box, topology: Box) -> bool:
   features = devices.get_device_features(node,topology.defaults)
   transport = node.get('evpn.transport','vxlan')            # Get configured VXLAN transport
   s_trans  = features.get('evpn.transport',[])              # Get supported transports
+  if not s_trans:                                           # Control-plane-only node
+    node.evpn._cp_only = True
+    return True
+
   if transport not in s_trans:                              # Is the requested transport supported by the device?
     log.error(
       f'Device {node.device} (node {node.name}) does not support EVPN transport {transport}',
@@ -566,6 +570,18 @@ def check_node_transport(node: Box, topology: Box) -> bool:
     node.evpn.transport = transport                         # Make sure node evpn.transport is always set
 
   return True
+
+"""
+Check if a CP-only node has any IP-VRF or MAC-VRF instances
+"""
+def check_cp_only(node: Box) -> None:
+  if not node.get('evpn._cp_only',False):
+    return
+  if node.evpn.get('vlans',[]) or node.evpn.get('vrfs',[]):
+    log.error(
+      f'Device {node.device} (node {node.name}) cannot have EVPN MAC-VRF or IP-VRF instances',
+      module='evpn',
+      category=log.IncorrectValue)
 
 class EVPN(_Module):
 
@@ -616,6 +632,7 @@ class EVPN(_Module):
     check_node_vrf_bundle(node,topology)
     check_vlan_rt_values(node,topology)
     trim_node_evpn_lists(node)
+    check_cp_only(node)
     set_local_evpn_rd(node)
 
   def node_cleanup(self, node: Box, topology: Box) -> None:

--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -555,9 +555,7 @@ def check_node_transport(node: Box, topology: Box) -> bool:
   s_trans  = features.get('evpn.transport',[])              # Get supported transports
   if not s_trans:                                           # Control-plane-only node
     node.evpn._cp_only = True
-    return True
-
-  if transport not in s_trans:                              # Is the requested transport supported by the device?
+  elif transport not in s_trans:                            # Is the requested transport supported by the device?
     log.error(
       f'Device {node.device} (node {node.name}) does not support EVPN transport {transport}',
       module='evpn',

--- a/tests/integration/evpn/10-vxlan-rr.yml
+++ b/tests/integration/evpn/10-vxlan-rr.yml
@@ -10,7 +10,7 @@ message: |
   STP learning phase
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
-plugin: [ files, fix_mtu, evpn-transport ]
+plugin: [ files, fix_mtu ]
 
 addressing:
   loopback.ipv6: 2001:db8:cafe::/48

--- a/tests/integration/evpn/evpn-transport/plugin.py
+++ b/tests/integration/evpn/evpn-transport/plugin.py
@@ -16,7 +16,7 @@ def init(topology: Box) -> None:
   def_device = topology.defaults.device               # Get features of the default device
   node = get_box({'device': def_device})
   features = get_device_features(node,topology.defaults)
-  if 'evpn.transport' not in features:                # Does the device specify available EVPN transports?
+  if not features.get('evpn.transport',[]):           # Does the device specify available EVPN transports?
     return
 
   transport = features.evpn.transport[0]


### PR DESCRIPTION
If a node has evpn.transport feature set to [], it's assumed to be a control-plane-only node. It can be a route reflector, but cannot have any MAC-VRF or IP-VRF instances.

Use case: cRPD (until someone implements EVPN/MPLS for Junos)

Replaces #3219, closes #3220