### PR TITLE
Fix: Merge Junos BGP advertise and propagate policies

### DIFF
--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -29,8 +29,7 @@
 {#
    Macro to create per-routing-instance advertise policy
 #}
-{% macro advertise_policy(bgp,vname) %}
-  policy-statement bgp-{{ vname }}-advertise {
+{% macro advertise_terms(bgp,vname) %}
 {%   for bgp_af in af %}
 {%     for pfx in bgp.advertise|default([]) if bgp_af in pfx %}
 {%       if loop.first %}
@@ -46,5 +45,4 @@
 {%      endif %}
 {%     endfor %}
 {%   endfor %}
-  }
 {% endmacro +%}

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -92,8 +92,7 @@ policy-options {
         route-filter 0.0.0.0/0 exact;
       }
       then {
-        community add x-route-permit-mark;
-        next policy;
+        accept;
       }
     }
     term default-route-v6 {
@@ -101,8 +100,7 @@ policy-options {
         route-filter ::/0 exact;
       }
       then {
-        community add x-route-permit-mark;
-        next policy;
+        accept;
       }
     }
   }

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -29,7 +29,21 @@ policy-options {
 policy-options {
 
 {{ bgpcfg.advertise_list(bgp,'default') }}
-{{ bgpcfg.advertise_policy(bgp,'default') }}
+
+  policy-statement bgp-default-redistribute {
+{{ bgpcfg.advertise_terms(bgp,'default') }}
+    term redis_bgp {
+      from protocol bgp;
+      then {
+        community add x-route-permit-mark;
+        next policy;
+      }
+    }
+    term default {
+      then reject;
+    }
+  }
+
 {% for af in ('ipv4','ipv6') %}
 {%   for nh in ['ebgp','all'] %}
   policy-statement next-hop-{{ nh }}-{{ af }} {
@@ -47,15 +61,6 @@ policy-options {
   }
 {%   endfor %}
 {% endfor %}
-  policy-statement bgp-default-redistribute {
-    term redis_bgp {
-      from protocol bgp;
-      then {
-        community add x-route-permit-mark;
-        next policy;
-      }
-    }
-  }
 
   policy-statement bgp-final {
     term final-option {

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -286,14 +286,15 @@ def _bgp_neigh_export_policy_chain_build(neigh: Box, default: list, vrf_name: st
         neigh_policy.append(policy_name)
         need_to_have_neigh_policy = True
   
+  if neigh.get('default_originate', False):
+    neigh_policy.append(JUNOS_POLICY_DEFAULT_ORIGINATE)
+    need_to_have_neigh_policy = True
+
   if vrf_name:
     neigh_policy.append(JUNOS_POLICY_VRF_EXPORT.format(vrf_name))
   else:
     neigh_policy.extend(JUNOS_GLOBAL_BGP_POLICIES)
   
-  if neigh.get('default_originate', False):
-    neigh_policy.append(JUNOS_POLICY_DEFAULT_ORIGINATE)
-    need_to_have_neigh_policy = True
   custom_policy = neigh.get('policy.out', '')
   if custom_policy:
     neigh_policy.append(custom_policy)

--- a/netsim/devices/junos.py
+++ b/netsim/devices/junos.py
@@ -20,7 +20,6 @@ JUNOS_MTU_FLEX_VLAN_HEADER_LENGTH = 22
 JUNOS_POLICY_NHS = 'next-hop-{ next_hop_self }-{ af }'
 JUNOS_POLICY_DEFAULT_ORIGINATE = 'bgp-default-route'
 JUNOS_GLOBAL_BGP_POLICIES = [
-  'bgp-default-advertise',
   'bgp-default-redistribute',
 ]
 JUNOS_POLICY_LAST = 'bgp-final'


### PR DESCRIPTION
Junos uses a chain of routing policies to implement the typical set of operations (redistribute, advertise, neighbor route map). The initial implementation used a separate policy for local network advertisements and a different one for propagation of BGP routes. None of those policies contained a 'reject' clause, causing all unmatched routes to 'fall through'.

That worked well until you added a 'real' neighbor routing policy which could match ALL routes from the IP routing table (due to the previous 'fall through' effect).

This commit merges the advertise- and propagate policies and rejects anything that is not matched, resulting in a clean local BGP table. It also establishes a framework for a clean route redistribution.