### PR TITLE
Use machine_type under vsrx device attribute instead of libvirt template

### DIFF
--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -23,6 +23,8 @@ virtualbox:
   image: juniper/vsrx3
 libvirt:
   image: juniper/vsrx3
+  node:
+    machine_type: pc-i440fx-6.2
   build: https://netlab.tools/labs/vsrx/
   create_iso: vsrx
   create:

--- a/netsim/templates/provider/libvirt/vsrx-domain.j2
+++ b/netsim/templates/provider/libvirt/vsrx-domain.j2
@@ -14,7 +14,6 @@
       domain.cpus = 2
       domain.memory = 4096
       domain.disk_bus = "ide"
-      domain.machine_type = "pc-i440fx-6.2"
       {% if "amd" in defaults.processor|lower %}
       domain.cpu_mode = "custom"
       {% endif %}

--- a/tests/topology/expected/dual-stack.yml
+++ b/tests/topology/expected/dual-stack.yml
@@ -339,6 +339,8 @@ nodes:
         ipv6: 2001:db8:1::4/64
         node: a_eos
       type: lan
+    libvirt:
+      machine_type: pc-i440fx-6.2
     loopback:
       ifindex: 0
       ifname: lo0.0

--- a/tests/topology/expected/isis-feature-test.yml
+++ b/tests/topology/expected/isis-feature-test.yml
@@ -891,6 +891,8 @@ nodes:
       net: 49.0002.0000.0000.0004.00
       system_id: 0000.0000.0004
       type: level-2
+    libvirt:
+      machine_type: pc-i440fx-6.2
     loopback:
       ifindex: 0
       ifname: lo0.0

--- a/tests/topology/expected/ospf.yml
+++ b/tests/topology/expected/ospf.yml
@@ -813,6 +813,9 @@ nodes:
         node: a_eos
       role: external
       type: lan
+    libvirt:
+      _removed_attr:
+      - machine_type
     loopback:
       ifindex: 0
       ifname: lo0.0

--- a/tests/topology/expected/unnumbered.yml
+++ b/tests/topology/expected/unnumbered.yml
@@ -267,6 +267,8 @@ nodes:
         node: c_nxos
       role: core
       type: p2p
+    libvirt:
+      machine_type: pc-i440fx-6.2
     loopback:
       ifindex: 0
       ifname: lo0.0

--- a/tests/topology/input/ospf.yml
+++ b/tests/topology/input/ospf.yml
@@ -25,6 +25,7 @@ nodes:
   device: eos
 - name: j_vsrx
   device: vsrx
+  libvirt.machine_type: false
 
 links:
 - c_nxos:


### PR DESCRIPTION
https://github.com/ipspace/netlab/pull/3406#pullrequestreview-4308096656

I didn't understand why it wouldn't work, until I've realised I needed to have it under `node` inside `libvirt`
