### PR TITLE
Adjust integration tests based on device type

### DIFF
--- a/tests/integration/evpn/05-vxlan-l3only.yml
+++ b/tests/integration/evpn/05-vxlan-l3only.yml
@@ -9,7 +9,7 @@ message: |
   phase.
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
-plugin: [ fix_mtu ]
+plugin: [ fix_mtu, adjust_test ]
 
 groups:
   _auto_create: True
@@ -39,6 +39,13 @@ links:
 - dut:
   s2:
   mtu: 1600
+
+_adjust:
+- nodes: [ dut ]              # Do not test the second VRF on vyos (broken) or NXOS (unknown)
+  devices: [ vyos, nxos ]
+  warning: The device does not work correctly with multiple L3VRFs
+  remove:
+  - validate.ping_other
 
 validate:
   ospf_adj:

--- a/tests/integration/evpn/21-bgp-ce-router.yml
+++ b/tests/integration/evpn/21-bgp-ce-router.yml
@@ -5,7 +5,7 @@ message: |
   External devices should be able to ping each other
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
-plugin: [ fix_mtu ]
+plugin: [ fix_mtu, adjust_test ]
 
 module: [ vlan, vxlan, ospf, bgp, evpn, vrf ]
 bgp.as: 65000
@@ -46,6 +46,13 @@ links:
 - dut:
   s2:
   mtu: 1600
+
+_adjust:
+- nodes: [ dut ]              # Do not test the second VRF on vyos (broken) or NXOS (unknown)
+  devices: [ vyos, nxos ]
+  warning: The device does not work correctly with multiple L3VRFs
+  remove:
+  - validate.ping_ce4
 
 validate:
   ebgp_s1:

--- a/tests/integration/plugin/adjust_test.py
+++ b/tests/integration/plugin/adjust_test.py
@@ -90,11 +90,12 @@ def check_faulty_devices(a_entry: Box, topology: Box) -> typing.Optional[Box]:
   if 'devices' not in a_entry:
     return None
 
+  dev_list = make_a_list(a_entry.devices)
   for n_name in get_a_list(a_entry,'nodes'):      # Iterate over nodes to check
     if n_name not in topology.nodes:              # Skip missing nodes
       continue
     n_data = topology.nodes[n_name]               # Get node data
-    if n_data.device in a_entry.devices:          # Faulty device?
+    if n_data.device in dev_list:                 # Faulty device?
       return n_data
 
   return None
@@ -106,7 +107,7 @@ def adjust_topology(a_entry: Box, topology: Box) -> None:
   if n_data is None:                              # No missing features or faulty devices?
     return                                        # Cool, we're out of here ;)
 
-  # The n_name/n_data contain the first node with missing feature(s)
+  # n_data contain the first node that triggered adjustment
   #
   w_text = a_entry.get('warning','')              # Do we have to add a warning?
   if w_text:                                      # Print the formatted warning

--- a/tests/integration/plugin/adjust_test.py
+++ b/tests/integration/plugin/adjust_test.py
@@ -73,18 +73,38 @@ def missing_features(a_entry: Box, node: Box, topology: Box) -> bool:
   # If we got to here, either all features are missing (in OR mode) or all features are OK (in AND mode)
   return check_mode == 'or'                       # Return the result corresponding to the check mode
 
-def adjust_topology(a_entry: Box, topology: Box) -> None:
-  OK = True
+def check_missing_features(a_entry: Box, topology: Box) -> typing.Optional[Box]:
+  if 'features' not in a_entry:
+    return None
+
   for n_name in get_a_list(a_entry,'nodes'):      # Iterate over nodes to check
     if n_name not in topology.nodes:              # Skip missing nodes
       continue
     n_data = topology.nodes[n_name]               # Get node data
     if missing_features(a_entry,n_data,topology): # ... and check for missing features
-      OK = False                                  # ... oops, we have a mismatch
-      break
+      return n_data
 
-  if OK:                                          # All good (or no nodes to check)
-    return                                        # ... so get out of here
+  return None
+
+def check_faulty_devices(a_entry: Box, topology: Box) -> typing.Optional[Box]:
+  if 'devices' not in a_entry:
+    return None
+
+  for n_name in get_a_list(a_entry,'nodes'):      # Iterate over nodes to check
+    if n_name not in topology.nodes:              # Skip missing nodes
+      continue
+    n_data = topology.nodes[n_name]               # Get node data
+    if n_data.device in a_entry.devices:          # Faulty device?
+      return n_data
+
+  return None
+
+def adjust_topology(a_entry: Box, topology: Box) -> None:
+  n_data = check_missing_features(a_entry,topology)
+  if n_data is None:                              # If all features are OK, check faulty devices
+    n_data = check_faulty_devices(a_entry,topology)
+  if n_data is None:                              # No missing features or faulty devices?
+    return                                        # Cool, we're out of here ;)
 
   # The n_name/n_data contain the first node with missing feature(s)
   #


### PR DESCRIPTION
The "integration test adjustment" plugin can modify integration tests based on the device type being tested.

Initial use case: EVPN L3VRF on Nexus OS and VyOS