### PR TITLE
Fix: Skip 'unused link module attributes' check for VLAN links

### DIFF
--- a/netsim/modules/__init__.py
+++ b/netsim/modules/__init__.py
@@ -525,6 +525,29 @@ def node_transform(method: str , topology: Box) -> None:
     for m in n.get('module',[]):
       call_module_hook(m,method=f"node_{method}",topology=topology,node=n)
 
+def check_extra_modules(l: Box, mod_list: dict, topology: Box, topo_mods: list) -> None:
+  """Checks whether the link has attributes from modules that no attached node uses"""
+  if 'vlan' in l:                               # Do not check VLAN links
+    return                                      # ... we don't have full visibility at this point
+
+  extra_mod = [ m for m in topo_mods if m in l and m not in mod_list ]
+  if not extra_mod:                             # Nope?
+    return                                      # ... great, move on
+  if '_warning_extra_mod' in l:                 # Did we already warn about them?
+    extra_mod = [ m for m in extra_mod if m not in l._warning_extra_mod ]
+    if not extra_mod:                           # Any attributes not warned about?
+      return                                    # ... everything was covered. Cool, move on
+
+  log.warning(                                  # Tell the user this makes little sense
+    text=f'Module attribute(s) {",".join(extra_mod)} are used on link {l._linkname} '+ \
+          f'but no attached nodes use these module(s)',
+    flag='no_nodes',
+    module='modules',
+    more_hints=['A module attribute on a link makes sense only when an attached node uses that module'])
+
+  # ... and remember what warnings we already generated
+  data.append_to_list(l,'_warning_extra_mod',extra_mod,flatten=True)
+
 def link_transform(method: str, topology: Box) -> None:
   if log.debug_active('modules'):
     print(f'Processing link_{method} hooks')
@@ -541,21 +564,4 @@ def link_transform(method: str, topology: Box) -> None:
     for m in mod_list.keys():                     # And call link hooks only for relevant (node) modules
       call_module_hook(m,method=f"link_{method}",topology=topology,link=l)
 
-    # Do we have any irrelevant module attributes on this link?
-    extra_mod = [ m for m in topo_mods if m in l and m not in mod_list ]
-    if not extra_mod:                             # Nope?
-      continue                                    # ... great, move on
-    if '_warning_extra_mod' in l:                 # Did we already warn about them?
-      extra_mod = [ m for m in extra_mod if m not in l._warning_extra_mod ]
-      if not extra_mod:                           # Any attributes not warned about?
-        continue                                  # ... everything was covered. Cool, move on
-
-    log.warning(                                  # Tell the user this makes little sense
-      text=f'Module attribute(s) {",".join(extra_mod)} are used on link {l._linkname} '+ \
-            f'but no attached nodes use these module(s)',
-      flag='no_nodes',
-      module='modules',
-      more_hints=['A module attribute on a link makes sense only when an attached node uses that module'])
-
-    # ... and remember what warnings we already generated
-    data.append_to_list(l,'_warning_extra_mod',extra_mod,flatten=True)
+    check_extra_modules(l,mod_list,topology,topo_mods)

--- a/netsim/modules/vrf.py
+++ b/netsim/modules/vrf.py
@@ -481,6 +481,8 @@ class VRF(_Module):
 
     create_vrf_links(topology)                          # Create VRF links (and remove 'links' attribute)
     for link in topology.get('links',[]):               # Check for VRF-enabled links without VRF-enabled nodes
+      if 'vlan' in link:                                # Skip VLAN links, as there could be ...
+        continue                                        # ... a VRF-enabled node attached to the VLAN
       _dataplane.validate_link_module_usage(link,topology,'vrf')
     log.exit_on_error()
     populate_vrf_static_ids(topology)

--- a/tests/coverage/expected/rt-vlan-anycast.yml
+++ b/tests/coverage/expected/rt-vlan-anycast.yml
@@ -36,8 +36,6 @@ links:
   role: stub
   type: lan
 - _linkname: links[2]
-  _warning_extra_mod:
-  - gateway
   bridge: input_2
   gateway: true
   interfaces:


### PR DESCRIPTION
Implements the easy part of #3381