### PR TITLE
CI: Capture rendered output and unified diff as pytest artifacts

### DIFF
--- a/.github/workflows/t-pull.yml
+++ b/.github/workflows/t-pull.yml
@@ -37,11 +37,31 @@ jobs:
         for file in netsim/extra/*/plugin.py; do
           python3 -m mypy $file
         done
+    - name: Compute pytest tmp path
+      if: ${{ github.event.pull_request.head.repo.full_name != 'ipspace/netlab' }}
+      run: echo "PYTEST_TMP=$RUNNER_TEMP/pytest-tmp" >> "$GITHUB_ENV"
     - name: Run transformation tests
+      id: pytest
       if: ${{ github.event.pull_request.head.repo.full_name != 'ipspace/netlab' }}
       run: |
         cd tests
-        PYTHONPATH="../" pytest
+        PYTHONPATH="../" pytest --basetemp="$PYTEST_TMP" --junit-xml="$PYTEST_TMP/junit.xml"
+    - name: Prune empty case dirs
+      if: >-
+        ${{ !cancelled() && steps.pytest.outcome == 'failure'
+            && github.event.pull_request.head.repo.full_name != 'ipspace/netlab' }}
+      run: |
+        find "$PYTEST_TMP" -type d -empty -delete
+        find "$PYTEST_TMP" -xtype l -delete
+    - name: Upload pytest artifacts
+      if: >-
+        ${{ !cancelled() && steps.pytest.outcome == 'failure'
+            && github.event.pull_request.head.repo.full_name != 'ipspace/netlab' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: pytest-tmp-py${{ matrix.python-version }}
+        path: ${{ env.PYTEST_TMP }}
+        retention-days: 7
     - name: Check integration tests
       run: |
         cd tests

--- a/.github/workflows/t-push.yml
+++ b/.github/workflows/t-push.yml
@@ -31,7 +31,22 @@ jobs:
         for file in netsim/extra/*/plugin.py; do
           python3 -m mypy $file
         done
+    - name: Compute pytest tmp path
+      run: echo "PYTEST_TMP=$RUNNER_TEMP/pytest-tmp" >> "$GITHUB_ENV"
     - name: Run transformation tests
+      id: pytest
       run: |
         cd tests
-        PYTHONPATH="../" pytest
+        PYTHONPATH="../" pytest --basetemp="$PYTEST_TMP" --junit-xml="$PYTEST_TMP/junit.xml"
+    - name: Prune empty case dirs
+      if: ${{ !cancelled() && steps.pytest.outcome == 'failure' }}
+      run: |
+        find "$PYTEST_TMP" -type d -empty -delete
+        find "$PYTEST_TMP" -xtype l -delete
+    - name: Upload pytest artifacts
+      if: ${{ !cancelled() && steps.pytest.outcome == 'failure' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: pytest-tmp-py${{ matrix.python-version }}
+        path: ${{ env.PYTEST_TMP }}
+        retention-days: 7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,22 @@
 #    transformation tests will be slower and create-error-tests.sh is
 #    unsupported (see https://github.com/ipspace/netlab/issues/3345).
 #
+# 4. Normalize the failure-report "reprcrash" message to its first line so
+#    pytest's `short test summary info` does not duplicate the diff body
+#    that `_report_mismatch` puts in the `pytest.fail(...)` message. The
+#    rich multi-line message stays in `longrepr`, so the `FAILURES`
+#    section is unaffected. Without this, pytest 9.x prints the entire
+#    failure message verbatim in the short summary whenever it detects
+#    CI (`CI`/`BUILD_NUMBER` env vars) or runs at `-vv`+ -- see
+#    `_pytest/terminal.py::_get_line_with_reprcrash_message`. Pytest's
+#    own `ReprFileLocation.toterminal` already trims to the first line;
+#    we just enforce the same invariant globally.
+#
 
 import os
 import pathlib
 import sys
+import typing
 
 import pytest
 
@@ -38,3 +50,12 @@ def pytest_configure(config: pytest.Config) -> None:
       ),
       stacklevel=2,
     )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) -> typing.Generator[None, None, None]:
+  outcome = yield
+  report = outcome.get_result()  # type: ignore[attr-defined]
+  crash = getattr(getattr(report, "longrepr", None), "reprcrash", None)
+  if crash is not None and "\n" in crash.message:
+    crash.message = crash.message.split("\n", 1)[0]

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -4,6 +4,7 @@
 # topology file
 #
 
+import difflib
 import glob
 import os
 import pathlib
@@ -20,6 +21,8 @@ from netsim.outputs import _TopologyOutput, ansible
 from netsim.utils import log
 from netsim.utils import read as _read
 
+MAX_PREVIEW_LINES = 20
+MAX_PREVIEW_LINES_VERBOSE = 2 * MAX_PREVIEW_LINES
 
 def run_test(fname: str) -> Box:
   log.init_log_system(header = False)
@@ -64,14 +67,62 @@ def transformation_results(test_case: str, tmp_path: pathlib.Path) -> typing.Tup
 
   return (result,expected)
 
-def run_transformation_test(test_case: str, tmp_path: pathlib.Path) -> None:
+# On mismatch, drop the rendered output and a unified diff into tmp_path
+# so CI's upload-artifact step can surface them, then raise pytest.fail
+# with a diff preview in the message.  Constructing the failure message
+# ourselves (rather than letting `assert actual == expected` go through)
+# skips pytest's assertion rewriter, which would otherwise emit an ndiff
+# truncated to ~8 lines of context at default verbosity and flooded with
+# matching lines at -vv.  pytest.fail is preferred over raise
+# AssertionError for its pytrace= argument: a fixture mismatch needs no
+# helper-frame traceback at default verbosity.
+#
+# Preview length and pytrace are tied to pytest's -v count:
+#   verbose<=0  ->  cap at MAX_PREVIEW_LINES         (CI / default pytest)
+#   verbose==1  ->  cap at MAX_PREVIEW_LINES_VERBOSE (run-tests.sh, -v)
+#   verbose>=2  ->  no cap                           (targeted local run)
+#   verbose>=3  ->  no cap, pytrace on               (debugging this harness)
+# The full diff is written to disk regardless, so CI artifact upload is
+# unaffected by the cap.
+def _report_mismatch(
+    test_case: str,
+    label: str,
+    actual: str,
+    expected: str,
+    tmp_path: pathlib.Path,
+    actual_name: str,
+    verbose: int,
+    ) -> None:
+  if actual == expected:
+    return
+
+  diff_lines = list(difflib.unified_diff(
+      expected.splitlines(keepends=True),
+      actual.splitlines(keepends=True),
+      fromfile='expected',tofile='actual'))
+  if verbose >= 2:
+    cap: typing.Optional[int] = None
+  elif verbose >= 1:
+    cap = MAX_PREVIEW_LINES_VERBOSE
+  else:
+    cap = MAX_PREVIEW_LINES
+  preview = "".join(diff_lines if cap is None else diff_lines[:cap])
+  if cap is not None and len(diff_lines) > cap:
+    preview += "\n... diff truncated ..."
+  actual_path = tmp_path / actual_name
+  actual_path.write_text(actual)
+  diff_path = actual_path.with_suffix(".diff")
+  diff_path.write_text("".join(diff_lines))
+  pytest.fail(f"{label} mismatch for {test_case}\n{preview}\n\nFull diff: {diff_path}",pytrace=verbose >= 3)
+
+def run_transformation_test(test_case: str, tmp_path: pathlib.Path, verbose: int) -> None:
   (result,expected) = transformation_results(test_case,tmp_path)
-  assert result == expected, f"transformation mismatch for {test_case}"
+  _report_mismatch(test_case,"transformation",result,expected,tmp_path,"result.yml",verbose)
 
 @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 @pytest.mark.parametrize('test_case',sorted(glob.glob('topology/input/*yml')))
-def test_xform_cases(test_case: str, tmp_path: pathlib.Path) -> None:
-  run_transformation_test(test_case,tmp_path)
+def test_xform_cases(test_case: str, tmp_path: pathlib.Path, pytestconfig: pytest.Config) -> None:
+  run_transformation_test(test_case,tmp_path,pytestconfig.getoption("verbose"))
 
 # Verbose test cases are executed only when we're running under coverage
 # (sys.gettrace() returns the tracer); skipped otherwise so the result is
@@ -83,10 +134,14 @@ def test_xform_cases(test_case: str, tmp_path: pathlib.Path) -> None:
 # exercise different code paths depending on iteration order.
 #
 @pytest.mark.skipif(not sys.gettrace(),reason="coverage-only test")
-def test_coverage_verbose_cases(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_coverage_verbose_cases(
+    tmp_path_factory: pytest.TempPathFactory,
+    pytestconfig: pytest.Config,
+    ) -> None:
   log.set_verbose()
+  verbose = pytestconfig.getoption("verbose")
   for test_case in sorted(glob.glob('topology/input/*yml')):
-    run_transformation_test(test_case,tmp_path_factory.mktemp("coverage"))
+    run_transformation_test(test_case,tmp_path_factory.mktemp("coverage"),verbose)
 
 def error_results(test_case: str) -> typing.Tuple[str, str]:
   log.set_flag(raise_error = True)
@@ -97,22 +152,22 @@ def error_results(test_case: str) -> typing.Tuple[str, str]:
   log_file = pathlib.Path(test_case.replace('.yml','.log'))
   expected_log = log_file.read_text().strip('\n') if log_file.exists() else ""
   return (error_log,expected_log)
-  
-def run_error_case(test_case: str) -> None:
+
+def run_error_case(test_case: str, tmp_path: pathlib.Path, verbose: int) -> None:
   (error_log,expected_log) = error_results(test_case)
-  assert error_log == expected_log, f"error-log mismatch for {test_case}"
+  _report_mismatch(test_case,"error-log",error_log,expected_log,tmp_path,"error_log.actual",verbose)
 
 @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 @pytest.mark.parametrize('test_case',sorted(glob.glob('errors/*yml')))
-def test_error_cases(test_case: str) -> None:
-  run_error_case(test_case)
+def test_error_cases(test_case: str, tmp_path: pathlib.Path, pytestconfig: pytest.Config) -> None:
+  run_error_case(test_case,tmp_path,pytestconfig.getoption("verbose"))
 
 @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 @pytest.mark.parametrize('test_case',sorted(glob.glob('coverage/input/*yml')))
-def test_coverage_xf_cases(test_case: str, tmp_path: pathlib.Path) -> None:
-  run_transformation_test(test_case,tmp_path)
+def test_coverage_xf_cases(test_case: str, tmp_path: pathlib.Path, pytestconfig: pytest.Config) -> None:
+  run_transformation_test(test_case,tmp_path,pytestconfig.getoption("verbose"))
 
 @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
 @pytest.mark.parametrize('test_case',sorted(glob.glob('coverage/errors/*yml')))
-def test_coverage_errors(test_case: str) -> None:
-  run_error_case(test_case)
+def test_coverage_errors(test_case: str, tmp_path: pathlib.Path, pytestconfig: pytest.Config) -> None:
+  run_error_case(test_case,tmp_path,pytestconfig.getoption("verbose"))


### PR DESCRIPTION
Follow-up to #3391 + #3402.  After those two PRs each YAML case is its own
pytest node and per-case file writes are isolated to `tmp_path`, but when a
transformation or error-log fixture mismatches in CI the GitHub Actions log
only shows pytest's truncated assertion diff -- there is no way to retrieve
the actual rendered YAML without re-running locally.  This PR plumbs the
artifact path end-to-end and makes the in-terminal failure message useful
in its own right.

## Summary

- `_report_mismatch` helper in `tests/test_transformation.py`, used by both
  `run_transformation_test` and `run_error_case`.  On mismatch it:
  1. writes the produced content to `tmp_path/<base>.{yml,actual}`,
  2. writes a `difflib.unified_diff` (hunks + 3 lines of context) to
     `tmp_path/<base>.diff`,
  3. calls `pytest.fail(message, pytrace=...)` with a diff preview embedded
     in the failure message.
- Preview length and pytrace scale with pytest's `-v` count -- CI / default
  cap at 20 lines, `-v` doubles it, `-vv` removes the cap, `-vvv` also
  re-enables `pytrace`.  The full diff is on disk regardless.
- `run_error_case` gains a `tmp_path` parameter, threaded through
  `test_error_cases` / `test_coverage_errors` so the helper drops
  `error_log.actual` / `error_log.diff` per case.
- `tests/conftest.py`: `pytest_runtest_makereport` hookwrapper trims
  `report.longrepr.reprcrash.message` to its first line so pytest 9.x's
  short summary doesn't duplicate the diff body that the helper already
  embeds in the failure message.
- CI workflows (`t-push.yml`, `t-pull.yml`): a `Compute pytest tmp path`
  step exports `PYTEST_TMP=$RUNNER_TEMP/pytest-tmp` to `$GITHUB_ENV`,
  pytest gets `--basetemp="$PYTEST_TMP" --junit-xml="$PYTEST_TMP/junit.xml"`,
  an `actions/upload-artifact@v7` step gated on `!cancelled() &&
  steps.pytest.outcome == 'failure'` (AND'd with the existing fork-skip
  guard in `t-pull.yml`), and a small prune step between them.

## Why

### Constructing the failure message ourselves, and `pytest.fail` over `raise AssertionError`

Two related but distinct choices in `_report_mismatch`.

**Why not `assert actual == expected`:** pytest's assertion rewriter
introspects `assert a == b` and emits an `ndiff` representation.  Two
truncation layers apply:

1. At default verbosity it strips the long identical prefix/suffix and the
   output is capped at ~8 lines with `use '-v'/'-vv' to show` messages.
2. At `-v` it would print the fist ~8 lines of the file potentially containing no diff
3. At `-vv` the cap is removed -- but `ndiff` emits every line of the file,
   so a one-line fixture mismatch surfaces as thousands of matching
   lines with the single changed line lost in the middle.

`difflib.unified_diff` (hunks + 3 lines of context) is the right algorithm
for fixture comparisons -- a single-line YAML mismatch is ~7 readable lines.
Constructing the message ourselves (whether via `pytest.fail` or
`raise AssertionError`) hands the rewriter a preformatted string with no
introspectable comparison, so it lands in the test output verbatim.

**Why `pytest.fail` over `raise AssertionError`:** `pytest.fail` takes
`pytrace=False` (here `pytrace=verbose >= 3`).  A fixture mismatch needs
no helper-frame traceback at default verbosity -- the diff preview and
the on-disk pointer are the whole story.  `-vvv` re-enables `pytrace` for
harness debugging.

### Trimming `reprcrash.message`

pytest 9.x prints the full `pytest.fail(...)` message verbatim in the
`short test summary info` block whenever it detects CI (`CI` /
`BUILD_NUMBER` env vars) or runs at `-vv`+, which would duplicate the
diff body the helper deliberately embeds in the failure message.
A `pytest_runtest_makereport` hookwrapper trims
`report.longrepr.reprcrash.message` to its first line; `longrepr` is
untouched, so the `FAILURES` section still carries the diff preview and
the `Full diff: ...` pointer.  Pytest's own `ReprFileLocation.toterminal`
already applies the same first-line trim at one display site; the hook
just enforces the invariant for every consumer (short summary, JUnit XML,
custom reporters).

### `$RUNNER_TEMP` basetemp

GitHub designates `$RUNNER_TEMP` for ephemeral writes on its runners --
whatever they do with that mount today or tomorrow (tmpfs, separate
volume, faster device), the workflow inherits.  The natural shape would
be a single `jobs.tests.env` entry, but `${{ runner.* }}` is not available
outside a step context (GitHub rejects with
`Unrecognized named-value: 'runner'`).  A `Compute pytest tmp path` step
writes `PYTEST_TMP=$RUNNER_TEMP/pytest-tmp` to `$GITHUB_ENV`, after which
`$PYTEST_TMP` is in every subsequent step's shell env and
`${{ env.PYTEST_TMP }}` resolves in every subsequent step's expressions.
Single source of truth, no per-step `env:` blocks.

### `actions/upload-artifact@v7`

`v4` runs on Node 20, which GitHub forces off the runner on 2026-09-16
(and switches to Node 24 by default on 2026-06-02).  `v7` is the latest
stable, defaults to Node 24, and the inputs we use (`name`, `path`,
`retention-days`) are unchanged.

### Prune step before the artifact upload

`--basetemp` creates a directory per test invocation (~273 for
transformation + errors).  Passing cases early-return from
`_report_mismatch` and leave their case dir empty, so without pruning the
uploaded zip is dominated by them.  `find -type d -empty -delete` clears
those; `find -xtype l -delete` then catches pytest's `<test>-current`
symlinks that go dangling after the empty-dir sweep, preventing
`upload-artifact` (which follows symlinks by default) from including
zero-byte placeholders.  `junit.xml` sits at the basetemp root as a regular
file and is unaffected by either find expression.  `find -delete` returns
0 on empty match, so the step is idempotent.

### `!cancelled() && steps.pytest.outcome == 'failure'` gating

The earlier draft of this PR gated the prune + upload on `if: failure()`,
which fires on any prior step failure.  If `pip install` or `mypy` failed
before pytest ran, `$PYTEST_TMP` did not exist, the `find` in the prune
step exited nonzero, and CI showed a misleading second red step with no
diagnostic value.  `!cancelled()` overrides the implicit `success()` that
GitHub prepends to every `if:`, and `steps.pytest.outcome == 'failure'`
narrows the trigger to pytest itself -- the prune and upload steps now
run iff there is something to upload.

## What changes

- **`tests/test_transformation.py`**
  - Adds `_report_mismatch(test_case, label, actual, expected, tmp_path,
    actual_name, verbose)`.  Uses `pathlib.Path.with_suffix(".diff")` to
    derive the diff filename from the actuals filename (so transformation
    gets `result.yml` + `result.diff`, errors get `error_log.actual` +
    `error_log.diff`).
  - `run_transformation_test` and `run_error_case` become thin wrappers
    that call their respective `*_results` helper and then
    `_report_mismatch`.
  - `run_error_case` gains `tmp_path`; `test_error_cases` and
    `test_coverage_errors` pass it through.
  - All four parametrized test functions take `pytestconfig` and forward
    `max(0, pytestconfig.getoption("verbose"))` so the helper can size
    its preview.
- **`tests/conftest.py`**
  - `pytest_runtest_makereport` hookwrapper that trims
    `report.longrepr.reprcrash.message` to its first line when present.
- **`.github/workflows/t-push.yml` and `t-pull.yml`**
  - `Compute pytest tmp path` step exports
    `PYTEST_TMP=$RUNNER_TEMP/pytest-tmp` to `$GITHUB_ENV`.
  - Pytest invocation becomes
    `pytest --basetemp="$PYTEST_TMP" --junit-xml="$PYTEST_TMP/junit.xml"`
    and gains `id: pytest`.
  - `Prune empty case dirs` step runs the two `find` calls.
  - `Upload pytest artifacts` step uses `actions/upload-artifact@v7`,
    named `pytest-tmp-py${{ matrix.python-version }}` so the per-matrix-cell
    artifacts do not collide.
  - `t-pull.yml` repeats the existing fork-skip guard
    (`github.event.pull_request.head.repo.full_name != 'ipspace/netlab'`)
    on the compute, prune and upload steps.

## Anticipated questions

- **"Why no `.gitignore` entry for `pytest-tmp/`?"**  Nothing in the repo
  points pytest at an in-tree basetemp anymore: CI writes to
  `$RUNNER_TEMP/pytest-tmp` and pytest's local default is
  `/tmp/pytest-of-<user>/`.  An entry would only fire on an explicit
  `--basetemp=tests/pytest-tmp` that nothing in the repo does or
  documents -- dead weight in a config that should describe paths the
  repo actually produces.
- **"Why a `_report_mismatch` helper instead of inlining in both wrappers?"**
  The two wrappers had ~8 lines of mechanical duplication (compute diff,
  write actual, write diff, fail).  One helper, two thin call sites.
- **"Will the prune step fight with a future test that legitimately leaves
  files in `tmp_path`?"**  Only deletes *empty* directories and *broken*
  symlinks.  A test that writes anything keeps its dir; the
  inventory-output cases already do, and they survive the prune unchanged.
- **"Cosmetic: unified-diff in pytest's terminal shows `-q+Fatal...` for
  trailing lines without newlines."**  Python's `difflib.unified_diff` does
  not emit GNU diff's `\ No newline at end of file` sentinel.  The byte
  content matches what's on disk; `diff -u` on the artifact files gives
  the GNU-annotated view.

## Test plan

- [ ] `cd tests && PYTHONPATH=../ pytest -q` -- all green.
- [ ] Corrupt `topology/expected/6pe.yml` (e.g. flip
      `advertise_loopback: true` -> `false`),
      `pytest --basetemp=/tmp/pytest-tmp -k 6pe`.
      Expect: failure message contains a `--- expected` / `+++ actual`
      unified diff with hunk headers; no `Skipping N identical leading
      characters` / `use -vv to show` markers; no helper-frame traceback;
      `/tmp/pytest-tmp/<case>/result.yml` and `result.diff` written;
      short summary holds only the first line.  Revert.
- [ ] Corrupt one error-log fixture (e.g. `echo q >> errors/<case>.log`),
      rerun.  Expect: `error-log mismatch` message with diff body;
      `error_log.actual` and `error_log.diff` in the case `tmp_path`.
      Revert.
- [ ] Full run with one corruption in place: confirm
      `find <basetemp> -type d -empty -delete && find <basetemp> -xtype
      l -delete` reduces the layout to the failing case (with its
      `.diff` pair) plus the non-empty inventory-output cases plus
      `junit.xml`.
- [ ] CI on this branch: t-push and t-pull both green; failure case
      (introduced temporarily) uploads a `pytest-tmp-py3.X` artifact
      with the expected contents.