### PR TITLE
Fix: Use configurable search locations in generic get_search_path

### DIFF
--- a/netsim/defaults/paths.yml
+++ b/netsim/defaults/paths.yml
@@ -104,3 +104,9 @@ collect:
   - "~/.netlab/fetch-config"
   - "/etc/netlab/fetch-config"
   - "package:ansible/tasks/fetch-config"
+
+user_locations:                   # Generic search locations used for "get_search_path"
+- "topology:"
+- "."
+- "~/.netlab"
+- "/etc/netlab"

--- a/netsim/outputs/ansible.py
+++ b/netsim/outputs/ansible.py
@@ -233,8 +233,7 @@ def ansible_config(
     cfg_text = templates.render_template(
                 j2_file='ansible.cfg.j2',
                 data={'inventory': inventory_file or 'hosts.yml'},
-                path='templates',
-                extra_path=_files.get_search_path('ansible'))
+                extra_path=_files.get_search_path('templates'))
   except Exception as ex:
     log.fatal(
       text=f"Error rendering ansible.cfg\n{strings.extra_data_printout(str(ex))}",

--- a/netsim/outputs/report.py
+++ b/netsim/outputs/report.py
@@ -62,7 +62,7 @@ class REPORT(_TopologyOutput):
 
   def write(self, topo: Box) -> None:
     global EXTRA_PATH
-    EXTRA_PATH = _files.get_search_path("reports")
+    EXTRA_PATH = _files.get_search_path("reports",topology=topo)
     outfile = self.select_output_file('-')
     if outfile is None:
       return

--- a/netsim/outputs/tools.py
+++ b/netsim/outputs/tools.py
@@ -47,7 +47,7 @@ def create_tool_config(tool: str, topology: Box) -> None:
                         j2_file=config.template,
                         data=topo_data,
                         path=f'tools/{tool}',
-                        extra_path=_files.get_search_path(f'tools/{tool}'))
+                        extra_path=_files.get_search_path(f'tools/{tool}',topology=topo_data))
       except Exception as ex:
         log.fatal(
           text=f"Error rendering {config.template}\n{strings.extra_data_printout(str(ex))}",

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -109,7 +109,7 @@ class _Provider(Callback):
     fname = self.get_output_name(fname,topology)
     tname = self.get_root_template()
     try:
-      search_path = _files.get_search_path(self.provider,pkg_path_component=self.get_template_path())
+      search_path = _files.get_search_path(self.provider,pkg_path_component=self.get_template_path(),topology=topology)
       r_text = templates.render_template(
         data=topology.to_dict(),
         j2_file=tname,

--- a/netsim/utils/files.py
+++ b/netsim/utils/files.py
@@ -10,6 +10,8 @@ import sys
 import textwrap
 import typing
 
+from box import Box
+
 from ..data import global_vars
 from . import log
 
@@ -48,24 +50,36 @@ def get_sysdir() -> pathlib.Path:
 def get_curdir() -> pathlib.Path:
   return pathlib.Path(os.path.expanduser(".")).resolve()
 
-#
-# Get the usual search path (current directory, user home directory, system-wide settings, package settings)
-#
-# If needer, augment the search path componentswith a subdirectory path. User/system subdirectory could
-# be different from package subdirectory
-#
-
 def get_search_path(
       path_component: typing.Optional[str] = None,
-      pkg_path_component: typing.Optional[str] = None) -> list:
-  path = [ get_curdir(),get_userdir(),get_sysdir() ]
-  if path_component:
-    path = [ pc / path_component for pc in path ]
+      pkg_path_component: typing.Optional[str] = None,
+      topology: typing.Optional[Box] = None) -> list:
+  """
+  Get the usual search path (current directory, user home directory, system-wide settings, package settings)
+  Use topology 'user_locations' path if the topology is specified, otherwise the hard-coded components
+
+  If needer, augment the search path componentswith a subdirectory path. User/system subdirectory could
+  be different from package subdirectory
+  """
+
+  path = None                                               # We know nothing about search paths
+  if topology:                                              # Did the caller specify topology locations to use?
+    path = topology.defaults.get('paths.user_locations',[]) # Fetch user locations from the topology
+    if path:                                                # Did we get user locations?
+      path = [ pathlib.Path(pc) for pc in path ]            # Turn them in Path objects to be compatible with hardcoded data
+
+  if not path or not isinstance(path,list):                 # Are user locations legit?
+    path = [ get_curdir(),get_userdir(),get_sysdir() ]      # Nope, use default
+
+  if path_component:                                        # Did the caller specify final component of search paths?
+    path = [ pc / path_component for pc in path ]           # He did... let's adjust the search paths
     pkg_path_component = pkg_path_component or path_component
 
+  # Finally, append package directory -- top-level or adjusted with the path component
+  #
   path.append(get_moddir() / pkg_path_component if pkg_path_component else get_moddir())
 
-  return [ str(pc) for pc in path ]
+  return [ str(pc) for pc in path ]                         # And return a list of strings (not Path objects)
 
 #
 # Get absolute path to a file (handling paths relative to other files and home directories)

--- a/netsim/utils/files.py
+++ b/netsim/utils/files.py
@@ -56,10 +56,10 @@ def get_search_path(
       topology: typing.Optional[Box] = None) -> list:
   """
   Get the usual search path (current directory, user home directory, system-wide settings, package settings)
-  Use topology 'user_locations' path if the topology is specified, otherwise the hard-coded components
+  Use topology 'user_locations' paths if the topology is specified, otherwise the hard-coded components
 
-  If needer, augment the search path componentswith a subdirectory path. User/system subdirectory could
-  be different from package subdirectory
+  If needed, augment the search path components with a subdirectory path. User/system subdirectory could
+  be different from the package subdirectory
   """
 
   path = None                                               # We know nothing about search paths

--- a/tests/platform-integration/config/01-initial.yml
+++ b/tests/platform-integration/config/01-initial.yml
@@ -33,13 +33,13 @@ nodes:
       echo "Wazzup" >/etc/wazzup
   r1:
     device: eos
-    provider: clab        # Arista EOS container, configured through Ansible
+    provider: clab        # Arista EOS container, configured through Ansible or Linux scripts
     config.inline: |      # Test custom config
       interface {{ interfaces[1].ifname }}
         no shutdown
   r2:
     device: frr
-    provider: clab        # FRR container, configured through Ansible
+    provider: clab        # FRR container, configured through Linux scripts
     clab.binds:
     - hello.txt:/etc/hello/world.txt
     config.inline: |
@@ -54,6 +54,9 @@ nodes:
     config.inline: |
       #!/bin/bash
       ip link set {{ interfaces[0].ifname }} up
+  r5:
+    device: srlinux       # SR Linux container, configured through JSON/Ansible
+    provider: clab
 
 links:
 - r1-h1
@@ -66,6 +69,8 @@ links:
 - r3:
   r4:
     shutdown: True
+- r3:
+  r5:
 
 files:
 - path: hello.txt
@@ -90,6 +95,10 @@ validate:
     nodes: [ r3 ]
     wait: ospfv2_adj_p2p
     plugin: ospf_neighbor(nodes.r4.ospf.router_id)
+  o_r5:
+    nodes: [ r3 ]
+    wait: ospfv2_adj_p2p
+    plugin: ospf_neighbor(nodes.r5.ospf.router_id)
   ping:
     wait: ospfv2_spf
     wait_msg: Waiting for OSPF SPF run


### PR DESCRIPTION
Also:
* Change the final component in 'ansible.cfg' search path to 'templates' (previously: ansible, but that wouldn't work anyway)