### PR TITLE
Fix: Warn about links having irrelevant module attributes

### DIFF
--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -529,9 +529,33 @@ def link_transform(method: str, topology: Box) -> None:
   if log.debug_active('modules'):
     print(f'Processing link_{method} hooks')
 
+  topo_mods = topology.get('module',[])
   for l in topology.get("links",[]):
-    mod_list: typing.Dict = {}
-    for node_data in l.get('interfaces',[]):
+    iflist = l.get('interfaces',[])               # Carefully get the list of attached interfaces
+    if not iflist:                                # Do we have anything attached to this link?
+      continue                                    # Nope, move on (hoping it's a LAG link)
+
+    mod_list: typing.Dict = {}                    # Build the list of modules used by attached nodes
+    for node_data in iflist:
       mod_list.update({ m: None for m in topology.nodes[node_data.node].get("module",[]) })
-    for m in mod_list.keys():
+    for m in mod_list.keys():                     # And call link hooks only for relevant (node) modules
       call_module_hook(m,method=f"link_{method}",topology=topology,link=l)
+
+    # Do we have any irrelevant module attributes on this link?
+    extra_mod = [ m for m in topo_mods if m in l and m not in mod_list ]
+    if not extra_mod:                             # Nope?
+      continue                                    # ... great, move on
+    if '_warning_extra_mod' in l:                 # Did we already warn about them?
+      extra_mod = [ m for m in extra_mod if m not in l._warning_extra_mod ]
+      if not extra_mod:                           # Any attributes not warned about?
+        continue                                  # ... everything was covered. Cool, move on
+
+    log.warning(                                  # Tell the user this makes little sense
+      text=f'Module attribute(s) {",".join(extra_mod)} are used on link {l._linkname} '+ \
+            f'but no attached nodes use these module(s)',
+      flag='no_nodes',
+      module='modules',
+      more_hints=['A module attribute on a link makes sense only when an attached node uses that module'])
+
+    # ... and remember what warnings we already generated
+    data.append_to_list(l,'_warning_extra_mod',extra_mod,flatten=True)

--- a/netsim/modules/_dataplane.py
+++ b/netsim/modules/_dataplane.py
@@ -5,7 +5,7 @@ import typing
 
 from box import Box
 
-from ..data import global_vars
+from ..data import append_to_list, global_vars
 from ..data.types import must_be_list
 from ..utils import log
 
@@ -208,3 +208,5 @@ def validate_link_module_usage(
     flag='link_no_nodes',
     category=category,
     more_hints=[f'At least one node attached to the link {t_should} use {module} module'])
+
+  append_to_list(link,'_warning_extra_mod',module)  # Remember we generated a warning about this module

--- a/tests/coverage/errors/link-no-node-module.log
+++ b/tests/coverage/errors/link-no-node-module.log
@@ -1,0 +1,4 @@
+ErrorAbort in modules: Module attribute(s) ospf are used on link vrfs.red.links[1] but no attached nodes use these module(s)
+... A module attribute on a link makes sense only when an attached node uses that module
+... Set defaults.modules.warnings.no_nodes to False to disable this check
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/link-no-node-module.yml
+++ b/tests/coverage/errors/link-no-node-module.yml
@@ -1,0 +1,13 @@
+defaults.device: none
+defaults.modules.warnings.no_nodes: error      # Must be an error to make pytest happy
+
+module: [ vrf, ospf ]
+vrfs:
+  red:
+    links:
+    - interfaces: [ a, b ]
+      ospf.cost: 20
+
+nodes:
+  a.module: []
+  b.module: []

--- a/tests/coverage/expected/rt-vlan-anycast.yml
+++ b/tests/coverage/expected/rt-vlan-anycast.yml
@@ -16,6 +16,8 @@ input:
 - package:topology-defaults.yml
 links:
 - _linkname: links[1]
+  _warning_extra_mod:
+  - gateway
   bridge: input_1
   gateway: true
   interfaces:
@@ -34,6 +36,8 @@ links:
   role: stub
   type: lan
 - _linkname: links[2]
+  _warning_extra_mod:
+  - gateway
   bridge: input_2
   gateway: true
   interfaces:

--- a/tests/coverage/input/rt-vlan-anycast.yml
+++ b/tests/coverage/input/rt-vlan-anycast.yml
@@ -1,6 +1,7 @@
 # Regression test for #671
 #
 defaults.device: eos
+defaults.modules.warnings.no_nodes: False
 
 nodes:
   h:


### PR DESCRIPTION
A module attribute on a link where no nodes are using it is mostly irrelevant -- the attribute is not copied into interfaces (because the nodes are not using the module) and even the link_transform hooks are not called because there's no reason to call them.

This commit adds a silenceable warning when that condition is encountered, taking into account previous similar work (VLAN/VRF _dataplane checks).