### PR TITLE
FortiOS: update logic in the initial playbook

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -350,8 +350,10 @@ Device-specific parameters:
 Device configuration:
 
 * Use a recent version of Ansible and **fortinet.fortios** Ansible Galaxy collection (version 2.3.6 or later)
-* _netlab_ tries to configure Fortinet devices with configuration scripts uploaded through the FortiOS Monitor API calls using username/password authentication.
+* When the **netlab_generate_api_token** device group variable is `True` (default behavior), _netlab_ generates the API token for the _netlab_ user (created during the Vagrant box creation process) and saves it in the `ansible_httpapi_session_key.access_token` Ansible host variable. You can disable the generation of API token with the `netlab_generate_api_token: False` node/group variable.
+* Without the API token, _netlab_ tries to configure Fortinet devices with configuration scripts uploaded through the FortiOS Monitor API calls using username/password authentication.
 * If the API call fails, _netlab_ tries to push the configuration to a Fortinet device through a regular SSH session. Use **netlab initial -vvv --limit _fw_device_** to troubleshoot the configuration download (Ansible displays full contents of the SSH session at this level of verbosity).
+* _netlab_ uses HTTPS to access FortiOS API. See [](caveats-fortios-70) if your device cannot use HTTPS due to licensing restrictions.
 * To troubleshoot API authentication, log into the FortiOS VM with **netlab connect** and enable HTTP debugging with the following commands:
 
 ```
@@ -364,18 +366,32 @@ diag debug application httpsd -1
 * We're not testing Fortinet implementation as part of the regular integration tests; the configuration scripts might be outdated. If you encounter a problem, please open an issue.
 ```
 
-### Fortinet FortiOS 6.x/7.0
+FortiOS restarts the HTTPS server after multi-VDOM configuration. The initial configuration playbook waits for the HTTPS server to become available after changing the VDOM mode to `multi-vdom`. The following device variables (which can also be set as node/group variables) control the wait time:
+
+(caveats-fortios-wait)=
+* `netlab_vdom_timer` -- the initial wait time (default: 0). Ansible won't try to reach the HTTPS server until this timer expires
+* `netlab_check_delay` -- the delay between retries (default: 5 seconds)
+* `netlab_check_retries` -- the number of retries (default: 20)
+
+(caveats-fortios-70)=
+### Fortinet FortiOS 7.0
 
 * FortiOS VM images have a default 15-day evaluation license. The VM has [limited capabilities](https://docs.fortinet.com/document/fortigate-private-cloud/7.2.0/kvm-administration-guide/504166/fortigate-vm-evaluation-license) without a license file. It will work for 15 days from the first boot, at which point you must install a license file or recreate the vagrant box completely from scratch.
 * The 15-day evaluation license only allows one single VDOM. Using the **netlab_vdom** node parameter will fail when using the built-in 15-day license.
+* You cannot use HTTPS without FortiOS license. Set these node/group variables to use HTTP:
+
+```
+ansible_httpapi_use_ssl: false
+ansible_httpapi_port: 80
+```
 
 ### Fortinet FortiOS 7.4.x/7.6.x
 
 * Starting from FortiOS 7.2, FortiGate devices do not come with a license out of the box. Users can link *one* device with a permanent evaluation license to an account on the Fortinet support portal.
 * The license needs to be added before creating the Vagrant box.
-* There are restrictions associated with the evaluation license, including a maximum of three interfaces, firewall policies, and routes... For more detailed information, refer to the [evaluation license restrictions](https://docs.fortinet.com/document/fortigate/7.6.3/administration-guide/441460).
+* There are restrictions associated with the evaluation license, including a maximum of three interfaces, firewall policies, and routes. For more detailed information, refer to the [evaluation license restrictions](https://docs.fortinet.com/document/fortigate/7.6.3/administration-guide/441460).
 * The license is linked to the serial number of the device and the UUID. To ensure that the serial number remains consistent each time you start the lab, set the `libvirt.uuid` (or `clab.env.FORTIGATE_UUID`) node parameter to the appropriate value.
-* MTU can be defined on the interface level, the default is forced to 1500 bytes due to a different behaviour between `7.4.8` and `7.6.3` releases.
+* MTU can be defined on the interface level; the default is forced to 1500 bytes due to a different behavior between `7.4.8` and `7.6.3` releases.
 * If you want to use a multi-vdom configuration, you just need to set the `netlab_vdom: <name>` in the node data. `root` vdom will be used as the management with interface `port1`, and everything else will be configured in the specified traffic vdom. Default is `netlab_vdom: root` vdom in a no-vdom configuration.
 
 (caveats-frr)=

--- a/docs/release.md
+++ b/docs/release.md
@@ -131,6 +131,7 @@ For older releases, check the [release notes archive](release-archive.md).
    :caption: Individual release notes
    :maxdepth: 1
 
+   release/26.05.md
    release/26.04.md
    release/26.03.md
    release/26.02.md

--- a/docs/release/26.05.md
+++ b/docs/release/26.05.md
@@ -1,0 +1,55 @@
+# Changes in Release 26.05
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+```
+
+(release-26.05)=
+## New Functionality
+
+* Something new
+
+**Minor improvements**
+
+* Something new
+
+(release-26.05-device-features)=
+## New Device Features
+
+FortiOS:
+* Generate API token during initial device configuration
+* Streamline and speed up the initial device configuration (which could be a [breaking change](release-26.05-breaking-fortios) if you use an old FortiOS version without a license).
+
+(release-26.05-device-fixes)=
+## Fixes in Configuration Templates
+
+Arista EOS:
+* Something new
+
+(release-26.05-breaking)=
+## Breaking changes
+
+(release-26.05-breaking-fortios)=
+We made major changes to the **fortinet** initial device configuration playbook:
+
+* The playbook generates an API token for the **netlab** user (which should have been added during the Vagrant box creation process). Set `netlab_generate_api_token` node/group variable to `False` to disable this step.
+* The configuration deployment process uses HTTPS instead of HTTP (which just redirects to HTTPS in most cases). This might not work if you're using a Fortinet device without a license. Set the following node/group variables to use HTTP:
+
+```
+ansible_httpapi_use_ssl: false
+ansible_httpapi_port: 80
+```
+
+* The playbook tries to reach the FortiOS HTTPS server immediately after switching to multi-VDOM mode and will retry several times. When needed, use [these node/group variables](caveats-fortios-70) to increase the wait time.
+
+(bug-fixes-26.05)=
+## Bug Fixes
+
+* Bugs were fixed
+
+(doc-fixes-26.05)=
+## Documentation Fixes
+
+* Docs were fixed

--- a/netsim/ansible/tasks/fortios/initial.yml
+++ b/netsim/ansible/tasks/fortios/initial.yml
@@ -3,42 +3,68 @@
   ansible.builtin.set_fact:
     netlab_vdom_is_enabled: "{{ netlab_vdom is defined and netlab_vdom != vdom }}"
 
+- name: Enable api-user authentication
+  block:
+  - name: Generate api-user token
+    delegate_to: localhost
+    expect:
+      command: >-
+        sshpass -p '{{ ansible_ssh_pass }}'
+        ssh -o UserKnownHostsFile=/dev/null
+          -o StrictHostKeyChecking=no
+          {{ ansible_user }}@{{ ansible_host }}
+      responses:
+        "password": "{{ ansible_ssh_pass }}"
+        "#":
+        - config global
+        - execute api-user generate-key netlab
+        - exit
+    register: raw_token
+
+  - name: Extract api-user token
+    set_fact:
+      ansible_httpapi_session_key:
+        access_token: "{{ raw_token.stdout | regex_search('New API key: (\\w+)', '\\1') | first }}"
+
+  - name: Create auth.yml in host_vars
+    delegate_to: localhost
+    copy:
+      dest: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}/auth.yml"
+      content: |
+        ---
+        ansible_httpapi_session_key:
+          access_token: "{{ ansible_httpapi_session_key.access_token }}"
+  when: netlab_generate_api_token|default(true)
+
 - name: Enable multi-VDOM mode if a traffic VDOM is defined
   fortinet.fortios.fortios_system_global:
     vdom: "{{ vdom }}"
     system_global:
-      vdom_mode: "{{ netlab_vdom_is_enabled|ternary('multi-vdom', 'no-vdom') }}"
+      vdom_mode: "{{ 'multi-vdom' if netlab_vdom_is_enabled else 'no-vdom' }}"
   register: vdom_mode_result
 
 - name: Ensure FortiGate is ready after VDOM mode change
-  block:
-  - name: Wait after VDOM mode change
-    ansible.builtin.wait_for:
-      host: "{{ ansible_host }}"
-      port: 443
-      timeout: 180
-      sleep: 10                          # time in seconds between checks
-      delay: "{{ netlab_vdom_timer }}"   # Initial delay in seconds before first check
-      state: started
-    when: netlab_vdom_timer|default(0) > 0
-  - name: Test FortiGate API readiness after VDOM mode change
-    fortinet.fortios.fortios_system_global:
-      vdom: "{{ vdom }}"
-      system_global:
-        hostname: '{{ inventory_hostname.replace("_","-") }}'
-    register: hostname_result
-    retries: 5
-    delay: 10       # waiting time between retries
-    until: hostname_result is not failed and hostname_result.meta.http_status == 200
-  when: >-
-    vdom_mode_result.meta is defined and
-    (vdom_mode_result.meta.http_status == 200 and vdom_mode_result.meta.revision_changed)
+  ansible.builtin.wait_for:
+    host: "{{ ansible_host }}"
+    port: 443
+    timeout: 180
+    sleep: 10                                       # time in seconds between checks
+    delay: "{{ netlab_vdom_timer|default(0) }}"    # Initial delay in seconds before first check
+    state: started
+  when:
+  - netlab_vdom_timer|default(0) > 0
+  - vdom_mode_result.meta.http_status == 200
+  - vdom_mode_result.meta.revision_changed
 
 - name: Ensure `{{ vdom }}` VDOM is set as admin
   fortinet.fortios.fortios_system_settings:
     vdom: "{{ vdom }}"
     system_settings:
       vdom_type: admin
+  register: api_result
+  retries: "{{ netlab_check_retries | default(20) }}"
+  delay: "{{ netlab_check_delay | default(5) }}"
+  until: api_result.meta.http_status == 200
   when: netlab_vdom_is_enabled
 
 - name: Deploy initial configuration from template

--- a/netsim/ansible/tasks/fortios/initial.yml
+++ b/netsim/ansible/tasks/fortios/initial.yml
@@ -7,22 +7,20 @@
   fortinet.fortios.fortios_system_global:
     vdom: "{{ vdom }}"
     system_global:
-      management_vdom: "{{ vdom }}"
-      vdom_mode: multi-vdom
-      hostname: '{{ inventory_hostname.replace("_","-") }}'
+      vdom_mode: "{{ netlab_vdom_is_enabled|ternary('multi-vdom', 'no-vdom') }}"
   register: vdom_mode_result
-  when: netlab_vdom_is_enabled
 
 - name: Ensure FortiGate is ready after VDOM mode change
   block:
-  - name: Wait 60 seconds after VDOM mode change
+  - name: Wait after VDOM mode change
     ansible.builtin.wait_for:
       host: "{{ ansible_host }}"
       port: 443
       timeout: 180
-      sleep: 10     # time in seconds between checks
-      delay: 60     # Initial delay in seconds before first check
+      sleep: 10                          # time in seconds between checks
+      delay: "{{ netlab_vdom_timer }}"   # Initial delay in seconds before first check
       state: started
+    when: netlab_vdom_timer|default(0) > 0
   - name: Test FortiGate API readiness after VDOM mode change
     fortinet.fortios.fortios_system_global:
       vdom: "{{ vdom }}"
@@ -30,7 +28,7 @@
         hostname: '{{ inventory_hostname.replace("_","-") }}'
     register: hostname_result
     retries: 5
-    delay: 10       # Initial delay and waiting time between retries
+    delay: 10       # waiting time between retries
     until: hostname_result is not failed and hostname_result.meta.http_status == 200
   when: >-
     vdom_mode_result.meta is defined and
@@ -41,14 +39,6 @@
     vdom: "{{ vdom }}"
     system_settings:
       vdom_type: admin
-  when: netlab_vdom_is_enabled
-
-- name: Configure `{{ netlab_vdom }}` virtual domain
-  fortinet.fortios.fortios_system_vdom:
-    vdom: "{{ vdom }}"
-    state: present
-    system_vdom:
-      name: "{{ netlab_vdom }}"
   when: netlab_vdom_is_enabled
 
 - name: Deploy initial configuration from template

--- a/netsim/ansible/tasks/fortios/initial.yml
+++ b/netsim/ansible/tasks/fortios/initial.yml
@@ -17,6 +17,11 @@
         "password": "{{ ansible_ssh_pass }}"
         "#":
         - config global
+        - config system api-user
+        - edit "netlab"
+        - set accprofile "super_admin"
+        - next
+        - end
         - execute api-user generate-key netlab
         - exit
     register: raw_token
@@ -44,15 +49,20 @@
   register: vdom_mode_result
 
 - name: Ensure FortiGate is ready after VDOM mode change
+  vars:
+    wait:
+      delay:   "{{ netlab_check_delay   | default(5)  | int }}"
+      retries: "{{ netlab_check_retries | default(20) | int }}"
+      timer:   "{{ netlab_vdom_timer    | default(0)  | int }}"
   ansible.builtin.wait_for:
     host: "{{ ansible_host }}"
-    port: 443
-    timeout: 180
-    sleep: 10                                       # time in seconds between checks
-    delay: "{{ netlab_vdom_timer|default(0) }}"    # Initial delay in seconds before first check
+    port: "{{ ansible_httpapi_port }}"
+    timeout: "{{ wait.delay | int * wait.retries | int + wait.timer | int }}"
+    sleep: "{{ wait.delay }}"
+    delay: "{{ wait.timer }}"
     state: started
   when:
-  - netlab_vdom_timer|default(0) > 0
+  - wait.timer | int > 0
   - vdom_mode_result.meta.http_status == 200
   - vdom_mode_result.meta.revision_changed
 

--- a/netsim/ansible/templates/initial/fortios.j2
+++ b/netsim/ansible/templates/initial/fortios.j2
@@ -5,6 +5,7 @@
 config global
 {% endif %}
 config system global
+    set management-vdom {{vdom}}
     set hostname {{ inventory_hostname.replace("_","-") }}
 end
 
@@ -15,6 +16,20 @@ config system interface
         set lldp-reception disable
         set allowaccess ping https ssh http fgfm
     next
+
+{% if multi_vdom %}
+end
+
+end
+
+{# End of `config global` #}
+
+config vdom
+    edit {{ vdom_traffic }}
+
+config system interface
+{% endif %}
+
 {%  if loopback is defined %}
     edit "{{ loopback.ifname }}"
         set vdom "{{ vdom_traffic }}"
@@ -66,19 +81,7 @@ config system interface
 {%  endfor %}
 end
 
-{% if multi_vdom %}
-end
-{% endif %}
-
-{# End of `config global` #}
-
 {% if netlab_default_policy|default(false) %}
-
-{%  if multi_vdom %}
-config vdom
-    edit {{ vdom_traffic }}
-{%  endif %}
-
 config firewall policy
     edit 1000
 {%   if not netlab_default_policy.enable|default(true) %}
@@ -97,9 +100,8 @@ config firewall policy
         set logtraffic disable
     next
 end
+{% endif %}
 
 {%  if multi_vdom %}
 end
 {%  endif %}
-
-{% endif %}

--- a/netsim/ansible/templates/initial/fortios.j2
+++ b/netsim/ansible/templates/initial/fortios.j2
@@ -2,6 +2,11 @@
 {% set multi_vdom = vdom_traffic != vdom %}
 
 {% if multi_vdom %}
+config vdom
+    edit {{ vdom_traffic }}
+    next
+end
+
 config global
 {% endif %}
 config system global
@@ -16,20 +21,6 @@ config system interface
         set lldp-reception disable
         set allowaccess ping https ssh http fgfm
     next
-
-{% if multi_vdom %}
-end
-
-end
-
-{# End of `config global` #}
-
-config vdom
-    edit {{ vdom_traffic }}
-
-config system interface
-{% endif %}
-
 {%  if loopback is defined %}
     edit "{{ loopback.ifname }}"
         set vdom "{{ vdom_traffic }}"
@@ -81,7 +72,19 @@ config system interface
 {%  endfor %}
 end
 
+{% if multi_vdom %}
+end
+{% endif %}
+
+{# End of `config global` #}
+
 {% if netlab_default_policy|default(false) %}
+
+{%  if multi_vdom %}
+config vdom
+    edit {{ vdom_traffic }}
+{%  endif %}
+
 config firewall policy
     edit 1000
 {%   if not netlab_default_policy.enable|default(true) %}
@@ -100,8 +103,9 @@ config firewall policy
         set logtraffic disable
     next
 end
-{% endif %}
 
 {%  if multi_vdom %}
 end
 {%  endif %}
+
+{% endif %}

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -28,9 +28,9 @@ group_vars:
   vdom: "root"
   netlab_vdom: "root"
   mgmt_if: port1
-  ansible_httpapi_use_ssl: no
-  ansible_httpapi_validate_certs: no
-  ansible_httpapi_port: 80
+  ansible_httpapi_use_ssl: true
+  ansible_httpapi_validate_certs: false
+  ansible_httpapi_port: 443
   netlab_console_connection: ssh
   netlab_ready: [ ansible ]
   netlab_device_type: fortios


### PR DESCRIPTION
Fix for https://github.com/ipspace/netlab/issues/3335
- Task "Enable multi-VDOM mode if a traffic VDOM is defined" is always executed and it set only the proper vdom-mode.
- Task "Wait after VDOM mode change" is executed when netlab_vdom_timer > 0 is set
- Creation of the traffic VDOM is offloaded to the template

netlab_vdom_timer would be 0, if not set. For backward compatibility it might be better choice to set it to 60.

Jinja template is optimized to reduce flow control after VDOM, but I am not sure if `system interfaces` stanza has always been available from a VDOM. 