### PR TITLE
Fix netlab down within the netlab restart command

### DIFF
--- a/netsim/cli/restart.py
+++ b/netsim/cli/restart.py
@@ -5,6 +5,7 @@
 #
 import argparse
 import typing
+import re 
 
 from . import common_parse_args, down, parser_lab_location, up
 
@@ -38,5 +39,5 @@ def run(cli_args: typing.List[str]) -> None:
   parser.parse_args(cli_args)
   up_only_args = ['--fast-config','--no-config','--snapshot']
 
-  down.run([ arg for arg in cli_args if arg not in up_only_args ])
+  down.run([ arg for arg in cli_args if arg not in up_only_args and not bool(re.search(r"\.ya?ml$", arg)) ])
   up.run(cli_args)


### PR DESCRIPTION
When using `netlab restart` to restart a lab the `netlab down` part of it fails as the topology file name is being passed in to the command (only needed for `netlab up`) 

```bash
ste@netlab-dev:~/labs$ netlab restart simple_topo.yml
usage: netlab down [-h] [-v] [--cleanup] [--dry-run] [--force] [-i INSTANCE] [--snapshot [SNAPSHOT]]
netlab down: error: unrecognized arguments: simple_topo.yml
```

Fixed in `restart.py` by adding the topology file to the filtering for netlab down. 

```bash
ste@netlab-dev:~/labs$ netlab restart simple_topo.yml

┌──────────────────────────────────────────────────────────────────────────────────┐
│ CHECKING virtualization provider installation                                    │
└──────────────────────────────────────────────────────────────────────────────────┘
[SUCCESS] clab installed and working correctly

┌──────────────────────────────────────────────────────────────────────────────────┐
│ STOPPING clab nodes                                                              │
└──────────────────────────────────────────────────────────────────────────────────┘
provider clab: executing sudo -E containerlab destroy --cleanup -t clab.yml
warning: preserving the entire environment is not supported, `-E` is ignored
23:43:11 INFO Parsing & checking topology file=clab.yml
23:43:11 INFO Parsing & checking topology file=clab.yml
23:43:11 INFO Destroying lab name=labs
23:43:11 INFO Removed container name=ACCESS_SWI
23:43:11 INFO Removing host entries path=/etc/hosts
23:43:11 INFO Removing SSH config path=/etc/ssh/ssh_config.d/clab-labs.conf

┌──────────────────────────────────────────────────────────────────────────────────┐
│ CREATING configuration files                                                     │
└──────────────────────────────────────────────────────────────────────────────────┘
[CONFIG]  ACCESS_SWI: ifstate,normalize,initial,vlan
[CREATED] provider configuration file: clab.yml
[CREATED] pickled transformed topology data into netlab.snapshot.pickle
[GROUPS]  group_vars for all
[GROUPS]  group_vars for modules
[GROUPS]  group_vars for ioll2
[HOSTS]   host_vars for ACCESS_SWI
[CREATED] minimized Ansible inventory hosts.yml
[CREATED] Ansible configuration file: ansible.cfg

┌──────────────────────────────────────────────────────────────────────────────────┐
│ CHECKING virtualization provider installation                                    │
└──────────────────────────────────────────────────────────────────────────────────┘
[SUCCESS] clab installed and working correctly

┌──────────────────────────────────────────────────────────────────────────────────┐
│ STARTING clab nodes                                                              │
└──────────────────────────────────────────────────────────────────────────────────┘
provider clab: executing sudo -E containerlab deploy --reconfigure -t clab.yml
warning: preserving the entire environment is not supported, `-E` is ignored
23:43:12 INFO Containerlab started version=0.75.0
```