### PR TITLE
Release notes for 26.04

### DIFF
--- a/.github/skills/release-notes/SKILL.md
+++ b/.github/skills/release-notes/SKILL.md
@@ -9,5 +9,10 @@ description: Create release notes for a new netlab release
 * Create release notes from commits after the last `release_xx.xx` tag
 * Categorize commits without the explicit category (usually 'Doc' or 'Fix') in the title into one of the categories based on their content and impact.
 * Try to identify breaking changes.
-* As a new policy, remove PR references from all sections except bug and documentation fixes (older release notes/templates may still show the previous style; follow this rule going forward).
+* Remove PR references from all sections except bug and documentation fixes (older release notes/templates may still show the previous style; follow this rule going forward).
 * Remove the "Doc: " or "Fix: " part of the commit title
+
+# IMPORTANT
+
+* DO NOT make up cross-reference anchors. Use only anchors already defined in the documentation files. Tell the user if you think something is crucial enough to warrant a new anchor.
+* DO NOT modify files outside the ‘docs’ directory. For example, DO NOT change the `netsim/__init__.py` file.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -24,7 +24,7 @@
 | Cisco IOS-on-Linux L2 image (IOL L2)[❗](caveats-iol) | ioll2               | full |
 | Cisco IOSv [❗](caveats-iosv)      | iosv   | full          |
 | [Cisco IOSvL2](https://developer.cisco.com/docs/modeling-labs/iosvl2/#iosvl2) [❗](caveats-iosv)   | iosvl2 | full |
-| Cisco IOS XRv/XRd [❗](caveats-iosxr) | iosxr  | minimal       |
+| Cisco IOS XRv/XRd [❗](caveats-iosxr) | iosxr  | full (XRd only) |
 | Cisco Nexus 9300v [❗](caveats-nxos) | nxos | best effort   |
 | Cumulus Linux 4.x/5.x [❗](caveats-cumulus) | cumulus | end of life |
 | Cumulus Linux 5.x (NVUE) [❗](caveats-cumulus-nvue) | cumulus_nvue | minimal |
@@ -33,7 +33,7 @@
 | Fortinet FortiOS [❗](caveats-fortios) | fortios | minimal  |
 | FRRouting (FRR) [❗](caveats-frr) | frr     | full          |
 | [Generic Linux host](generic-linux-devices) | linux | full          |
-| Juniper cRPD | crpd | best effort |
+| Juniper cRPD | crpd | full |
 | Juniper vMX [❗](caveats-vmx) | vmx         | best effort   |
 | Juniper vPTX (vJunos EVO) [❗](caveats-vptx) | vptx | full  |
 | Juniper vSRX 3.0 [❗](caveats-vsrx) | vsrx  | best effort   |

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,7 +3,7 @@ Release Notes
 
 **Release 26.04 (2026-04-10)**
 
-* New [**bgp.advertise**](bgp-advertise-prefix) node attribute — advertise connected/static networks into BGP on over a dozen platforms
+* New [**bgp.advertise**](bgp-advertise-prefix) node/VRF attribute — advertise prefixes from IP routing tables into BGP on most platforms.
 * The **bgp.originate** node attribute can be used to [originate IPv4 and IPv6 prefixes](bgp-advertise-prefix) in global and VRF BGP instances.
 * Extreme Networks EXOS initial platform support
 * Static routes on Nexus OS, Nokia SR OS, SR Linux, OpenBSD

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+**Release 26.04 (2026-04-10)**
+
+* New [**bgp.advertise**](bgp-advertise-prefix) node attribute — advertise connected/static networks into BGP on over a dozen platforms
+* The **bgp.originate** node attribute can be used to [originate IPv4 and IPv6 prefixes](bgp-advertise-prefix) in global and VRF BGP instances.
+* Extreme Networks EXOS initial platform support
+* Static routes on Nexus OS, Nokia SR OS, SR Linux, OpenBSD
+* EVPN/VXLAN-over-IPv6 on FRRouting
+
+[More details](release-26.04)
+
 **Release 26.03 (2026-03-10)**
 
 * [New Cisco IOS XR features](release-26.03-ios-xr): SR-MPLS, MPLS/VPN, MPLS 6PE, EVPN over MPLS, VRRP, full BGP routing policy support
@@ -121,6 +131,7 @@ For older releases, check the [release notes archive](release-archive.md).
    :caption: Individual release notes
    :maxdepth: 1
 
+   release/26.04.md
    release/26.03.md
    release/26.02.md
    release/26.01.md

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-**Release 26.04 (2026-04-10)**
+**Release 26.04 (2026-04-12)**
 
 * New [**bgp.advertise**](bgp-advertise-prefix) node/VRF attribute — advertise prefixes from IP routing tables into BGP on most platforms.
 * The **bgp.originate** node attribute can be used to [originate IPv4 and IPv6 prefixes](bgp-advertise-prefix) in global and VRF BGP instances.

--- a/docs/release/26.04.md
+++ b/docs/release/26.04.md
@@ -1,0 +1,123 @@
+# Changes in Release 26.04
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+```
+
+(release-26.04)=
+## New Functionality
+
+* **Extreme Networks EXOS** is supported as a Vagrant box or containerlab node with OSPF, VLAN, and VRRP configuration (by [Seb d'Argoeuves](https://github.com/sdargoeuves)).
+* The new [**bgp.advertise**](bgp-advertise-prefix) node attribute allows you to advertise networks in the IP routing table into BGP. It’s supported on most platforms.
+* The **bgp.originate** attribute is now [dual-stack and VRF-aware](bgp-advertise-prefix), allowing you to originate IPv4 and IPv6 prefixes into per-VRF BGP instances.
+* Static routes (including VRF and discard routes) are now supported on **Nexus OS**, **Nokia SR OS**, **Nokia SR Linux**, and **OpenBSD**.
+* **EVPN/VXLAN-over-IPv6** is now supported on **FRRouting**.
+* **BIRD** now supports [OSPF area parameters](plugin-ospf-areas).
+* **Junos** now supports BGP confederations and [route import](routing_import) into global and VRF BGP instances.
+
+**Minor improvements**
+
+* **EVPN control-plane-only nodes** (route reflectors) can now be configured for EVPN/VXLAN running over IPv6.
+* New *devices* [**netlab report**](netlab-report): nodes, node IDs, devices, and images — a quick summary of all nodes in the lab topology.
+* The **netlab show modules** command now splits module support tables into groups and multiple tables for better readability.
+* The Fortinet configuration templates have been renamed from `fortinet.fortios.fortios` to `fortios...`.
+
+(release-26.04-device-features)=
+## New Device Features
+
+Bird:
+* OSPF area parameters
+
+Extreme Networks EXOS:
+* Initial platform support
+* OSPF, VLANs, VRRP configuration
+
+FRRouting:
+* EVPN/VXLAN-over-IPv6
+* Upgraded to release 10.6.0
+
+Junos:
+* BGP confederations
+* Route import into global and VRF BGP instances
+* `bgp.advertise` support
+
+Nexus OS:
+* Static routes (including VRF and discard routes)
+* `bgp.advertise` support
+
+Nokia SR Linux:
+* Static routes (including VRF and discard routes)
+* `bgp.advertise` support
+* Upgraded default container release to 26.3.1
+
+Nokia SR OS:
+* Static routes (including VRF and discard routes)
+* `bgp.advertise` support
+
+OpenBSD:
+* Discard static routes
+* `bgp.advertise` support
+
+(release-26.04-device-fixes)=
+## Fixes in Configuration Templates
+
+Bird:
+* Cleanup of OSPF configuration template
+
+Cisco IOS XE:
+* Fix BGP neighbor TCP-AO configuration
+
+Junos:
+* Use standard interface names for cRPD loopbacks
+* Fix global routing instance policy names
+* Merge BGP advertise and propagate policies
+
+Nokia SR Linux:
+* Fix BGP policies for release 26.3
+* Fix inter-instance policies for release 26.3
+
+Nokia SR OS:
+* Fix BGP TCP-AO configuration
+
+(release-26.03-breaking)=
+## Potentially Breaking Changes
+
+We had to make a few changes to support the changed **bgp.originate** attribute and the new **bgp.advertise** attribute. There should be no impact unless you modified the _netlab_ device configuration templates.
+
+* The **bgp.originate** attribute is no longer present in the device data when the device supports *discard* static routes. When needed, _netlab_ adds entries to the **routing.static** list to create the routing table prefixes needed for BGP prefix origination and auto-enables the *routing* module.
+* We had to change the chains of Junos policies in global and VRF BGP instances.
+
+(bug-fixes-26.04)=
+## Bug Fixes
+
+* Enable EVPN on IPv6 BGP sessions on control-plane-only nodes (#3302)
+* Use topology-level `vxlan.use_v6_vtep` attribute in VXLAN transformation (#3301)
+* Handle node routing policies referring to missing global policies (#3299)
+* Sort modules after plugin `post_transform` step (#3298)
+* Use shared `ansible_extra_vars` function across providers (#3293)
+* Rearrange search list components for provider-related templates (#3292)
+* Add topology file information to `netlab status` printout (#3260)
+* `netlab status` crashed after a reboot killed containers (#3247)
+* Disable PHY control frames on EOS configured with FastCLI
+* Using an invalid variable in an error message crashed netlab
+* Skip disabled routing protocol blocks when iterating over routing policy data
+* Skip all meta-devices when displaying device/module support (#3266)
+* Set explicit `evpn.transport` feature on VXLAN-only devices (#3229)
+* Always check the EVPN transport module before configuring EVPN (#3228)
+* Display supported EVPN transports in `netlab show modules`
+* Auto-generate node RD when its value is empty (#3227)
+* Use `subnet_of` instead of `overlaps` for reserved IP range checks (#3223)
+* Add node-level `router_id` when missing (#3224)
+* Add a newline after each node in `netlab exec` output (#3222)
+* Use updated suzieq container image (#3218)
+* Avoid creating an empty `node.module` in the `bgp.policy` plugin (#3216)
+* Fix custom task paths in custom config deployment (#3203)
+
+(doc-fixes-26.04)=
+## Documentation Fixes
+
+* Fix common IOS/IOS XE caveats pointing to IOSv caveats instead (#3294)
+* EOS `sh` config mode works only on recent EOS releases (#3255)
+* Clarify that the global `bgp.as` value is used in global VRF RD/RT (#3226)

--- a/docs/release/26.04.md
+++ b/docs/release/26.04.md
@@ -22,7 +22,6 @@
 * **EVPN control-plane-only nodes** (route reflectors) can now be configured for EVPN/VXLAN running over IPv6.
 * New *devices* [**netlab report**](netlab-report): nodes, node IDs, devices, and images — a quick summary of all nodes in the lab topology.
 * The **netlab show modules** command now splits module support tables into groups and multiple tables for better readability.
-* The Fortinet configuration templates have been renamed from `fortinet.fortios.fortios` to `fortios...`.
 
 (release-26.04-device-features)=
 ## New Device Features
@@ -69,6 +68,9 @@ Bird:
 Cisco IOS XE:
 * Fix BGP neighbor TCP-AO configuration
 
+FortiOS:
+* The FortiOS configuration templates have been renamed from `fortinet.fortios.fortios` to `fortios`.
+
 Junos:
 * Use standard interface names for cRPD loopbacks
 * Fix global routing instance policy names
@@ -81,7 +83,7 @@ Nokia SR Linux:
 Nokia SR OS:
 * Fix BGP TCP-AO configuration
 
-(release-26.03-breaking)=
+(release-26.04-breaking)=
 ## Potentially Breaking Changes
 
 We had to make a few changes to support the changed **bgp.originate** attribute and the new **bgp.advertise** attribute. There should be no impact unless you modified the _netlab_ device configuration templates.

--- a/docs/release/26.04.md
+++ b/docs/release/26.04.md
@@ -49,15 +49,20 @@ Nexus OS:
 Nokia SR Linux:
 * Static routes (including VRF and discard routes)
 * `bgp.advertise` support
+* Enable redistribution of static routes into IGPs
 * Upgraded default container release to 26.3.1
 
 Nokia SR OS:
 * Static routes (including VRF and discard routes)
+* Enable redistribution of static routes into IGPs
 * `bgp.advertise` support
 
 OpenBSD:
 * Discard static routes
 * `bgp.advertise` support
+
+VyOS:
+* Prepended AS path can contain as single AS number
 
 (release-26.04-device-fixes)=
 ## Fixes in Configuration Templates
@@ -67,6 +72,14 @@ Bird:
 
 Cisco IOS XE:
 * Fix BGP neighbor TCP-AO configuration
+* **next-hop-self** is required on EVPN/MPLS AF to make L3VRFs work with BGP-speaking CE-routers
+
+Cisco IOS XR:
+* The `route-map` keyword used in route redistribution commands should be `route-policy`
+* IOS XRd is fully tested and supported
+
+Dell OS10:
+* Dell OS10 needs the "normalize" step to shut down layer-2 interfaces in VLAN 1
 
 FortiOS:
 * The FortiOS configuration templates have been renamed from `fortinet.fortios.fortios` to `fortios`.
@@ -75,6 +88,7 @@ Junos:
 * Use standard interface names for cRPD loopbacks
 * Fix global routing instance policy names
 * Merge BGP advertise and propagate policies
+* cRPD is fully tested and supported
 
 Nokia SR Linux:
 * Fix BGP policies for release 26.3
@@ -116,6 +130,13 @@ We had to make a few changes to support the changed **bgp.originate** attribute 
 * Use updated suzieq container image (#3218)
 * Avoid creating an empty `node.module` in the `bgp.policy` plugin (#3216)
 * Fix custom task paths in custom config deployment (#3203)
+* Fix: Cisco IOS gets upset when 'ge' in prefix list matches prefix len
+* Fix: Pings in integration tests should have **wait** option
+* Fix: Clear BGP sessions before starting the integration tests
+* Fix: OSPF route redistribution policy used in the integration test should not have MED attribute (that fails with IOS XR)
+* Fix: OSPF "passive interface" tests have to reset OSPF on probes first
+* Adjust integration tests based on device type (#3318)
+* Fix: Implement interactive integration tests
 
 (doc-fixes-26.04)=
 ## Documentation Fixes


### PR DESCRIPTION
- New bgp.advertise node attribute (14+ platforms)
- Extreme Networks EXOS initial platform support
- EVPN control-plane-only nodes
- Static routes on Nexus OS, Nokia SR OS/SRL, OpenBSD
- EVPN/VXLAN-over-IPv6 on FRRouting
- BIRD OSPF area parameters
- Junos BGP confederations and route import
- bgp.originate dual-stack and VRF-aware improvements
- New netlab report: nodes/IDs/devices/images