### PR TITLE
Fix: Use standard Junos interface names for cRPD loopbacks

### DIFF
--- a/netsim/devices/crpd.yml
+++ b/netsim/devices/crpd.yml
@@ -13,7 +13,7 @@ group_vars:
 
 mgmt_if: eth0
 interface_name: eth{ifindex+1}
-#loopback_interface_name: "lo0"
+#loopback_interface_name: "lo0" -- this was set in initial cRPD implementation, now it inherits Junos default
 mtu: 1500
 
 features:

--- a/netsim/devices/crpd.yml
+++ b/netsim/devices/crpd.yml
@@ -13,7 +13,7 @@ group_vars:
 
 mgmt_if: eth0
 interface_name: eth{ifindex+1}
-loopback_interface_name: "lo0"
+#loopback_interface_name: "lo0"
 mtu: 1500
 
 features:


### PR DESCRIPTION
I have no idea why we decided to hard-code the cRPD loopback to "lo0", but it doesn't work well.