### PR TITLE
Use (optional) reduced OSPF timers in BGP integration tests

### DIFF
--- a/tests/integration/bgp/02-ibgp-ebgp-session.yml
+++ b/tests/integration/bgp/02-ibgp-ebgp-session.yml
@@ -4,12 +4,22 @@ message: |
   and next-hop-self on IBGP sessions.
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
 
 module: [ bgp, ospf ]
-plugin: [ bgp.session ]
+plugin: [ bgp.session, adjust_test ]
 
-defaults.bgp.as: 65000
+bgp.as: 65000
+ospf.timers.hello: 1
+ospf.timers.dead: 3
+
 defaults.interfaces.mtu: 1500
+
+_adjust:
+- nodes: [ dut ]
+  features: [ ospf.timers ]
+  remove:
+  - nodes:ospf.timers
 
 groups:
   probes:

--- a/tests/integration/bgp/03-ibgp-rr.yml
+++ b/tests/integration/bgp/03-ibgp-rr.yml
@@ -5,9 +5,10 @@ message: |
   reflected route).
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
 
 module: [ bgp, ospf ]
-plugin: [ bgp.session ]
+plugin: [ bgp.session, adjust_test ]
 
 groups:
   probes:
@@ -15,7 +16,16 @@ groups:
     device: frr
     provider: clab
 
-defaults.bgp.as: 65000
+bgp.as: 65000
+ospf.timers.hello: 1
+ospf.timers.dead: 3
+
+_adjust:
+- nodes: [ dut ]
+  features: [ ospf.timers ]
+  remove:
+  - nodes:ospf.timers
+
 defaults.interfaces.mtu: 1500
 
 nodes:

--- a/tests/integration/bgp/04-originate.yml
+++ b/tests/integration/bgp/04-originate.yml
@@ -15,7 +15,10 @@ groups:
     provider: clab
     members: [ x1, x2, r1 ]
 
-defaults.bgp.as: 65000
+bgp.as: 65000
+ospf.timers.hello: 1
+ospf.timers.dead: 3
+
 defaults.interfaces.mtu: 1500
 
 prefix:
@@ -64,6 +67,10 @@ _adjust:
   remove:
   - nodes.dut.bgp.advertise
   - validate.adv_ipv4
+- nodes: [ dut ]
+  features: [ ospf.timers ]
+  remove:
+  - nodes:ospf.timers
 
 validate:
   ospf_adj:

--- a/tests/integration/bgp/05-community.yml
+++ b/tests/integration/bgp/05-community.yml
@@ -9,7 +9,8 @@ message: |
   one, an extended one, and a long one (standard communitiy using 4-octet AS)
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
-plugin: [ files ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
+plugin: [ files, adjust_test ]
 
 module: [ bgp, ospf ]
 
@@ -19,8 +20,17 @@ groups:
     device: frr
     provider: clab
 
-defaults.bgp.as: 65000
+bgp.as: 65000
+ospf.timers.hello: 1
+ospf.timers.dead: 3
+
 defaults.interfaces.mtu: 1500
+
+_adjust:
+- nodes: [ dut ]
+  features: [ ospf.timers ]
+  remove:
+  - nodes:ospf.timers
 
 nodes:
   dut:

--- a/tests/integration/bgp/08-ibgp-localas.yml
+++ b/tests/integration/bgp/08-ibgp-localas.yml
@@ -11,6 +11,8 @@ message: |
   local-as IBGP neighbor.
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
+plugin: [ adjust_test ]
 
 module: [ bgp, ospf ]
 
@@ -23,7 +25,16 @@ groups:
     members: [ x1 ]
     module: [ bgp ]
 
-defaults.bgp.as: 65000
+bgp.as: 65000
+ospf.timers.hello: 1
+ospf.timers.dead: 3
+
+_adjust:
+- nodes: [ dut ]
+  features: [ ospf.timers ]
+  remove:
+  - nodes:ospf.timers
+
 defaults.interfaces.mtu: 1500
 
 nodes:

--- a/tests/integration/plugin/adjust_test.py
+++ b/tests/integration/plugin/adjust_test.py
@@ -108,7 +108,13 @@ def adjust_topology(a_entry: Box, topology: Box) -> None:
 
   for rm_item in get_a_list(a_entry,'remove'):
     log.print_verbose(f'Removing {rm_item}')
-    topology.pop(rm_item,None)
+    if ":" not in rm_item:
+      topology.pop(rm_item,None)
+      continue
+
+    (object,item) = rm_item.split(":",1)
+    for data in topology.get(object,{}).values():
+      data.pop(item,None)
 
   for rp_item in get_a_list(a_entry,'replace'):
     rp_key = rp_item.get('key',None)


### PR DESCRIPTION
This change tries to use the short OSPF timers in BGP integration tests (guarded with _adjust entry that checks the device capability) and can reduce the runtime of an integration test by ~10 seconds.