### PR TITLE
Remove support for Python 3.8/3.9 and Ubuntu 20.04

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.repository == 'ipspace/netlab' && github.actor == 'ipspace'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Log into registry ${{ env.REGISTRY }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/integration')
     runs-on: [ self-hosted, integration ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run integration tests
       env:
         GITHUB_COMMENT: ${{ github.event.comment.body }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         python -m pip install -r requirements-dev.txt

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,9 +9,9 @@ jobs:
     if: github.repository == 'ipspace/netlab'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install dependencies

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.14'
 
     - name: Install ruff
       run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,10 +17,10 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.14'
 

--- a/.github/workflows/t-pull.yml
+++ b/.github/workflows/t-pull.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [ "3.8", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.12", "3.13", "3.14" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/t-pull.yml
+++ b/.github/workflows/t-pull.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.12", "3.13", "3.14" ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/t-push.yml
+++ b/.github/workflows/t-push.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/t-push.yml
+++ b/.github/workflows/t-push.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 7
       matrix:
-        python-version: [ "3.8", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/t-yamllint.yml
+++ b/.github/workflows/t-yamllint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.14
+        python-version: '3.14'
     - name: Install yamllint
       run: |
         python -m pip install yamllint

--- a/.github/workflows/t-yamllint.yml
+++ b/.github/workflows/t-yamllint.yml
@@ -13,9 +13,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.14'
     - name: Install yamllint

--- a/.github/workflows/t-yamllint.yml
+++ b/.github/workflows/t-yamllint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: 3.14
     - name: Install yamllint
       run: |
         python -m pip install yamllint

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -11,9 +11,9 @@ jobs:
     if: github.repository == 'ipspace/netlab'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ When you don't have to change the code for other reasons:
 - **requests**: HTTP client
 
 ## Platform Requirements
-- **Python**: 3.8+ (due to subprocess.capture_output and typing.Final)
+- **Python**: 3.10+ (to support Ubuntu 22.04)
 - **OS**: Linux, macOS
 - **Package managers**: pip, setuptools
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Installation
 
-*netlab* is a Python3 package[^NSL] that uses Python 3.8[^P38] or later. We recommend using _netlab_ on Linux (we're doing all our tests on Ubuntu), including Windows Subsystem for Linux or [Multipass on macOS](https://blog.ipspace.net/2024/03/netlab-bgp-apple-silicon/). While you might be able to get _netlab_ to run natively on Windows or macOS with VirtualBox, we no longer support that.
+*netlab* is a Python3 package[^NSL] that uses Python 3.10[^P310] or later. We recommend using _netlab_ on Linux (we're doing all our tests on Ubuntu), including Windows Subsystem for Linux or [Multipass on macOS](https://blog.ipspace.net/2024/03/netlab-bgp-apple-silicon/). While you might be able to get _netlab_ to run natively on Windows or macOS with VirtualBox, we no longer support that.
 
-[^P38]: We keep supporting Python 3.8 because it's the default Python distribution on Ubuntu 20.04.
+[^P38]: We keep supporting Python 3.10 because it's the default Python distribution on Ubuntu 22.04.
 
 [^NSL]: For legacy reasons, the *netlab* Python code resides in *netsim.\** modules.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,7 +2,7 @@
 
 *netlab* is a Python3 package[^NSL] that uses Python 3.10[^P310] or later. We recommend using _netlab_ on Linux (we're doing all our tests on Ubuntu), including Windows Subsystem for Linux or [Multipass on macOS](https://blog.ipspace.net/2024/03/netlab-bgp-apple-silicon/). While you might be able to get _netlab_ to run natively on Windows or macOS with VirtualBox, we no longer support that.
 
-[^P38]: We keep supporting Python 3.10 because it's the default Python distribution on Ubuntu 22.04.
+[^P310]: Python 3.10 is the minimum supported version because it's the default Python distribution on Ubuntu 22.04.
 
 [^NSL]: For legacy reasons, the *netlab* Python code resides in *netsim.\** modules.
 

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -9,18 +9,14 @@ We test _netlab_ on Ubuntu to ensure we provide a reasonably hassle-free experie
 
 ## Prerequisite Software Installation
 
-*netlab* is a Python package that uses KVM to run virtual machines and Docker to run containers. Virtual machines in the KVM environment and the associated Linux bridges are created with Vagrant using libvirt API. Ansible is used to configure the network devices.
+*netlab* is a Python package that uses KVM to run virtual machines and Docker to run containers. Virtual machines in the KVM environment and the associated Linux bridges are created with Vagrant using libvirt API. Ansible is used to configure most network devices.
 
 ![netlab on Linux](linux-architecture.png)
 
 To build a Linux environment needed to run network devices as virtual machines or containers:
 
-* Install Python 3.8 or later (use the latest Python version supported by your Linux distribution)
-* Install Ansible 2.9.1 or later and any Ansible networking dependencies (example: paramiko)
-
-```{warning}
-At the moment, _netlab_ does not work with Ansible release 12.x. Install the latest Ansible 11.x release.
-```
+* Install Python 3.10 or later (use the latest Python version supported by your Linux distribution)
+* Install Ansible 2.9.1 or later and any Ansible networking dependencies (example: paramiko). We recommend using the latest Ansible 11.x release.
 
 If you want to run network devices as virtual machines with KVM:
 
@@ -29,6 +25,10 @@ If you want to run network devices as virtual machines with KVM:
 * Install *vagrant-libvirt* plugin with `vagrant plugin install libvirt --plugin-version=0.12.2`
 
 If you want to run network devices as containers (or virtual machines in *vrnetlab* containers), install Docker and containerlab.
+
+```{tip}
+If possible, [use containerlab](lab-clab) and package the virtual machines you need in [_vrnetlab_ containers](clab-vrnetlab). Getting Vagrant to work on some Linux distributions could be a bit challenging.
+```
 
 [^CSV]: We must change the recommended Vagrant release every few months. Please check the [libvirt installation script](https://github.com/ipspace/netlab/blob/dev/netsim/install/libvirt.sh) for details.
 

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -1,7 +1,7 @@
 (install-linux-server)=
 # Running *netlab* on a Linux Server
 
-This page describes generic installation steps for creating a virtual lab environment on any Linux distribution ([follow these instructions](ubuntu.md) if you plan to run your labs on an Ubuntu server).
+This page describes generic installation steps for creating a virtual lab environment on any Linux distribution ([follow these instructions](ubuntu.md) if you plan to run your labs on a Debian or Ubuntu server, including Windows Subsystem for Linux).
 
 ```{warning}
 We test _netlab_ on Ubuntu to ensure we provide a reasonably hassle-free experience to networking engineers without Linux sysadmin skills. Unfortunately, we cannot help you if you run _netlab_ on another Linux distribution (dealing with one distro is more than enough pain). Still, please try to make it work; we would appreciate it if you could add your findings to this document. Thank you!
@@ -16,7 +16,6 @@ We test _netlab_ on Ubuntu to ensure we provide a reasonably hassle-free experie
 To build a Linux environment needed to run network devices as virtual machines or containers:
 
 * Install Python 3.10 or later (use the latest Python version supported by your Linux distribution)
-* Install Ansible 2.9.1 or later and any Ansible networking dependencies (example: paramiko). We recommend using the latest Ansible 11.x release.
 
 If you want to run network devices as virtual machines with KVM:
 
@@ -31,6 +30,8 @@ If possible, [use containerlab](lab-clab) and package the virtual machines you n
 ```
 
 [^CSV]: We must change the recommended Vagrant release every few months. Please check the [libvirt installation script](https://github.com/ipspace/netlab/blob/dev/netsim/install/libvirt.sh) for details.
+
+Finally, install Ansible 2.9.1 or later and any Ansible networking dependencies (example: paramiko). We recommend using the latest Ansible 11.x release. You _might_ be able to use the **netlab install ansible** command (after [installing netlab](install-linux-netlab)) instead of manual installation.
 
 (linux-commands-mandatory)=
 *netlab* also needs (at least) these Linux commands to provide its full functionality:
@@ -49,6 +50,7 @@ If possible, [use containerlab](lab-clab) and package the virtual machines you n
 
 To see the Linux commands executed by various _netlab_ commands, use the `--dry-run` option of **netlab up**, **netlab down**, or **netlab connect**.
 
+(install-linux-netlab)=
 ## netlab Installation
 
 Install the Python package with `sudo python3 -m pip install networklab` or your preferred Python package installation procedure.

--- a/docs/labs/libvirt-box-caveats.md
+++ b/docs/labs/libvirt-box-caveats.md
@@ -1,9 +1,9 @@
 # Box-Building Caveats
 
-The Vagrant box-building process relies on numerous Linux tools that have changed their behavior across Ubuntu releases. These caveats might apply if you're not using the *netlab* release 1.8.2 or later:
+The Vagrant box-building process relies on numerous Linux tools whose behavior has changed across Ubuntu releases. These caveats probably no longer apply unless you're using an ancient _netlab_ release older than 1.8.2 (released in May 2024):
 
-* On Ubuntu 22.04 LTS (and later), the `libvirt-qemu` user needs read- and execute access to the VM disk file. It’s easiest to create Vagrant boxes in a subdirectory of the /tmp directory. This caveat does not apply to Ubuntu 20.04. Starting with release 1.8.2, the **netlab libvirt package** script always builds boxes within the /tmp directory.
+* On Ubuntu 22.04 LTS (and later), the `libvirt-qemu` user needs read- and execute access to the VM disk file. It’s easiest to create Vagrant boxes in a subdirectory of the /tmp directory. Starting with release 1.8.2, the **netlab libvirt package** script always builds boxes within the /tmp directory.
 * *‌virt-install* might report a fatal error on Ubuntu 22.04 (and later). Execute `export VIRTINSTALL_OSINFO_DISABLE_REQUIRE=1` in your shell and restart the build process. Starting with release 1.8.1, the **netlab libvirt package** script sets this parameter.
 * If you downloaded an OVA file, you have to unpack it with the **tar xvf _ova_filename_** command. Starting with release 1.8.2, the **netlab libvirt package** script automatically unpacks the OVA files.
 
-Finally, we tested the box-building scripts on Ubuntu 20.04 or 22.04. The **netlab libvirt package** might not work correctly on other Linux distributions.
+Finally, we tested the box-building scripts on Ubuntu 22.04. The **netlab libvirt package** might not work correctly on other Linux distributions.

--- a/docs/netlab/install.md
+++ b/docs/netlab/install.md
@@ -40,7 +40,7 @@ Running multiple installation scripts with **‌netlab install** or **netlab ins
 * The *graph* script installs GraphViz and D2 software needed to generate graphs from _netlab_ topologies
 * The *grpc* script installs gRPC Python libraries needed to configure Nokia SR Linux and Nokia SR OS.
 
-[^U20]: Tested on Ubuntu 20.04, 22.04, and 24.04
+[^U20]: Tested on Ubuntu 22.04 and 24.04
 
 [^D10]: Tested on Debian 12 (bookworm)
 

--- a/docs/netlab/install.md
+++ b/docs/netlab/install.md
@@ -3,7 +3,7 @@
 
 **netlab install** uses internal installation scripts to install nice-to-have Ubuntu software, Ansible and related networking libraries, or libvirt+vagrant.
 
-The *ubuntu*, *libvirt*, and *containerlab* installation scripts run only on Ubuntu[^U20] and Debian[^D10]; the *ansible* and *grpc* installation scripts should run in any environment with **bash** and **pip3**.
+The *ubuntu*, *libvirt*, and *containerlab* installation scripts run only on Ubuntu[^UT] and Debian[^DT]; the *ansible* and *grpc* installation scripts should run in any environment with **bash** and **pip3**.
 
 ## Usage
 
@@ -40,9 +40,9 @@ Running multiple installation scripts with **‌netlab install** or **netlab ins
 * The *graph* script installs GraphViz and D2 software needed to generate graphs from _netlab_ topologies
 * The *grpc* script installs gRPC Python libraries needed to configure Nokia SR Linux and Nokia SR OS.
 
-[^U20]: Tested on Ubuntu 22.04 and 24.04
+[^UT]: Tested on Ubuntu 22.04 and 24.04
 
-[^D10]: Tested on Debian 12 (bookworm)
+[^DT]: Tested on Debian 12 (bookworm)
 
 You can display an up-to-date list of installation scripts with **netlab install** command:
 

--- a/legacy/setup.py
+++ b/legacy/setup.py
@@ -23,13 +23,14 @@ setup(
     "Topic :: Utilities",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
   ],
   url="https://github.com/ipspace/netlab",
-  python_requires='>=3.8',  # Due to e.g. 'capture_output' in subprocess.run
+  python_requires='>=3.10',  # Due to e.g. 'capture_output' in subprocess.run
 )

--- a/netsim/install/install.yml
+++ b/netsim/install/install.yml
@@ -9,7 +9,7 @@ scripts:
     intro: |
       This script updates your Ubuntu/Debian system, installs additional APT
       packages, and nice-to-have tools like git, jq... The script was tested on
-      Debian 12 (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
+      Debian 12 (bookworm) and Ubuntu 22.04 and 24.04.
 
   libvirt:
     description: QEMU, KVM, libvirt, and Vagrant
@@ -18,7 +18,7 @@ scripts:
     intro: |
       This script installs QEMU, KVM, Libvirt, Vagrant, and vagrant-libvirt
       plugin on a Ubuntu/Debian system. The script was tested on Debian 12
-      (bookworm) and Ubuntu 20.04, 22.04, and 24.04.
+      (bookworm) and Ubuntu 22.04 and 24.04.
     epilog: |
       * You might need to log out and log in to start using netlab with libvirt.
       * Use 'netlab test libvirt' command to test your installation
@@ -28,9 +28,8 @@ scripts:
     distro: [ ubuntu, debian ]
     uses: [ apt ]
     intro: |
-      This script installs Docker and containerlab on a Debian or Ubuntu
-      system. The script was tested on Debian 12 (bookworm) and Ubuntu 20.04,
-      22.04, and 24.04.
+      This script installs Docker and containerlab on a Debian or Ubuntu system.
+      The script was tested on Debian 12 (bookworm) and Ubuntu 22.04 and 24.04.
     epilog: |
       * Log out and back in to start using netlab with containerlab/Docker
       * Use 'netlab test clab' command to test your installation
@@ -40,9 +39,9 @@ scripts:
     uses: [ pip ]
     intro: |
       This script installs Ansible and related Python3 packages required to run
-      netlab Ansible playbooks. The script was tested on Ubuntu 20.04, 22.04,
-      and 24.04, and Debian 12 (bookworm), and should work on other Linux
-      distributions as well.
+      netlab Ansible playbooks. The script was tested on Ubuntu 22.04 and 24.04,
+      and Debian 12 (bookworm), and should work on other Linux distributions as
+      well.
 
       The script assumes that you already set up Python3 environment. If that's
       not the case, please run "netlab install ubuntu" first.

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 with open("requirements.txt", "r") as fs:
   reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
-if sys.version_info < (3, 8):
-  raise RuntimeError("This package requires Python 3.8+")
+if sys.version_info < (3, 10):
+  raise RuntimeError("This package requires Python 3.10+")
 
 setup(
   name="networklab",
@@ -38,7 +38,7 @@ setup(
   url="https://github.com/ipspace/netlab",
   include_package_data=True,
   setup_requires=["wheel"],
-  python_requires='>=3.8',  # Due to e.g. 'capture_output' in subprocess.run, and use of typing.Final
+  python_requires='>=3.10',  # To support Ubuntu 22.04
   install_requires=reqs,
   scripts=[ "netlab" ],
 #  entry_points={

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
     "Topic :: Utilities",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
* Remove Python 3.8/3.9 from package setup and CI/CD pipelines
  (that will make netlab uninstallable on most Ubuntu 20.04 hosts)
* The lowest Python version that needs to be tested is 3.10
* Remove all references to Ubuntu 20.04

Other cleanup:
* Reword 'box building caveats' documentation
* Use a specific Python version in ruff CI/CD action
* Use a consistent Python version in all CI/CD actions that specify one