### PR TITLE
Fix: Enable EVPN on IPv6 BGP sessions on control-plane-only nodes

### DIFF
--- a/netsim/modules/evpn.py
+++ b/netsim/modules/evpn.py
@@ -48,18 +48,21 @@ def validate_evpn_lists(toponode: Box, obj_path: str, topology: Box, create: boo
 
 def get_evpn_af(node: Box, topology: Box) -> typing.Optional[str]:
   evpn_transport = node.get('evpn.transport','vxlan')
-  if evpn_transport == 'vxlan':                   # For VXLAN transport
-    evpn_af = node.get('vxlan.transport','ipv4')  # Check the transport address family
-    if evpn_af == 'ipv6':                         # ... and enable EVPN over corresponding BGP session
-      features = devices.get_device_features(node,topology.defaults)
-      if not features.evpn.ipv6:                  # ... but only if the device supports it
-        log.error(
-          f'node {node.name}/device {node.device} cannot use EVPN with IPv6 next hops',
-          more_hints=['The node is using VXLAN-over-IPv6 transport, but does not support EVPN over IPv6'],
-          category=log.IncorrectValue)
-        return None
-  else:                                           # For MPLS transport
-    evpn_af = 'ipv4'                              # ... assume we're using IPv4 with LDP
+  if evpn_transport != 'vxlan':                   # Are we using VXLAN transport?
+    return 'ipv4'                                 # No, assume IPv4 next hops for MPLS/LDP and SR-MPLS transport
+
+  if 'vxlan.transport' in node:                   # Data-plane node with VXLAN module?
+    evpn_af = node.vxlan.transport
+  else:                                           # Otherwise figure out the AF from topology settings
+    evpn_af = 'ipv6' if topology.get('vxlan.use_v6_vtep',False) else 'ipv4'
+  if evpn_af == 'ipv6':                           # Enable EVPN over IPv6 BGP sessions
+    features = devices.get_device_features(node,topology.defaults)
+    if not features.evpn.ipv6:                    # ... only if the device supports it
+      log.error(
+        f'node {node.name}/device {node.device} cannot use EVPN with IPv6 next hops',
+        more_hints=['The node is using VXLAN-over-IPv6 transport, but does not support EVPN over IPv6'],
+        category=log.IncorrectValue)
+      return None
 
   return evpn_af
 

--- a/netsim/modules/vxlan.py
+++ b/netsim/modules/vxlan.py
@@ -110,7 +110,6 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
   if topology.get('vxlan.use_v6_vtep',False):
     vtep_af = 'ipv6'
     features = devices.get_device_features(node,topology.defaults)
-    node.vxlan.transport = vtep_af
     if not features.get('vxlan.vtep6'):
       log.error(
         f'Device {node.device} (node {node.name}) does not support VXLAN over IPv6',
@@ -119,6 +118,8 @@ def node_set_vtep(node: Box, topology: Box) -> bool:
       return False
   else:
     vtep_af = 'ipv4'
+
+  node.vxlan.transport = vtep_af
 
   if not vtep_af in vtep_interface:
     log.error(

--- a/tests/integration/evpn/41-vxlan-ipv6-bridging.yml
+++ b/tests/integration/evpn/41-vxlan-ipv6-bridging.yml
@@ -88,16 +88,16 @@ validate:
     wait_msg: Waiting for IBGP session
     plugin: bgp_neighbor(node.bgp.neighbors,'s2',af='ipv6')
 
-#  evpn_adj_s1:
-#    description: Check EVPN AF on IBGP adjacencies with S1
-#    nodes: [ probe ]
-#    plugin: bgp_neighbor(node.bgp.neighbors,'s1',activate='evpn',af='ipv6')
-#    stop_on_error: True
-#  evpn_adj_s2:
-#    description: Check EVPN AF on IBGP adjacencies with S2
-#    nodes: [ probe ]
-#    plugin: bgp_neighbor(node.bgp.neighbors,'s2',activate='evpn',af='ipv6')
-#    stop_on_error: True
+  evpn_adj_s1:
+    description: Check EVPN AF on IBGP adjacencies with S1
+    nodes: [ probe ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'s1',activate='evpn',af='ipv6')
+    stop_on_error: True
+  evpn_adj_s2:
+    description: Check EVPN AF on IBGP adjacencies with S2
+    nodes: [ probe ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'s2',activate='evpn',af='ipv6')
+    stop_on_error: True
 
   ping_red:
     description: Ping-based reachability test in VLAN red

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -758,6 +758,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - red
       - blue
@@ -1118,6 +1119,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - red
       - blue

--- a/tests/topology/expected/evpn-hub-spoke.yml
+++ b/tests/topology/expected/evpn-hub-spoke.yml
@@ -156,6 +156,7 @@ nodes:
       flooding: evpn
       l3vnis:
       - hub
+      transport: ipv4
       vtep: 10.0.0.1
       vtep_interface: Loopback0
   r2:
@@ -266,6 +267,7 @@ nodes:
       flooding: evpn
       l3vnis:
       - spoke
+      transport: ipv4
       vtep: 10.0.0.2
       vtep_interface: Loopback0
 provider: clab

--- a/tests/topology/expected/evpn-node-vrf.yml
+++ b/tests/topology/expected/evpn-node-vrf.yml
@@ -183,6 +183,7 @@ nodes:
       flooding: evpn
       l3vnis:
       - tenant
+      transport: ipv4
       vlans:
       - red
       vtep: 10.0.0.1

--- a/tests/topology/expected/evpn-vlan-attr.yml
+++ b/tests/topology/expected/evpn-vlan-attr.yml
@@ -149,6 +149,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - red
       vtep: 10.0.0.1

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -682,6 +682,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - red
       - blue
@@ -873,6 +874,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - red
       vtep: 10.0.0.2
@@ -1016,6 +1018,7 @@ nodes:
     vxlan:
       domain: global
       flooding: evpn
+      transport: ipv4
       vlans:
       - blue
       vtep: 10.0.0.3

--- a/tests/topology/expected/vxlan-router-stick.yml
+++ b/tests/topology/expected/vxlan-router-stick.yml
@@ -253,6 +253,7 @@ nodes:
     vxlan:
       domain: global
       flooding: static
+      transport: ipv4
       vlans:
       - red
       - blue
@@ -582,6 +583,7 @@ nodes:
     vxlan:
       domain: global
       flooding: static
+      transport: ipv4
       vlans:
       - blue
       - red

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -829,6 +829,7 @@ nodes:
     vxlan:
       domain: global
       flooding: static
+      transport: ipv4
       vlans:
       - red_transport
       - blue_transport
@@ -1131,6 +1132,7 @@ nodes:
     vxlan:
       domain: global
       flooding: static
+      transport: ipv4
       vlans:
       - red_transport
       - blue_transport
@@ -1324,6 +1326,7 @@ nodes:
     vxlan:
       domain: global
       flooding: static
+      transport: ipv4
       vlans:
       - red_transport
       vtep: 10.0.0.8


### PR DESCRIPTION
This fix uses node-level vxlan.transport variable for data-plane nodes and topology-level vxlan.use_v6_vtep variable for control-plane-only nodes to figure out which BGP transport session to use for EVPN AF in VXLAN deployments.

Other changes:
* Consistently set 'vxlan.transport' node variable to 'ipv4' or 'ipv6' (previously, it was only set to 'ipv6')
* Modify the EVPN/VXLAN-over-IPv6 integration test to check the activation of EVPN over IPv6 BGP session

Closes #3262