### PR TITLE
ForitOS: Shift indexes of ospf networks by 1 to accommodate loopack

### DIFF
--- a/netsim/ansible/templates/ospf/fortios.j2
+++ b/netsim/ansible/templates/ospf/fortios.j2
@@ -55,7 +55,7 @@ config router ospf
 
     config network
 {%  for intf in netlab_interfaces if intf.ospf.area is defined %}
-        edit {{ intf.ifindex + 1 }}
+        edit {{ loop.index }}
             set prefix {{ intf.ipv4|ansible.utils.ipaddr('subnet') }}
             set area {{ intf.ospf.area }}
         next

--- a/netsim/ansible/templates/ospf/fortios.j2
+++ b/netsim/ansible/templates/ospf/fortios.j2
@@ -55,7 +55,7 @@ config router ospf
 
     config network
 {%  for intf in netlab_interfaces if intf.ospf.area is defined %}
-        edit {{ intf.ifindex }}
+        edit {{ intf.ifindex + 1 }}
             set prefix {{ intf.ipv4|ansible.utils.ipaddr('subnet') }}
             set area {{ intf.ospf.area }}
         next


### PR DESCRIPTION
In FortiOS `edit 0` is equivalent `edit <next available>`.
As loopack has index 0 it will only work for the first time. 
The solution is to shift interface index by 1 for ospf networks list.