### PR TITLE
EXOS Normalize interface

### DIFF
--- a/netsim/ansible/templates/initial/exos.j2
+++ b/netsim/ansible/templates/initial/exos.j2
@@ -50,21 +50,21 @@ disable router-discovery ipv6 vlan {{ vlan_name }}
 enable router-discovery ipv6 vlan {{ vlan_name }}
 configure vlan {{ vlan_name }} router-discovery ipv6 max-interval 5
 configure vlan {{ vlan_name }} router-discovery ipv6 min-interval 3
-{%       if ra_prefix %}
+{%         if ra_prefix %}
 configure vlan {{ vlan_name }} router-discovery ipv6 add prefix {{ ra_prefix }}
-{%         if l.ra.slaac|default(true) is false %}
+{%           if l.ra.slaac|default(true) is false %}
 configure vlan {{ vlan_name }} router-discovery ipv6 set prefix {{ ra_prefix }} autonomous-flag off
-{%         endif %}
-{%         if l.ra.onlink|default(true) is false %}
+{%           endif %}
+{%           if l.ra.onlink|default(true) is false %}
 configure vlan {{ vlan_name }} router-discovery ipv6 set prefix {{ ra_prefix }} onlink-flag off
+{%           endif %}
 {%         endif %}
-{%       endif %}
-{%       if l.ra.dhcp|default(false) == 'all' %}
+{%         if l.ra.dhcp|default(false) == 'all' %}
 configure vlan {{ vlan_name }} router-discovery ipv6 managed-config-flag on
-{%       endif %}
-{%       if l.ra.dhcp|default(false) == 'other' %}
+{%         endif %}
+{%         if l.ra.dhcp|default(false) == 'other' %}
 configure vlan {{ vlan_name }} router-discovery ipv6 other-config-flag on
-{%       endif %}
+{%         endif %}
 {%       endif %}
 {%     endif %}
 {%     if l.ipv4 is defined %}

--- a/netsim/ansible/templates/initial/exos.j2
+++ b/netsim/ansible/templates/initial/exos.j2
@@ -39,14 +39,14 @@ enable jumbo-frame ports {{ l.ifname }}
 {%     endif %}
 {%   endif %}
 {%   if has_l3_vlan %}
-{%   if l.vrf is defined %}
+{%     if l.vrf is defined %}
 configure vlan {{ vlan_name }} virtual-router {{ l.vrf }}
-{%   endif %}
-{%   if not is_loopback and role == 'router' and l.ipv6 is defined %}
-{%     set ra_prefix = l.ipv6|ansible.utils.ipaddr(0) if l.ipv6 is string and l.ipv6|ansible.utils.ipv6 else None %}
-{%     if l.ra.disable|default(false) is true %}
+{%     endif %}
+{%     if not is_loopback and role == 'router' and l.ipv6 is defined %}
+{%       set ra_prefix = l.ipv6|ansible.utils.ipaddr(0) if l.ipv6 is string and l.ipv6|ansible.utils.ipv6 else None %}
+{%       if l.ra.disable|default(false) is true %}
 disable router-discovery ipv6 vlan {{ vlan_name }}
-{%     else %}
+{%       else %}
 enable router-discovery ipv6 vlan {{ vlan_name }}
 configure vlan {{ vlan_name }} router-discovery ipv6 max-interval 5
 configure vlan {{ vlan_name }} router-discovery ipv6 min-interval 3
@@ -65,30 +65,33 @@ configure vlan {{ vlan_name }} router-discovery ipv6 managed-config-flag on
 {%       if l.ra.dhcp|default(false) == 'other' %}
 configure vlan {{ vlan_name }} router-discovery ipv6 other-config-flag on
 {%       endif %}
+{%       endif %}
 {%     endif %}
-{%   endif %}
-{%   if l.ipv4 is defined %}
-{%     if l.ipv4 is sameas True %}
+{%     if l.ipv4 is defined %}
+{%       if l.ipv4 is sameas True %}
 ! Unnumbered IPv4 not implemented for EXOS
-{%     elif l.ipv4 is string and l.ipv4|ansible.utils.ipv4 %}
+{%       elif l.ipv4 is string and l.ipv4|ansible.utils.ipv4 %}
 configure vlan {{ vlan_name }} ipaddress {{ l.ipv4|ansible.utils.ipaddr('address') }} {{ l.ipv4|ansible.utils.ipaddr('netmask') }}
 enable ipforwarding vlan {{ vlan_name }}
-{%     else %}
+{%       else %}
 ! Invalid IPv4 address {{ l.ipv4 }}
+{%       endif %}
 {%     endif %}
-{%   endif %}
-{%   if l.ipv6 is defined %}
-{%     if l.ipv6 is sameas True %}
+{%     if l.ipv6 is defined %}
+{%       if l.ipv6 is sameas True %}
 ! Link-local-only IPv6 not implemented for EXOS
-{%     elif l.ipv6 is string and l.ipv6|ansible.utils.ipv6 %}
+{%       elif l.ipv6 is string and l.ipv6|ansible.utils.ipv6 %}
 configure vlan {{ vlan_name }} ipaddress {{ l.ipv6|upper }}
 enable ipforwarding ipv6 vlan {{ vlan_name }}
-{%     else %}
+{%       else %}
 ! Invalid IPv6 address {{ l.ipv6 }}
+{%       endif %}
+{%     endif %}
+{%     if not is_loopback and l.mtu is defined %}
+configure ip-mtu {{ l.mtu }} vlan {{ vlan_name }}
 {%     endif %}
 {%   endif %}
-{%   if not is_loopback and l.mtu is defined %}
-configure ip-mtu {{ l.mtu }} vlan {{ vlan_name }}
-{%   endif %}
+{%   if not is_loopback and not is_svi %}
+enable ports {{ l.ifname }}
 {%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/normalize/exos.j2
+++ b/netsim/ansible/templates/normalize/exos.j2
@@ -1,0 +1,7 @@
+{#
+   We need to ensure physical interfaces are shutdown.
+   https://github.com/ipspace/netlab/issues/3252
+#}
+{% for intf in interfaces if intf.virtual_interface is not defined %}
+disable port {{ intf.ifname }}
+{% endfor %}

--- a/netsim/ansible/templates/normalize/exos.j2
+++ b/netsim/ansible/templates/normalize/exos.j2
@@ -1,7 +1,10 @@
 {#
-   We need to ensure physical interfaces are shutdown.
+   We need to ensure physical interfaces are shutdown and ports
+   are removed from VLAN Default
+
    https://github.com/ipspace/netlab/issues/3252
 #}
+configure vlan Default delete ports all
 {% for intf in interfaces if intf.virtual_interface is not defined %}
 disable port {{ intf.ifname }}
 {% endfor %}

--- a/netsim/devices/exos.yml
+++ b/netsim/devices/exos.yml
@@ -12,6 +12,7 @@ features:
     min_mtu: 1500
     max_mtu: 9216
     ra: true
+    normalize: true
   ospf:
     loopback:
       passive: true


### PR DESCRIPTION
@ipspace I'm not sure how to run the test to see if this branch fixes the issue #3252 , do you mind having a look, or sharing how you did the test?

This PR disabled the physical ports as part of the normalization, and will re-enable those interfaces at the end of the initial task, so hopefully that should be enough to sort this issue.

I've also added a caveat, as I've realised the EXOS initial configuration is not idempotent due to the Vlan creation. I'm not sure how to workaround this at the moment, so caveat it is!