### PR TITLE
Split module support tables into groups and multiple tables

### DIFF
--- a/netsim/cli/show/modules.py
+++ b/netsim/cli/show/modules.py
@@ -9,7 +9,7 @@ import typing
 from box import Box
 
 from ... import data
-from ...utils import strings
+from ...utils import log, strings
 from .. import error_and_exit
 from .utils import DEVICES_TO_SKIP, get_modlist, parser_add_module, show_common_parser, split_table
 
@@ -105,6 +105,19 @@ def device_module_feature_row(
     rows.append(row)
   return has_feature and add_empty
 
+# The core "show_feature_table" processing displays a table of features
+# supported by netlab platforms. The table is limited to selected features
+# (feature_list), selected devices (dev_list) and potentially uses category-
+# specific feature names (features).
+#
+# The final flag (show_notes) controls whether the "some devices support no
+# extra features" text is printed. The default (true) is used for non-category
+# features and the core category (category with '_title' set to none).
+#
+# Finally, the function splits the table into multiple tables when it has to
+# display more than args.columns features and recursively calls itself to
+# generate the split tables
+#
 def show_feature_table(
       settings: Box,
       feature_list: list,
@@ -113,12 +126,12 @@ def show_feature_table(
       features: typing.Optional[dict] = None,
       show_notes: bool = True) -> None:
   m = args.module
-  if len(feature_list) > args.columns:
+  if len(feature_list) > args.columns:            # Do we need to generate multiple tables?
     for cnt,feature_cols in enumerate(split_table(feature_list,args.columns)):
-      if cnt:
+      if cnt:                                     # Empty line between tables
         print()
       show_feature_table(settings,feature_cols,args,dev_list,features,show_notes)
-      show_notes=False
+      show_notes=False                            # Do not show notes after the first table
     return
 
   heading = ['device']
@@ -158,6 +171,13 @@ Notes:
   for f in heading[1:]:
     print(f"* {f}: {features[f]}")
 
+# The top-level "show features table" function splits feature categories from
+# regular features, iterates over categories (printing title and showing category
+# table), and finally prints regular features table.
+#
+# The "show notes" which displays "some devices support no features" note is set
+# to True only when the category title is None (indicating "core" features
+#
 def show_module_features(settings: Box, args: argparse.Namespace,dev_list: list) -> None:
   m = args.module
   mod_features = settings[m].features
@@ -190,9 +210,19 @@ def show(settings: Box, args: argparse.Namespace) -> None:
   else:
     mod_list = get_modlist(settings,args)
 
+  if args.columns < 2 or args.columns > 20:
+    log.info('The value of --columns flag should be between 2 and 20. Using default value (7)')
+    args.columns = 7
+
   result = data.get_empty_box()
 
+  # When the user specifies the --feature flag, we have to unroll the categories features
+  # into a flat list, use the flat list to check the feature value (or generate a list of
+  # features) and limit the printout to the selected feature
+  #
   if args.feature:
+    if not args.module:
+      log.fatal('The --feature flag can be used only with the --module flag')
     flat_features = get_module_flat_features(settings[args.module].features)
     if not args.module:
       error_and_exit('The --feature parameter is only valid with the --module parameter')

--- a/netsim/cli/show/modules.py
+++ b/netsim/cli/show/modules.py
@@ -138,6 +138,9 @@ Notes:
   print("Feature legend:")
   if not features:
     features = settings[m].features
+  if not features:
+    return
+
   for f in heading[1:]:
     print(f"* {f}: {features[f]}")
 

--- a/netsim/cli/show/modules.py
+++ b/netsim/cli/show/modules.py
@@ -27,6 +27,7 @@ def parse() -> argparse.ArgumentParser:
     dest='columns',
     action='store',
     default=7,
+    type=int,
     help='Maximum number of columns in the feature table(s)')
   return parser
 
@@ -41,6 +42,19 @@ def get_feature_list(features: dict,prefix: str = '') -> list:
       f_list.append(prefix+k)
 
   return f_list
+
+def get_module_flat_features(features: Box, prefix: str = '', path: str = '', f_dict: dict = {}) -> dict:
+  for k,v in features.items():
+    if k == '_title':
+      continue
+    if not isinstance(v,Box):
+      f_dict[prefix+k] = {'path': path + k, 'name': v }
+    elif '_title' in v:
+      get_module_flat_features(v,prefix,path+k+'.',f_dict)
+    else:
+      get_module_flat_features(v,prefix+k+'.',path+k+'.',f_dict)
+
+  return f_dict
 
 def device_module_feature_row(
       settings: Box, *,
@@ -179,16 +193,18 @@ def show(settings: Box, args: argparse.Namespace) -> None:
   result = data.get_empty_box()
 
   if args.feature:
+    flat_features = get_module_flat_features(settings[args.module].features)
     if not args.module:
       error_and_exit('The --feature parameter is only valid with the --module parameter')
-    if args.feature not in settings[args.module].features:
+    if args.feature not in flat_features:
+      f_list = [ f"* {k}: {flat_features[k]['name']}" for k in sorted(flat_features.keys())]
       error_and_exit(
         f'Module {args.module} does not have feature {args.feature}',
-        more_hints=f'Use "netlab show defaults {args.module}.features" to display valid device features')
+        more_hints=[f'Valid {args.module} features are:\n']+f_list)
 
     # Remove all other features from the module feature list to display just the selected feature
     #
-    f = settings[args.module].features[args.feature]
+    f = settings[args.module].features[flat_features[args.feature]['path']]
     settings[args.module].features = { args.feature: f }
 
   if args.format == 'table':

--- a/netsim/cli/show/modules.py
+++ b/netsim/cli/show/modules.py
@@ -11,7 +11,7 @@ from box import Box
 from ... import data
 from ...utils import strings
 from .. import error_and_exit
-from .utils import DEVICES_TO_SKIP, get_modlist, parser_add_module, show_common_parser
+from .utils import DEVICES_TO_SKIP, get_modlist, parser_add_module, show_common_parser, split_table
 
 
 def parse() -> argparse.ArgumentParser:
@@ -22,11 +22,19 @@ def parse() -> argparse.ArgumentParser:
     dest='feature',
     action='store',
     help='Display information for a single feature of the selected module')
+  parser.add_argument(
+    '--columns',
+    dest='columns',
+    action='store',
+    default=7,
+    help='Maximum number of columns in the feature table(s)')
   return parser
 
-def get_feature_list(features: Box,prefix: str = '') -> list:
+def get_feature_list(features: dict,prefix: str = '') -> list:
   f_list = []
   for k in features.keys():
+    if k == '_title':
+      continue
     if isinstance(features[k],dict):
       f_list.extend(get_feature_list(features[k],k+'.'))
     else:
@@ -40,7 +48,8 @@ def device_module_feature_row(
       heading: list,
       device: str,
       module: str,
-      provider: typing.Optional[str]) -> bool:
+      provider: typing.Optional[str] = None,
+      add_empty: bool = True) -> bool:
 
   d_data = settings.devices[device]
   if provider:
@@ -78,32 +87,48 @@ def device_module_feature_row(
     value = value.center(len(f))
     row.append(value)
 
-  rows.append(row)
-  return has_feature
+  if has_feature or add_empty:
+    rows.append(row)
+  return has_feature and add_empty
 
-def show_module_features(settings: Box, args: argparse.Namespace,dev_list: list) -> None:
+def show_feature_table(
+      settings: Box,
+      feature_list: list,
+      args: argparse.Namespace,
+      dev_list: list,
+      features: typing.Optional[dict] = None,
+      show_notes: bool = True) -> None:
   m = args.module
+  if len(feature_list) > args.columns:
+    for cnt,feature_cols in enumerate(split_table(feature_list,args.columns)):
+      if cnt:
+        print()
+      show_feature_table(settings,feature_cols,args,dev_list,features,show_notes)
+      show_notes=False
+    return
+
   heading = ['device']
-  heading.extend(get_feature_list(settings[m].features))
+  heading.extend(feature_list)
   providers = settings.providers.keys()
 
   rows: list = []
   need_notes = False
-
   for d in sorted(dev_list):
     if d in DEVICES_TO_SKIP:
       continue
 
-    if not device_module_feature_row(settings,rows=rows,heading=heading,device=d,module=m,provider=None):
+    if not device_module_feature_row(
+              settings,rows=rows,heading=heading,device=d,module=m,provider=None,add_empty=show_notes):
       need_notes = True
 
     for p_name in providers:
-      if not device_module_feature_row(settings,rows=rows,heading=heading,device=d,module=m,provider=p_name):
+      if not device_module_feature_row(
+              settings,rows=rows,heading=heading,device=d,module=m,provider=p_name,add_empty=show_notes):
         need_notes = True
 
   strings.print_table(heading,rows)
 
-  if need_notes:
+  if need_notes and show_notes:
     print(f"""
 Notes:
 * All devices listed in the table support {m} configuration module.
@@ -111,8 +136,36 @@ Notes:
     
   print("")
   print("Feature legend:")
+  if not features:
+    features = settings[m].features
   for f in heading[1:]:
-    print(f"* {f}: {settings[m].features[f]}")
+    print(f"* {f}: {features[f]}")
+
+def show_module_features(settings: Box, args: argparse.Namespace,dev_list: list) -> None:
+  m = args.module
+  mod_features = settings[m].features
+  categories = [ cname for cname,cdata in mod_features.items()
+                    if isinstance(cdata,Box) and '_title' in cdata ]
+  features = { k:v for k,v in mod_features.items() if k not in categories }
+
+  for cname in categories:
+    cdata = mod_features[cname]
+    sub_category = bool(cdata.get('_title',None))
+    if sub_category:
+      print("\n")
+      strings.print_colored_text(cdata._title,"bold")
+      print("\n")
+
+    show_feature_table(
+      settings,
+      feature_list=get_feature_list(cdata),
+      args=args,
+      dev_list=dev_list,
+      features=cdata,
+      show_notes=not sub_category)
+
+  if features:
+    show_feature_table(settings,get_feature_list(features),args,dev_list)
 
 def show(settings: Box, args: argparse.Namespace) -> None:
   if args.module == 'initial':

--- a/netsim/cli/show/utils.py
+++ b/netsim/cli/show/utils.py
@@ -66,17 +66,29 @@ def get_modlist(settings: Box, args: argparse.Namespace) -> list:
     
   return sorted([ m for m in settings.keys() if 'supported_on' in settings[m]])
 
+# The "split_table" function is a generator that yields subsets of table headings
+# no longer than max_column. It returns:
+#
+# * A single entry when the input list short enough
+# * A sequence of balanced entries for longer lists
+#
 def split_table(f_list: list, max_column: int) -> typing.Generator:
   fl_len = len(f_list)
   if fl_len <= max_column:
     yield(f_list)
     return
 
+  # Calculate the number of tables we need and the number of columns in each
+  # table. The number of tables is easy to calculate (we need at least
+  # list_len/columns tables), the number of columns is unchanged when it cleanly
+  # divides the list length (just in case to avoid floating point errors),
+  # otherwise it's rounded up from the average number of columns per table.
+  #
   num_tables = math.ceil(fl_len/max_column)
   cols = max_column if fl_len % max_column == 0 else math.floor(fl_len / num_tables)
-  while f_list:
-    cols = min(cols,len(f_list))
-    yield(f_list[:cols])
-    f_list = f_list[cols:]
+  while f_list:                                   # More work to do?
+    cols = min(cols,len(f_list))                  # Return at most "cols" columns
+    yield(f_list[:cols])                          # (note: the "cols" value changes only on last iteration)
+    f_list = f_list[cols:]                        # ... and shorten the input list
 
   return

--- a/netsim/cli/show/utils.py
+++ b/netsim/cli/show/utils.py
@@ -3,6 +3,7 @@
 #
 
 import argparse
+import math
 import typing
 
 from box import Box
@@ -64,3 +65,18 @@ def get_modlist(settings: Box, args: argparse.Namespace) -> list:
       log.fatal(f'Unknown module: {args.module}')
     
   return sorted([ m for m in settings.keys() if 'supported_on' in settings[m]])
+
+def split_table(f_list: list, max_column: int) -> typing.Generator:
+  fl_len = len(f_list)
+  if fl_len <= max_column:
+    yield(f_list)
+    return
+
+  num_tables = math.ceil(fl_len/max_column)
+  cols = max_column if fl_len % max_column == 0 else math.floor(fl_len / num_tables)
+  while f_list:
+    cols = min(cols,len(f_list))
+    yield(f_list[:cols])
+    f_list = f_list[cols:]
+
+  return

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -131,9 +131,9 @@ features:
     advertise: Can advertise IGP prefixes
     local_as: Supports local-as functionality
     vrf_local_as: Supports local-as within a VRF
-    local_as_ibgp: Can use local-as to create IBGP sesssion
+    local_as_ibgp: Can use local-as to create IBGP sesssions
     ipv6_lla: Can run EBGP sessions over IPv6 link-local addresses
-    rfc8950: Can run IPv4 AF over regular IPv6 EBGP session
+    rfc8950: Can run IPv4 AF over regular IPv6 EBGP sessions
     community: Granular BGP community propagation
     confederation: BGP confederations
     import: Import routes from other routing protocols

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -125,15 +125,39 @@ attributes:
         type: list
         _subtype: str
 features:
-  local_as: Supports local-as functionality
-  vrf_local_as: Supports local-as within a VRF
-  local_as_ibgp: Can use local-as to create IBGP sesssion
-  activate_af: Can control activation of individual address families
-  ipv6_lla: Can run EBGP sessions over IPv6 link-local addresses
-  rfc8950: Can run IPv4 AF over regular IPv6 EBGP session
-  community: Granular BGP community propagation
-  confederation: BGP confederations
-  import: Import routes from other routing protocols
+  core:
+    _title:
+    activate_af: Can control activation of individual address families
+    advertise: Can advertise IGP prefixes
+    local_as: Supports local-as functionality
+    vrf_local_as: Supports local-as within a VRF
+    local_as_ibgp: Can use local-as to create IBGP sesssion
+    ipv6_lla: Can run EBGP sessions over IPv6 link-local addresses
+    rfc8950: Can run IPv4 AF over regular IPv6 EBGP session
+    community: Granular BGP community propagation
+    confederation: BGP confederations
+    import: Import routes from other routing protocols
+  session:
+    _title: BGP session parameters
+    allowas_in: Allow own AS in incoming AS path (allowas in)
+    as_override: Override AS in AS path
+    bfd: Use BFD to detect BGP neighbor failure
+    default_originate: Originate per-neighbor default route
+    description: Use "description" attribute
+    gtsm: Supports GTSM
+    passive: Supports passive BGP peers
+    password: Supports MD5 passwords
+    remove_private_as: Can remove private AS from AS path
+    rs: Can be a BGP route server
+    rs_client: Can be a client of a BGP route server
+    timers: Can configure BGP timers
+    tcp_ao: Supports TCP-AO session protection
+    multihop: Supports EBGP multihop sessions
+  policy:
+    _title: BGP policy parameters
+    _default_locpref: Device-wide local preference
+    aggregate: BGP route aggregation
+    bandwidth: Support BGP DMZ bandwidth
 warnings:
   missing_igp: True
   igp_list: [ ospf, eigrp, isis, ripv2 ]

--- a/netsim/modules/sr.yml
+++ b/netsim/modules/sr.yml
@@ -54,3 +54,4 @@ attributes:
 
 features:
   af: Address family support
+  protocol: Supported routing protocols


### PR DESCRIPTION
The module support tables became way too large. This PR:

* Splits the support tables into multiple tables when the number of features exceeds the maximum number of columns (default: 7)
* Display features in groups when configured in the module 'features' dictionary (example: bgp)