### PR TITLE
Support PEP 517 isolated builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 """setup.py file."""
+import re
 import sys
 from pathlib import Path
 
 from setuptools import find_packages, setup
 
-import netsim
-
 long_description = (Path(__file__).parent / "README.md").read_text()
+version = re.search(
+  r'__version__\s*=\s*[\'"]([^\'"]+)[\'"]',
+  (Path(__file__).parent / "netsim" / "__init__.py").read_text()
+).group(1)
 
 with open("requirements.txt", "r") as fs:
   reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
@@ -16,7 +19,7 @@ if sys.version_info < (3, 10):
 
 setup(
   name="networklab",
-  version=netsim.__version__,
+  version=version,
   packages=find_packages(),
   author="Ivan Pepelnjak",
   author_email="ip@ipspace.net",
@@ -37,7 +40,6 @@ setup(
   ],
   url="https://github.com/ipspace/netlab",
   include_package_data=True,
-  setup_requires=["wheel"],
   python_requires='>=3.10',  # To support Ubuntu 22.04
   install_requires=reqs,
   scripts=[ "netlab" ],


### PR DESCRIPTION
On Ubuntu 26.04 deprecation warnings are printed for `pip install -e .`  and every time netlab is executed.
This is a minimal change to comply with the general tooling direction and hide the warnings in a meaningful way.
PEP 621 is left to the author. 

## What

Add a `pyproject.toml` `[build-system]` section so `pip` builds netlab in an
isolated environment, and stop importing the package in `setup.py` to read its
version.

## Why

Without a `[build-system]` table, `pip` falls back to a legacy, non-isolated
build that happens to work only because netlab's runtime dependencies are
already present in the ambient environment. Modern `pip` / setuptools (and the
Python 3.14 toolchain) build in an **isolated** env containing just the declared
build requirements. In that env `import netsim` — which `setup.py` used solely to
read `netsim.__version__` — is no longer a safe way to obtain the version, since
the package pulls in runtime deps at import time.

This makes netlab install cleanly under Python 3.14 / current setuptools while
keeping a single source of version truth.

## Changes

- **`pyproject.toml` (new):** declares the build backend
  (`setuptools.build_meta`, `setuptools>=40.8`, `wheel`). The `40.8` floor is the
  version that introduced `setuptools.build_meta` — i.e. the true minimum at which
  this build works; anything older fails to import the backend. It is deliberately
  *not* a higher "modern default" like `>=64`: nothing here needs newer setuptools,
  and a lower floor avoids breaking `--no-build-isolation` / offline source installs
  on distros that ship older setuptools (e.g. Ubuntu 22.04, which netlab still
  supports).
- **`setup.py`:** read `__version__` from `netsim/__init__.py` with a regex
  instead of `import netsim` — no package import during the build. The version
  string stays defined in exactly one place (`netsim/__init__.py`).
  - Path is resolved relative to `setup.py` (`Path(__file__).parent / ...`),
    consistent with the adjacent `README.md` read, so it works regardless of the
    build backend's working directory.
  - Dropped `setup_requires=["wheel"]` — `wheel` is now declared in
    `[build-system].requires`, and `setup_requires` is deprecated.

## Testing

```
$ ruff check setup.py
All checks passed!

$ python3 -m mypy -p netsim
Success: no issues found in 305 source files

$ python3 -m build          # isolated PEP 517 build
...
Successfully built networklab-26.5.tar.gz and networklab-26.5-py3-none-any.whl
```

The isolated build succeeds with neither `netsim` nor its dependencies importable
in the build env, and the version is read correctly from `netsim/__init__.py`.
(`26.05` → `26.5` is setuptools' standard PEP 440 normalization, unchanged from
the previous build path.)

## Note / future work

This PR is intentionally minimal. A fuller modernization — migrating all metadata
into a `pyproject.toml [project]` table (PEP 621), using
`version = {attr = "netsim.__version__"}` so setuptools resolves the version via
static AST parsing (no regex, no import), and retiring `setup.py` — is left out as
a separate, larger decision about the project's packaging layout.
