### PR TITLE
Fix: Null update/delete values become empty lists in SR Linux config

### DIFF
--- a/netsim/ansible/tasks/deploy-config/srlinux.yml
+++ b/netsim/ansible/tasks/deploy-config/srlinux.yml
@@ -8,9 +8,9 @@
     ansible_network_os: nokia.srlinux.srlinux
     ansible_connection: ansible.netcommon.httpapi
     cfg: "{{ yaml_config | from_yaml }}"
-    d: "{{ cfg.delete | default([]) }}"
-    u: "{{ cfg.updates | default([]) }}"
-    r: "{{ cfg.replace | default([]) }}"
+    d: "{{ cfg.delete | default([],true) }}"
+    u: "{{ cfg.updates | default([],true) }}"
+    r: "{{ cfg.replace | default([],true) }}"
   nokia.srlinux.config:
     delete: "{{ d }}"
     replace: "{{ r }}"


### PR DESCRIPTION
As a safeguard against 'updates:' (or some such) lists generated by the Jinja2 templates becoming "null", the 'default([])' filter used to set the Ansible module parameters now converts falsy values into empty lists.

Based on a review comment in #3414 