### PR TITLE
Add OSPFv3 support for FortiOS

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -63,7 +63,7 @@ The following table describes the per-platform support of individual router-leve
 | Dell OS10 ([❗](caveats-os10)) | ✅| ✅| ✅| ✅| ✅|
 | Cumulus Linux 5.x (NVUE) | ✅| ✅| ❌ | ✅ | ✅|
 | Extreme Networks EXOS    | ✅| ✅| ✅| ❌ | ❌ | 
-| Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ❌ | ❌ | ❌ |
+| Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ✅ | ❌ | ❌ |
 | FRR                      | ✅| ✅| ✅| ✅| ✅|
 | Junos[^Junos]            | ✅| ✅| ✅| ✅| ❌ |
 | Mikrotik RouterOS 6      | ✅| ❌ | ❌ | ❌ | ❌ |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -523,6 +523,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | Cumulus Linux NVUE    |  ❌ | ❌ | ❌ | ✅ | ❌ |
 | Dell OS10             | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Extreme Networks EXOS | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Fortinet FortiOS      | ✅ | ❌ | ❌ | ❌ | ❌ |
 | FRR                   | ✅ | ✅ | ❌ | ✅ | ❌ |
 | Junos[^Junos]         | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Mikrotik RouterOS 6   |  ❌ | ❌ | ❌ | ✅ | ❌ |

--- a/netsim/ansible/templates/ospf/fortios.j2
+++ b/netsim/ansible/templates/ospf/fortios.j2
@@ -1,26 +1,37 @@
 {% set vdom_traffic = netlab_vdom|default(vdom) %}
 {% set multi_vdom = vdom_traffic != vdom %}
-
-{% if multi_vdom %}
-config vdom
-    edit {{ vdom_traffic }}
-{% endif %}
-
-config router ospf
+{#
+  Shared OSPFv2/OSPFv3 renderer. 'proto' is the FortiOS render token ('ospf' or 'ospf6') and
+  doubles as the address-family fork discriminator. 'intf_list' is pre-filtered by the caller to
+  the interfaces that run OSPF on this AF, so the macro never sees an off-AF interface.
+#}
+{% macro ospf_config(proto, intf_list, ospf) %}
+{% set intf_stanza = proto ~ '-interface' %}
+{% set passive_intfs = intf_list|selectattr('ospf.passive', 'defined')|selectattr('ospf.passive')|map(attribute='ifname')|list %}
+config router {{ proto }}
     set router-id {{ ospf.router_id }}
 {%  if ospf.reference_bandwidth is defined %}
     set auto-cost-ref-bandwidth {{ ospf.reference_bandwidth }}
 {%  endif %}
-{%  set passive_intfs = netlab_interfaces|selectattr('ospf', 'defined')|selectattr('ospf.passive', 'defined')|selectattr('ospf.passive')|map(attribute='ifname')|list %}
 {%  if passive_intfs|length > 0 %}
     set passive-interface {{ passive_intfs|join(' ') }}
 {%  endif %}
-{%  if netlab_interfaces|selectattr('ospf', 'defined')|list|length > 0 %}
 
-    config ospf-interface
-{%  for intf in netlab_interfaces if 'ospf' in intf %}
+    config area
+{%  for area_data in ospf.areas|default([]) %}
+        edit {{ area_data.area }}
+        next
+{%  endfor %}
+    end
+{%  if intf_list|length > 0 %}
+
+    config {{ intf_stanza }}
+{%      for intf in intf_list %}
         edit "{{ intf.ifname }}"
             set interface "{{ intf.ifname }}"
+{%          if proto == 'ospf6' %}
+            set area-id {{ intf.ospf.area }}
+{%          endif %}
 {%          if intf.ospf.network_type is defined %}
             set network-type {{ intf.ospf.network_type }}
 {%          endif %}
@@ -36,33 +47,41 @@ config router ospf
 {%          if intf.ospf.priority is defined %}
             set priority {{ intf.ospf.priority }}
 {%          endif %}
-{%          if intf.ospf.password is defined %}
+{%          if proto == 'ospf' and intf.ospf.password is defined %}
             set authentication text
             set authentication-key {{ intf.ospf.password }}
 {%          endif %}
             set status enable
         next
-{%  endfor %}
+{%      endfor %}
     end
 {%  endif %}
-
-    config area
-{%  for area_data in ospf.areas|default([]) %}
-        edit {{ area_data.area }}
-        next
-{%  endfor %}
-    end
+{%  if proto == 'ospf' %}
 
     config network
-{%  for intf in netlab_interfaces if intf.ospf.area is defined %}
+{%      for intf in intf_list if intf.ospf.area is defined %}
         edit {{ loop.index }}
             set prefix {{ intf.ipv4|ansible.utils.ipaddr('subnet') }}
             set area {{ intf.ospf.area }}
         next
-{%  endfor %}
+{%      endfor %}
     end
+{%  endif %}
 end
-
+{% endmacro %}
+{% if multi_vdom %}
+config vdom
+    edit {{ vdom_traffic }}
+{% endif %}
+{% set ospf_intf = netlab_interfaces|selectattr('ospf', 'defined')|list %}
+{% set v4 = ospf_intf|selectattr('ipv4', 'defined')|list %}
+{% set v6 = ospf_intf|selectattr('ipv6', 'defined')|list %}
+{% if ospf.af.ipv4 is defined %}
+{{ ospf_config('ospf', v4, ospf) }}
+{% endif %}
+{% if ospf.af.ipv6 is defined %}
+{{ ospf_config('ospf6', v6, ospf) }}
+{% endif %}
 {% if multi_vdom %}
 end
 {% endif %}


### PR DESCRIPTION
## Why

Apart from OSPFv3 support this PR also fixes a bug related to the fact that
the netlab FortiOS template shipped with OSPFv2 only, but this was not recorded.
The device manifest declares neither `ospf.ipv4` nor `ospf.ipv6`, so `_routing.py`
auto-enables `ospf.af.ipv6` on any node that has IPv6 OSPF interfaces. The
single, address-family-agnostic `ospf/fortios.j2` then ran its IPv4-only body
against those interfaces and failed in `ansible.utils.ipaddr` (`'width' is undefined`)
the moment it tried to format `intf.ipv4` on an IPv6-only link.

This surfaced while bringing up IPv6 iBGP labs, which require an IPv6 IGP to
carry loopback reachability — FortiOS had none.

## What

`ospf/fortios.j2` now renders both OSPF instances from a single
`ospf_config(proto, intf_list, ospf)` macro, invoked once per active address
family inside the VDOM wrapper:

- The dispatcher extracts the OSPF interfaces once, splits them by address
  family, and calls the macro with `proto='ospf'` for the IPv4 set and
  `proto='ospf6'` for the IPv6 set.
- `proto` is both the FortiOS configuration keyword (`config router ospf` /
  `config router ospf6`, `config ospf-interface` / `config ospf6-interface`)
  and the discriminator for the few places the two instances diverge.
- Because the interface lists are pre-filtered by address family before the
  macro runs, address-family correctness is established once at the boundary:
  the macro never sees an interface that does not belong in the instance it is
  rendering, which is what makes the original `ipaddr` failure impossible.

No device-manifest change is required: support is the default, and the
dispatcher's `ospf.af.*` gates decide which instance renders.

## Device-specific constraints (notes for reviewers)

- **OSPFv2 membership is prefix-based.** FortiOS binds an interface to its area
  through a prefix in `config network`, which needs the interface's IPv4 subnet.
  The IPv4 interface list must therefore exclude interfaces without an IPv4
  address; this is enforced by the pre-filtering. OSPFv3 instead binds the area
  with `set area-id` inside `config ospf6-interface`.
- **Areas must be defined before they are referenced.** `set area-id` under
  `config ospf6-interface` fails on the device with *"Please input a defined
  area id!"* unless the area already exists, so `config area` is emitted before
  the interface stanza. `ospf.areas` already aggregates every area the
  interfaces use, so the ordering alone is sufficient.
- Passive interfaces are a top-level `set passive-interface` list, not a
  per-interface flag.
- OSPFv3 authentication on FortiOS is IPsec-based; plaintext and MD5 keys do not
  apply, so the password line is emitted for OSPFv2 only.

## Testing

Verified live against a FortiOS 8.0.0 DUT (libvirt; FRR probes on clab), one
lab at a time, using the OSPFv2 and OSPFv3 integration suites under
`tests/integration/ospf/`. After excluding topologies that depend on FortiOS
feature gaps unrelated to this change (the `bgp`/`bfd`/`vrf` modules, VLAN
interfaces, unnumbered and link-local-only IPv6 interfaces, static-route
import), the eligible set is seven OSPFv2 and seven OSPFv3 topologies; all pass.

| Test | OSPFv2 | OSPFv3 |
|---|---|---|
| 01-network | PASS | PASS |
| 02-areas | PASS | PASS |
| 03-cost | PASS | PASS |
| 04-passive | PASS | PASS |
| 06-lb-prefix | n/a | PASS (loopback advertised as /128) |
| 30-timers | PASS | PASS |
| 31-priority | PASS (DR election) | PASS |
| 32-password | PASS (plaintext auth) | n/a |

Two clarifications on the run:

- On `30-timers`, `31-priority`, and `32-password`, netlab deliberately skips
  the VRF-specific subtests on FortiOS (VRF OSPF is out of scope) and reports a
  warning; the OSPF subtests themselves pass.
- `06-lb-prefix` checks an OSPFv3 LSA and can report the prefix as absent if it
  is validated before the LSA has propagated on a cold boot; a re-run after a
  short wait confirms the loopback is advertised as `/128`.

Offline render checks (`netlab create`) confirm per-address-family membership on
a node with three links — dual-stack, IPv4-only, and IPv6-only: the IPv4-only
interface appears under `config router ospf` only, the IPv6-only interface under
`config router ospf6` only, and the dual-stack interface under both.

## Docs

The per-platform OSPF support matrix and the IPv6 address-family table are
updated to mark FortiOS OSPFv3 as supported (`docs/module/ospf.md`,
`docs/platforms.md`).

## Out of scope

VRF OSPFv3, BFD for OSPFv3, redistribution/import, and default-route
origination are intentionally left out of this basic implementation.