### PR TITLE
Rewrite the 'netlab restart' functionality

### DIFF
--- a/docs/netlab/restart.md
+++ b/docs/netlab/restart.md
@@ -1,26 +1,20 @@
-# Restart Virtual Lab
+# Restart a Virtual Lab Instance
 
-**netlab restart** executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the transformed lab topology stored in `netlab.snapshot.pickle` snapshot file.
+Use the **netlab restart** command to shut down and restart a running lab instance. You can use this command if the lab is messed up beyond hope, or after changing the lab topology file.
 
-You can use **netlab restart** to restart the existing lab (use `--snapshot` keyword) or recreate the lab configuration files if you changed the lab topology.
+This command executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the lab topology from which the lab snapshot file (usually `netlab.snapshot.pickle`) was created.
 
 ```{warning}
-* **netlab restart** does not support `-d`, `-p` or `-s` flags used by **netlab create** or **netlab up**. If you want to change lab topology settings with CLI parameters, use **netlab down** and **netlab up** commands.
-* You must execute the **‌netlab restart** command within the lab directory.
+* **netlab restart** does not support the extra parameters that can be used with **netlab create** or **netlab up** to adjust the lab topology. If you want to change lab topology settings with CLI parameters, use the **netlab down** and **netlab up** commands.
 ```
 
 ## Usage
 
 ```text
-$ netlab restart -h
-usage: netlab [-h] [--log] [-v] [-q] [--no-config] [--fast-config]
+usage: netlab [-h] [--log] [-v] [-q] [--no-config] [--fast-config] [-i INSTANCE]
               [--snapshot [SNAPSHOT]]
-              [topology]
 
 Reconfigure and restart the virtual lab
-
-positional arguments:
-  topology              Topology file (default: topology.yml)
 
 options:
   -h, --help            show this help message and exit
@@ -29,6 +23,8 @@ options:
   -q, --quiet           Report only major errors
   --no-config           Do not configure lab devices
   --fast-config         Use fast device configuration (Ansible strategy = free)
+  -i, --instance INSTANCE
+                        Specify the lab instance to restart
   --snapshot [SNAPSHOT]
                         Transformed topology snapshot file
 ```

--- a/docs/netlab/restart.md
+++ b/docs/netlab/restart.md
@@ -2,7 +2,7 @@
 
 Use the **netlab restart** command to shut down and restart a running lab instance. You can use this command if the lab is messed up beyond hope, or after changing the lab topology file.
 
-This command executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the lab topology from which the lab snapshot file (usually `netlab.snapshot.pickle`) was created.
+This command executes **[netlab down](down.md)** followed by **[netlab up](up.md)** to restart your lab from the lab topology from which the lab snapshot file (usually `netlab.snapshot.pickle`) was created. The commands are executed in the current directory unless you specify a different lab instance with the `--instance` parameter.
 
 ```{warning}
 * **netlab restart** does not support the extra parameters that can be used with **netlab create** or **netlab up** to adjust the lab topology. If you want to change lab topology settings with CLI parameters, use the **netlab down** and **netlab up** commands.
@@ -11,8 +11,8 @@ This command executes **[netlab down](down.md)** followed by **[netlab up](up.md
 ## Usage
 
 ```text
-usage: netlab [-h] [--log] [-v] [-q] [--no-config] [--fast-config] [-i INSTANCE]
-              [--snapshot [SNAPSHOT]]
+usage: netlab restart [-h] [--log] [-v] [-q] [--no-config] [--fast-config] [-i INSTANCE]
+                      [--snapshot [SNAPSHOT]]
 
 Reconfigure and restart the virtual lab
 
@@ -28,3 +28,8 @@ options:
   --snapshot [SNAPSHOT]
                         Transformed topology snapshot file
 ```
+
+Notes:
+
+* **netlab restart** gets the original lab topology name from the `netlab.snapshot.pickle` file created by **netlab up** or **netlab create**. You could (but probably should not) specify a different snapshot file with the `--snapshot` parameter.
+* With the `--instance` flag, you can shut down a lab instance running in a different directory. Use the `netlab status --all` command to display all running instances.

--- a/netsim/cli/restart.py
+++ b/netsim/cli/restart.py
@@ -15,6 +15,7 @@ from . import common_parse_args, down, load_snapshot, parser_lab_location, up
 #
 def restart_parse_args() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(
+    prog="netlab restart",
     description='Reconfigure and restart the virtual lab',
     parents = [ common_parse_args() ],
     add_help=True)
@@ -53,13 +54,14 @@ def up_args(args: argparse.Namespace, topo_name: str) -> list:
 def run(cli_args: typing.List[str]) -> None:
   parser = restart_parse_args()
   args = parser.parse_args(cli_args)
+  log.set_logging_flags(args)
   topology = load_snapshot(args,warn_modified=False)
   if not topology:
     log.fatal(f'Cannot read the snapshot file {args.snapshot}')
   try:
     topo_name = topology.get('input',[])[0]
-  except:
-    log.fatal('Cannot find the original topology name from the snapshot file')
+  except Exception as ex:
+    log.fatal(f'Cannot find the original topology name from the snapshot file: {str(ex)}')
 
   down.run(down_args(args,with_snapshot=True))
   log.section_header('Progress','Lab has been stopped, starting new instance',color='bright_cyan')

--- a/netsim/cli/restart.py
+++ b/netsim/cli/restart.py
@@ -6,7 +6,8 @@
 import argparse
 import typing
 
-from . import common_parse_args, down, parser_lab_location, up
+from ..utils import log
+from . import common_parse_args, down, load_snapshot, parser_lab_location, up
 
 
 #
@@ -27,16 +28,39 @@ def restart_parse_args() -> argparse.ArgumentParser:
     dest='fast_config',
     action='store_true',
     help='Use fast device configuration (Ansible strategy = free)')
-  parser.add_argument(
-    dest='topology', action='store', nargs='?',
-    help='Topology file (default: topology.yml)')
-  parser_lab_location(parser,snapshot=True,action='restart')
+  parser_lab_location(parser,instance=True,snapshot=True,action='restart')
   return parser
+
+def down_args(args: argparse.Namespace, with_snapshot: bool = False) -> list:
+  args_list = []
+  if args.verbose:
+    args_list.append("-" + "v" * args.verbose)
+  if args.snapshot and with_snapshot:
+    args_list += ["--snapshot", args.snapshot]
+  return args_list
+
+def up_args(args: argparse.Namespace, topo_name: str) -> list:
+  args_list = down_args(args,with_snapshot=False)
+  if args.quiet:
+    args_list.append("-q")
+  if args.no_config:
+    args_list.append('--no-config')
+  if args.fast_config:
+    args_list.append('--fast-config')
+  args_list.append(topo_name)
+  return args_list
 
 def run(cli_args: typing.List[str]) -> None:
   parser = restart_parse_args()
-  parser.parse_args(cli_args)
-  up_only_args = ['--fast-config','--no-config','--snapshot']
+  args = parser.parse_args(cli_args)
+  topology = load_snapshot(args,warn_modified=False)
+  if not topology:
+    log.fatal(f'Cannot read the snapshot file {args.snapshot}')
+  try:
+    topo_name = topology.get('input',[])[0]
+  except:
+    log.fatal('Cannot find the original topology name from the snapshot file')
 
-  down.run([ arg for arg in cli_args if arg not in up_only_args ])
-  up.run(cli_args)
+  down.run(down_args(args,with_snapshot=True))
+  log.section_header('Progress','Lab has been stopped, starting new instance',color='bright_cyan')
+  up.run(up_args(args,topo_name))

--- a/tests/platform-integration/cli/11-restart.yml
+++ b/tests/platform-integration/cli/11-restart.yml
@@ -1,0 +1,38 @@
+---
+message: |
+  This topology tests the "restart lab" functionality.
+
+defaults.sources.extra: [ ../../integration/wait_times.yml ]
+defaults.device: frr
+provider: clab
+
+module: [ ospf ]
+
+plugin: [ files ]
+
+files:
+  restart.sh: |
+    set -e
+    netlab restart
+
+defaults.netlab.integration:
+  up: netlab up --snapshot
+  initial: bash restart.sh                       # Try to restart the lab
+
+nodes:
+  dut:
+  x1:
+
+links:
+- dut:
+  x1:
+  mtu: 1500
+  ospf.timers.hello: 1
+
+validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait: ospfv2_adj_p2p
+    wait_msg: Waiting for OSPF adjacency process to complete
+    nodes: [ x1 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)


### PR DESCRIPTION
The 'netlab restart' functionality was mostly broken and did not work with the 'more recent' additions like non-default snapshot files or explicit lab instances.

This commit completely rewrites the top-level 'netlab restart' workflow and hopefully makes the code and documentation match.

Closes #3359 and replaces #3354