### PR TITLE
Fix FRR bgp_prefix validation to query VRF BGP tables.

### DIFF
--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -9,6 +9,7 @@ from box import Box, BoxList
 from netsim.data import global_vars
 
 from ...utils import log
+from ...utils import routing as _rp_utils
 from .. import _common
 from . import BGP_PREFIX_NAMES, check_community_kw
 
@@ -243,13 +244,17 @@ BGP prefix validation function:
 * Use single-prefix show command
 * Use the run_prefix_checks framework for validation
 """
-def show_bgp_prefix(pfx: str, af: str = 'ipv4', **kwargs: typing.Any) -> str:
-  return f"bgp {af} {pfx} json"
+def show_bgp_prefix(pfx: str, af: str = 'ipv4', vrf: str = 'default', **kwargs: typing.Any) -> str:
+  pfx = _rp_utils.get_prefix(pfx)
+  if vrf == 'default':
+    return f"bgp {af} {pfx} json"
+  return f"bgp vrf {vrf} {af} unicast {pfx} json"
 
 def valid_bgp_prefix(
       pfx: str,*,
       af: str = 'ipv4',
       state: str = 'present',
+      vrf: str = 'default',
       **kwargs: typing.Any) -> str:
   _result = global_vars.get_result_dict('_result')
 
@@ -270,4 +275,5 @@ def valid_bgp_prefix(
               'aspath': check_aspath,
               'locpref': check_locpref,
               'med': check_med },
-            names = BGP_PREFIX_NAMES)
+            names = BGP_PREFIX_NAMES,
+            vrf = vrf)

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -246,8 +246,6 @@ BGP prefix validation function:
 """
 def show_bgp_prefix(pfx: str, af: str = 'ipv4', vrf: str = 'default', **kwargs: typing.Any) -> str:
   pfx = _rp_utils.get_prefix(pfx)
-  if vrf == 'default':
-    return f"bgp {af} {pfx} json"
   return f"bgp vrf {vrf} {af} unicast {pfx} json"
 
 def valid_bgp_prefix(

--- a/tests/integration/mpls/15-vpnv4-rr.yml
+++ b/tests/integration/mpls/15-vpnv4-rr.yml
@@ -21,7 +21,7 @@ groups:
     module: [ ospf, bgp, mpls, vrf ]
     mpls.ldp: True
     mpls.vpn: True
-    device: eos
+    device: frr
     provider: clab
   p:
     members: [ core ]


### PR DESCRIPTION
The show command ignored vrf= and always used the default BGP instance. Imported L3VPN prefixes live in the VRF RIB (e.g. tenant), so checks failed even when VPN propagation worked.

Use "bgp vrf <name> <af> unicast <pfx> json" for non-default VRFs, matching EOS behavior. 

Example failure: tests/integration/mpls/15-vpnv4-rr.yml replace 'eos' with 'frr'
pfx_tenant (bgp_prefix('172.16.0.0/24', vrf='tenant') on pe2).