### PR TITLE
Use 'vrf_check' plugin on OSPF area parameter integration tests

### DIFF
--- a/tests/integration/ospf/ospfv2/40-area-parameters.yml
+++ b/tests/integration/ospf/ospfv2/40-area-parameters.yml
@@ -12,7 +12,7 @@ message: |
 
 defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
 
-plugin: [ ospf.areas ]
+plugin: [ ospf.areas, test.vrf_check ]
 module: [ ospf ]
 
 ospf.areas:
@@ -65,6 +65,7 @@ vrfs:
 nodes:
   dut:
     module: [ ospf, vrf ]
+    role: router
     vrfs:
       tenant:
         ospf.router_id: 10.1.0.1
@@ -116,6 +117,11 @@ links:
 defaults.devices.vptx.netlab_validate.default.wait: 30
 
 validate:
+  reset:
+    description: Reset OSPF processes
+    nodes: [ r11, r12, r21, r22 ]
+    exec.frr: >-
+      vtysh -c 'clear ip ospf process'
   adj:
     description: Check OSPF adjacencies
     wait: ospfv2_adj_p2p

--- a/tests/integration/ospf/ospfv3/40-area-parameters.yml
+++ b/tests/integration/ospf/ospfv3/40-area-parameters.yml
@@ -11,7 +11,7 @@ message: |
   * Configuration of VRF instances
 
 defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
-plugin: [ ospf.areas ]
+plugin: [ ospf.areas, test.vrf_check ]
 module: [ ospf ]
 addressing.loopback.prefix6: 128
 
@@ -63,6 +63,7 @@ vrfs:
 nodes:
   dut:
     module: [ ospf, vrf ]
+    role: router
     id: 1
     vrfs:
       tenant:

--- a/tests/integration/warnings.yml
+++ b/tests/integration/warnings.yml
@@ -7,3 +7,6 @@ devices:
 
 warnings:
   providers.change: False
+
+ospf:
+  warnings.inactive: False


### PR DESCRIPTION
Also:
* Disable 'no OSPF interfaces on this node' warning
* Reset IPv4 OSPF adjacencies before starting the validation due to a Bird quirk :(