### PR TITLE
WTAF: Junos configuration cannot start with 'delete:'

### DIFF
--- a/netsim/ansible/templates/routing/junos.j2
+++ b/netsim/ansible/templates/routing/junos.j2
@@ -1,16 +1,16 @@
 {% if routing.prefix is defined %}
-{%   include 'junos/prefix_list.j2' %}
+{%   include 'junos/prefix_list.j2' +%}
 {% endif %}
 {% if routing.aspath is defined %}
-{%   include 'junos/aspath.j2' %}
+{%   include 'junos/aspath.j2' +%}
 {% endif %}
 {% if routing.community is defined %}
-{%   include 'junos/community.j2' %}
+{%   include 'junos/community.j2' +%}
 {% endif %}
 {% if routing.policy is defined %}
 {%   import 'junos/route_policy.j2' as routemap with context %}
 {{   routemap.create_route_maps(routing.policy) }}
 {% endif %}
 {% if routing.static is defined %}
-{%   include 'junos/static.j2' %}
+{%   include 'junos/static.j2' +%}
 {% endif %}

--- a/netsim/ansible/templates/routing/junos/community.j2
+++ b/netsim/ansible/templates/routing/junos/community.j2
@@ -1,12 +1,12 @@
+policy-options {
 {%   for c_name,c_value in routing.community.items() %}
-delete: policy-options policy-statement x_comm_match_{{ c_name }};
+  delete: policy-statement x_comm_match_{{ c_name }};
 {%     for c_line in c_value.value %}
 {# we need to create both indexed communities, required for permit/deny matching, and "full" communities for set #}
-policy-options community {{ c_name }} members [ "{{ c_line._value }}" ];
-policy-options community {{ c_name }}_idx{{ loop.index }} members [ "{{ c_line._value }}" ];
+  community {{ c_name }} members [ "{{ c_line._value }}" ];
+  community {{ c_name }}_idx{{ loop.index }} members [ "{{ c_line._value }}" ];
 
 {# we need to create a subroutine for community matching if we want to use permit/deny, and use the community name defined above #}
-policy-options {
   policy-statement x_comm_match_{{ c_name }} {
     term seq{{ loop.index }} {
       from community {{ c_name }}_idx{{ loop.index }};
@@ -18,15 +18,12 @@ policy-options {
 {%       endif %}
       }
     }
-  }
-}
-{%     endfor %}
-{# add reject as last resort for subroutine #}
-policy-options {
-  policy-statement x_comm_match_{{ c_name }} {
+{%       if loop.last %}
     term default-reject {
       then reject;
     }
+{%       endif %}
   }
-}
+{%     endfor %}
 {%   endfor %}
+}


### PR DESCRIPTION
The BGP community configuration crashes on all Junos devices apart from cRPD (which does not use NETCONF configuration). For whatever crazy reason, using 'delete:' as the first command in Junos config does not work.

Impact: BGP community list configuration because we got rid of the internal route-accepted community.