### PR TITLE
Fix: Remove sets from topology (subset) rendered into JSON

### DIFF
--- a/netsim/outputs/yaml.py
+++ b/netsim/outputs/yaml.py
@@ -15,11 +15,13 @@ from . import _TopologyOutput, check_writeable
 We have to remove sets from the topology when rendering into JSON. YAML
 can take them, JSON can't.
 """
-def remove_sets(d: typing.Any) -> typing.Any:
+def transform_sets(d: typing.Any) -> typing.Any:
+  if isinstance(d,set):
+    return BoxList([transform_sets(v) for v in list(d)])
   if isinstance(d,dict):
-    return Box({ k:remove_sets(v) for k,v in d.items() if not isinstance(v,set)})
+    return Box({ k:transform_sets(v) for k,v in d.items()})
   elif isinstance(d,list):
-    return BoxList([ remove_sets(v) for v in d if not isinstance(v,set)])
+    return BoxList([transform_sets(v) for v in d])
   else:
     return d
 
@@ -63,7 +65,7 @@ class YAML(_TopologyOutput):
       r_txt = strings.get_yaml_string(cleantopo)
     else:
       r_fmt = 'json'
-      r_txt = remove_sets(cleantopo).to_json(indent=2,sort_keys=True)
+      r_txt = transform_sets(cleantopo).to_json(indent=2,sort_keys=True)
 
     if outfile != '-':
       output.write(r_txt)

--- a/netsim/outputs/yaml.py
+++ b/netsim/outputs/yaml.py
@@ -11,6 +11,17 @@ from ..utils import files as _files
 from ..utils import log, strings
 from . import _TopologyOutput, check_writeable
 
+"""
+We have to remove sets from the topology when rendering into JSON. YAML
+can take them, JSON can't.
+"""
+def remove_sets(d: typing.Any) -> typing.Any:
+  if isinstance(d,dict):
+    return Box({ k:remove_sets(v) for k,v in d.items() if not isinstance(v,set)})
+  elif isinstance(d,list):
+    return BoxList([ remove_sets(v) for v in d if not isinstance(v,set)])
+  else:
+    return d
 
 class YAML(_TopologyOutput):
 
@@ -52,7 +63,7 @@ class YAML(_TopologyOutput):
       r_txt = strings.get_yaml_string(cleantopo)
     else:
       r_fmt = 'json'
-      r_txt = cleantopo.to_json(indent=2,sort_keys=True)
+      r_txt = remove_sets(cleantopo).to_json(indent=2,sort_keys=True)
 
     if outfile != '-':
       output.write(r_txt)


### PR DESCRIPTION
JSON cannot render sets (which appear only as a single variable in defaults._globals). However, as the use can inspect/render a subset of 'defaults' dictionary, we cannot just remove that key but have to scrub the whole data structure when rendering into JSON.

Fixes #3346