### PR TITLE
SR Linux: Fix LDP configuration template

### DIFF
--- a/netsim/ansible/templates/mpls/srlinux.j2
+++ b/netsim/ansible/templates/mpls/srlinux.j2
@@ -1,3 +1,4 @@
+updates:
 {% if ldp is defined %}
 {%   include 'srlinux.ldp.j2' +%}
 {% endif %}

--- a/netsim/ansible/templates/mpls/srlinux.ldp.j2
+++ b/netsim/ansible/templates/mpls/srlinux.ldp.j2
@@ -1,25 +1,24 @@
-{# Note: LDP only supported on 7250 IXR #}
-{% if clab.type not in ['ixr6','ixr10','ixr6e','ixr10e'] %}
-{{ type_ixr | mandatory('LDP only supported on 7250 IXR; use e.g. clab.type "ixr6e" instead of '+clab.type) }}
-{% else %}
-updates:
+- path: /system/mpls/label-ranges/dynamic[name=ldp]
+  value:
+    start-label: 10000
+    end-label: 15000
 
-- path: system/mpls/label-ranges/dynamic[name=D1]
-  val:
-   start-label: 100
-   end-label: 200
+- path: /network-instance[name=default]/mpls
+  value:
+    icmp-tunneling: true
 
-- path: network-instance[name=default]/protocols/ldp
-  val:
-   admin-state: enable
-   dynamic-label-block: D1
+- path: /network-instance[name=default]/protocols/ldp
+  value:
+    admin-state: enable
+    dynamic-label-block: ldp
 
 {% for l in interfaces if ('ldp' in l) and not l.ldp.passive %}
-{%  set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
-- path: network-instance[name=default]/protocols/ldp/discovery/interfaces
-  val:
-   interface:
-   - name: "{{ ifname }}"
+{%   if loop.first %}
+    discovery:
+      interfaces:
+        interface:
+{%   endif %}
+        - name: "{{ l.ifname }}{{ '.0' if '.' not in l.ifname else '' }}"
+          ipv4:
+            admin-state: enable
 {% endfor %}
-
-{% endif %}

--- a/tests/integration/mpls/topology-defaults.yml
+++ b/tests/integration/mpls/topology-defaults.yml
@@ -1,0 +1,6 @@
+#
+# Change SR Linux node type to make MPLS work
+#
+devices:
+  srlinux:
+    clab.node.type: ixr6


### PR DESCRIPTION
* Use correct interface name syntax and enable LDP for IPv4 in the 'protocols/ldp/discovery' block (the major showstopper)
* Merge LDP configuration blocks into a single block
* Enable MPLS ICMP tunneling
* Allocate more labels to the LDP pool and change its name to 'ldp'
* Remove the template checks for device type (that's done in device quirks)