### PR TITLE
Fix: Remove extra parameter in EXOS OSPFv2 timer configuration

### DIFF
--- a/netsim/ansible/templates/ospf/exos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/exos.ospfv2.j2
@@ -25,7 +25,7 @@ configure ospf vlan {{ vlan_name }} cost {{ l.ospf.cost }}
 configure ospf vlan {{ vlan_name }} priority {{ l.ospf.priority }}
 {%     endif %}
 {%     if l.ospf.timers.hello is defined and l.ospf.timers.dead is defined %}
-configure ospf vlan {{ vlan_name }} timer 5 1 {{ l.ospf.timers.hello }} {{ l.ospf.timers.dead }} 0
+configure ospf vlan {{ vlan_name }} timer 5 1 {{ l.ospf.timers.hello }} {{ l.ospf.timers.dead }}
 {%     endif %}
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
The fifth parameter in the 'configure ospf vlan timer' command should be positive (the template value is zero) on SW release 33.1.1.31

The parameter seems to be optional, so it might be better to remove it?

Closes #3253