### PR TITLE
Juniper cSRX support

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -445,7 +445,7 @@ Implementation limitations in import/export route filters (reported as errors th
 ## Juniper cSRX
 
 * cSRX might require a license file to unlock additional features. You can specify the location of the license file with the **clab.license** node parameter or **defaults.devices.crpd.clab.node.license** [device default](topo-defaults).
-* If using more than 2 data interfaces, `clab.env.CSRX_PORT_NUM` must be increased to the number of interfaces + 1 (because it includes the management interface). Setting it higher will result in none of the data interfaces functioning correctly, e.g. no ARP.
+* cSRX container supports up to 17 interfaces: 1 Out-of-band management Interface (eth0) and 16 In-band interfaces (ge-0/0/0 to ge-0/0/15).
 * Since cSRX does not support any dynamic routing protocols, the use of the routing module and static routes is recommended.
 
 (caveats-crpd)=

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -441,6 +441,13 @@ Implementation limitations in import/export route filters (reported as errors th
 * When prepending an AS number different than the local one, JunOS puts the prepended AS at the beginning of the *AS_PATH* while other vendors perform the prepending and then add the device's own AS at the beginning. Most EBGP peers deny a BGP update that does not have the neighbor's AS number at the beginning of the *AS_PATH*. If needed, _netlab_ automatically adds the *local-as* to the prepend list to get it at the beginning of the *AS_PATH*.
 * *as-path* regex syntax for JunOS has different rules than other vendors. For example, a *null as-path* is represented as `()`. netlab tries some as-path conversion, but sometimes it could be wrong.
 
+(caveats-csrx)=
+## Juniper cSRX
+
+* cSRX might require a license file to unlock additional features. You can specify the location of the license file with the **clab.license** node parameter or **defaults.devices.crpd.clab.node.license** [device default](topo-defaults).
+* If using more than 2 data interfaces, `clab.env.CSRX_PORT_NUM` must be increased to the number of interfaces + 1 (because it includes the management interface). Setting it higher will result in none of the data interfaces functioning correctly, e.g. no ARP.
+* Since cSRX does not support any dynamic routing protocols, the use of the routing module and static routes is recommended.
+
 (caveats-crpd)=
 ## Juniper cRPD
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -445,7 +445,7 @@ Implementation limitations in import/export route filters (reported as errors th
 ## Juniper cSRX
 
 * cSRX might require a license file to unlock additional features. You can specify the location of the license file with the **clab.license** node parameter or **defaults.devices.crpd.clab.node.license** [device default](topo-defaults).
-* cSRX container supports up to 17 interfaces: 1 Out-of-band management Interface (eth0) and 16 In-band interfaces (ge-0/0/0 to ge-0/0/15).
+* cSRX supports up to 17 interfaces: 1 Out-of-band management Interface (eth0) and 16 In-band interfaces (ge-0/0/0 to ge-0/0/15).
 * Since cSRX does not support any dynamic routing protocols, the use of the routing module and static routes is recommended.
 
 (caveats-crpd)=

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -441,13 +441,6 @@ Implementation limitations in import/export route filters (reported as errors th
 * When prepending an AS number different than the local one, JunOS puts the prepended AS at the beginning of the *AS_PATH* while other vendors perform the prepending and then add the device's own AS at the beginning. Most EBGP peers deny a BGP update that does not have the neighbor's AS number at the beginning of the *AS_PATH*. If needed, _netlab_ automatically adds the *local-as* to the prepend list to get it at the beginning of the *AS_PATH*.
 * *as-path* regex syntax for JunOS has different rules than other vendors. For example, a *null as-path* is represented as `()`. netlab tries some as-path conversion, but sometimes it could be wrong.
 
-(caveats-csrx)=
-## Juniper cSRX
-
-* cSRX might require a license file to unlock additional features. You can specify the location of the license file with the **clab.license** node parameter or **defaults.devices.crpd.clab.node.license** [device default](topo-defaults).
-* cSRX supports up to 17 interfaces: 1 Out-of-band management Interface (eth0) and 16 In-band interfaces (ge-0/0/0 to ge-0/0/15).
-* Since cSRX does not support any dynamic routing protocols, the use of the routing module and static routes is recommended.
-
 (caveats-crpd)=
 ## Juniper cRPD
 
@@ -455,6 +448,14 @@ Implementation limitations in import/export route filters (reported as errors th
 * Inter-VRF route leaking does not work correctly
 * VRRPv3 for IPv4 implementation uses the [checksum calculation that is incompatible with most other VRRP implementations](https://blog.ipspace.net/2025/01/sturgeon-law-vrrp-edition/). The `checksum-without-pseudoheader` configuration command does not seem to be available.
 * Anycast gateway is unsupported
+
+(caveats-csrx)=
+## Juniper cSRX
+
+* cSRX is a native container and should not be confused with vSRX which is a vrnetlab VM in a container. See [Juniper's cSRX documentation](https://www.juniper.net/documentation/us/en/software/csrx/csrx-consolidated-deployment-guide/topics/concept/security-csrx-docker-feature-support.html) for more details.
+* cSRX might require a license file to unlock additional features. You can specify the location of the license file with the **clab.license** node parameter or **defaults.devices.csrx.clab.node.license** [device default](topo-defaults).
+* cSRX supports up to 17 interfaces: 1 out-of-band management Interface (eth0) and 16 in-band interfaces (ge-0/0/0 to ge-0/0/15).
+* Since cSRX does not support any dynamic routing protocols, use the **routing** module and static routes.
 
 (caveats-vmx)=
 ## Juniper vMX

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -220,7 +220,7 @@ Ansible playbooks included with **netlab** can deploy and collect device configu
 
 [^XE]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL) and IOL Layer-2 image
 
-[^Junos]: Includes cRPD, vMX, vSRX, vPTX, vJunos-switch, and vJunos-router
+[^Junos]: Includes cRPD, vMX, vSRX, vPTX, vJunos-switch, and vJunos-router but not cSRX
 
 [^SROS]: Includes the Nokia SR-SIM container and the Virtualized 7750 SR and 7950 XRS Simulator (vSIM) virtual machine
 
@@ -289,7 +289,7 @@ The following system-wide features are configured on supported network operating
 | Fortinet FortiOS         | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | FRR                      | ✅  | ✅[^HIF]  |  ❌  | ✅  | ✅  |
 | Generic Linux            | ✅  | ✅[^HIF]  |  ✅[❗](linux-lldp) | ✅  | ✅  |
-| Juniper cSRX            | ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
+| Juniper cSRX            | ✅  | ✅  |  ❌  |  ❌  |  ❌  |
 | Junos[^Junos]            | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | Mikrotik RouterOS 6      | ✅  | ✅  | ✅[❗](caveats-routeros6) | ✅ | ✅ |
 | Mikrotik RouterOS 7      | ✅ | ✅ | ✅[❗](caveats-routeros7) | ✅ | ✅ |
@@ -397,7 +397,6 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Extreme Networks EXOS | ✅   |   ❌   |   ❌   |   ❌   |  ❌  |
 | Fortinet FortiOS      | ✅ [❗](caveats-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |
 | FRR                   | ✅   |  ✅   |   ❌  | ✅  |  ✅  |
-| Juniper cSRX         |   ❌  |   ❌  |   ❌  |   ❌  |   ❌  |
 | Junos[^Junos]         | ✅   |  ✅   |   ❌  | ✅  |   ❌  |
 | Mikrotik RouterOS 6   | ✅   |   ❌   |   ❌  | ✅  |   ❌  |
 | Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌  | ✅  |   ❌  |
@@ -427,7 +426,6 @@ These devices support additional control-plane protocols or BGP address families
 | Dell OS10             | ✅  | ✅  |  ❌  |  ❌  |
 | Extreme Networks EXOS |  ❌  |  ❌  |  ❌  | ✅  |
 | FRR                   | ✅  | ✅  | ✅  |  ❌  |
-| Juniper cSRX          |  ❌  |  ❌  |  ❌  |  ❌  |
 | Juniper cRPD          | ✅  |  ❌  | ✅  |  ❌  |
 | Juniper vMX           | ✅  |  ❌  | ✅  | ✅  |
 | Juniper vPTX          | ✅  | ✅  | ✅  | ✅  |
@@ -477,7 +475,6 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Dell OS10             | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
 | Extreme Networks EXOS | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | FRR                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Juniper cSRX          |  ❌ |  ❌ |   ❌ |   ❌ |   ❌ |  ❌ |
 | Juniper cRPD          |  ❌ |  ❌ |   ❌ | ✅ | ✅ |  ❌ |
 | Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ |
 | Juniper vPTX          | ✅ | ✅ | ✅ [❗](caveats-vptx) | ✅ | ✅ |  ❌ |
@@ -527,7 +524,6 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Dell OS10             | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Extreme Networks EXOS | ✅ | ❌ | ❌ | ❌ | ❌ |
 | FRR                   | ✅ | ✅ | ❌ | ✅ | ❌ |
-| Juniper cSRX         | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Junos[^Junos]         | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Mikrotik RouterOS 6   |  ❌ | ❌ | ❌ | ✅ | ❌ |
 | Mikrotik RouterOS 7   | ✅ | ❌ | ❌ | ✅ | ❌ |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -34,6 +34,7 @@
 | FRRouting (FRR) [❗](caveats-frr) | frr     | full          |
 | [Generic Linux host](generic-linux-devices) | linux | full          |
 | Juniper cRPD | crpd | full |
+| Juniper cSRX [❗](caveats-csrx) | csrx | minimal |
 | Juniper vMX [❗](caveats-vmx) | vmx         | best effort   |
 | Juniper vPTX (vJunos EVO) [❗](caveats-vptx) | vptx | full  |
 | Juniper vSRX 3.0 [❗](caveats-vsrx) | vsrx  | best effort   |
@@ -131,6 +132,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | FRR | [✅](build-frr)[❗](caveats-frr) | ✅[❗](caveats-frr) | ✅ |
 | Generic Linux (Ubuntu/Alpine) [❗](labs/linux.md) | ✅  | ✅  | ✅  |
 | Juniper cRPD       |  ❌  |  ❌  | ✅  |
+| Juniper cSRX       |  ❌  |  ❌  | ✅  |
 | Juniper vMX        |  ❌  |  ❌  | ✅[❗](clab-vrnetlab)   |
 | Juniper vPTX       | [✅](build-vptx)  |  ❌  | ✅[❗](clab-vrnetlab)  |
 | Juniper vSRX 3.0   | [✅](build-vsrx)  | ✅  | ✅[❗](caveats-vsrx)  |
@@ -201,6 +203,7 @@ Ansible playbooks included with **netlab** can deploy and collect device configu
 | Fortinet FortiOS      | ✅ | ✅ |
 | FRR                   | ✅ [❗](caveats-frr)  | ✅[❗](caveats-frr) |
 | Generic Linux         | ✅ | ❌  |
+| Juniper cSRX         | ✅ | ❌  |
 | Junos[^Junos]         | ✅ | ✅ |
 | Mikrotik RouterOS 6   | ✅ | ✅ |
 | Mikrotik RouterOS 7   | ✅ | ✅ |
@@ -286,6 +289,7 @@ The following system-wide features are configured on supported network operating
 | Fortinet FortiOS         | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | FRR                      | ✅  | ✅[^HIF]  |  ❌  | ✅  | ✅  |
 | Generic Linux            | ✅  | ✅[^HIF]  |  ✅[❗](linux-lldp) | ✅  | ✅  |
+| Juniper cSRX            | ✅  |  ❌  |  ❌  |  ❌  |  ❌  |
 | Junos[^Junos]            | ✅  |  ❌  | ✅  | ✅  | ✅  |
 | Mikrotik RouterOS 6      | ✅  | ✅  | ✅[❗](caveats-routeros6) | ✅ | ✅ |
 | Mikrotik RouterOS 7      | ✅ | ✅ | ✅[❗](caveats-routeros7) | ✅ | ✅ |
@@ -317,6 +321,7 @@ The following interface parameters are configured on supported network operating
 | Fortinet FortiOS      | ✅  | ✅  |  ✅[❗](caveats-fortios)  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
 | Generic Linux         |  ❌  |  ❌  | ✅  |  ❌  |
+| Juniper cSRX         | ✅  |  ❌  | ✅  |  ❌  |
 | Junos[^Junos]         | ✅  | ✅  | ✅  |  ❌  |
 | Mikrotik RouterOS 6   | ✅  |  ❌  | ✅  |  ❌  |
 | Mikrotik RouterOS 7   | ✅  |  ❌  | ✅  | ✅  |
@@ -345,6 +350,7 @@ The following interface addresses are supported on various platforms; most daemo
 | Fortinet FortiOS      | ✅  | ✅  |  ❌  |  ❌  |
 | FRR                   | ✅  | ✅  | ✅  | ✅  |
 | Generic Linux         | ✅  | ✅  |  ❌  |  ❌  |
+| Juniper cSRX         | ✅  | ✅  |  ❌  |  ❌  |
 | Junos[^Junos]         | ✅  | ✅  | ✅  |  ❌  |
 | Mikrotik RouterOS 6   | ✅  | ✅  |  ❌  |  ❌  |
 | Mikrotik RouterOS 7   | ✅  | ✅  |  ❌  |  ❌  |
@@ -391,6 +397,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | Extreme Networks EXOS | ✅   |   ❌   |   ❌   |   ❌   |  ❌  |
 | Fortinet FortiOS      | ✅ [❗](caveats-fortios) |   ❌   |   ❌   |   ❌   |  ❌  |
 | FRR                   | ✅   |  ✅   |   ❌  | ✅  |  ✅  |
+| Juniper cSRX         |   ❌  |   ❌  |   ❌  |   ❌  |   ❌  |
 | Junos[^Junos]         | ✅   |  ✅   |   ❌  | ✅  |   ❌  |
 | Mikrotik RouterOS 6   | ✅   |   ❌   |   ❌  | ✅  |   ❌  |
 | Mikrotik RouterOS 7   | ✅   |   ❌   |   ❌  | ✅  |   ❌  |
@@ -420,6 +427,7 @@ These devices support additional control-plane protocols or BGP address families
 | Dell OS10             | ✅  | ✅  |  ❌  |  ❌  |
 | Extreme Networks EXOS |  ❌  |  ❌  |  ❌  | ✅  |
 | FRR                   | ✅  | ✅  | ✅  |  ❌  |
+| Juniper cSRX          |  ❌  |  ❌  |  ❌  |  ❌  |
 | Juniper cRPD          | ✅  |  ❌  | ✅  |  ❌  |
 | Juniper vMX           | ✅  |  ❌  | ✅  | ✅  |
 | Juniper vPTX          | ✅  | ✅  | ✅  | ✅  |
@@ -469,9 +477,10 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Dell OS10             | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
 | Extreme Networks EXOS | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | FRR                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Juniper cSRX          |  ❌ |  ❌ |   ❌ |   ❌ |   ❌ |  ❌ |
 | Juniper cRPD          |  ❌ |  ❌ |   ❌ | ✅ | ✅ |  ❌ |
-| Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ | 
-| Juniper vPTX          | ✅ | ✅ | ✅ [❗](caveats-vptx) | ✅ | ✅ |  ❌ | 
+| Juniper vMX           | ✅ | ✅ |  ❌ | ✅ | ✅ |  ❌ |
+| Juniper vPTX          | ✅ | ✅ | ✅ [❗](caveats-vptx) | ✅ | ✅ |  ❌ |
 | Juniper vSRX 3.0      | ❌  | ✅ |  ❌ |  ❌ |  ❌ |  ❌ |
 | vJunos-switch         | ✅ | ✅ | ✅ |  ❌ |  ❌ |  ❌ |
 | vJunos-router         | ❌  | ✅ |  ❌ |  ❌ |  ❌ |  ❌ |
@@ -518,6 +527,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Dell OS10             | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Extreme Networks EXOS | ✅ | ❌ | ❌ | ❌ | ❌ |
 | FRR                   | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Juniper cSRX         | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Junos[^Junos]         | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Mikrotik RouterOS 6   |  ❌ | ❌ | ❌ | ✅ | ❌ |
 | Mikrotik RouterOS 7   | ✅ | ❌ | ❌ | ✅ | ❌ |

--- a/netsim/ansible/templates/initial/crpd.j2
+++ b/netsim/ansible/templates/initial/crpd.j2
@@ -2,60 +2,6 @@
 {% include 'junos.vrf.j2' %}
 {% endif %}
 
-interfaces {
-{% for l in netlab_interfaces|default([]) %}
-  {{ l.ifname }} {
-{%   if l.mtu is defined %}
-    mtu {{ l.mtu }};
-{%   endif %}
-{%   if l.name is defined %}
-    description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}";
-{%   elif l.type|default("") == "stub" %}
-    description "Stub interface"
-{%   endif %}
-    unit 0 {
-{#
-    IPv4 addresses
-#}
-{%   if 'ipv4' in l %}
-      family inet {
-{%     if l.ipv4 == True %}
-        unnumbered-address lo0.0;
-{%     elif l.ipv4|ansible.utils.ipv4 %}
-        address {{ l.ipv4 }};
-{%     else %}
-! Invalid IPv4 address {{ l.ipv4 }}
-{%     endif %}
-      }
-{%   endif %}
-{#
-    IPv6 addresses
-#}
-{%   if 'ipv6' in l %}
-      family inet6 {
-{%     if l.ipv6 is string %}
-        address {{ l.ipv6 }};
-{%     endif %}
-      }
-{%   endif %}
-    }
-  }
-{% endfor %}
-}
-protocols {
-  lldp {
-    interface {{ mgmt.ifname|default('fxp0') }} {
-      disable;
-    }
-    interface all;
-  }
-{% for l in interfaces if 'ipv6' in l and l.type != 'loopback' %}
-{%   if loop.first %}
-  router-advertisement {
-{%   endif %}
-    interface {{ l.ifname }};
-{%   if loop.last %}
-  }
-{%   endif %}
-{% endfor %}
-}
+{% include 'junos/container_interfaces.j2' %}
+
+{% include 'junos/lldp.j2' %}

--- a/netsim/ansible/templates/initial/csrx.j2
+++ b/netsim/ansible/templates/initial/csrx.j2
@@ -1,0 +1,65 @@
+system {
+  host-name {{ inventory_hostname }};
+  static-host-mapping {
+{% for k,v in hostvars.items() if k != inventory_hostname %}
+{%   if v.loopback.ipv4 is defined %}
+    {{ k|replace('_','') }} inet {{ v.loopback.ipv4|ansible.utils.ipaddr('address') }};
+{%   elif v.interfaces|default([]) and v.interfaces[0].ipv4|default(False) is string %}
+    {{ k|replace('_','') }} inet {{ v.interfaces[0].ipv4|ansible.utils.ipaddr('address') }};
+{%   endif %}
+{% endfor %}
+  }
+}
+
+interfaces {
+{% for l in netlab_interfaces|default([]) %}
+  {{ l.ifname }} {
+{%   if l.mtu is defined %}
+    mtu {{ l.mtu }};
+{%   endif %}
+{%   if l.name is defined %}
+    description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}";
+{%   elif l.type|default("") == "stub" %}
+    description "Stub interface"
+{%   endif %}
+    unit 0 {
+{#
+    IPv4 addresses
+#}
+{%   if 'ipv4' in l %}
+      family inet {
+{%     if l.ipv4 == True %}
+        unnumbered-address lo0.0;
+{%     elif l.ipv4|ansible.utils.ipv4 %}
+        address {{ l.ipv4 }};
+{%     else %}
+! Invalid IPv4 address {{ l.ipv4 }}
+{%     endif %}
+      }
+{%   endif %}
+{#
+    IPv6 addresses
+#}
+{%   if 'ipv6' in l %}
+      family inet6 {
+{%     if l.ipv6 is string %}
+        address {{ l.ipv6 }};
+{%     endif %}
+      }
+{%   endif %}
+    }
+  }
+{% endfor %}
+}
+
+security {
+    zones {
+        security-zone default {
+            interfaces {
+                {% for l in netlab_interfaces|default([]) %}
+                {{ l.ifname }}.0;
+                {% endfor %}
+            }
+        }
+    }
+}

--- a/netsim/ansible/templates/initial/csrx.j2
+++ b/netsim/ansible/templates/initial/csrx.j2
@@ -1,56 +1,6 @@
-system {
-  host-name {{ inventory_hostname }};
-  static-host-mapping {
-{% for k,v in hostvars.items() if k != inventory_hostname %}
-{%   if v.loopback.ipv4 is defined %}
-    {{ k|replace('_','') }} inet {{ v.loopback.ipv4|ansible.utils.ipaddr('address') }};
-{%   elif v.interfaces|default([]) and v.interfaces[0].ipv4|default(False) is string %}
-    {{ k|replace('_','') }} inet {{ v.interfaces[0].ipv4|ansible.utils.ipaddr('address') }};
-{%   endif %}
-{% endfor %}
-  }
-}
+{% include 'junos/hosts.j2' %}
 
-interfaces {
-{% for l in netlab_interfaces|default([]) %}
-  {{ l.ifname }} {
-{%   if l.mtu is defined %}
-    mtu {{ l.mtu }};
-{%   endif %}
-{%   if l.name is defined %}
-    description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}";
-{%   elif l.type|default("") == "stub" %}
-    description "Stub interface"
-{%   endif %}
-    unit 0 {
-{#
-    IPv4 addresses
-#}
-{%   if 'ipv4' in l %}
-      family inet {
-{%     if l.ipv4 == True %}
-        unnumbered-address lo0.0;
-{%     elif l.ipv4|ansible.utils.ipv4 %}
-        address {{ l.ipv4 }};
-{%     else %}
-! Invalid IPv4 address {{ l.ipv4 }}
-{%     endif %}
-      }
-{%   endif %}
-{#
-    IPv6 addresses
-#}
-{%   if 'ipv6' in l %}
-      family inet6 {
-{%     if l.ipv6 is string %}
-        address {{ l.ipv6 }};
-{%     endif %}
-      }
-{%   endif %}
-    }
-  }
-{% endfor %}
-}
+{% include 'junos/container_interfaces.j2' %}
 
 security {
     zones {

--- a/netsim/ansible/templates/initial/junos.j2
+++ b/netsim/ansible/templates/initial/junos.j2
@@ -1,15 +1,4 @@
-system {
-  host-name {{ inventory_hostname }};
-  static-host-mapping {
-{% for k,v in hostvars.items() if k != inventory_hostname %}
-{%   if v.loopback.ipv4 is defined %}
-    {{ k|replace('_','') }} inet {{ v.loopback.ipv4|ansible.utils.ipaddr('address') }};
-{%   elif v.interfaces|default([]) and v.interfaces[0].ipv4|default(False) is string %}
-    {{ k|replace('_','') }} inet {{ v.interfaces[0].ipv4|ansible.utils.ipaddr('address') }};
-{%   endif %}
-{% endfor %}
-  }
-}
+{% include 'junos/hosts.j2' %}
 
 {% if vrfs is defined %}
 {% include 'junos.vrf.j2' %}
@@ -38,7 +27,7 @@ interfaces {
 {% elif l.type|default("") == "stub" %}
     description "Stub interface"
 {% endif %}
-    
+
 {% if l.bandwidth is defined %}
       bandwidth {{ l.bandwidth * 1000 }};
 {% endif %}
@@ -74,24 +63,8 @@ interfaces {
         mtu {{ l.mtu }};
 {%   endif %}
       }
-{% endif %}    
+{% endif %}
   }
 {% endfor %}
 }
-protocols {
-  lldp {
-    interface {{ mgmt.ifname|default('fxp0') }} {
-      disable;
-    }
-    interface all;
-  }
-{% for l in netlab_interfaces if 'ipv6' in l and l.type != 'loopback' %}
-{%   if loop.first %}
-  router-advertisement {
-{%   endif %}
-    interface {{ l.ifname }};
-{%   if loop.last %}
-  }
-{%   endif %}
-{% endfor %}
-}
+{% include 'junos/lldp.j2' %}

--- a/netsim/ansible/templates/initial/junos/container_interfaces.j2
+++ b/netsim/ansible/templates/initial/junos/container_interfaces.j2
@@ -1,0 +1,40 @@
+interfaces {
+{% for l in netlab_interfaces|default([]) %}
+  {{ l.ifname }} {
+{%   if l.mtu is defined %}
+    mtu {{ l.mtu }};
+{%   endif %}
+{%   if l.name is defined %}
+    description "{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}";
+{%   elif l.type|default("") == "stub" %}
+    description "Stub interface"
+{%   endif %}
+    unit 0 {
+{#
+    IPv4 addresses
+#}
+{%   if 'ipv4' in l %}
+      family inet {
+{%     if l.ipv4 == True %}
+        unnumbered-address lo0.0;
+{%     elif l.ipv4|ansible.utils.ipv4 %}
+        address {{ l.ipv4 }};
+{%     else %}
+! Invalid IPv4 address {{ l.ipv4 }}
+{%     endif %}
+      }
+{%   endif %}
+{#
+    IPv6 addresses
+#}
+{%   if 'ipv6' in l %}
+      family inet6 {
+{%     if l.ipv6 is string %}
+        address {{ l.ipv6 }};
+{%     endif %}
+      }
+{%   endif %}
+    }
+  }
+{% endfor %}
+}

--- a/netsim/ansible/templates/initial/junos/hosts.j2
+++ b/netsim/ansible/templates/initial/junos/hosts.j2
@@ -1,0 +1,12 @@
+system {
+  host-name {{ inventory_hostname }};
+  static-host-mapping {
+{% for k,v in hostvars.items() if k != inventory_hostname %}
+{%   if v.loopback.ipv4 is defined %}
+    {{ k|replace('_','') }} inet {{ v.loopback.ipv4|ansible.utils.ipaddr('address') }};
+{%   elif v.interfaces|default([]) and v.interfaces[0].ipv4|default(False) is string %}
+    {{ k|replace('_','') }} inet {{ v.interfaces[0].ipv4|ansible.utils.ipaddr('address') }};
+{%   endif %}
+{% endfor %}
+  }
+}

--- a/netsim/ansible/templates/initial/junos/lldp.j2
+++ b/netsim/ansible/templates/initial/junos/lldp.j2
@@ -1,0 +1,17 @@
+protocols {
+  lldp {
+    interface {{ mgmt.ifname|default('fxp0') }} {
+      disable;
+    }
+    interface all;
+  }
+{% for l in netlab_interfaces if 'ipv6' in l and l.type != 'loopback' %}
+{%   if loop.first %}
+  router-advertisement {
+{%   endif %}
+    interface {{ l.ifname }};
+{%   if loop.last %}
+  }
+{%   endif %}
+{% endfor %}
+}

--- a/netsim/ansible/templates/routing/csrx.j2
+++ b/netsim/ansible/templates/routing/csrx.j2
@@ -1,26 +1,3 @@
 {% if routing.static is defined %}
-{% for sr_data in routing.static %}
-{#   recursive lookup is triggered by a route without the intf parameter #}
-{%   set route_resolve = ' resolve' if not 'intf' in sr_data.nexthop else '' %}
-    routing-options {
-{%   if 'ipv4' in sr_data %}
-      static route {{sr_data.ipv4}} {
-{%     if 'discard' in sr_data.nexthop %}
-        discard;
-{%     else %}
-        next-hop {{sr_data.nexthop.ipv4}}{{route_resolve}};
-{%     endif %}
-      }
-{%   endif %}
-{%   if 'ipv6' in sr_data %}
-        rib inet6.0 static route {{sr_data.ipv6}} {
-{%     if 'discard' in sr_data.nexthop %}
-          discard;
-{%     else %}
-          next-hop {{sr_data.nexthop.ipv6}}{{route_resolve}};
-{%     endif %}
-        }
-{%   endif %}
-    }
-{% endfor %}
+{%   include 'junos/static.j2' %}
 {% endif %}

--- a/netsim/ansible/templates/routing/csrx.j2
+++ b/netsim/ansible/templates/routing/csrx.j2
@@ -1,0 +1,26 @@
+{% if routing.static is defined %}
+{% for sr_data in routing.static %}
+{#   recursive lookup is triggered by a route without the intf parameter #}
+{%   set route_resolve = ' resolve' if not 'intf' in sr_data.nexthop else '' %}
+    routing-options {
+{%   if 'ipv4' in sr_data %}
+      static route {{sr_data.ipv4}} {
+{%     if 'discard' in sr_data.nexthop %}
+        discard;
+{%     else %}
+        next-hop {{sr_data.nexthop.ipv4}}{{route_resolve}};
+{%     endif %}
+      }
+{%   endif %}
+{%   if 'ipv6' in sr_data %}
+        rib inet6.0 static route {{sr_data.ipv6}} {
+{%     if 'discard' in sr_data.nexthop %}
+          discard;
+{%     else %}
+          next-hop {{sr_data.nexthop.ipv6}}{{route_resolve}};
+{%     endif %}
+        }
+{%   endif %}
+    }
+{% endfor %}
+{% endif %}

--- a/netsim/devices/csrx.py
+++ b/netsim/devices/csrx.py
@@ -6,6 +6,7 @@ from box import Box
 from ..utils import log
 from . import _Quirks, report_quirk
 
+
 def csrx_port_num(node: Box) -> None:
   if_count = len(node.get('interfaces', []))
   node.clab.env.CSRX_PORT_NUM = if_count + 1

--- a/netsim/devices/csrx.py
+++ b/netsim/devices/csrx.py
@@ -4,10 +4,20 @@
 from box import Box
 
 from ..utils import log
-from . import _Quirks
+from . import _Quirks, report_quirk
+
+def csrx_port_num(node: Box) -> None:
+  if_count = len(node.get('interfaces', []))
+  node.clab.env.CSRX_PORT_NUM = if_count + 1
+  if if_count > 16:
+    report_quirk(
+        f'cSRX supports a maximum of 16 interfaces. Node {node.name} has {if_count} interfaces.',
+        node=node,
+        category=log.ErrorAbort,
+        quirk='csrx_port_num')
 
 class CSRX(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
-    return
+    csrx_port_num(node)

--- a/netsim/devices/csrx.py
+++ b/netsim/devices/csrx.py
@@ -1,0 +1,13 @@
+#
+# Juniper cSRX quirks
+#
+from box import Box
+
+from ..utils import log
+from . import _Quirks, report_quirk
+
+class CSRX(_Quirks):
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    from . import junos

--- a/netsim/devices/csrx.py
+++ b/netsim/devices/csrx.py
@@ -4,18 +4,17 @@
 from box import Box
 
 from ..utils import log
-from . import _Quirks, report_quirk
+from . import _Quirks
 
 
 def csrx_port_num(node: Box) -> None:
   if_count = len(node.get('interfaces', []))
-  node.clab.env.CSRX_PORT_NUM = if_count + 1
+  node.clab.env.CSRX_PORT_NUM = if_count + 1 # +1 for the management interface
   if if_count > 16:
-    report_quirk(
-        f'cSRX supports a maximum of 16 interfaces. Node {node.name} has {if_count} interfaces.',
-        node=node,
-        category=log.ErrorAbort,
-        quirk='csrx_port_num')
+    log.error(
+      f'cSRX supports a maximum of 16 interfaces. Node {node.name} has {if_count} interfaces.',
+      category=log.IncorrectValue,
+      module=node.device)
 
 class CSRX(_Quirks):
 

--- a/netsim/devices/csrx.py
+++ b/netsim/devices/csrx.py
@@ -4,10 +4,10 @@
 from box import Box
 
 from ..utils import log
-from . import _Quirks, report_quirk
+from . import _Quirks
 
 class CSRX(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
-    from . import junos
+    return

--- a/netsim/devices/csrx.yml
+++ b/netsim/devices/csrx.yml
@@ -1,0 +1,55 @@
+---
+description: Juniper cSRX container
+group_vars:
+  ansible_user: root
+  ansible_ssh_pass: "clab123"
+  netlab_device_type: csrx
+  netlab_check_retries: 20
+
+mgmt_if: fxp0
+ifindex_offset: 0
+interface_name: ge-0/0/{ifindex}
+loopback_interface_name: "" # Unsupported on cSRX
+mtu: 1500
+
+features:
+  initial:
+    ipv4:
+      unnumbered: false               # The 'unnumbered-address' family inet command does not work on cSRX
+    ipv6:
+      lla: true
+  routing:
+    static:
+      vrf: False
+      discard: True
+
+clab:
+  image: csrx:23.4R1.9
+  build: https://containerlab.dev/manual/kinds/csrx/
+  node:
+    kind: juniper_csrx
+    env:
+      # Number of interfaces to create
+      # cSRX default is 3 (management + 2 data interfaces)
+      # If more interfaces are required, this must be increased.
+      # Setting to a higher value than required will break interfaces (no arp etc)
+      CSRX_PORT_NUM: 3
+    config_templates:
+      hosts: /etc/hosts:shared
+      netlab-config: /config/netlab/netlab-config.sh:sh
+  interface:
+    name: eth{ifindex+1}
+  features:
+    initial:
+      config_mode: [ sh ]
+  group_vars:
+    netlab_config_mode: sh
+    netlab_show_command: [ cli, -c, 'show $@' ]
+    netlab_check_command: who
+    netlab_ready: [ ssh ]
+    netlab_default_shebang: '#!/config/netlab/netlab-config.sh'
+#    ansible_connection: docker
+#    netlab_console_connection: docker
+    netlab_config_path: /config/netlab/
+
+graphite.icon: firewall

--- a/netsim/devices/csrx.yml
+++ b/netsim/devices/csrx.yml
@@ -9,7 +9,6 @@ group_vars:
 mgmt_if: fxp0
 ifindex_offset: 0
 interface_name: ge-0/0/{ifindex}
-loopback_interface_name: "" # Unsupported on cSRX
 mtu: 1500
 
 features:
@@ -42,8 +41,6 @@ clab:
     netlab_check_command: who
     netlab_ready: [ ssh ]
     netlab_default_shebang: '#!/config/netlab/netlab-config.sh'
-#    ansible_connection: docker
-#    netlab_console_connection: docker
     netlab_config_path: /config/netlab/
 
 graphite.icon: firewall

--- a/netsim/devices/csrx.yml
+++ b/netsim/devices/csrx.yml
@@ -28,12 +28,6 @@ clab:
   build: https://containerlab.dev/manual/kinds/csrx/
   node:
     kind: juniper_csrx
-    env:
-      # Number of interfaces to create
-      # cSRX default is 3 (management + 2 data interfaces)
-      # If more interfaces are required, this must be increased.
-      # Setting to a higher value than required will break interfaces (no arp etc)
-      CSRX_PORT_NUM: 3
     config_templates:
       hosts: /etc/hosts:shared
       netlab-config: /config/netlab/netlab-config.sh:sh

--- a/netsim/templates/provider/clab/csrx/hosts.j2
+++ b/netsim/templates/provider/clab/csrx/hosts.j2
@@ -1,0 +1,1 @@
+{% include 'linux/hosts.j2' %}

--- a/netsim/templates/provider/clab/csrx/netlab-config.j2
+++ b/netsim/templates/provider/clab/csrx/netlab-config.j2
@@ -1,0 +1,19 @@
+#!/bin/bash
+tail -n +2 $1 > /tmp/config.conf # stop shebang being included in pushed config
+cat <<CONFIG | cli | tee /tmp/cli-status
+configure
+load merge /tmp/config.conf
+CONFIG
+if grep -i error /tmp/cli-status >/dev/null; then
+  echo "Configuration load failed, aborting"
+  exit 1
+else
+  cat <<CONFIG | cli | tee /tmp/cli-status
+configure
+commit and-quit
+CONFIG
+  if grep -i error /tmp/cli-status | grep -vi "Device or resource busy" >/dev/null; then
+    echo "Commit failed, aborting"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
Juniper cSRX was added to ContainerLab 0.75.0 https://github.com/srl-labs/containerlab/releases/tag/v0.75.0. This PR adds support for it in Netlab.

There are limited features in cSRX e.g. it does not support routing protocols or VLANs. See https://www.juniper.net/documentation/us/en/software/csrx/csrx-consolidated-deployment-guide/topics/concept/security-csrx-docker-feature-support.html and https://www.juniper.net/documentation/us/en/software/csrx/csrx-consolidated-deployment-guide/csrx-consolidated-deployment-guide.pdf.

It might not be useful to many but I had to lab a weird NAT issue today and netlab would have sped it up so why not spend 20 times longer adding support than it took to do manually?!