### PR TITLE
Fix: Change Junos global routing instance policy names

### DIFF
--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -10,3 +10,41 @@
 {%     endif %}
 {%   endfor %}
 {%- endmacro %}
+{#
+   Macro to create the per-routing-instance advertise prefix lists
+#}
+{% macro advertise_list(bgp,vname) %}
+{%   for bgp_af in af %}
+{%     for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
+{%       if loop.first %}
+  route-filter-list bgp-{{ vname }}-announce-{{ bgp_af }} {
+{%       endif %}
+    {{ pfx[bgp_af] }} exact;
+{%       if loop.last %}
+  }
+{%       endif %}
+{%     endfor %}
+{%   endfor %}
+{% endmacro +%}
+{#
+   Macro to create per-routing-instance advertise policy
+#}
+{% macro advertise_policy(bgp,vname) %}
+  policy-statement bgp-default-advertise {
+{%   for bgp_af in af %}
+{%     for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
+{%       if loop.first %}
+    term advertise-{{ bgp_af }} {
+      from {
+        route-filter-list bgp-default-announce-{{ bgp_af }};
+      }
+      then {
+        community add x-route-permit-mark;
+        next policy;
+      }
+    }
+{%      endif %}
+{%     endfor %}
+{%   endfor %}
+  }
+{% endmacro +%}

--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -14,7 +14,7 @@
    Macro to create the per-routing-instance advertise prefix lists
 #}
 {% macro advertise_list(bgp,vname) %}
-{%   for bgp_af in af %}
+{%   for bgp_af in ['ipv4','ipv6'] %}
 {%     for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
 {%       if loop.first %}
   route-filter-list bgp-{{ vname }}-announce-{{ bgp_af }} {
@@ -30,13 +30,13 @@
    Macro to create per-routing-instance advertise policy
 #}
 {% macro advertise_policy(bgp,vname) %}
-  policy-statement bgp-default-advertise {
+  policy-statement bgp-{{ vname }}-advertise {
 {%   for bgp_af in af %}
 {%     for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
 {%       if loop.first %}
     term advertise-{{ bgp_af }} {
       from {
-        route-filter-list bgp-default-announce-{{ bgp_af }};
+        route-filter-list bgp-{{ vname }}-announce-{{ bgp_af }};
       }
       then {
         community add x-route-permit-mark;

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -1,3 +1,4 @@
+{% import "junos.macro.j2" as bgpcfg with context %}
 {# initialize default policies #}
 
 {# internal community to handle policy flows #}
@@ -15,8 +16,8 @@
 policy-options community x-route-permit-mark members large:65535:0:65536;
 
 policy-options {
-  delete: policy-statement bgp-advertise;
-  delete: policy-statement bgp-redistribute;
+  delete: policy-statement bgp-default-advertise;
+  delete: policy-statement bgp-default-redistribute;
 {% for af in ['ipv4','ipv6'] %}
 {%   for nhs_type in ['ebgp','all'] %}
   delete: policy-statement next-hop-{{ nhs_type }}-{{ af }};
@@ -27,18 +28,8 @@ policy-options {
 
 policy-options {
 
-{% for bgp_af in af %}
-{%   for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
-{%     if loop.first %}
-  route-filter-list bgp-announce-{{ bgp_af }} {
-{%     endif %}
-    {{ pfx[bgp_af] }} exact;
-{%     if loop.last %}
-  }
-{%     endif %}
-{%   endfor %}
-{% endfor %}
-
+{{ bgpcfg.advertise_list(bgp,'default') }}
+{{ bgpcfg.advertise_policy(bgp,'default') }}
 {% for af in ('ipv4','ipv6') %}
 {%   for nh in ['ebgp','all'] %}
   policy-statement next-hop-{{ nh }}-{{ af }} {
@@ -54,29 +45,9 @@ policy-options {
       }
     }
   }
-
 {%   endfor %}
 {% endfor %}
-
-  policy-statement bgp-advertise {
-{% for bgp_af in af %}
-{%   for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
-{%     if loop.first %}
-    term advertise-{{ bgp_af }} {
-      from {
-        route-filter-list bgp-announce-{{ bgp_af }};
-      }
-      then {
-        community add x-route-permit-mark;
-        next policy;
-      }
-    }
-{%    endif %}
-{%   endfor %}
-{% endfor %}
-  }
-
-  policy-statement bgp-redistribute {
+  policy-statement bgp-default-redistribute {
     term redis_bgp {
       from protocol bgp;
       then {

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -23,7 +23,7 @@ policy-options {
   delete: policy-statement next-hop-{{ nhs_type }}-{{ af }};
 {%   endfor %}
 {% endfor %}
-  delete: route-filter-list bgp-announce;
+  delete: route-filter-list bgp-default-announce;
 }
 
 policy-options {

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -19,9 +19,9 @@ JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH = 22
 # constants used in BGP Policies
 JUNOS_POLICY_NHS = 'next-hop-{ next_hop_self }-{ af }'
 JUNOS_POLICY_DEFAULT_ORIGINATE = 'bgp-default-route'
-JUNOS_COMMON_BGP_POLICIES = [
-  'bgp-advertise',
-  'bgp-redistribute',
+JUNOS_GLOBAL_BGP_POLICIES = [
+  'bgp-default-advertise',
+  'bgp-default-redistribute',
 ]
 JUNOS_POLICY_LAST = 'bgp-final'
 JUNOS_POLICY_IN_CLEANUP = 'bgp-initial'
@@ -290,7 +290,7 @@ def _bgp_neigh_export_policy_chain_build(neigh: Box, default: list, vrf_name: st
   if vrf_name:
     neigh_policy.append(JUNOS_POLICY_VRF_EXPORT.format(vrf_name))
   else:
-    neigh_policy.extend(JUNOS_COMMON_BGP_POLICIES)
+    neigh_policy.extend(JUNOS_GLOBAL_BGP_POLICIES)
   
   if neigh.get('default_originate', False):
     neigh_policy.append(JUNOS_POLICY_DEFAULT_ORIGINATE)
@@ -346,7 +346,7 @@ def build_bgp_import_export_policy_chain(node: Box, topology: Box) -> None:
       policy_name = strings.eval_format(JUNOS_POLICY_NHS,{ 'next_hop_self': 'ebgp', 'af': af })
       node.bgp._junos_policy.ibgp.append(policy_name)
 
-  node.bgp._junos_policy.export.extend(JUNOS_COMMON_BGP_POLICIES)
+  node.bgp._junos_policy.export.extend(JUNOS_GLOBAL_BGP_POLICIES)
   node.bgp._junos_policy.export.append(JUNOS_POLICY_LAST)
   def_policy = node.bgp._junos_policy.ibgp + node.bgp._junos_policy.export
   # - per neighbor policies


### PR DESCRIPTION
The names of the global routing instance policies include the 'vrf' name (default) to make shared macros applicable across all VRFs.