### PR TITLE
Consistent device features.initial.{collect,reload} flags

### DIFF
--- a/docs/dev/devices.md
+++ b/docs/dev/devices.md
@@ -115,6 +115,8 @@ Device parameters file can also include numerous *features*. The following featu
 * **features.initial.ipv6.lla** -- The device supports IPv6 interfaces using just link-local addresses.
 * **features.initial.ipv6.use_ra** -- The device (when running as a host) listens to IPv6 RA messages to generate a default route
 * **features.initial.roles** -- The list of roles a device can have (default: `[ router ]`)
+* **features.initial.collect** (bool) -- netlab knows how to collect device configuration (default: False). When this feature is set, the device MUST have the `fetch-config` tasklist.
+* **features.initial.reload** (bool) -- netlab can reload the complete saved device configuration after starting the lab (default: False). Device configuration reload uses the `deploy-config` tasklist to merge the saved configuration with the startup configuration. Add a `reload-config` tasklist if your device requires a different approach (for example, **configure replace** command).
 * **features.initial.normalize** -- The device needs the configuration normalization step before the initial configuration is applied to any devices in the lab. Usually used for devices that act as simple bridges when started (Arista cEOS, Cisco IOLL2). When this feature is set, the device MUST have the `normalize` template.
 * **features.groups** -- The groups this device belongs to. You can set this feature to [`[ unprovisioned ]`](group-special-names) for devices that _netlab_ cannot configure yet. Don't forget to remove the **unprovisioned** group once you implement the Ansible [device configuration task list](dev-new-devices-configure).
 

--- a/docs/release/26.05.md
+++ b/docs/release/26.05.md
@@ -44,6 +44,10 @@ ansible_httpapi_port: 80
 
 * The playbook tries to reach the FortiOS HTTPS server immediately after switching to multi-VDOM mode and will retry several times. When needed, use [these node/group variables](caveats-fortios-70) to increase the wait time.
 
+Other breaking changes:
+
+* The 'reload device configuration' functionality relied on **initial.reload: False** feature flag to detect devices that do not support it. We added an explicit **initial.reload** feature to all devices, and changed the default behavior to "device does not support configuration reloads". This might prevent configuration reloads from working on custom devices.
+
 (bug-fixes-26.05)=
 ## Bug Fixes
 

--- a/netsim/augment/nodes.py
+++ b/netsim/augment/nodes.py
@@ -490,8 +490,10 @@ def augment_node_device_data(n: Box, topology: Box) -> None:
         category=log.IncorrectType,
         module='nodes')
 
-  if not features.get('initial.reload',True):
+  if not features.get('initial.reload',False):
     append_to_list(topology.groups.netlab_no_reload,'members',n.name)
+  if not features.get('initial.collect',False):
+    append_to_list(topology.groups.netlab_no_collect,'members',n.name)
 
 '''
 Main node transformation code

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -41,6 +41,8 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+    collect: true
+    reload: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/asav.yml
+++ b/netsim/devices/asav.yml
@@ -18,6 +18,8 @@ group_vars:
 external:
   image: none
 features:
+  initial:
+    collect: True
   bgp: True
   isis:
     circuit_type: True

--- a/netsim/devices/csrx.yml
+++ b/netsim/devices/csrx.yml
@@ -3,6 +3,7 @@ description: Juniper cSRX container
 group_vars:
   ansible_user: root
   ansible_ssh_pass: "clab123"
+  ansible_network_os: junos
   netlab_device_type: csrx
   netlab_check_retries: 20
 
@@ -17,6 +18,8 @@ features:
       unnumbered: false               # The 'unnumbered-address' family inet command does not work on cSRX
     ipv6:
       lla: true
+    collect: true
+    reload: false
   routing:
     static:
       vrf: False

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -54,6 +54,8 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    collect: true
+    reload: true
   bfd: True
   bgp:
     activate_af: True

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -37,6 +37,8 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    collect: true
+    reload: false
   bgp:
     activate_af: True
     advertise: true

--- a/netsim/devices/dellos10.yml
+++ b/netsim/devices/dellos10.yml
@@ -13,6 +13,8 @@ features:
       lla: true
     delay: 30
     normalize: true
+    collect: true
+    reload: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -31,6 +31,8 @@ features:
     mgmt_vrf: true
     generate_mac: [ ethernet ]
     normalize: true
+    collect: true
+    reload: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/exos.yml
+++ b/netsim/devices/exos.yml
@@ -13,6 +13,8 @@ features:
     max_mtu: 9216
     ra: true
     normalize: true
+    collect: true
+    reload: true
   ospf:
     loopback:
       passive: true

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -44,4 +44,6 @@ features:
   routing:
     static:
       discard: true
+  initial:
+    collect: true
 graphite.icon: firewall

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -83,6 +83,8 @@ features:
     ra: true
     roles: [ host, router, bridge ]
     generate_mac: [ svi ]
+    collect: true
+    reload: true
   bfd: True
   bgp:
     activate_af: true

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -81,6 +81,8 @@ features:
     roles: [ host, router, bridge ]
     mgmt_vrf: true
     ra: true
+    collect: true
+    reload: true
   isis:
     circuit_type: true
     import: [ bgp, ospf, ripv2, connected, static ]

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -21,6 +21,8 @@ features:
       unnumbered: true
     ipv6:
       lla: true
+    collect: true
+    reload: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -10,6 +10,7 @@ features:
   routing:
     static: true
   initial:
+    collect: false
     reload: false
     ipv4:
       unnumbered: peer

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -74,6 +74,8 @@ features:
     mgmt_vrf: True
     ra: True
     roles: [ router, bridge, host ]
+    collect: True
+    reload: True
   isis:
     import: [ bgp, ospf, ripv2, connected, vrf ]
     vrf: True

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -37,6 +37,8 @@ features:
     ipv6:
       lla: true
     generate_mac: [ ethernet ]
+    collect: true
+    reload: true
   bfd: true
   bgp:
     advertise: true

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -14,6 +14,7 @@ features:
     ipv6:
       use_ra: true
       lla: true
+    collect: false
     reload: false
     roles: [ host, router ]
   ospf:

--- a/netsim/devices/routeros.yml
+++ b/netsim/devices/routeros.yml
@@ -15,6 +15,8 @@ group_vars:
   ansible_user: admin
   ansible_ssh_pass: admin
 features:
+  initial:
+    collect: true
   bgp: true
   mpls:
     ldp: true

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -22,6 +22,7 @@ group_vars:
 features:
   initial:
     roles: [ router ]
+    collect: true
   bgp:
     default_originate: true
     allowas_in: true

--- a/netsim/devices/sonic.yml
+++ b/netsim/devices/sonic.yml
@@ -28,6 +28,7 @@ features:
     ipv6:
       lla: true
     reload: false
+    collect: true
   bgp:
     activate_af: true
     advertise: true

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -41,6 +41,8 @@ features:
       unnumbered: True
     ipv6:
       lla: True
+    collect: true
+    reload: true
   bfd: True
   bgp:
     advertise: true

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -36,6 +36,8 @@ features:
       lla: True
     min_phy_mtu: 1500
     max_mtu: 9782
+    collect: true
+    reload: true
   bfd: True
   bgp:
     advertise: true

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -18,6 +18,8 @@ features:
       unnumbered: true
     ipv6:
       lla: True
+    collect: true
+    reload: true
   bfd: true
   bgp:
     activate_af: true

--- a/netsim/devices/xr.yml
+++ b/netsim/devices/xr.yml
@@ -25,6 +25,8 @@ features:
     min_mtu: 68
     min_phy_mtu: 1500
     max_mtu: 9216
+    collect: true
+    reload: true
   bgp:
     activate_af: True
     advertise: true

--- a/netsim/modules/initial.yml
+++ b/netsim/modules/initial.yml
@@ -9,3 +9,5 @@ features:
   max_mtu: "Maximum layer-3 MTU supported by the device"
   min_phy_mtu: "Minimum MTU that can be configured with 'mtu' command. Lower MTU settings use 'ip mtu'"
   roles: Valid device roles
+  collect: Collect device configuration
+  reload: Reload collected device configuration after a lab restart

--- a/tests/coverage/expected/device-node-defaults.yml
+++ b/tests/coverage/expected/device-node-defaults.yml
@@ -1,4 +1,8 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/coverage/expected/rt-vlan-anycast.yml
+++ b/tests/coverage/expected/rt-vlan-anycast.yml
@@ -5,6 +5,9 @@ gateway:
   vrrp:
     group: 1
 groups:
+  netlab_no_collect:
+    members:
+    - h
   netlab_no_reload:
     members:
     - h

--- a/tests/coverage/expected/rt-vlan-mode-link-route.yml
+++ b/tests/coverage/expected/rt-vlan-mode-link-route.yml
@@ -1,4 +1,7 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h
   netlab_no_reload:
     members:
     - h

--- a/tests/coverage/expected/rt-vlan-no-gateway.yml
+++ b/tests/coverage/expected/rt-vlan-no-gateway.yml
@@ -4,6 +4,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/anycast-gateway.yml
+++ b/tests/topology/expected/anycast-gateway.yml
@@ -13,6 +13,12 @@ groups:
     - h2
     - h3
     - h4
+  netlab_no_collect:
+    members:
+    - h4
+    - h1
+    - h2
+    - h3
   netlab_no_reload:
     members:
     - h4

--- a/tests/topology/expected/bridge-module-attr.yml
+++ b/tests/topology/expected/bridge-module-attr.yml
@@ -1,4 +1,7 @@
 groups:
+  netlab_no_collect:
+    members:
+    - br
   netlab_no_reload:
     members:
     - br

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -68,6 +68,12 @@ groups:
     - pod_2_l2_leaf
     node_data:
       name: l2
+  netlab_no_collect:
+    members:
+    - pod_1_l1_srv
+    - pod_1_l2_srv
+    - pod_2_l1_srv
+    - pod_2_l2_srv
   netlab_no_reload:
     members:
     - pod_1_l1_srv

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -7,6 +7,10 @@ dhcp:
     ipv4: 172.16.0.0/24
     name: links[1]
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - dhs
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -29,6 +29,12 @@ groups:
     - h1
     - h2
     - h3
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - dhs
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
+++ b/tests/topology/expected/evpn-asymmetric-irb-ospf.yml
@@ -29,6 +29,12 @@ groups:
     - h3
     - h4
     module: []
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/evpn-vxlan.yml
+++ b/tests/topology/expected/evpn-vxlan.yml
@@ -26,6 +26,12 @@ groups:
   as65002:
     members:
     - s4
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/fabric-ebgp.yml
+++ b/tests/topology/expected/fabric-ebgp.yml
@@ -45,6 +45,10 @@ groups:
     - l4
     node_data:
       bgp: {}
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/group-ansible-variables.yml
+++ b/tests/topology/expected/group-ansible-variables.yml
@@ -8,6 +8,11 @@ groups:
     node_data:
       ansible_connection: ac
       netlab_device_type: hx
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/groups-vlan-vrf.yml
+++ b/tests/topology/expected/groups-vlan-vrf.yml
@@ -20,6 +20,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/lag-mlag-m_to_m.yml
+++ b/tests/topology/expected/lag-mlag-m_to_m.yml
@@ -4,6 +4,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -7,6 +7,10 @@ groups:
     node_data:
       box: none
       provider: clab
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/link-loopback.yml
+++ b/tests/topology/expected/link-loopback.yml
@@ -1,4 +1,7 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/node.clone-plugin.yml
+++ b/tests/topology/expected/node.clone-plugin.yml
@@ -6,6 +6,11 @@ groups:
     - host_w_long_n-01
     - host_w_long_n-02
     - host_w_long_n-03
+  netlab_no_collect:
+    members:
+    - host_w_long_n-01
+    - host_w_long_n-02
+    - host_w_long_n-03
   netlab_no_reload:
     members:
     - host_w_long_n-01

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -8,6 +8,12 @@ groups:
     - h4
     node_data:
       provider: clab
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -8,6 +8,12 @@ groups:
     - h4
     node_data:
       provider: clab
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/unmanaged-device.yml
+++ b/tests/topology/expected/unmanaged-device.yml
@@ -1,4 +1,7 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -1,4 +1,8 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-access-node.yml
+++ b/tests/topology/expected/vlan-access-node.yml
@@ -4,6 +4,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -1,4 +1,8 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-bridge-trunk-router.yml
+++ b/tests/topology/expected/vlan-bridge-trunk-router.yml
@@ -4,6 +4,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-coverage.yml
+++ b/tests/topology/expected/vlan-coverage.yml
@@ -1,4 +1,8 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-native-routed.yml
+++ b/tests/topology/expected/vlan-native-routed.yml
@@ -1,4 +1,7 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-routed.yml
+++ b/tests/topology/expected/vlan-routed.yml
@@ -1,4 +1,8 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-trunk-native.yml
+++ b/tests/topology/expected/vlan-trunk-native.yml
@@ -1,4 +1,11 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
+    - h5
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-vrf-lite.yml
+++ b/tests/topology/expected/vlan-vrf-lite.yml
@@ -6,6 +6,12 @@ groups:
     - h2
     - h3
     - h4
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vlan-vrrp.yml
+++ b/tests/topology/expected/vlan-vrrp.yml
@@ -10,6 +10,10 @@ groups:
     members:
     - h1
     - h2
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vxlan-static.yml
+++ b/tests/topology/expected/vxlan-static.yml
@@ -1,4 +1,10 @@
 groups:
+  netlab_no_collect:
+    members:
+    - h1
+    - h2
+    - h3
+    - h4
   netlab_no_reload:
     members:
     - h1

--- a/tests/topology/expected/vxlan-vrf-lite.yml
+++ b/tests/topology/expected/vxlan-vrf-lite.yml
@@ -23,6 +23,13 @@ groups:
     - bh1
     - bh2
     module: []
+  netlab_no_collect:
+    members:
+    - rh1
+    - rh2
+    - rh3
+    - bh1
+    - bh2
   netlab_no_reload:
     members:
     - rh1


### PR DESCRIPTION
We already had 'features.initial.reload' flag that could be set to False when a device could not do configuration reload. This commit sets an explicit 'reload' feature on all devices that support config reload and adds 'collect' feature for devices that can collect device configurations

The new 'collect' flag is also used to generate the 'netlab_no_collect' group which will be used in 'netlab collect' and 'collect-configs' playbook

The addition of the new group triggered a change in transformation test results which is limited to netlab_no_collect.members.