### PR TITLE
Libvirt machine type

### DIFF
--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -111,8 +111,11 @@ The following node parameters influence the VM configuration created by *vagrant
 * **libvirt.nic_model_type** -- VM NIC model (example: e1000). The default _netlab_ settings usually work fine.
 * **libvirt.nic_adapter_count** -- maximum number of VM NICs (default: 8)
 * **libvirt.uuid** -- sets the libvirt VM UUID (some devices use the UUID to create their serial numbers). The value of this parameter is not checked[^UUID].
+* **libvirt.machine_type** -- QEMU machine type passed to *vagrant-libvirt* (example: `pc-i440fx-6.2`, `q35`). Useful when a Vagrant box requires a specific machine type to boot (for example, older guest kernels that fail on the QEMU 8.x default on Ubuntu 24.04). Overrides any value set by the device template. The value of this parameter is not checked[^MACHTYPE].
 
 [^UUID]: In other words, you're on your own. After starting a lab, you can get a valid VM UUID with the **virsh dumpxml _vm_name_|grep uuid** command (use **netlab status** to display the VM name).
+
+[^MACHTYPE]: Use with caution -- an invalid or unsupported machine type will surface as a *vagrant-libvirt* / QEMU boot error rather than a *netlab* validation message. List the machine types available on your host with **qemu-system-x86_64 -machine help**.
 
 (libvirt-box-replace)=
 ### Replacing Vagrant Boxes

--- a/netsim/providers/libvirt.yml
+++ b/netsim/providers/libvirt.yml
@@ -35,6 +35,7 @@ attributes:
     image: str
     uuid: str
     ports: list
+    machine_type: str
   link:
     permanent: bool
     public: { type: str, valid_values: [ bridge, vepa, passthrough, private ], true_value: bridge }

--- a/netsim/templates/provider/libvirt/define-domain.j2
+++ b/netsim/templates/provider/libvirt/define-domain.j2
@@ -39,6 +39,9 @@
 {%   if 'uuid' in n.libvirt %}
       domain.uuid = '{{ n.libvirt.uuid }}'
 {%   endif %}
+{%   if 'machine_type' in n.libvirt %}
+      domain.machine_type = "{{ n.libvirt.machine_type }}"
+{%   endif %}
 {%   include 'forwarded-ports.j2' %}
 {% endif %}
     end


### PR DESCRIPTION
> Not at the moment, and until we get other similar issues, I wouldn't add one.

I know this was said in https://github.com/ipspace/netlab/issues/3397#issuecomment-4458095443 regarding configuring the machine_type for libvirt.

Still dealing with the aftermath of my upgrade from 20.04 to 24.04, this time it's my F5 load balancer vagrant box that was affected — a linux device as far as netlab is concerned. Very similar to the Juniper VSRX issue and the fix is also changing the `machine_type` for that device.

I didn't want to change it for all libvirt linux hosts, as it could have a wider blast radius, and it seems to be something quite specific for my use case. For that reason, I thought having an option to select the `machine_type` in the node attribute would work quite well.