### PR TITLE
Fix: Generate partial initial config for ASAv config reload

### DIFF
--- a/netsim/ansible/templates/initial/asa.j2
+++ b/netsim/ansible/templates/initial/asa.j2
@@ -1,49 +1,51 @@
 hostname {{ inventory_hostname }}
 domain-name lab.local
 !
-{% for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) %}
-{%   if v.loopback.ipv4 is defined %}
+{% if not netlab_initial_reload|default(False) %}
+{%   for k,v in hostvars.items() if k != inventory_hostname and v.af.ipv4|default(False) %}
+{%     if v.loopback.ipv4 is defined %}
 name {{ v.loopback.ipv4|ansible.utils.ipaddr('address') }} {{ k }}
-{%   endif %}
-{% endfor %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
 !
 {% for l in interfaces|default([]) %}
 interface {{ l.ifname }}
-  no shutdown
-  nameif {{ l.ifname }}
-{% if l.name is defined %}
+{%   if l.shutdown|default(False) %}
+ shutdown
+{%   else %}
+ no shutdown
+{%   endif %}
+{%   if not netlab_initial_reload|default(False) %}
+ nameif {{ l.ifname }}
+{%     if l.name is defined %}
  description {{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}
-{% elif l.type|default("") == "stub" %}
+{%     elif l.type|default("") == "stub" %}
  description Stub interface
-{% endif %}
+{%     endif %}
 {#
     Set interface addresses: IPv4
 #}
-{% if 'ipv4' in l %}
-{%   if l.ipv4|ansible.utils.ipv4 %}
+{%     if 'ipv4' in l %}
  ip address {{ l.ipv4|ansible.utils.ipaddr('address') }} {{ l.ipv4|ansible.utils.ipaddr('netmask') }}
-{%   else %}
-! Invalid IPv4 address {{ l.ipv4 }}
-{%   endif %}
-{% endif %}
+{%     endif %}
 {#
     Set interface addresses: IPv6
 #}
-{% if 'ipv6' in l %}
-{%   if l.ipv6 == True %}
+{%     if 'ipv6' in l %}
+{%       if l.ipv6 == True %}
  ipv6 enable
-{%   elif l.ipv6|ansible.utils.ipv6 %}
+{%       else %}
  ipv6 address {{ l.ipv6|upper }}
-{%   else %}
-! Invalid IPv6 address {{ l.ipv6 }}
-{%   endif %}
-{% endif %}
+{%       endif %}
+{%     endif %}
 !
 {#
     Set MTU
 #}
-{% if l.mtu is defined %}
+{%     if l.mtu is defined %}
 mtu {{ l.ifname }} {{ l.mtu }}
-{% endif %}
+{%     endif %}
 !
+{%   endif %}
 {% endfor %}

--- a/netsim/devices/asav.yml
+++ b/netsim/devices/asav.yml
@@ -15,14 +15,16 @@ group_vars:
   # yamllint disable-line rule:line-length
   netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group14-sha1 -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
   netlab_check_retries: 50
+  netlab_initial: always
 external:
   image: none
 features:
   initial:
-    collect: True
-  bgp: True
+    collect: true
+    reload: true
+  bgp: true
   isis:
-    circuit_type: True
+    circuit_type: true
   ospf:
     unnumbered: false
     import: false


### PR DESCRIPTION
The ASAv 'initial config' template checks the 'netlab_initial_reload' flag and generates only shut/no-shut commands when we need the initial config to prime the device for config reload.

Also:
* Fix indentation in initial config template
* Fix True/true inconsistencies in ASAv device YAML file

Fixes #3351