### PR TITLE
Set bgp.advertise feature flag for Junos, Cumulus and SoNIC

### DIFF
--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -56,9 +56,10 @@ features:
       lla: True
   bfd: True
   bgp:
+    activate_af: True
+    advertise: True
     ipv6_lla: True
     rfc8950: true
-    activate_af: True
     local_as: True
     vrf_local_as: True
     import: [ ospf, ripv2, connected, static, vrf ]

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -24,6 +24,7 @@ features:
   bfd: true
   bgp:
     activate_af: true
+    advertise: true
     local_as: true
     local_as_ibgp: true
     vrf_local_as: true

--- a/netsim/devices/sonic.yml
+++ b/netsim/devices/sonic.yml
@@ -30,6 +30,7 @@ features:
     reload: false
   bgp:
     activate_af: true
+    advertise: true
     ipv6_lla: true
     local_as: true
     local_as_ibgp: true


### PR DESCRIPTION
Junos has bgp.advertise implemented for global routing table, but not for VRFs (where it uses fixed redistribution). Cumulus and SoNIC use FRR template, so they have it working anyway.