### PR TITLE
Fix: FRR BGP validation functions need **kwargs to ignore 'vrf'

### DIFF
--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -123,7 +123,7 @@ Select BGP paths with the specified next hop
 
 Implements custom exception listing next hops found in the data
 """
-def filter_bgp_nh(data: list, value: typing.Any, pfx: str, state: str) -> list:
+def filter_bgp_nh(data: list, value: typing.Any, pfx: str, state: str, **kwargs: typing.Any) -> list:
   value = value.split('/')[0]                         # Get IP address from a CIDR address
   found_nh = []
   result = []
@@ -149,7 +149,7 @@ def filter_best(data: list, value: typing.Any, **kwargs: typing.Any) -> list:
 """
 Check BGP cluster ID on BGP paths
 """
-def check_cluster_id(data: list, value: typing.Any, pfx: str, state: str) -> list:
+def check_cluster_id(data: list, value: typing.Any, pfx: str, state: str, **kwargs: typing.Any) -> list:
   result = [ p_element for p_element in data
                 if 'clusterList' in p_element and value in p_element.clusterList.get('list',[]) ]
 
@@ -161,7 +161,7 @@ def check_cluster_id(data: list, value: typing.Any, pfx: str, state: str) -> lis
 """
 Check presence or absence of BGP communities
 """
-def check_community(data: list, value: typing.Any, pfx: str, state: str) -> list:
+def check_community(data: list, value: typing.Any, pfx: str, state: str, **kwargs: typing.Any) -> list:
   if not isinstance(value,dict):
     raise Exception('Community check expects a dictionary of communities')
 
@@ -184,7 +184,7 @@ def check_community(data: list, value: typing.Any, pfx: str, state: str) -> list
 """
 Check complete AS path
 """
-def check_aspath(data: list, value: typing.Any, pfx: str, state: str) -> list:
+def check_aspath(data: list, value: typing.Any, pfx: str, state: str, **kwargs: typing.Any) -> list:
   result = []
   p_found = []
 
@@ -202,7 +202,7 @@ def check_aspath(data: list, value: typing.Any, pfx: str, state: str) -> list:
 """
 Check elements of an AS path
 """
-def check_as_elements(data: list, value: typing.Any, pfx: str, state: str) -> list:
+def check_as_elements(data: list, value: typing.Any, pfx: str, state: str, **kwargs: typing.Any) -> list:
   result = []
   p_found = []
 


### PR DESCRIPTION
missed the impact of the extra parameter on all other BGP prefix checking functions. This fix (suggested by #3453) adds the 'ignore extra parameters' functionality to prefix checking callbacks.