### PR TITLE
SR Linux: SR-MPLS over IPv6

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -569,7 +569,7 @@ Other caveats you might encounter:
 * Only supported on top of *Containerlab*
 * Supports SR Linux release 24.7.1 or later (due to YANG model changes)
 * Requires `nokia.srlinux` Ansible Galaxy collection (minimum version 0.5.0). Use **ansible-galaxy collection install nokia.srlinux** command to install it.
-* MPLS and LDP are only supported on 7250 IXR (clab.type in ['ixr6','ixr6e','ixr10','ixr10e']). You need a license to run these containers.
+* MPLS, LDP, and SR-MPLS are only supported on 7250 IXR (clab.type in ['ixr6','ixr6e','ixr10','ixr10e']). You need a license to run these containers.
 * Nokia SR Linux needs an EVPN control plane to enable VXLAN functionality. VXLAN ingress replication lists are built from EVPN Route Type 3 updates.
 * Inter-VRF route leaking is supported only in combination with BGP EVPN
 * SR Linux does not support configurable propagation of extended BGP communities.

--- a/docs/module/sr-mpls.md
+++ b/docs/module/sr-mpls.md
@@ -33,7 +33,7 @@ SR-MPLS is implemented on the following platforms:
 | Cisco IOS XR[^XR]     |   ✅  |  ✅  |  ✅   |  ✅   |
 | FRRouting             |   ✅  |  ✅  |  ✅   |  ✅   |
 | Junos[^Junos]         |   ✅  |  ✅  |  ✅   |  ❌   |
-| Nokia SR Linux [❗](caveats-srlinux) |   ✅  |  ❌   |  ✅   |  ❌   |
+| Nokia SR Linux [❗](caveats-srlinux) | ✅ | ✅ | ✅ | ❌ |
 | Nokia SR OS[^SROS]    |   ✅  |  ✅  |  ✅   |  ❌   |
 
 [^xe]: Catalyst 8000v, Cisco CSR 1000v, Cisco IOS on Linux (IOL) and IOL layer-2 image.

--- a/netsim/ansible/templates/bgp/srlinux.j2
+++ b/netsim/ansible/templates/bgp/srlinux.j2
@@ -24,5 +24,6 @@ updates:
             add: ibgp-mark
         policy-result: accept
 
-{% from "srlinux.macro.j2" import bgp_config with context %}
+{% from "srlinux.macro.j2" import bgp_config,bgp_shortcut with context %}
 {{ bgp_config('default',bgp.as,bgp.router_id,bgp,{ 'af' : af }) }}
+{{ bgp_shortcut(bgp,'default') }}

--- a/netsim/ansible/templates/bgp/srlinux.macro.j2
+++ b/netsim/ansible/templates/bgp/srlinux.macro.j2
@@ -265,15 +265,19 @@
 {%     endif %}
 {%   endfor %}
 {% endfor %}
+{% endmacro %}
 
-{% if 'sr' in module|default([]) or ('mpls' in module|default([]) and ldp is defined) %}
-{# Configure BGP shortcuts via SR-ISIS or LDP #}
-- path: /network-instance[name={{vrf}}]/protocols/bgp/afi-safi[afi-safi-name=ipv4-unicast]/ipv4-unicast/next-hop-resolution
+{% macro bgp_shortcut(bgp,vrf='default') %}
+{#   Configure BGP shortcuts via SR-ISIS or LDP #}
+{%   if 'sr' in module|default([]) or ('mpls' in module|default([]) and ldp is defined) %}
+{%     for af in ['ipv4','ipv6'] if af in bgp %}
+- path: /network-instance[name={{vrf}}]/protocols/bgp/afi-safi[afi-safi-name={{ af }}-unicast]/{{ af }}-unicast/next-hop-resolution
   value:
-    ipv4-next-hops:
+    {{ af }}-next-hops:
       tunnel-resolution:
         mode: prefer
         _annotate_mode: "tunnel-table lookup over FIB"
         allowed-tunnel-types: [ {{ "sr-isis" if 'sr' in module|default([]) else 'ldp' }} ]
-{% endif %}
+{%     endfor %}    
+{%   endif %}
 {% endmacro %}

--- a/netsim/ansible/templates/isis/srlinux.macro.j2
+++ b/netsim/ansible/templates/isis/srlinux.macro.j2
@@ -14,12 +14,7 @@
 {% if isis.af.ipv6 is defined %}
      ipv6-unicast:
        admin-state: enable
-{%   if clab.type in ['ixr6','ixr10','ixr6e','ixr10e'] %}
-       multi-topology: {{ 'sr' not in module|default([]) }}
-       _annotate_multi-topology: "Not supported in combination with SR"
-{%   else %}
        multi-topology: True
-{%   endif %}
 {% endif %}
 {% if ldp is defined and ldp.igp_sync|default(True) %}
      ldp-synchronization: { }

--- a/netsim/ansible/templates/sr/srlinux.j2
+++ b/netsim/ansible/templates/sr/srlinux.j2
@@ -55,10 +55,6 @@ updates:
 {%   for af in ['ipv4','ipv6'] if af in loopback and sr.node_sid[af]|default(False) %}
                 {{ af }}-node-sid:
                   index: "{{ sr.node_sid[af] }}"
-{%     if af == 'ipv4' %}
                   _annotate_index: "References a label from the global static range"
-{%     else %}
-                  _annotate_index: "ipv6 can be provisioned but not currently supported"
-{%     endif %}
 {%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/sr/srlinux.j2
+++ b/netsim/ansible/templates/sr/srlinux.j2
@@ -8,55 +8,57 @@ delete:
 updates:
 - path: /system/mpls/label-ranges
   value:
-   #
-   # EOS default ranges: https://www.arista.com/en/um-eos/eos-is-is
-   # Dynamic Global Range--(100000) (262144)
-   # IS-IS SR Global Range -- (900000) (65536)
-   # Static Global Range -- (16) (99984)
-   #
-   # IOS-XR: https://packetpushers.net/yet-another-blog-about-segment-routing-part-1/
-   # default SRGB range is from 16000-23999 and Dynamic label range is 24000-1048575
-   #
-   static:
-   - name: static-srgb
-     start-label: {{ sr.srgb.start }}
-     end-label: {{ sr.srgb.start + (sr.srgb.size/2)|int }}
+    #
+    # EOS default ranges: https://www.arista.com/en/um-eos/eos-is-is
+    # Dynamic Global Range--(100000) (262144)
+    # IS-IS SR Global Range -- (900000) (65536)
+    # Static Global Range -- (16) (99984)
+    #
+    # IOS-XR: https://packetpushers.net/yet-another-blog-about-segment-routing-part-1/
+    # default SRGB range is from 16000-23999 and Dynamic label range is 24000-1048575
+    #
+    static:
+    - name: static-srgb
+      start-label: {{ sr.srgb.start }}
+      end-label: {{ sr.srgb.start + (sr.srgb.size/2)|int }}
 
-   dynamic:
-   - name: dynamic-srgb
-     start-label: {{ sr.srgb.start + (sr.srgb.size/2)|int + 1 }}
-     end-label: {{ sr.srgb.start + sr.srgb.size }}
+    dynamic:
+    - name: dynamic-srgb
+      start-label: {{ sr.srgb.start + (sr.srgb.size/2)|int + 1 }}
+      end-label: {{ sr.srgb.start + sr.srgb.size }}
 
 - path: /network-instance[name=default]
   value:
-   interface:
-   - name: system0.0
-   segment-routing:
-    mpls:
-     global-block:
-      label-range: static-srgb
-      _annotate_label-range: "static SRGB, required"
-   protocols:
-    isis:
-     dynamic-label-block: dynamic-srgb # Required but not currently used
-     _annotate_dynamic-label-block: "Required but not currently used"
-     instance:
-     - name: {{ isis.instance }}
-       max-ecmp-paths: 64 # Since release 23.7.1
-       segment-routing:
-        mpls: {}
-       interface:
-       - interface-name: system0.0
-         passive: True
-         segment-routing:
-          mpls:
+    interface:
+    - name: system0.0
+    segment-routing:
+      mpls:
+        global-block:
+          label-range: static-srgb
+          _annotate_label-range: "static SRGB, required"
+    protocols:
+      isis:
+        dynamic-label-block: dynamic-srgb
+        instance:
+        - name: {{ isis.instance }}
+          max-ecmp-paths: 64 # Since release 23.7.1
+          segment-routing:
+            mpls:
+              adjacency-sid-hold-time: 20
+              dynamic-adjacency-sids:
+                all-interfaces: true
+          interface:
+          - interface-name: system0.0
+            passive: True
+            segment-routing:
+              mpls:
 {%   for af in ['ipv4','ipv6'] if af in loopback and sr.node_sid[af]|default(False) %}
-           {{ af }}-node-sid:
-            index: "{{ sr.node_sid[af] }}"
+                {{ af }}-node-sid:
+                  index: "{{ sr.node_sid[af] }}"
 {%     if af == 'ipv4' %}
-            _annotate_index: "References a label from the global static range"
+                  _annotate_index: "References a label from the global static range"
 {%     else %}
-            _annotate_index: "ipv6 can be provisioned but not currently supported"
+                  _annotate_index: "ipv6 can be provisioned but not currently supported"
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -127,13 +127,6 @@ class SRLINUX(_Quirks):
           quirk='vrf_route_leaking',
           category=log.IncorrectType)
 
-    if 'isis' in mods:
-      if node.get('isis.af.ipv6',False) and 'srx' in mods:
-        report_quirk(
-          text=f'SR Linux on "{node.name}" does not support IS-IS multi-topology for IPv6 in combination with segment routing',
-          node=node,
-          quirk='ipv6_sr')
-
     if 'bgp' in mods:
       cleanup_neighbor_transport(node,topology)
       if node._srl_version < [ 25, 3 ]:

--- a/netsim/devices/srlinux.py
+++ b/netsim/devices/srlinux.py
@@ -128,7 +128,7 @@ class SRLINUX(_Quirks):
           category=log.IncorrectType)
 
     if 'isis' in mods:
-      if node.get('isis.af.ipv6',False) and 'sr' in mods:
+      if node.get('isis.af.ipv6',False) and 'srx' in mods:
         report_quirk(
           text=f'SR Linux on "{node.name}" does not support IS-IS multi-topology for IPv6 in combination with segment routing',
           node=node,

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -16,8 +16,8 @@ group_vars:
     isis: [ isis ]
     static: [ static ]
 sr:
-  srgb.start: 500000
-  srgb.size: 1000
+  srgb.start: 16000
+  srgb.size: 10000
 bfd:                                    # SR Linux supports lower BFD timers than the global default
   min_tx: 100
   min_rx: 100
@@ -98,7 +98,7 @@ features:
       vrf: True
       discard: True
   sr:
-    af: [ ipv4 ]
+    af: [ ipv4, ipv6 ]
     protocol: [ isis ]
   vlan:
     model: router


### PR DESCRIPTION
* Remove caveats from srlinux device quirks
* Enable SR-MPLS shortcuts for BGP IPv4 and IPv6 AF, but only for the default BGP instance
* Use SR-MPLS with multi-topology IS-IS (it works now)
* Configure generation of adjacency SIDs