### PR TITLE
Fix: Use Ansible reload playbook to deploy initial configuration

### DIFF
--- a/netsim/cli/ansible.py
+++ b/netsim/cli/ansible.py
@@ -89,6 +89,9 @@ def ansible_extra_vars(topology: Box, reload: bool = False, extra_vars: typing.O
   ev = get_box(extra_vars)
   ev.node_files = str(Path("./node_files").resolve().absolute())
 
+  if reload:                                                  # Extra variables needed to make reload work
+    ev.netlab_ansible_skip_module = []                        # Do not skip modules in Ansible playbooks (there's no other mechanism)
+
   ev.paths_t_files.files = "{{ config_module }}" + cfg_sfx    # Take only module file from node_files
   ev.paths_custom.files = "{{ custom_config }}" + cfg_sfx     # And rendered custom config from node_files
   for p in ['templates','custom']:                            # Change the search paths to node_files

--- a/netsim/cli/config.py
+++ b/netsim/cli/config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from box import Box
 
+from ..augment import devices as a_devices
 from ..utils import log
 from . import (
   _nodeset,
@@ -182,8 +183,13 @@ def reload_node_configs(topology: Box,nodeset: list,args: argparse.Namespace, re
   * Change the node "config" parameter to request configuration reload
   """
   topology.defaults.paths.custom.dirs = [ str(cfg_path.parent) ]
-  for n in nodeset:
-    topology.nodes[n].netlab_initial_reload = True
+  for n in nodeset:                               # Change the node parameters for 'create_node_files'
+    ndata = topology.nodes[n]
+    n_provider = a_devices.get_provider(ndata,topology.defaults)
+    ndata.netlab_initial_reload = True            # Set "we're reloading configuration" flag
+    ndata.netlab_config_mode = None               # Fall back to Ansible config mode (we're using Ansible playbook to reload config)
+    ndata.pop(f'{n_provider}.config_templates')   # And do not generate fancy container configuration files
+
   create_node_files(topology,nodeset,args,str(cfg_path.name),initial=True,cfg_suffix='.cfg')
 
   # Run the Ansible playbook with modified path variables and an adjusted nodeset

--- a/netsim/cli/config.py
+++ b/netsim/cli/config.py
@@ -183,12 +183,12 @@ def reload_node_configs(topology: Box,nodeset: list,args: argparse.Namespace, re
   * Change the node "config" parameter to request configuration reload
   """
   topology.defaults.paths.custom.dirs = [ str(cfg_path.parent) ]
-  for n in nodeset:                               # Change the node parameters for 'create_node_files'
+  for n in nodeset:                                   # Change the node parameters for 'create_node_files'
     ndata = topology.nodes[n]
     n_provider = a_devices.get_provider(ndata,topology.defaults)
-    ndata.netlab_initial_reload = True            # Set "we're reloading configuration" flag
-    ndata.netlab_config_mode = None               # Fall back to Ansible config mode (we're using Ansible playbook to reload config)
-    ndata.pop(f'{n_provider}.config_templates')   # And do not generate fancy container configuration files
+    ndata.netlab_initial_reload = True                # Set "we're reloading configuration" flag
+    ndata.netlab_config_mode = None                   # Fall back to Ansible config mode (we're using Ansible playbook to reload config)
+    ndata.pop(f'{n_provider}.config_templates',None)  # And do not generate fancy container configuration files
 
   create_node_files(topology,nodeset,args,str(cfg_path.name),initial=True,cfg_suffix='.cfg')
 


### PR DESCRIPTION
The devices that need initial configuration before configuration reload have to have the initial configuration applied through the Ansible playbook. That requires a number of tweaks to undo the fancy config methods we might use for containers (for example, FRR)