### PR TITLE
Fix: Junos routing policies no longer need an internal community

### DIFF
--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -61,7 +61,6 @@
         route-filter-list bgp-{{ vname }}-announce-{{ bgp_af }};
       }
       then {
-        community add x-route-permit-mark;
         next policy;
       }
     }
@@ -86,7 +85,6 @@
 {%     endif %}
       }
       then {
-        community add x-route-permit-mark;
         next policy;
       }
     }
@@ -101,7 +99,6 @@
     term redis_bgp {
       from protocol bgp;
       then {
-        community add x-route-permit-mark;
         next policy;
       }
     }

--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -6,18 +6,19 @@
   delete: route-filter-list bgp-{{ vname }}-announce-ipv4;
   delete: route-filter-list bgp-{{ vname }}-announce-ipv6;
 
-  community x-route-permit-mark members large:65535:0:65536;
-
+{#
+  Real BGP export policies can end at "advertise" policy or at neighbor
+  route map. To support both, the "advertise" policy uses "next-policy"
+  instead of "accept" to get the neighbor route map a chance to do its
+  work. However, that approach would fail to accept routes in case there
+  is no neighbor route-map, so we need a "catch all" last step that just
+  allows everything.
+#}
   policy-statement bgp-final {
     term final-option {
-      from community x-route-permit-mark;
       then {
-        community delete x-route-permit-mark;
         accept;
       }
-    }
-    term default-reject {
-      then reject;
     }
   }
 {% endmacro %}

--- a/netsim/ansible/templates/bgp/junos.policy.j2
+++ b/netsim/ansible/templates/bgp/junos.policy.j2
@@ -44,9 +44,7 @@ policy-options {
 
   policy-statement bgp-initial {
     term initial-cleanup {
-      from community x-route-permit-mark;
       then {
-        community delete x-route-permit-mark;
         next policy;
       }
     }

--- a/netsim/ansible/templates/evpn/junos/common.j2
+++ b/netsim/ansible/templates/evpn/junos/common.j2
@@ -174,7 +174,6 @@ policy-options {
         term redis_evpn {
             from protocol evpn;
             then {
-                community add x-route-permit-mark;
                 next policy;
             }
         }

--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -1,6 +1,3 @@
-{# since routing is applied before bgp, need to set the internal community for flow control also here #}
-policy-options community x-route-permit-mark members large:65535:0:65536;
-
 {% if routing.prefix is defined %}
 {%   include 'junos/prefix_list.j2' %}
 {% endif %}

--- a/netsim/ansible/templates/routing/junos/route_policy.j2
+++ b/netsim/ansible/templates/routing/junos/route_policy.j2
@@ -77,7 +77,6 @@
 {% macro common_route_map_action(p_entry) %}
       then {
 {%     if p_entry.action|default('permit') == 'permit' %}
-        community add x-route-permit-mark;
         next policy;
 {%     else %}
         reject;


### PR DESCRIPTION
The Junos routing policies used an internal community to indicate a route was accepted. With the rewrite of default/advertise/redistribute policies, those policies result in either a reject or a 'next-policy' statement, making it unnecessary to use the internal community to mark route acceptance.