### PR TITLE
Fix: Check OSPF AF when configuring passive interfaces on EOS

### DIFF
--- a/netsim/ansible/templates/ospf/eos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/eos.ospfv2.j2
@@ -25,7 +25,7 @@ router ospf {{ ospf_pid }}
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% for l in intf_data if l.ospf.passive|default(False) %}
+{% for l in intf_data if l.ospf.passive|default(False) and 'ipv4' in l %}
  passive-interface {{ l.ifname }}
 {% endfor %}
 !

--- a/netsim/ansible/templates/ospf/eos.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/eos.ospfv3.j2
@@ -48,7 +48,7 @@ ipv6 router ospf {{ ospf_pid }}
 {% endif %}
 {{ ospf_default.config(ospf_data,'ipv6') }}
 {{ redistribute.config(ospf_data,af='ipv6',vrf=ospf_vrf) }}
-{% for l in intf_data if l.ospf.passive|default(False) %}
+{% for l in intf_data if l.ospf.passive|default(False) and 'ipv6' in l %}
  passive-interface {{ l.ifname }}
 {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
EOS does not like having OSPFv3 "passive interface" defined for interfaces that have no IPv6 address. Interestingly, most other network operating systems work just fine with the same gotcha.

Closes #3361