### PR TITLE
Fix: Use topology-level vxlan.use_v6_vtep attribute

### DIFF
--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -107,7 +107,7 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
       loopback_name = intf.ifname
       break
 
-  if topology.defaults.vxlan.use_v6_vtep:
+  if topology.get('vxlan.use_v6_vtep',False):
     vtep_af = 'ipv6'
     features = devices.get_device_features(node,topology.defaults)
     node.vxlan.transport = vtep_af
@@ -196,7 +196,6 @@ class VXLAN(_Module):
 
     if not 'use_v6_vtep' in topology.vxlan:                         # Copy IPv6 VTEP setting into global parameter
       topology.vxlan.use_v6_vtep = topology.defaults.vxlan.use_v6_vtep
-
     for name,ndata in topology.nodes.items():
       if not 'vxlan' in ndata.get('module',[]):                     # Skip nodes without VXLAN module
         continue

--- a/tests/integration/evpn/41-vxlan-ipv6-bridging.yml
+++ b/tests/integration/evpn/41-vxlan-ipv6-bridging.yml
@@ -22,7 +22,7 @@ addressing:
   p2p.ipv6: 2001:db8:1::/48
   p2p.ipv4: False
 
-defaults.vxlan.use_v6_vtep: true
+vxlan.use_v6_vtep: true
 
 module: [ vlan, vxlan, ospf, bgp, evpn ]
 

--- a/tests/integration/vxlan/07-vxlan-bridging-v6only.yml
+++ b/tests/integration/vxlan/07-vxlan-bridging-v6only.yml
@@ -12,7 +12,7 @@ message: |
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 plugin: [ fix_mtu ]
 
-defaults.vxlan.use_v6_vtep: true
+vxlan.use_v6_vtep: true
 
 groups:
   _auto_create: True

--- a/tests/topology/expected/evpn-l3vni-only.yml
+++ b/tests/topology/expected/evpn-l3vni-only.yml
@@ -27,15 +27,18 @@ links:
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.1/30
+    ipv6: true
     node: r1
   - ifindex: 1
     ifname: eth1
     ipv4: 10.1.0.2/30
+    ipv6: true
     node: r2
   linkindex: 1
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
+    ipv6: true
   type: p2p
 - _linkname: vrfs.red.links[1]
   bridge: input_2
@@ -77,10 +80,12 @@ nodes:
   r1:
     af:
       ipv4: true
+      ipv6: true
       vpnv4: true
     bgp:
       advertise:
       - ipv4: 10.0.0.1/32
+        ipv6: 2001:db8:cafe:1::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -93,19 +98,23 @@ nodes:
         - standard
         - extended
       ipv4: true
+      ipv6: true
       neighbors:
       - _source_intf:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.1/32
+          ipv6: 2001:db8:cafe:1::1/64
           neighbors: []
           type: loopback
           virtual_interface: true
         activate:
           ipv4: true
+          ipv6: true
         as: 65000
-        evpn: ipv4
+        evpn: ipv6
         ipv4: 10.0.0.2
+        ipv6: 2001:db8:cafe:2::1
         name: r2
         next_hop_self: ebgp
         type: ibgp
@@ -125,11 +134,13 @@ nodes:
     - ifindex: 1
       ifname: eth1
       ipv4: 10.1.0.1/30
+      ipv6: true
       linkindex: 1
       name: r1 -> r2
       neighbors:
       - ifname: eth1
         ipv4: 10.1.0.2/30
+        ipv6: true
         node: r2
       ospf:
         area: 0.0.0.0
@@ -154,6 +165,7 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.1/32
+      ipv6: 2001:db8:cafe:1::1/64
       neighbors: []
       ospf:
         area: 0.0.0.0
@@ -175,6 +187,7 @@ nodes:
     ospf:
       af:
         ipv4: true
+        ipv6: true
       area: 0.0.0.0
       areas:
       - _area_int: 0
@@ -210,15 +223,18 @@ nodes:
       flooding: evpn
       l3vnis:
       - red
-      vtep: 10.0.0.1
+      transport: ipv6
+      vtep: 2001:db8:cafe:1::1
       vtep_interface: Loopback0
   r2:
     af:
       ipv4: true
+      ipv6: true
       vpnv4: true
     bgp:
       advertise:
       - ipv4: 10.0.0.2/32
+        ipv6: 2001:db8:cafe:2::/64
       advertise_loopback: true
       as: 65000
       community:
@@ -231,19 +247,23 @@ nodes:
         - standard
         - extended
       ipv4: true
+      ipv6: true
       neighbors:
       - _source_intf:
           ifindex: 0
           ifname: Loopback0
           ipv4: 10.0.0.2/32
+          ipv6: 2001:db8:cafe:2::1/64
           neighbors: []
           type: loopback
           virtual_interface: true
         activate:
           ipv4: true
+          ipv6: true
         as: 65000
-        evpn: ipv4
+        evpn: ipv6
         ipv4: 10.0.0.1
+        ipv6: 2001:db8:cafe:1::1
         name: r1
         next_hop_self: ebgp
         type: ibgp
@@ -263,11 +283,13 @@ nodes:
     - ifindex: 1
       ifname: eth1
       ipv4: 10.1.0.2/30
+      ipv6: true
       linkindex: 1
       name: r2 -> r1
       neighbors:
       - ifname: eth1
         ipv4: 10.1.0.1/30
+        ipv6: true
         node: r1
       ospf:
         area: 0.0.0.0
@@ -292,6 +314,7 @@ nodes:
       ifindex: 0
       ifname: Loopback0
       ipv4: 10.0.0.2/32
+      ipv6: 2001:db8:cafe:2::1/64
       neighbors: []
       ospf:
         area: 0.0.0.0
@@ -313,6 +336,7 @@ nodes:
     ospf:
       af:
         ipv4: true
+        ipv6: true
       area: 0.0.0.0
       areas:
       - _area_int: 0
@@ -348,7 +372,8 @@ nodes:
       flooding: evpn
       l3vnis:
       - red
-      vtep: 10.0.0.2
+      transport: ipv6
+      vtep: 2001:db8:cafe:2::1
       vtep_interface: Loopback0
 ospf:
   area: 0.0.0.0
@@ -369,4 +394,4 @@ vrfs:
 vxlan:
   domain: global
   flooding: evpn
-  use_v6_vtep: false
+  use_v6_vtep: true

--- a/tests/topology/input/evpn-l3vni-only.yml
+++ b/tests/topology/input/evpn-l3vni-only.yml
@@ -2,6 +2,11 @@ defaults.device: none
 provider: clab
 module: [bgp, vlan, vxlan, vrf, evpn, ospf]
 
+addressing:
+  loopback.ipv6: 2001:db8:cafe::/48
+  p2p.ipv6: True
+vxlan.use_v6_vtep: True
+
 bgp.as: 65000
 
 vrfs:

--- a/tests/topology/input/vxlan-static.yml
+++ b/tests/topology/input/vxlan-static.yml
@@ -5,7 +5,7 @@ addressing:
   loopback.ipv6: 2001:db8:cafe::/48
   p2p.ipv6: True
 
-defaults.vxlan.use_v6_vtep: True
+vxlan.use_v6_vtep: True
 
 vlans:
   red:


### PR DESCRIPTION
The VXLAN module used defaults.vxlan.use_v6_vtep attribute instead of the topology-level one. This commit fixes that discrepancy but also:

* Changes the settings in IPv6 VXLAN and EVPN integration tests to ensure they are tested with the correct settings.
* Consistently uses correct settings in transformation tests
* Converts an EVPN integration test to use IPv6 VXLAN transport

Closes #3265