### PR TITLE
Fix: Handle node routing policies referring to missing global policies

### DIFF
--- a/netsim/modules/routing/normalize.py
+++ b/netsim/modules/routing/normalize.py
@@ -110,6 +110,7 @@ def import_routing_object(
         f'Global routing {o_name} {pname} referenced in node {node.name} does not exist',
         category=log.MissingValue,
         module='routing')
+      node.routing[o_name].pop(pname,None)
       return None
 
     node.routing[o_name][pname] = topo_pdata[pname]         # Otherwise, copy global policy to node policy

--- a/netsim/modules/routing/policy.py
+++ b/netsim/modules/routing/policy.py
@@ -133,6 +133,8 @@ the attributes make sense.
 """
 def check_routing_policy(p_name: str,o_type: str, node: Box,topology: Box) -> bool:
   p_data = node.get(f'routing.policy.{p_name}',None)        # Use this convoluted getter in case we get called out of context
+  if p_data is None:
+    return False
   d_features = devices.get_device_features(node,topology.defaults)
   d_features = d_features.routing.policy                    # Get per-device routing policy features
 

--- a/tests/coverage/errors/routing-missing-global-object.log
+++ b/tests/coverage/errors/routing-missing-global-object.log
@@ -1,0 +1,5 @@
+MissingValue in routing: Global routing policy x referenced in node dut does not exist
+MissingValue in routing: Global routing prefix z referenced in node dut does not exist
+MissingValue in routing: Global routing aspath y referenced in node dut does not exist
+MissingValue in routing: Global routing community w referenced in node dut does not exist
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/routing-missing-global-object.yml
+++ b/tests/coverage/errors/routing-missing-global-object.yml
@@ -1,0 +1,14 @@
+provider: clab
+module: [ routing ]
+
+nodes:
+  dut:
+    device: frr
+    routing.policy:
+      x:
+    routing.aspath:
+      y:
+    routing.prefix:
+      z:
+    routing.community:
+      w:


### PR DESCRIPTION
If a node routing policy referred to a missing global routing policy, the policy check code crashed because it tried to work with a None value.

Fixed that, added one more safeguard, and a coverage test

Closes #3282