### PR TITLE
Implement bgp.advertise node attribute

### DIFF
--- a/docs/module/bgp.md
+++ b/docs/module/bgp.md
@@ -197,12 +197,18 @@ Instead of using a global list of autonomous systems, you could specify a BGP au
 
 Additional per-node BGP configuration parameters include:
 
+* **bgp.advertise** -- the list of prefixes that should be advertised into BGP. These prefixes must usually be in the IP routing table (for example, learned via IGP).
+
+```{tip}
+Use **bgp.advertise** link/interface attribute to advertise connected subnets without configuring route redistribution
+```
+
 * **bgp.advertise_loopback** -- When set to `False`, BGP does not advertise the IP prefix configured on the loopback interface. See also [*Advanced Global Configuration Parameters*](#advanced-global-configuration-parameters).
 * **bgp.community** -- override global BGP community propagation defaults for this node. See *[](bgp-community-propagation)* for more details.
 * **bgp.import** -- [import (redistribute) IPv4 and IPv6 routes](routing_import) into global BGP instance (default: **false**)
 * **bgp.local_as** -- the autonomous system used on all EBGP sessions. See *[IBGP local-as](bgp-ibgp-localas)* on how this could also result in **IBGP** sessions.
 * **bgp.next_hop_self** -- Use *next-hop-self* on IBGP sessions. This parameter can also be specified as a global value; the system default is **true**.
-* **bgp.originate** -- a list of additional prefixes to advertise. The advertised prefixes are supported with a static route pointing to *Null0*.
+* **bgp.originate** -- a list of additional prefixes to advertise. Unlike the prefixes listed in the **bgp.advertise**  attribute, these prefixes are supported with a static discard route (usually pointing to *Null0*).
 * **bgp.router_id** -- Set a static router ID. The default **router_id** is taken from the IPv4 address of the loopback interface or the **router_id** address pool if the device does not have a loopback interface or there is no usable IPv4 address on the loopback interface.
 
 (bgp-advanced-node)=
@@ -233,6 +239,7 @@ Finally, the BGP configuration module supports these advanced node parameters th
 ## VRF Parameters
 
 * BGP is always enabled for all VRF address families. By default, _netlab_ redistributes connected interfaces and IGP routes into BGP VRF address families. You can change that on devices supporting configurable route import with the **[bgp.import](routing_import)** VRF parameter.
+* You can use **bgp.advertise** VRF attribute and **bgp.advertise** interface/link attribute to advertise VRF prefixes into VRF BGP instance without configuring route redistribution.
 * You can set a VRF-specific BGP router ID with **bgp.router_id** VRF parameter. Use this setting when building topologies with back-to-back links between VRFs on the same device.
 * To stop the creation of VRF EBGP sessions, set the **bgp** VRF parameter to *False* (see also [](routing_disable_vrf)).
 
@@ -268,12 +275,20 @@ You can also [turn off all EBGP sessions on an interface](routing_disable).
 (bgp-advertise-prefix)=
 ## Advertised BGP Prefixes
 
-The following IPv4/IPv6 prefixes are configured with **network** statements within the BGP routing process:
+The following IPv4/IPv6 prefixes are configured with **network** statements (or a corresponding export-to-BGP routing policy) within the BGP routing process:
 
 * IPv4/IPv6 prefixes configured on the default loopback interface and [loopback links](links-loopback) unless the **bgp.advertise_loopback** is set to `False`.
 * IPv4/IPv6 prefixes from links with **bgp.advertise** parameter set to **true**.
 * Prefixes assigned to *stub* networks -- links with a single node attached to them or links with a single router or daemon attached to them (these links would have **role** set to **stub**). To prevent a stub prefix from being advertised, set **bgp.advertise** link parameter to **false**
-* IPv4 prefixes in **bgp.originate** list. Static routes to *Null0* are created for those prefixes if needed.
+* Prefixes in the **bgp.advertise** list.
+* IPv4 prefixes in the **bgp.originate** list. Static routes to *Null0* are created for those prefixes if needed.
+
+The entries in the **bgp.advertise** list can be:
+
+* IPv4 subnets
+* IPv6 subnets
+* [Named prefixes](named-prefixes)
+* Dictionaries with **ipv4** and **ipv6** keys
 
 ### Using bgp.advertise Link Attribute
 

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -86,6 +86,7 @@ features:
   bfd: True
   bgp:
     activate_af: true
+    advertise: true
     ipv6_lla: true
     rfc8950: true
     local_as: true

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -563,6 +563,24 @@ def bgp_set_advertise(node: Box, topology: Box) -> None:
       l.bgp.advertise = True                # ... also advertise loopback prefixes if bgp.advertise_loopback is set
 
 """
+check_advertise_data: check whether the device supports bgp.advertise list (if it's used)
+"""
+def check_advertise_data(node: Box, topology: Box) -> None:
+  features = devices.get_device_features(node,topology.defaults)
+  if features.bgp.advertise:                      # Device supports the new advertise features, nothing to check
+    return
+
+  for (bgp_data,_,vname) in _rp_utils.rp_data(node,'bgp'):
+    if 'advertise' in bgp_data:
+      text_msg = f'Device {node.device} (node {node.name}) does not support bgp.advertise attribute'
+      text_msg += f' (vrf {vname})' if vname else ''
+      log.warning(
+        text=text_msg,
+        module='bgp',
+        flag='advertise',
+        category=log.IncorrectAttr)
+
+"""
 bgp_build_advertise_list: build per-VRF bgp.advertise lists from interface bgp.advertise flags
 """
 def bgp_build_advertise_list(node: Box) -> None:
@@ -955,5 +973,6 @@ class BGP(_Module):
     bgp_transform_community_list(node,topology)
     _routing.check_vrf_protocol_support(node,'bgp',None,'bgp',topology)
     _routing.process_imports(node,'bgp',topology,global_vars.get_const('vrf_igp_protocols',['connected']))
+    check_advertise_data(node,topology)
     sanitize_bgp_data(node)
     bgp_build_advertise_list(node)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -567,7 +567,7 @@ check_advertise_data: check whether the device supports bgp.advertise list (if i
 """
 def check_advertise_data(node: Box, topology: Box) -> None:
   features = devices.get_device_features(node,topology.defaults)
-  if features.bgp.advertise:                      # Device supports the new advertise features, nothing to check
+  if features.get('bgp.advertise',False):         # Device supports the new advertise features, nothing to check
     return
 
   for (bgp_data,_,vname) in _rp_utils.rp_data(node,'bgp'):

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -102,6 +102,7 @@ attributes:
     import: _r_import
   vrf:
     router_id: { type: ipv4, use: id }
+    advertise: bgp_prefix_list
     import: _r_import
   node_copy: [ local_as, replace_global_as ]
   link:

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -38,6 +38,13 @@ _top:                         # Define custom data types used by the BGP module
         extended:
         large:
         2octet:
+    bgp_prefix_list:
+      _description: BGP prefix list
+      type: list
+      _subtype:
+        ipv4: { type: ipv4, use: subnet_prefix }
+        ipv6: { type: ipv6, use: subnet_prefix }
+        _alt_types: [ prefix_str ]
 
 attributes:
   global:
@@ -81,6 +88,7 @@ attributes:
     rr: bool
     rr_cluster_id: { copy: global }
     rr_mesh: { copy: global }
+    advertise: bgp_prefix_list
     originate:
       type: list
       _subtype: { type: ipv4, use: subnet_prefix, named: True }

--- a/tests/errors/vrf-invalid-attr.log
+++ b/tests/errors/vrf-invalid-attr.log
@@ -1,5 +1,6 @@
-IncorrectAttr in bgp: Invalid bgp vrf attribute 'as' found in topology.vrfs.red.bgp
+IncorrectType in bgp: attribute 'topology.vrfs.red.bgp.advertise[1]' must be a dictionary or IPv4 or IPv6 prefix, found bool
 ... use 'netlab show attributes --module bgp vrf' to display valid attributes
+IncorrectAttr in bgp: Invalid bgp vrf attribute 'as' found in topology.vrfs.red.bgp
 IncorrectAttr in topology: Invalid vrf attribute 'wrong' found in topology.vrfs.red
 ... use 'netlab show attributes vrf' to display valid attributes
 IncorrectAttr in topology: topology.vrfs.red uses an attribute from module ospf which is not enabled in topology

--- a/tests/integration/bgp/04-originate.yml
+++ b/tests/integration/bgp/04-originate.yml
@@ -4,6 +4,8 @@ message: |
   of IPv4 prefixes.
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
+plugin: [ adjust_test ]
 
 module: [ bgp ]
 
@@ -16,9 +18,14 @@ groups:
 defaults.bgp.as: 65000
 defaults.interfaces.mtu: 1500
 
+prefix:
+  adv_beacon:
+    ipv4: 172.42.43.0/24
+
 nodes:
   dut:
     bgp.originate: [ 172.42.42.0/24 ]
+    bgp.advertise: [ adv_beacon ]
     bgp.advertise_loopback: False
     loopback: True
     module: [ bgp, ospf ]
@@ -42,9 +49,19 @@ links:
 - dut:
   prefix.ipv4: 172.0.42.0/24
   bgp.advertise: True
+- r1:
+  prefix: adv_beacon
 
 defaults.devices.cisco8000v.netlab_validate.originate.wait: 80
 defaults.devices.cisco8000v.netlab_validate.loopback.wait: 80
+
+_adjust:
+- nodes: [ dut ]              # Remove 'bgp.advertise' if the device does not support it
+  features: [ bgp.advertise ]
+  warning: The BGP configuration template for {device} does not support bgp.advertise attribute
+  remove:
+  - nodes.dut.bgp.advertise
+  - validate.adv_ipv4
 
 validate:
   ospf_adj:
@@ -83,3 +100,9 @@ validate:
     description: Check whether DUT originates an unwanted prefix on a P2P link
     nodes: [ x1, x2, r1 ]
     plugin: bgp_prefix('172.0.66.0/24',state='missing')
+  adv_ipv4:
+    description: Check whether DUT advertises OSPF prefix into BGP
+    wait: bgp_scan_time
+    wait_msg: Waiting for advertised OSPF prefix
+    nodes: [ x1, x2 ]
+    plugin: bgp_prefix(prefix.adv_beacon.ipv4)


### PR DESCRIPTION
The bgp.advertise attribute is used to advertise BGP prefixes from IPv4/IPv6 prefixes already in the IP routing table (as opposed to bgp.originate that adds a static route).

This PR contains:

* The definition of bgp.advertise attribute -- a list that accepts IPv4 prefixes, IPv6 prefixes, named prefixes (including dual- stack ones) and ipv4/ipv6 dictionaries
* Modifications in the BGP module to do sanity checks (values in the bgp.advertise list are adjusted in the data validation process)
* Updated documentation
* Sample implementation on FRR
* Updated integration test