### PR TITLE
Fix: Mismatch between plugin cfg name and its internal name

### DIFF
--- a/netsim/providers/clab.py
+++ b/netsim/providers/clab.py
@@ -117,7 +117,7 @@ def add_config_filemaps(node: Box, topology: Box) -> None:
     # Adjust the configuration templates based on whether the skip_config is set
     #
     if skip_config:
-      add_config = { k:v for k,v in node[kw].items() if k not in skip_config }
+      add_config = { k:v for k,v in node[kw].items() if k.replace('@','.') not in skip_config }
     else:
       add_config = node[kw]
 

--- a/tests/platform-integration/config/05-skip-config.yml
+++ b/tests/platform-integration/config/05-skip-config.yml
@@ -1,6 +1,6 @@
 message: |
   This topology tests the "skip_config" functionality for daemons and devices
-  configured with Bash scripts (future) and Ansible
+  configured with Bash scripts and Ansible
 
 defaults.sources.extra: [ ../../integration/wait_times.yml ]
 
@@ -19,6 +19,7 @@ nodes:
   eos_nd:
     device: eos
     bgp.as: 65003
+    netlab_config_mode:
     skip_config: [ bgp.session ]
   frr_f:
     device: frr


### PR DESCRIPTION
When generating config scripts (or mapped config files), the dots in plugin names are changed into "@" to avoid the Box dot-parsing functionality. That was not taken into account when comparing config names with skip_config list, resulting in mappings that had no corresponding config files.

This simple change fixes that problem

Also: updated the platform integration test to use both config deployment methods (scripts and Ansible).