### PR TITLE
Build bgp.advertise lists to simplify configuration templates

### DIFF
--- a/docs/dev/config/bgp.md
+++ b/docs/dev/config/bgp.md
@@ -158,14 +158,14 @@ After configuring the BGP neighbors, you should configure individual address fam
 
 ### Configure Prefix Origination
 
-A BGP instance must advertise the prefixes from the **bgp.advertise** list (present in node and VRF data). The list is created from interface data (for interfaces with **bgp.advertise** attribute) and **bgp.originate** list.
+A BGP instance must advertise the prefixes from the optional **bgp.advertise** list present in node and VRF data when a BGP instance needs to advertise BGP prefixes. The list is created from interface data (for interfaces with **bgp.advertise** attribute) and **bgp.originate** list.
 
 Each entry in the list is a dictionary that can have **ipv4** and **ipv6** attributes -- the prefixes to advertise.
 
 Iterate over the prefixes in the **bgp.advertise** list and generate **network** statements (or prefix list entries if your device uses export policy to advertise BGP prefixes)
 
 ```
-{%   for n in vdata.bgp.advertise|default([]) if af in n %}
+{%   for n in bgp.advertise|default([]) if af in n %}
   network {{ n[af]|ansible.utils.ipaddr('0') }}
 {%   endfor %}
 ```

--- a/docs/dev/config/bgp.md
+++ b/docs/dev/config/bgp.md
@@ -158,30 +158,19 @@ After configuring the BGP neighbors, you should configure individual address fam
 
 ### Configure Prefix Origination
 
-Within each address family, iterate over interfaces and create **network** statements (or whatever it takes to originate BGP prefixes) if:
+A BGP instance must advertise the prefixes from the **bgp.advertise** list (present in node and VRF data). The list is created from interface data (for interfaces with **bgp.advertise** attribute) and **bgp.originate** list.
 
-* The **bgp.advertise** interface attribute is set
-* The target address family is configured on the interface
-* The **vrf** interface attribute matches the VRF you're configuring (or is missing for global BGP configuration)
+Each entry in the list is a dictionary that can have **ipv4** and **ipv6** attributes -- the prefixes to advertise.
 
-Use **netlab_interfaces** list to include the loopback interface.
+Iterate over the prefixes in the **bgp.advertise** list and generate **network** statements (or prefix list entries if your device uses export policy to advertise BGP prefixes)
 
 ```
-{%   for l in netlab_interfaces if l.bgp.advertise|default(False) and l[af] is defined and not 'vrf' in l %}
-  network {{ l[af]|ipaddr(0) }}
+{%   for n in vdata.bgp.advertise|default([]) if af in n %}
+  network {{ n[af]|ansible.utils.ipaddr('0') }}
 {%   endfor %}
 ```
 
-For the global IPv4 address family, check the **bgp.originate** list and advertise the prefixes listed in that list. No such mechanism exists for IPv6 prefixes or VRFs
-
-```
-{%   for pfx in bgp.originate|default([]) if af == 'ipv4' %}
-  network {{ pfx|ipaddr('0') }}
-{%   endfor %}
-!
-```
-
-The extra prefixes configured with **bgp.originate** usually have to be supported by discard static routes. Configure those static routes outside of the BGP routing process:
+When your device originates a BGP prefix only based on a corresponding prefix in the IP routing table, add global IPv4 discard static routes for the extra prefixes in the **bgp.originate** list. The **bgp.originate** list is present only in the node-level data and contains IPv4 prefixes as strings.
 
 ```
 {% for pfx in bgp.originate|default([]) %}

--- a/docs/dev/config/vrf.md
+++ b/docs/dev/config/vrf.md
@@ -25,9 +25,8 @@ VRFs used on a device are defined in the **vrfs** dictionary. Dictionary keys ar
 * **import** -- list of import route targets
 * **export** -- list of export route targets
 * **af** -- list of address families (`ipv4` and/or `ipv6`) used by the VRF
-* **networks** (optional) -- list of subnets advertised as BGP prefixes
-* **ospf** (optional) -- VRF OSPF parameters (when there's an OSPF routing process running in the VRF)
-* **bgp** (optional) -- VRF BGP parameters (when the VRF contains at least one CE router running BGP) 
+* **ospf** (optional) -- VRF OSPF parameters when there's an OSPF routing process running in the VRF
+* **bgp** (optional) -- VRF BGP parameters when the lab topology requires a VRF BGP instance.
 
 Other parameters:
 
@@ -148,7 +147,7 @@ Cisco IOS example:
 (dev-vrf-bgp)=
 ### Configuring VRF BGP Instances
 
-In the BGP configuration process, configure VRF address families, OSPF-to-BGP redistribution, redistribution of connected interfaces, and advertise VRF-specific networks.
+In the BGP configuration process, configure VRF address families, OSPF-to-BGP redistribution, redistribution of connected interfaces, and advertise VRF-specific networks. Use attributes defined in the [](dev-config-bgp) document; many of them (for example, **bgp.advertise**, **bgp.import**, and **bgp.neighbors**) are available in the VRF **bgp** data.
 
 ```{warning}
 Some devices don't inherit the VRF BGP router ID from the global router ID and may fail to function correctly in IPv6-only deployments.
@@ -170,7 +169,7 @@ router bgp {{ bgp.as }}
   redistribute ospf {{ vdata.vrfidx }}
 {%     endif %}
 !
-{%     for n in vdata.networks|default([]) if af in n %}
+{%     for n in vdata.bgp.advertise|default([]) if af in n %}
 {{       bgpcfg.bgp_network(af,n[af]) }}
 {%     endfor %}
 !
@@ -204,7 +203,7 @@ router bgp {{ bgp.as }}
 {%     endfor %}
 {%   endfor %}
 {%   for af in ['ipv4','ipv6'] %}
-{%     for n in vdata.networks|default([]) if af in n %}
+{%     for n in vdata.bgp.advertise|default([]) if af in n %}
 {%       if loop.index == 1 %}
   address-family {{ af }}
 {%       endif %}

--- a/netsim/ansible/templates/bgp/frr.j2
+++ b/netsim/ansible/templates/bgp/frr.j2
@@ -46,21 +46,8 @@ router bgp {{ bgp.as }}
  address-family {{ af }} unicast
 !
 {{   redistribute.config(bgp,af=af) }}
-{%   for l in netlab_interfaces if l.bgp.advertise|default("") and l[af] is defined and not 'vrf' in l %}
-{%     if loop.first %}
-!
-! Originate networks from connected subnets
-!
-{%     endif %}
-  network {{ l[af]|ansible.utils.ipaddr(0) }}
-{%   endfor %}
-{%   for pfx in bgp.originate|default([]) if af == 'ipv4' %}
-{%     if loop.first %}
-!
-! Originate networks from static routes
-!
-{%     endif %}
-  network {{ pfx|ansible.utils.ipaddr('0') }}
+{%   for pfx in bgp.advertise|default([]) if af in pfx %}
+  network {{ pfx[af] }}
 {%   endfor %}
 !
 {%   for n in bgp.neighbors if n.activate[af]|default(false) %}

--- a/netsim/ansible/templates/vrf/frr.bgp.j2
+++ b/netsim/ansible/templates/vrf/frr.bgp.j2
@@ -29,7 +29,7 @@ router bgp {{ vdata.as|default(bgp.as) }} vrf {{ vname }}
   rd vpn export {{ vdata.rd }}
   rt vpn import {{ vdata.import|join(" ") }}
   rt vpn export {{ vdata.export|join(" ") }}
-{%   for n in vdata.networks|default([]) if af in n %}
+{%   for n in vdata.bgp.advertise|default([]) if af in n %}
   network {{ n[af]|ansible.utils.ipaddr('0') }}
 {%   endfor %}
 {%   for n in vdata.bgp.neighbors|default([]) if n[af] is defined %}

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -566,15 +566,18 @@ def bgp_set_advertise(node: Box, topology: Box) -> None:
 bgp_build_advertise_list: build per-VRF bgp.advertise lists from interface bgp.advertise flags
 """
 def bgp_build_advertise_list(node: Box) -> None:
-  for intf in node.interfaces:
+  lb_list = [ node.loopback ] if 'loopback' in node else []
+  for intf in lb_list + node.interfaces:          # Iterate over loopback and regular interfaces
     if not intf.get('bgp.advertise',False):       # Interface prefix not advertised in BGP?
       continue                                    # ... move on
 
-    # Collect interface AF data, turning interface addresses into prefixes
+    # Collect interface AF data. Take only string values (skip unnumbereds)
+    # and turn interface addresses into prefixes
     #
-    af_data = { af: str(ipaddress.ip_network(intf[af],strict=False)) for af in log.AF_LIST if af in intf }
+    af_data = { af: str(ipaddress.ip_network(intf[af],strict=False)) 
+                  for af in log.AF_LIST if af in intf and isinstance(intf[af],str) }
     if not af_data:
-      continue                                    # L2-only interface
+      continue                                    # L2-only or unnumbered interface
 
     # Create the correct bgp.advertise list name, either global or in-vrf
     list_name = 'bgp.advertise' if 'vrf' not in intf else f'vrfs.{intf.vrf}.bgp.advertise'
@@ -947,10 +950,10 @@ class BGP(_Module):
       return
     build_bgp_sessions(node,topology)
     bgp_set_advertise(node,topology)
-    bgp_build_advertise_list(node)
     bgp_set_originate_af(node,topology)
     _routing.remove_vrf_routing_blocks(node,'bgp')
     bgp_transform_community_list(node,topology)
     _routing.check_vrf_protocol_support(node,'bgp',None,'bgp',topology)
     _routing.process_imports(node,'bgp',topology,global_vars.get_const('vrf_igp_protocols',['connected']))
     sanitize_bgp_data(node)
+    bgp_build_advertise_list(node)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -1,6 +1,7 @@
 #
 # BGP transformation module
 #
+import ipaddress
 import typing
 
 from box import Box
@@ -562,6 +563,30 @@ def bgp_set_advertise(node: Box, topology: Box) -> None:
       l.bgp.advertise = True                # ... also advertise loopback prefixes if bgp.advertise_loopback is set
 
 """
+bgp_build_advertise_list: build per-VRF bgp.advertise lists from interface bgp.advertise flags
+"""
+def bgp_build_advertise_list(node: Box) -> None:
+  for intf in node.interfaces:
+    if not intf.get('bgp.advertise',False):       # Interface prefix not advertised in BGP?
+      continue                                    # ... move on
+
+    # Collect interface AF data, turning interface addresses into prefixes
+    #
+    af_data = { af: str(ipaddress.ip_network(intf[af],strict=False)) for af in log.AF_LIST if af in intf }
+    if not af_data:
+      continue                                    # L2-only interface
+
+    # Create the correct bgp.advertise list name, either global or in-vrf
+    list_name = 'bgp.advertise' if 'vrf' not in intf else f'vrfs.{intf.vrf}.bgp.advertise'
+    data.append_to_list(node,list_name,af_data)   # And append prefix data to the list
+
+  if 'originate' in node.bgp:                     # Next, append originate data to the advertise list
+    for o_pfx in node.bgp.originate:
+      # Convert old-style data (IPv4 string) into prefix
+      af_data = o_pfx if isinstance(o_pfx,Box) else {'ipv4': o_pfx }
+      data.append_to_list(node,'bgp.advertise',af_data)
+
+"""
 bgp_set_originate_af: set bgp[af] flags based on prefixes that should be originated
 """
 
@@ -922,6 +947,7 @@ class BGP(_Module):
       return
     build_bgp_sessions(node,topology)
     bgp_set_advertise(node,topology)
+    bgp_build_advertise_list(node)
     bgp_set_originate_af(node,topology)
     _routing.remove_vrf_routing_blocks(node,'bgp')
     bgp_transform_community_list(node,topology)

--- a/tests/coverage/expected/device-module-defaults.yml
+++ b/tests/coverage/expected/device-module-defaults.yml
@@ -44,6 +44,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -137,6 +139,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65002
       community:

--- a/tests/coverage/expected/module-node-global-params.yml
+++ b/tests/coverage/expected/module-node-global-params.yml
@@ -88,6 +88,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/coverage/expected/module-node-global.yml
+++ b/tests/coverage/expected/module-node-global.yml
@@ -44,6 +44,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/coverage/expected/module-node-only.yml
+++ b/tests/coverage/expected/module-node-only.yml
@@ -51,6 +51,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/coverage/expected/module-node-params.yml
+++ b/tests/coverage/expected/module-node-params.yml
@@ -89,6 +89,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/coverage/expected/module-reorder.yml
+++ b/tests/coverage/expected/module-reorder.yml
@@ -91,6 +91,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -275,6 +277,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:
@@ -395,6 +399,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/coverage/expected/removed-attr-inheritance.yml
+++ b/tests/coverage/expected/removed-attr-inheritance.yml
@@ -101,6 +101,8 @@ nodes:
       - 10.1.0.2
       - 10.1.0.6
       - 10.1.0.10
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -224,6 +226,8 @@ nodes:
       _session_clear:
       - 10.1.0.1
       - 10.1.0.5
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65001
       community:
@@ -319,6 +323,8 @@ nodes:
     bgp:
       _session_clear:
       - 10.1.0.9
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65002
       community:

--- a/tests/topology/expected/6pe.yml
+++ b/tests/topology/expected/6pe.yml
@@ -132,6 +132,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+        ipv6: 2001:db8:0:4::/64
       advertise_loopback: true
       as: 65001
       community:
@@ -197,6 +200,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
+        ipv6: 2001:db8:0:5::/64
       advertise_loopback: true
       as: 65002
       community:
@@ -333,6 +339,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -450,6 +459,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:0:2::/64
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/addressing-ipv6-only.yml
+++ b/tests/topology/expected/addressing-ipv6-only.yml
@@ -109,6 +109,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:0:7::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -269,6 +271,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:0:15::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -426,6 +430,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:0:2a::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -561,6 +567,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/addressing-ipv6-prefix.yml
+++ b/tests/topology/expected/addressing-ipv6-prefix.yml
@@ -85,6 +85,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8::7/128
       advertise_loopback: true
       as: 65000
       community:
@@ -214,6 +216,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8::15/128
       advertise_loopback: true
       as: 65000
       community:
@@ -356,6 +360,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8::2a/128
       advertise_loopback: true
       as: 65000
       community:
@@ -485,6 +491,8 @@ nodes:
     af:
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8::1/128
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -66,6 +66,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -115,6 +117,7 @@ nodes:
       - large
       - link-bandwidth
       advertise:
+      - ipv4: 10.0.0.2/32
       - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65001

--- a/tests/topology/expected/bgp-af-rt-929.yml
+++ b/tests/topology/expected/bgp-af-rt-929.yml
@@ -114,6 +114,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65001
       community:
@@ -174,6 +176,9 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.1.0.0/24
+      - ipv4: 0.0.0.0/0
       advertise_loopback: false
       as: 65002
       community:
@@ -223,6 +228,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.1.0/24
       advertise_loopback: false
       as: 65003
       community:

--- a/tests/topology/expected/bgp-anycast.yml
+++ b/tests/topology/expected/bgp-anycast.yml
@@ -41,6 +41,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -125,6 +127,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       anycast: 10.42.42.42/32
       as: 65000

--- a/tests/topology/expected/bgp-autogroup.yml
+++ b/tests/topology/expected/bgp-autogroup.yml
@@ -396,6 +396,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -481,6 +483,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -602,6 +606,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:
@@ -705,6 +711,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-community.yml
+++ b/tests/topology/expected/bgp-community.yml
@@ -61,6 +61,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 4259840001
       community:
@@ -145,6 +147,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 4259840001
       community:
@@ -235,6 +239,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 4259840001
       community:

--- a/tests/topology/expected/bgp-confederation.yml
+++ b/tests/topology/expected/bgp-confederation.yml
@@ -151,6 +151,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:1:1::/64
       advertise_loopback: true
       as: 65001
       community:
@@ -250,6 +253,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:1:2::/64
       advertise_loopback: true
       as: 65002
       community:
@@ -375,6 +381,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
+        ipv6: 2001:db8:1:3::/64
       advertise_loopback: true
       as: 65002
       community:
@@ -499,6 +508,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+        ipv6: 2001:db8:1:4::/64
       advertise_loopback: true
       as: 65100
       community:
@@ -573,6 +585,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
+        ipv6: 2001:db8:1:5::/64
       advertise_loopback: true
       as: 65101
       community:

--- a/tests/topology/expected/bgp-ibgp-localas.yml
+++ b/tests/topology/expected/bgp-ibgp-localas.yml
@@ -115,6 +115,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.42.42.0/24
       advertise_loopback: true
       as: 65000
       community:
@@ -447,6 +449,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.42.3.0/24
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-ibgp-localas.yml
+++ b/tests/topology/expected/bgp-ibgp-localas.yml
@@ -116,6 +116,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.1/32
       - ipv4: 172.42.42.0/24
       advertise_loopback: true
       as: 65000
@@ -280,6 +281,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.42.1.0/24
       advertise_loopback: true
       as: 65100
       community:
@@ -344,6 +347,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.42.2.0/24
       advertise_loopback: true
       as: 65101
       community:
@@ -450,6 +455,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.4/32
       - ipv4: 172.42.3.0/24
       advertise_loopback: true
       as: 65000
@@ -535,6 +541,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.42.4.0/24
       advertise_loopback: true
       as: 65101
       community:

--- a/tests/topology/expected/bgp-ibgp.yml
+++ b/tests/topology/expected/bgp-ibgp.yml
@@ -84,6 +84,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -208,6 +210,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -329,6 +333,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:
@@ -464,6 +470,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-interface-disable.yml
+++ b/tests/topology/expected/bgp-interface-disable.yml
@@ -79,6 +79,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -160,6 +162,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65101
       community:

--- a/tests/topology/expected/bgp-members.yml
+++ b/tests/topology/expected/bgp-members.yml
@@ -138,6 +138,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
       advertise_loopback: true
       as: 65001
       community:
@@ -197,6 +199,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.6/32
       advertise_loopback: true
       as: 65002
       community:
@@ -256,6 +260,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:
@@ -365,6 +371,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65000
       community:
@@ -474,6 +482,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -567,6 +577,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/bgp-rs-2as.yml
+++ b/tests/topology/expected/bgp-rs-2as.yml
@@ -60,6 +60,8 @@ nodes:
       _session_clear:
       - 172.16.0.3
       - 172.16.0.4
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -140,6 +142,8 @@ nodes:
       _session_clear:
       - 172.16.0.3
       - 172.16.0.4
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65001
       community:
@@ -221,6 +225,8 @@ nodes:
       - 172.16.0.1
       - 172.16.0.2
       - 172.16.0.4
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65100
       community:
@@ -302,6 +308,8 @@ nodes:
       - 172.16.0.3
       - 172.16.0.1
       - 172.16.0.2
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65101
       community:

--- a/tests/topology/expected/bgp-sessions.yml
+++ b/tests/topology/expected/bgp-sessions.yml
@@ -78,6 +78,9 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:0:2::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -204,6 +207,9 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
+        ipv6: 2001:db8:0:3::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -307,6 +313,9 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65100
       community:

--- a/tests/topology/expected/bgp-unnumbered-dual-stack.yml
+++ b/tests/topology/expected/bgp-unnumbered-dual-stack.yml
@@ -141,6 +141,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -327,6 +330,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:0:2::/64
       advertise_loopback: true
       as: 65001
       community:
@@ -420,6 +426,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
+        ipv6: 2001:db8:0:3::/64
       advertise_loopback: true
       as: 65002
       community:
@@ -489,6 +498,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+        ipv6: 2001:db8:0:4::/64
       advertise_loopback: true
       as: 65003
       community:
@@ -550,6 +562,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
+        ipv6: 2001:db8:0:5::/64
       advertise_loopback: true
       as: 65004
       community:

--- a/tests/topology/expected/bgp-unnumbered.yml
+++ b/tests/topology/expected/bgp-unnumbered.yml
@@ -72,6 +72,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:cafe:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -142,6 +145,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:cafe:2::/64
       advertise_loopback: true
       as: 65100
       community:
@@ -230,6 +236,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
+        ipv6: 2001:db8:cafe:3::/64
       advertise_loopback: true
       as: 65200
       community:

--- a/tests/topology/expected/bgp-vrf-local-as.yml
+++ b/tests/topology/expected/bgp-vrf-local-as.yml
@@ -119,6 +119,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65100
       community:
@@ -287,6 +289,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -590,6 +594,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65101
       community:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -196,6 +196,8 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:2::/64
       advertise_loopback: true
       as: 65001
       community:
@@ -285,6 +287,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv6: 2001:db8:2:1::/64
+      - ipv6: 2001:db8:2:2::/64
       advertise_loopback: true
       as: 65002
       community:

--- a/tests/topology/expected/bgp.yml
+++ b/tests/topology/expected/bgp.yml
@@ -197,6 +197,8 @@ nodes:
       ipv6: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.5/32
+        ipv6: 2001:db8:0:5::/64
       - ipv6: 2001:db8:2::/64
       advertise_loopback: true
       as: 65001
@@ -288,6 +290,8 @@ nodes:
       ipv6: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.6/32
+        ipv6: 2001:db8:0:6::/64
       - ipv6: 2001:db8:2:1::/64
       - ipv6: 2001:db8:2:2::/64
       advertise_loopback: true
@@ -443,6 +447,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
+        ipv6: 2001:db8:0:3::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -586,6 +593,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+        ipv6: 2001:db8:0:4::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -729,6 +739,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -874,6 +887,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:0:2::/64
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -526,6 +526,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65101
       community:
@@ -752,6 +754,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65101
       community:
@@ -1278,6 +1282,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.16.2.0/24
       advertise_loopback: true
       as: 65102
       community:
@@ -1504,6 +1510,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 172.16.3.0/24
       advertise_loopback: true
       as: 65102
       community:

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -346,6 +346,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65100
       community:
@@ -436,6 +438,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65100
       community:
@@ -527,6 +531,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.4/32
       - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65101
@@ -755,6 +760,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.6/32
       - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65101
@@ -982,6 +988,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.7/32
       advertise_loopback: true
       as: 65101
       community:
@@ -1132,6 +1140,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.8/32
       advertise_loopback: true
       as: 65101
       community:
@@ -1283,6 +1293,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.10/32
       - ipv4: 172.16.2.0/24
       advertise_loopback: true
       as: 65102
@@ -1511,6 +1522,7 @@ nodes:
       ipv4: true
     bgp:
       advertise:
+      - ipv4: 10.0.0.12/32
       - ipv4: 172.16.3.0/24
       advertise_loopback: true
       as: 65102
@@ -1738,6 +1750,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.13/32
       advertise_loopback: true
       as: 65102
       community:
@@ -1888,6 +1902,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.14/32
       advertise_loopback: true
       as: 65102
       community:

--- a/tests/topology/expected/ebgp.utils.yml
+++ b/tests/topology/expected/ebgp.utils.yml
@@ -143,6 +143,8 @@ nodes:
       - 10.0.0.4
       - 10.1.0.2
       - 10.1.0.6
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65001
       community:
@@ -342,6 +344,8 @@ nodes:
       _session_clear:
       - 10.1.0.1
       - 10.0.0.3
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65002
       community:
@@ -500,6 +504,8 @@ nodes:
       _session_clear:
       - 10.1.0.5
       - 10.0.0.2
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65003
       community:
@@ -608,6 +614,8 @@ nodes:
       - link-bandwidth
       _session_clear:
       - 10.0.0.1
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -640,6 +640,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.2.0/24
           import:
             connected:
               auto: true
@@ -996,6 +998,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.3.0/24
           import:
             connected:
               auto: true

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -413,6 +413,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -771,6 +773,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -53,6 +53,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -161,6 +163,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -186,6 +186,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.0.0/24
           import:
             connected:
               auto: true
@@ -320,6 +322,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.1.0/24
           import:
             connected:
               auto: true

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -79,6 +79,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -215,6 +217,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -55,6 +55,7 @@ nodes:
       - large
       - link-bandwidth
       advertise:
+      - ipv4: 10.0.0.1/32
       - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65000

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -54,6 +54,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65000
       community:
@@ -158,6 +160,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.0.0/24
           import:
             connected:
               auto: true

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -50,6 +50,9 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.1.0/24
+      - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -51,6 +51,7 @@ nodes:
       - large
       - link-bandwidth
       advertise:
+      - ipv4: 10.0.0.1/32
       - ipv4: 172.16.1.0/24
       - ipv4: 172.16.0.0/24
       advertise_loopback: true

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -451,6 +451,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -694,6 +696,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -882,6 +886,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65001
       community:
@@ -1024,6 +1030,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65002
       community:

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -233,6 +233,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
       advertise_loopback: true
       as: 65100
       community:
@@ -363,6 +365,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.6/32
       advertise_loopback: true
       as: 65100
       community:
@@ -601,6 +605,7 @@ nodes:
       - large
       - link-bandwidth
       advertise:
+      - ipv4: 10.0.0.1/32
       - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65001
@@ -705,6 +710,7 @@ nodes:
       - large
       - link-bandwidth
       advertise:
+      - ipv4: 10.0.0.2/32
       - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65002
@@ -808,6 +814,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65003
       community:
@@ -895,6 +903,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65004
       community:

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -600,6 +600,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.0.0/24
       advertise_loopback: true
       as: 65001
       community:
@@ -702,6 +704,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 172.16.1.0/24
       advertise_loopback: true
       as: 65002
       community:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -228,6 +228,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/groups-node-data.yml
+++ b/tests/topology/expected/groups-node-data.yml
@@ -57,6 +57,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -128,6 +130,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -199,6 +203,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:
@@ -270,6 +276,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
       advertise_loopback: true
       as: 65001
       community:
@@ -341,6 +349,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
       advertise_loopback: true
       as: 65001
       community:
@@ -412,6 +422,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.6/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -79,6 +79,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65001
       community:
@@ -219,6 +221,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/mpls-vpn-simple.yml
+++ b/tests/topology/expected/mpls-vpn-simple.yml
@@ -196,6 +196,9 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.0.0/24
+          - ipv4: 10.2.0.1/32
           import:
             connected:
               auto: true
@@ -333,6 +336,9 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.1.0/24
+          - ipv4: 10.2.0.2/32
           import:
             connected:
               auto: true

--- a/tests/topology/expected/mpls.yml
+++ b/tests/topology/expected/mpls.yml
@@ -132,6 +132,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.5/32
+        ipv6: 2001:db8:0:5::/64
       advertise_loopback: true
       as: 65101
       community:
@@ -208,6 +211,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.6/32
+        ipv6: 2001:db8:0:6::/64
       advertise_loopback: true
       as: 65102
       community:
@@ -379,6 +385,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:0:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -527,6 +536,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:0:2::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -673,6 +685,9 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+        ipv6: 2001:db8:0:4::/64
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/null-vrfs.yml
+++ b/tests/topology/expected/null-vrfs.yml
@@ -49,6 +49,8 @@ nodes:
       ipv4: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -140,6 +142,8 @@ nodes:
     af:
       ipv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/rp-aspath-numbers.yml
+++ b/tests/topology/expected/rp-aspath-numbers.yml
@@ -103,6 +103,9 @@ nodes:
     bgp:
       _session_clear:
       - 10.1.0.2
+      advertise:
+      - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:cafe:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -204,6 +207,9 @@ nodes:
     bgp:
       _session_clear:
       - 10.1.0.1
+      advertise:
+      - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:cafe:2::/64
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/vlan-access-neighbors.yml
+++ b/tests/topology/expected/vlan-access-neighbors.yml
@@ -72,6 +72,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -153,6 +155,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -142,6 +142,8 @@ nodes:
       vpnv4: true
       vpnv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -415,6 +417,8 @@ nodes:
       vpnv4: true
       vpnv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -704,6 +708,8 @@ nodes:
       ipv4: true
       ipv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/vrf-igp.yml
+++ b/tests/topology/expected/vrf-igp.yml
@@ -267,6 +267,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 10.2.0.1/32
           import:
             connected:
               auto: true
@@ -540,6 +542,9 @@ nodes:
           ipv4: true
           ipv6: true
         bgp:
+          advertise:
+          - ipv4: 10.11.0.1/32
+            ipv6: 2001:db8:cafe::1/128
           import:
             connected:
               auto: true

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -106,6 +106,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -355,6 +357,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -544,6 +548,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65000
       community:

--- a/tests/topology/expected/vrf-links.yml
+++ b/tests/topology/expected/vrf-links.yml
@@ -281,6 +281,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.0.0/24
           import:
             connected:
               auto: true
@@ -665,6 +667,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.1.0/24
           import:
             connected:
               auto: true

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -194,6 +194,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -697,6 +699,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65000
       community:
@@ -1053,6 +1057,8 @@ nodes:
       - extended
       - large
       - link-bandwidth
+      advertise:
+      - ipv4: 10.0.0.3/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/vrf-routing-blocks.yml
+++ b/tests/topology/expected/vrf-routing-blocks.yml
@@ -455,6 +455,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 10.2.0.1/32
           import:
             connected:
               auto: true
@@ -638,6 +640,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.0.0/24
           import:
             connected:
               auto: true
@@ -860,6 +864,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 10.2.0.2/32
           import:
             connected:
               auto: true

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -96,6 +96,8 @@ nodes:
       vpnv4: true
       vpnv6: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
       advertise_loopback: true
       as: 65000
       community:
@@ -287,6 +289,8 @@ nodes:
       ipv6: true
       vpnv4: true
     bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
       advertise_loopback: true
       as: 65001
       community:

--- a/tests/topology/expected/vrf.yml
+++ b/tests/topology/expected/vrf.yml
@@ -187,6 +187,8 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 10.2.0.2/32
           import:
             connected:
               auto: true
@@ -253,6 +255,8 @@ nodes:
           ipv4: true
           ipv6: true
         bgp:
+          advertise:
+          - ipv4: 10.2.0.1/32
           import:
             connected:
               auto: true
@@ -375,6 +379,9 @@ nodes:
         af:
           ipv4: true
         bgp:
+          advertise:
+          - ipv4: 172.16.1.0/24
+          - ipv4: 10.0.0.1/32
           import:
             connected:
               auto: true


### PR DESCRIPTION
This commit builds node- and VRF-level bgp.advertise lists that contain IPv4/IPv6 prefixes that have to be advertised as BGP prefixes. The list is built from interface data (using bgp.advertise attribute) and the bgp.originate node-level list.

FRR implementation is included as a proof-of-concept.