### PR TITLE
Fix: use shlex.split and shlex.join in run_command

### DIFF
--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -2,6 +2,7 @@
 # Run external commands from netlab CLI
 #
 import os
+import shlex
 import subprocess
 import sys
 import typing
@@ -21,7 +22,7 @@ def print_step(n: int, txt: str, spacing: typing.Optional[bool] = False) -> None
 
 def stringify(cmd : typing.Union[str,list]) -> str:
   if isinstance(cmd,list):
-    return " ".join(cmd)
+    return shlex.join(cmd)
   return str(cmd)
 
 """
@@ -99,15 +100,15 @@ def run_command(
       print(f"DRY RUN: {cmd}")
       return True
 
-  if log.VERBOSE or log.debug_active('external'):
-    print(f"run_command executing: {cmd}",flush=True)
-
   add_netlab_path()
   if isinstance(cmd,str):
-    cmd = [ arg for arg in cmd.split(" ") if arg not in (""," ") ]
+    cmd = shlex.split(cmd)
 
   if not cmd:                                               # Skip empty commands
     return True
+
+  if log.VERBOSE or log.debug_active('external'):
+    print(f"run_command executing: {shlex.join(cmd)}",flush=True)
 
   try:
     result = subprocess.run(

--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -102,7 +102,11 @@ def run_command(
 
   add_netlab_path()
   if isinstance(cmd,str):
-    cmd = shlex.split(cmd)
+    try:
+      cmd = shlex.split(cmd)
+    except ValueError:
+      log.error(f'Malformed shell command: {cmd}',module='cli',category=log.IncorrectValue)
+      return False
 
   if not cmd:                                               # Skip empty commands
     return True

--- a/tests/platform-integration/cli/01-up-hooks.yml
+++ b/tests/platform-integration/cli/01-up-hooks.yml
@@ -13,7 +13,7 @@ links: [ x ]
 defaults.netlab:
   up:                                           # Define 'netlab up' hooks
     pre_start_lab: bash pre_start.sh
-    post_start_lab: touch post_start.hook
+    post_start_lab: touch "post_start.hook"
   integration:
     validate: bash validate.sh                  # Define the validate action
 


### PR DESCRIPTION
shlex is the correct way to deal with shell argument peculiarities like quoted arguments. Now that we use that library, it would be a shame not to use it for the reverse path (list -> command).