### PR TITLE
netlab status - node unknown instead of AttributeError

### DIFF
--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -176,7 +176,7 @@ def fetch_node_status(ls: Box, topology: Box) -> None:
       node_stat.provider = n_provider
       wk_name = p_module.call('get_node_name',n_name,topology)
       node_stat.provider_name = wk_name
-      wk_state = p_status[n_provider].get(wk_name,None) or p_status[n_provider].get(n_name,None)
+      wk_state = p_status[n_provider].get(wk_name,None) or p_status[n_provider].get(n_name,None) or get_empty_box()
       node_stat.status = wk_state.get('status','Unknown')
 
   for t_name,t_data in topology.tools.items():


### PR DESCRIPTION
this should fix #3217

Instead of failing with an AttributeError, the command now falls back to Unknown for that node’s status.

```before
╰─❯ netlab status 
Traceback (most recent call last):
  File "/home/seb/code/netlab/netlab/netlab", line 15, in <module>
    netsim.cli.lab_commands(__file__)
  File "/home/seb/code/netlab/netlab/netsim/cli/__init__.py", line 524, in lab_commands
    mod.run(sys.argv[arg_start:])   # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/seb/code/netlab/netlab/netsim/cli/status.py", line 374, in run
    show_lab(args,lab_states)
  File "/home/seb/code/netlab/netlab/netsim/cli/status.py", line 253, in show_lab
    fetch_node_status(lab_state,topology)
  File "/home/seb/code/netlab/netlab/netsim/cli/status.py", line 180, in fetch_node_status
    node_stat.status = wk_state.get('status','Unknown')
                       ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

```after
╰─❯ dnetlab status
Lab 3 in /home/seb/code/netlab/labs/extreme-dev
  status: 2026-03-28T00:11:48.012649+00:00: libvirt workload started
  provider(s): libvirt,clab

┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ node     ┃ device ┃ image           ┃ mgmt IPv4    ┃ connection       ┃ provider ┃ VM/container    ┃ status      ┃
┡━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ exos1    │ exos   │ vrnetlab/extre… │ 192.168.3.12 │ ansible.netcomm… │ clab     │ clab-ml-3-exos1 │ Unknown     │
├──────────┼────────┼─────────────────┼──────────────┼──────────────────┼──────────┼─────────────────┼─────────────┤
│ exos2    │ exos   │ netlab/exos:32… │ 192.168.3.13 │ ansible.netcomm… │ libvirt  │ ml-3_exos2      │ running     │
├──────────┼────────┼─────────────────┼──────────────┼──────────────────┼──────────┼─────────────────┼─────────────┤
│ exos3    │ exos   │ vrnetlab/extre… │ 192.168.3.14 │ ansible.netcomm… │ clab     │ clab-ml-3-exos3 │ Unknown     │
├──────────┼────────┼─────────────────┼──────────────┼──────────────────┼──────────┼─────────────────┼─────────────┤
│ exos4    │ exos   │ netlab/exos:32… │ 192.168.3.15 │ ansible.netcomm… │ libvirt  │ ml-3_exos4      │ running     │
├──────────┼────────┼─────────────────┼──────────────┼──────────────────┼──────────┼─────────────────┼─────────────
```