### PR TITLE
Tests: harden ruamel detection and gate fixture generators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+#
+# Pytest hooks shared across the netlab test tree
+#
+
+from utils import HAS_RUAMEL
+
+
+def pytest_configure(config):
+  if not HAS_RUAMEL:
+    return
+  config.issue_config_time_warning(
+    UserWarning(
+      "ruamel.yaml is installed; transformation tests will be slower and "
+      "`create-error-tests.sh` is unsupported "
+      "(see https://github.com/ipspace/netlab/issues/3345)."
+    ),
+    stacklevel=2,
+  )

--- a/tests/create-error-tests.sh
+++ b/tests/create-error-tests.sh
@@ -4,6 +4,12 @@
 # on STDERR into a file that will be used in the test harness
 # to validate the error handling hasn't been broken.
 #
+if python3 -c "import ruamel.yaml" 2>/dev/null; then
+  echo "ERROR: ruamel.yaml is installed; error-test fixtures cannot be generated" >&2
+  echo "       correctly. Uninstall ruamel.yaml first (see #3345)." >&2
+  exit 2
+fi
+
 ERR_PATH="errors"
 
 # Check for "coverage" first

--- a/tests/create-transformation-test-case.py
+++ b/tests/create-transformation-test-case.py
@@ -5,6 +5,7 @@
 #
 
 import argparse
+import sys
 
 import utils
 from box import Box
@@ -34,6 +35,12 @@ def parse() -> argparse.Namespace:
 
 def main() -> None:
   args = parse()
+  if utils.HAS_RUAMEL:
+    print(
+      "WARNING: ruamel.yaml is installed; fixture generation will be slower. "
+      "Consider uninstalling ruamel.yaml (see #3345).",
+      file=sys.stderr,
+    )
   print(f"Reading {args.topology}")
   topology = _read.load(args.topology,user_defaults=[],relative_topo_name=True)
   if utils.HAS_RUAMEL:

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -72,7 +72,7 @@ def test_xform_cases(tmpdir: str) -> None:
 
 # Verbose test cases are executed only when we're doing a coverage report
 #
-def test_coverage_verbose_cases(tmpdir: str ) -> None:
+def test_coverage_verbose_cases(tmpdir: str) -> None:
   if not sys.gettrace():
     return
   log.set_verbose()
@@ -81,7 +81,6 @@ def test_coverage_verbose_cases(tmpdir: str ) -> None:
 def run_error_case(test_case: str) -> None:
   log.set_flag(raise_error = True)
   print("Test case: %s" % test_case)
-  log._ERROR_LOG = []
   with pytest.raises(log.ErrorAbort):
     run_test(test_case)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,18 +10,17 @@ from box import Box
 from netsim.augment.nodes import ghost_buster
 
 try:
-  import ruamel  # type: ignore # noqa: F401 -- dear ruff, please do not complain, we need to know what we're dealing with
+  import ruamel.yaml  # type: ignore # noqa: F401 -- detect the actual library, not just the namespace shim
   HAS_RUAMEL = True
-except:
+except ImportError:
   HAS_RUAMEL = False
 
-"""
-Ruamel loves to use data types derived from int/str/float. If we want to
-create YAML via PyYAML (see #3345), we need to go through the whole data
-structure and clean it up. Yeah, it will be slow. Hooray for consistency!
-"""
 def clean_ruamel(data: typing.Any) -> typing.Any:
-  global HAS_RUAMEL
+  """
+  Ruamel loves to use data types derived from int/str/float. If we want to
+  create YAML via PyYAML (see #3345), we need to go through the whole data
+  structure and clean it up. Yeah, it will be slow. Hooray for consistency!
+  """
   if not HAS_RUAMEL:
     return data
   
@@ -54,4 +53,4 @@ def transformation_results_yaml(topology: Box) -> str:
   if 'unmanaged' in ignore:
     topology = ghost_buster(topology)
 
-  return yaml.dump(topology.to_dict(),width=120)
+  return yaml.dump(topology.to_dict(),default_flow_style=False,width=120)


### PR DESCRIPTION
A few items I'd suggest addressing before merging PR #3345, plus two small follow-ups:

### 1. The detection probe matches the namespace shim, not the library

`tests/utils.py` does `import ruamel`, but `ruamel` is a PEP 420 namespace package — it can survive uninstalls of `ruamel.yaml` (the `ruamel/` directory often lingers, or another package owns part of the namespace). On my system right now:

```
>>> import ruamel
>>> import ruamel.yaml
ModuleNotFoundError: No module named 'ruamel.yaml'
```

`HAS_RUAMEL` becomes `True` while `Box`/PyYAML disagree, and `clean_ruamel` runs for nothing. python-box itself probes with `from ruamel.yaml import version_info, YAML` (`box/converters.py:22`). Suggested:

```python
try:
  import ruamel.yaml  # noqa: F401
  HAS_RUAMEL = True
except ImportError:
  HAS_RUAMEL = False
```

### 2. `yaml.dump` should pin `default_flow_style=False`

`Box.to_yaml(...)` in python-box 7.x defaults to `default_flow_style=False, width=120` and calls `yaml.dump(obj, default_flow_style=default_flow_style, width=width, ...)` (`box/converters.py:195`, `box/box.py:1018`). The PR replaces it with:

```python
return yaml.dump(topology.to_dict(), width=120)
```

PyYAML's own default for `default_flow_style` is `None` ("auto: flow for inner scalar-only collections"), not `False`. Today's fixtures are all under-mappings, so the two modes coincide and the suite passes. The next fixture with a top-level scalar list, or a deeply nested scalar-only structure, will silently diverge from the format every committed `expected/*.yml` was generated in. One-line fix:

```python
return yaml.dump(topology.to_dict(), default_flow_style=False, width=120)
```

### 3. `log._ERROR_LOG = []` is redundant

The previous line was `log.err_count = 0`, which was a typo from the start — `log.err_count` doesn't exist; the public counter is `get_error_count()` at `netsim/utils/log.py:389`. The new `log._ERROR_LOG = []` does target a real attribute, but `run_test` immediately calls `log.init_log_system(header=False)`, which itself does `_ERROR_LOG = []` (`log.py:539`). The reset is redundant, and reaching into a leading-underscore symbol from outside the module is a smell. Either drop the line, or call `log.init_log_system(header=False)` if a defensive reset is desired.

### Two small follow-ups worth folding in

- **`tests/conftest.py` (new):** the standard-pytest-safe way to surface "ruamel.yaml is installed, things will be slower" is `pytest_configure` + `config.issue_config_time_warning(UserWarning(...))`. It appears in pytest's warnings summary, never fails a run, and doesn't touch collection / `-k` filtering / parallelism. Import `HAS_RUAMEL` from `tests/utils.py` so there's a single source of truth.
- **Gate the fixture generators.** The PR docs already say error-log fixtures can't be generated under ruamel, but `tests/create-error-tests.sh` doesn't enforce it — a user can still run it and commit broken `.log` files. A 4-line `python3 -c "import ruamel.yaml" && exit 2` guard at the top closes that hole. `tests/create-transformation-test-case.py` *does* work under ruamel (the `clean_ruamel` walk handles it), so a stderr advisory there is enough.

Reference implementation of all of the above on `a-v-popov/netlab@pr-3353-followup` ([compare view](https://github.com/ipspace/netlab/compare/dev...a-v-popov:netlab:pr-3353-followup)) — verified end-to-end:

- Without `ruamel.yaml`: xform + error tests pass; no warning.
- With `ruamel.yaml` 0.19.1: xform + error tests pass (+~40% wall time, matching the "slower" claim); `UserWarning` appears in pytest's warnings summary; nothing fails or skips.
- `create-error-tests.sh` with `ruamel.yaml` installed: exits 2 with an actionable message before doing anything destructive.
- `ruff check .` clean.
