### PR TITLE
Implement _value_to_dict validation attribute

### DIFF
--- a/docs/dev/validation.md
+++ b/docs/dev/validation.md
@@ -501,7 +501,7 @@ ospf:
 Some _netlab_ attributes that are supposed to be dictionaries can accept non-dictionary values. You can use the **_value_to_dict** type definition key to specify a template dictionary that is used to create a replacement dictionary. The values of the replacement dictionary can be f-strings with `{value}` representing the original value.
 
 ```{warning}
-The `{value}`string could be interpreted as a YAML dictionary and MUST therefore be quoted.
+The `{value}` string could be interpreted as a YAML dictionary and MUST therefore be quoted.
 ```
 
 For example, to transform a BGP role specified as a string into a dictionary with the role name and `strict` flag, use this type definition:

--- a/docs/dev/validation.md
+++ b/docs/dev/validation.md
@@ -495,6 +495,43 @@ ospf:
         ipv6: bool
 ```
 
+(validation-value-to-dict)=
+### Dictionary Specified As a Single Value
+
+Some _netlab_ attributes that are supposed to be dictionaries can accept non-dictionary values. You can use the **_value_to_dict** type definition key to specify a template dictionary that is used to create a replacement dictionary. The values of the replacement dictionary can be f-strings with `{value}` representing the original value.
+
+```{warning}
+The `{value}`string could be interpreted as a YAML dictionary and MUST therefore be quoted.
+```
+
+For example, to transform a BGP role specified as a string into a dictionary with the role name and `strict` flag, use this type definition:
+
+```
+attributes:
+  node:
+    role:
+      name:
+        type: str
+        valid_values: [ provider, customer, peer, rs-server, rs-client ]
+      strict: bool
+      _value_to_dict:
+        name: '{value}'
+        strict: False
+```
+
+You can often use the `_value_to_dict` functionality instead of `_alt_types` or custom data transformation. For example, the following data type definition for the BGP community attribute replaced a chunk of somewhat convoluted Python code:
+
+```
+attributes:
+  global:
+    community:
+      ibgp: { type: list, _subtype: bgp_community_type }
+      ebgp: { type: list, _subtype: bgp_community_type }
+      _value_to_dict:
+        ibgp: '{value}'
+        ebgp: '{value}'
+```
+
 (validation-ip-address)=
 ## IP Address Validation
 

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -6,8 +6,8 @@ import typing
 
 from box import Box
 
-from ..utils import log
-from . import get_a_list, get_empty_box
+from ..utils import log, strings
+from . import get_a_list, get_box, get_empty_box
 
 # We also need to import the whole data.types module to be able to do validation function lookup
 from . import types as _tv
@@ -482,6 +482,23 @@ def check_valid_with(
           category=log.IncorrectAttr,
           module=module)
 
+def transform_value_to_dict(data: typing.Any, mapping: typing.Any) -> typing.Any:
+  """
+  Transform a non-dict value to a dictionary using 'mapping' template
+  """
+  if isinstance(mapping,dict):                    # Recursively transform boxes and dicts
+    return get_box({ k: transform_value_to_dict(data,v) for k,v in mapping.items() })
+  if isinstance(mapping,list):                    # Recursively transform lists
+    return [ transform_value_to_dict(data,v) for v in mapping ]
+  if not isinstance(mapping,str) or '{' not in mapping:
+    return mapping                                # Return values that are not f-string verbatim
+
+  result = strings.eval_format(mapping,{ 'value': data })
+  try:                                            # Evalute f-string and try evaluate its results
+    return eval(result)                           # as we could use f-string to generate a list or a computed int
+  except Exception:
+    return result                                 # If the f-string result doesn't parse, return it as string
+
 """
 validate_item -- validate a single item from an object:
 
@@ -549,6 +566,23 @@ def validate_item(
     parent[key] = { k: data_type._list_to_dict for k in data }        # Transform lists into a dictionary (updating parent will make it into a Box)
     data = parent[key]
     data_type = Box(data_type)                                        # and fix datatype definition
+
+  # Another corner case: data type is a dictionary, we have a non-dict value, and the data type definition
+  # gives us a template to transform that value into a dictionary
+  #
+  if not isinstance(data,dict) and '_value_to_dict' in data_type and parent is not None:
+    try:
+      parent[key] = transform_value_to_dict(data,data_type._value_to_dict)
+    except Exception as ex:
+      log.error(                                                    # ... to log all dependency errors
+        f"Cannot transform value of attribute {parent_path}.{key}' into a dictionary",
+        more_data=[str(ex)],
+        category=log.IncorrectValue,
+        module=module)
+      return
+
+    data = parent[key]
+    data_type = Box(data_type)
 
   alt_context = {}                                                    # Alt-type context passed to validation functions
   if '_alt_types' in data_type:                                       # Deal with alternate types first

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -2,6 +2,7 @@
 # Data validation routines
 #
 
+import ast
 import typing
 
 from box import Box
@@ -495,7 +496,7 @@ def transform_value_to_dict(data: typing.Any, mapping: typing.Any) -> typing.Any
 
   result = strings.eval_format(mapping,{ 'value': data })
   try:                                            # Evalute f-string and try evaluate its results
-    return eval(result)                           # as we could use f-string to generate a list or a computed int
+    return ast.literal_eval(result)               # as we could use f-string to generate a list or a computed int
   except Exception:
     return result                                 # If the f-string result doesn't parse, return it as string
 

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -575,11 +575,11 @@ def validate_item(
       parent[key] = transform_value_to_dict(data,data_type._value_to_dict)
     except Exception as ex:
       log.error(                                                    # ... to log all dependency errors
-        f"Cannot transform value of attribute {parent_path}.{key}' into a dictionary",
+        f"Cannot transform value of attribute '{parent_path}.{key}' into a dictionary",
         more_data=[str(ex)],
         category=log.IncorrectValue,
         module=module)
-      return
+      return False
 
     data = parent[key]
     data_type = Box(data_type)

--- a/netsim/modules/bgp.py
+++ b/netsim/modules/bgp.py
@@ -61,33 +61,6 @@ def check_bgp_parameters(node: Box, topology: Box) -> None:
 
   must_be_asn(parent=node,key='bgp.as',path=f'nodes.{node.name}',module='bgp')
 
-  if "community" in node.bgp:
-    bgp_comm = node.bgp.community
-    if isinstance(bgp_comm,str):
-      node.bgp.community = { 'ibgp' : [ bgp_comm ], 'ebgp': [ bgp_comm ]}
-    elif isinstance(bgp_comm,list):
-      node.bgp.community = { 'ibgp' : bgp_comm, 'ebgp': bgp_comm }
-    elif not(isinstance(bgp_comm,dict)):
-      log.error(
-        f"bgp.community attribute in node {node.name} should be a string, a list, or a dictionary (found: {bgp_comm})",
-        log.IncorrectType,
-        'bgp')
-      return
-
-    for k in node.bgp.community.keys():
-      if not k in ['ibgp','ebgp']:
-        log.error(
-          text=f"Invalid BGP community setting in {k} node {node.name}",
-          category=log.IncorrectValue,
-          module='bgp')
-      else:
-        must_be_list(
-          parent=node.bgp.community,
-          path=f'nodes.{node.name}.bgp.community',
-          key=k,
-          valid_values=topology['defaults.attributes.global.bgp_community_type.valid_values'],
-          module='bgp')
-
 def validate_bgp_sessions(node: Box, sessions: Box, attribute: str) -> bool:
   OK = True
   for k in list(sessions.keys()):

--- a/netsim/modules/bgp.yml
+++ b/netsim/modules/bgp.yml
@@ -66,7 +66,9 @@ attributes:
     community:
       ibgp: { type: list, _subtype: bgp_community_type }
       ebgp: { type: list, _subtype: bgp_community_type }
-      _alt_types: [ str, BoxList ]
+      _value_to_dict:
+        ibgp: '{value}'
+        ebgp: '{value}'
     replace_global_as: bool
     confederation:
       type: dict

--- a/tests/coverage/expected/value-as-dict.yml
+++ b/tests/coverage/expected/value-as-dict.yml
@@ -1,0 +1,358 @@
+bgp:
+  advertise_loopback: true
+  as: 65000
+  community:
+    ebgp:
+    - standard
+    ibgp:
+    - standard
+    - extended
+  next_hop_self: true
+groups:
+  as65000:
+    members:
+    - a
+    - b
+    - c
+    - d
+input:
+- coverage/input/value-as-dict.yml
+- package:topology-defaults.yml
+module:
+- bgp
+name: input
+nodes:
+  a:
+    af:
+      ipv4: true
+    bgp:
+      advertise:
+      - ipv4: 10.0.0.1/32
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        localas_ibgp:
+        - standard
+      ipv4: true
+      neighbors:
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.2
+        name: b
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.3
+        name: c
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.1/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.4
+        name: d
+        next_hop_self: ebgp
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.1
+    box: none
+    brn:
+      name: provider
+      strict: false
+    device: none
+    id: 1
+    interfaces: []
+    loopback:
+      bgp:
+        advertise: true
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    module:
+    - bgp
+    name: a
+  b:
+    af:
+      ipv4: true
+    bgp:
+      advertise:
+      - ipv4: 10.0.0.2/32
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        - extended
+        ibgp:
+        - standard
+        - extended
+        localas_ibgp:
+        - standard
+        - extended
+      ipv4: true
+      neighbors:
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.1
+        name: a
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.3
+        name: c
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.2/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.4
+        name: d
+        next_hop_self: ebgp
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.2
+    box: none
+    brn:
+      name: customer
+      strict: true
+    device: none
+    id: 2
+    interfaces: []
+    loopback:
+      bgp:
+        advertise: true
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    module:
+    - bgp
+    name: b
+  c:
+    af:
+      ipv4: true
+    bgp:
+      advertise:
+      - ipv4: 10.0.0.3/32
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - standard
+        localas_ibgp:
+        - standard
+      ipv4: true
+      neighbors:
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.1
+        name: a
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.2
+        name: b
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.3/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.4
+        name: d
+        next_hop_self: ebgp
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.3
+    box: none
+    device: none
+    id: 3
+    interfaces: []
+    loopback:
+      bgp:
+        advertise: true
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.3/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: ca:fe:00:03:00:00
+    module:
+    - bgp
+    name: c
+  d:
+    af:
+      ipv4: true
+    bgp:
+      advertise:
+      - ipv4: 10.0.0.4/32
+      advertise_loopback: true
+      as: 65000
+      community:
+        ebgp:
+        - standard
+        ibgp:
+        - extended
+        localas_ibgp:
+        - extended
+      ipv4: true
+      neighbors:
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.1
+        name: a
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.2
+        name: b
+        next_hop_self: ebgp
+        type: ibgp
+      - _source_intf:
+          ifindex: 0
+          ifname: Loopback0
+          ipv4: 10.0.0.4/32
+          neighbors: []
+          type: loopback
+          virtual_interface: true
+        activate:
+          ipv4: true
+        as: 65000
+        ipv4: 10.0.0.3
+        name: c
+        next_hop_self: ebgp
+        type: ibgp
+      next_hop_self: true
+      router_id: 10.0.0.4
+    box: none
+    device: none
+    id: 4
+    interfaces: []
+    loopback:
+      bgp:
+        advertise: true
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.4/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: ca:fe:00:04:00:00
+    module:
+    - bgp
+    name: d
+provider: libvirt

--- a/tests/coverage/input/value-as-dict.yml
+++ b/tests/coverage/input/value-as-dict.yml
@@ -1,0 +1,34 @@
+#
+# This code coverage topology tests the _value_to_dict functionality using a custom data type and
+# BGP community expansion
+#
+defaults:
+  device: none
+  bgp.warnings.missing_igp: False
+  attributes:
+    node:
+      brn:
+        name:
+          type: str
+          valid_values: [ provider, customer, peer, rs-server, rs-client ]
+        strict: bool
+        _value_to_dict:
+          name: '{value}'
+          strict: False
+
+module: [ bgp ]
+bgp.as: 65000
+
+nodes:
+  a:
+    brn: provider
+    bgp.community: standard                       # Single-value BGP community
+  b:
+    brn:
+      name: customer
+      strict: True
+    bgp.community: [ standard, extended ]         # List of BGP communities, have to be applied to IBGP and EBGP
+  c:
+    bgp.community.ibgp: standard                  # String value must be transformed to list
+  d:
+    bgp.community.ibgp: [ extended ]              # Leave as-is

--- a/tests/errors/bgp-community.log
+++ b/tests/errors/bgp-community.log
@@ -1,5 +1,9 @@
-IncorrectType in bgp: attribute 'nodes.r1.bgp.community' must be a dictionary or a string, found int
+IncorrectType in bgp: attribute 'nodes.r1.bgp.community.ibgp[1]' must be a string, found int
 ... use 'netlab show attributes --module bgp node' to display valid attributes
+IncorrectType in bgp: attribute 'nodes.r1.bgp.community.ebgp[1]' must be a string, found int
+IncorrectValue in bgp: attribute nodes.r2.bgp.community.ibgp[1] has invalid value(s): none
+... valid values are: standard, extended, large, 2octet
+IncorrectValue in bgp: attribute nodes.r2.bgp.community.ebgp[1] has invalid value(s): none
 IncorrectAttr in bgp: Incorrect bgp node attribute 'my' in nodes.r3.bgp.community
 IncorrectAttr in bgp: Incorrect bgp node attribute 'his' in nodes.r3.bgp.community
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting


### PR DESCRIPTION
The _value_to_dict validation attribute transforms a non-dict value into a dictionary using the value of the _value_to_dict key as the template dictionary. You can use it whenever you have a dict attribute that can accept non-dict values.

Sample use case included in the PR: BGP communities