### PR TITLE
Fix: Dell OS10 needs the "normalize" step

### DIFF
--- a/netsim/ansible/templates/normalize/dellos10.j2
+++ b/netsim/ansible/templates/normalize/dellos10.j2
@@ -1,0 +1,5 @@
+{% for intf in interfaces if intf.virtual_interface is not defined %}
+!
+interface {{ intf.ifname }}
+ shutdown
+{% endfor %}

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -12,6 +12,7 @@ features:
     ipv6:
       lla: true
     delay: 30
+    normalize: true
   bfd: true
   bgp:
     activate_af: true


### PR DESCRIPTION
Dell OS10 Vagrant box starts with all interfaces enabled and VLAN 1 configured on all of them.