### PR TITLE
FortiOS: Allow any policy

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -343,6 +343,12 @@ ansible-galaxy collection install community.network
 (caveats-fortios)=
 ## Fortinet FortiOS
 
+Device-specific parameters:
+
+* A FortiGate firewall does not pass any traffic by default. If you want the firewall to behave like a router after the initial configuration, set the `netlab_default_policy` node- or group variable to `True`. To create a disabled default policy, set the `netlab_default_policy.enable` variable to `False`.
+
+Device configuration:
+
 * Use a recent version of Ansible and **fortinet.fortios** Ansible Galaxy collection (version 2.3.6 or later)
 * _netlab_ tries to configure Fortinet devices with configuration scripts uploaded through the FortiOS Monitor API calls using username/password authentication.
 * If the API call fails, _netlab_ tries to push the configuration to a Fortinet device through a regular SSH session. Use **netlab initial -vvv --limit _fw_device_** to troubleshoot the configuration download (Ansible displays full contents of the SSH session at this level of verbosity).

--- a/netsim/ansible/templates/initial/fortios.j2
+++ b/netsim/ansible/templates/initial/fortios.j2
@@ -72,7 +72,7 @@ end
 
 {# End of `config global` #}
 
-{% if netlab_allow is defined and netlab_allow != false %}
+{% if netlab_default_policy|default(false) %}
 
 {%  if multi_vdom %}
 config vdom
@@ -81,10 +81,10 @@ config vdom
 
 config firewall policy
     edit 1000
-{%   if netlab_allow is mapping and netlab_allow.disable | default(false) %}
+{%   if not netlab_default_policy.enable|default(true) %}
         set status disable
 {%   endif %}
-        set name "netlab_allow"
+        set name "netlab_default_policy"
         set srcintf "any"
         set dstintf "any"
         set action accept

--- a/netsim/ansible/templates/initial/fortios.j2
+++ b/netsim/ansible/templates/initial/fortios.j2
@@ -69,3 +69,37 @@ end
 {% if multi_vdom %}
 end
 {% endif %}
+
+{# End of `config global` #}
+
+{% if netlab_allow is defined and netlab_allow != false %}
+
+{%  if multi_vdom %}
+config vdom
+    edit {{ vdom_traffic }}
+{%  endif %}
+
+config firewall policy
+    edit 1000
+{%   if netlab_allow is mapping and netlab_allow.disable | default(false) %}
+        set status disable
+{%   endif %}
+        set name "netlab_allow"
+        set srcintf "any"
+        set dstintf "any"
+        set action accept
+        set srcaddr "all"
+        set dstaddr "all"
+        set srcaddr6 "all"
+        set dstaddr6 "all"
+        set schedule "always"
+        set service "ALL"
+        set logtraffic disable
+    next
+end
+
+{%  if multi_vdom %}
+end
+{%  endif %}
+
+{% endif %}


### PR DESCRIPTION
This is possible variant to address https://github.com/ipspace/netlab/issues/3323

Policy is injected in initial configuration.

It is configured by device configuration:
```
$ cat ~/.netlab.yml 
---
devices.fortios:
  group_vars:
    netlab_allow:
      disable: false
```
