### PR TITLE
Fix: rearrange search list components for provider-related templates

### DIFF
--- a/netsim/utils/templates.py
+++ b/netsim/utils/templates.py
@@ -175,8 +175,9 @@ def config_template_paths(
     path_suffix = [ fname ]
   else:
     path_suffix = [ node.device ]
-    path_prefix = [ provider_path ] if provider_path else []
+    path_prefix = []
     path_prefix += topology.defaults.paths.templates.dirs
+    path_prefix += [ provider_path ] if provider_path else []
     path_prefix += [ str(get_moddir() / 'ansible') ]
 
     if node.get('_daemon',False):


### PR DESCRIPTION
The generic 'config_template_paths' function added the provider path as the first entry in the search list, effectively disabling custom templates overriding standard provider templates.

This fix adds the provider template path after the generic search path components, making it the location of last resort.

Fixes #3198