### PR TITLE
Fix: Cleanup Junos BGP route import policies

### DIFF
--- a/netsim/ansible/templates/bgp/junos.macro.j2
+++ b/netsim/ansible/templates/bgp/junos.macro.j2
@@ -81,7 +81,7 @@
       from {
         protocol {{ protomap[proto]|default(proto) }};
 {%     if pdata.import[proto].policy is defined %}
-        policy [ {{ pdata.import[proto].policy }} bgp-final ];
+        policy {{ pdata.import[proto].policy }};
 {%     endif %}
       }
       then {
@@ -93,7 +93,7 @@
 {#
    Macro to create per-routing-instance import/propagate/advertise policy
 #}
-{% macro redistribute(bgp,vname) %}
+{% macro redistribute(bgp,vname,has_evpn=false) %}
   policy-statement bgp-{{ vname }}-redistribute {
 {{ advertise_terms(bgp,vname) }}
     term redis_bgp {
@@ -102,6 +102,14 @@
         next policy;
       }
     }
+{% if has_evpn %}
+    term redis_evpn {
+      from protocol evpn;
+      then {
+        next policy;
+      }
+    }
+{% endif %}
 {{ import_terms(bgp) }}
     term default {
       then reject;

--- a/netsim/ansible/templates/evpn/junos/common.j2
+++ b/netsim/ansible/templates/evpn/junos/common.j2
@@ -157,25 +157,6 @@ routing-instances {
 
 }
 
-{# update ospf, ibgp and ebgp export policy options for VRFs #}
-policy-options {
-{%   for n,v in vrfs.items() if v.af is defined and v.evpn is defined %}
-    policy-statement bgp-{{n}}-redistribute {
-        delete: term default;
-
-        term redis_evpn {
-            from protocol evpn;
-            then {
-                next policy;
-            }
-        }
-        term default {
-            then reject;
-        }
-    }
-{%   endfor %}
-}
-
 {# according to JunOS doc, in case NO ANYCAST GATEWAY is configured, enable 'proxy-macip-advertisement' on central IRB interfaces #}
 interfaces {
 {%   for vname in vxlan.vlans|default([]) if vlans[vname].vni is defined and vlans[vname].mode|default('') == 'irb' and vlans[vname].vrf is defined %}

--- a/netsim/ansible/templates/vrf/junos/bgp.j2
+++ b/netsim/ansible/templates/vrf/junos/bgp.j2
@@ -6,7 +6,7 @@ policy-options {
 {% for vname,vdata in vrfs.items() %}
 {{ bgpcfg.common(vname) }}
 {{ bgpcfg.advertise_list(vdata.bgp,vname) }}
-{{ bgpcfg.redistribute(vdata.bgp,vname) }}
+{{ bgpcfg.redistribute(vdata.bgp,vname,has_evpn=vdata.evpn is defined) }}
 
 {% endfor %}
 }

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -32,7 +32,7 @@ features:
     bfd: true
     confederation: true
     default_originate: true
-    import: [ ospf, isis, ripv2, connected, static, vrf ]
+    import: [ ospf, isis, connected, static, vrf ]
     local_as: true
     local_as_ibgp: true
     multihop.vrf: true
@@ -54,7 +54,7 @@ features:
     vpn: true
   ospf:
     unnumbered: true
-    import: [ bgp, isis, ripv2, connected, static, vrf ]
+    import: [ bgp, isis, connected, static, vrf ]
     areas: true
   routing:
     policy:


### PR DESCRIPTION
Minor changes to make the BGP route import policies more like their OSPF counterparts from #3386