### PR TITLE
Fix: Implement checks on routing.prefix min/max attributes

### DIFF
--- a/docs/module/routing-prefix.txt
+++ b/docs/module/routing-prefix.txt
@@ -12,6 +12,12 @@ Prefix filters are lists of conditions (usually known as *lists*) that permit or
 * **min**: Minimum prefix length. It could be specified as an integer or a dictionary with **ipv4** and **ipv6** keys.
 * **max**: Maximum prefix length in the same format as the **min** parameters.
 
+```{warning}
+* The **‌min** and **‌max** lengths must be greater than or equal to the prefix length an entry is matching, and less than the maximum imposed by the address family prefix size.
+* Some devices (for example, Cisco IOS) require the **‌min** and **‌max** lengths to be strictly greater than the matched prefix length
+* You cannot specify **‌min** and **‌max** lengths for host prefixes (/32 for IPv4 and /128 for IPv6)
+```
+
 Prefix filters are specified in the global- or node-level **routing.prefix** dictionary (see [](routing-object-import) and  [](routing-object-merge) for more details). 
 
 The keys of the **routing.prefix** dictionary are filter names (prefix-list names), and the values are prefix filters (lists of prefix filter entries).

--- a/docs/module/routing-prefix.txt
+++ b/docs/module/routing-prefix.txt
@@ -13,9 +13,9 @@ Prefix filters are lists of conditions (usually known as *lists*) that permit or
 * **max**: Maximum prefix length in the same format as the **min** parameters.
 
 ```{warning}
-* The **‌min** and **‌max** lengths must be greater than or equal to the prefix length an entry is matching, and less than the maximum imposed by the address family prefix size.
-* Some devices (for example, Cisco IOS) require the **‌min** and **‌max** lengths to be strictly greater than the matched prefix length
-* You cannot specify **‌min** and **‌max** lengths for host prefixes (/32 for IPv4 and /128 for IPv6)
+* The **min** and **max** lengths must be greater than or equal to the prefix length an entry is matching, and less than or equal to the maximum imposed by the address family prefix size.
+* Some devices (for example, Cisco IOS) require the **min** and **max** lengths to be strictly greater than the matched prefix length
+* You cannot specify **min** and **max** lengths for host prefixes (/32 for IPv4 and /128 for IPv6)
 ```
 
 Prefix filters are specified in the global- or node-level **routing.prefix** dictionary (see [](routing-object-import) and  [](routing-object-merge) for more details). 

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -129,7 +129,7 @@ features:
         aspath: True
         community:
           standard: True
-    prefix: True
+    prefix.strict: True
     aspath: True
     community:
       standard: True

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -112,7 +112,7 @@ def create_pfx_af_entry(p_entry: Box, af: str, p_name: str, node: Box, min_stric
   pfx_len = ipaddress.ip_network(p_entry[af]).prefixlen
 
   for m_kw in ('min','max'):
-    if pfx_len == pfx_max:
+    if m_kw in p_entry and pfx_len == pfx_max:
       log.error(
         f'Cannot use prefix filter {m_kw} keyword with prefix {p_entry[af]}',
         more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -5,10 +5,12 @@
 # * Routing filters (prefixes, communities, as-paths)
 # * Static routes
 #
+import ipaddress
 import typing
 
 from box import Box
 
+from ...augment import devices as a_devices
 from ...data import get_new_box
 from ...utils import log
 
@@ -46,10 +48,26 @@ def expand_prefix_entry(p_entry: Box, topology: Box) -> Box:
 
   return p_entry
 
-"""
-adjust_pfx_min_max: Adjust prefix list entry min/max keywords
-"""
-def adjust_pfx_min_max(p_entry: Box, m_kw: str, af: str, p_name: str, node: Box) -> None:
+def adjust_pfx_min_max(
+      p_entry: Box,
+      m_kw: str,
+      af: str,
+      p_name: str,
+      node: Box,
+      min_pfx_len: int,
+      max_pfx_len: int) -> None:
+  """
+  adjust_pfx_min_max: Adjust prefix list entry min/max keywords
+
+  Arguments:
+  - p_entry: the prefix we're checking
+  - m_kw: the parameter we're checking (min/max)
+  - af: the address family we're checking
+  - p_name: prefix list name for error messages
+  - node: node data (needed for error messages)
+  - min_pfx_len: minimum prefix length we can match (depends on prefix)
+  - max_pfx_len: maximum prefix length we can match (depends on address family)
+  """
   if m_kw not in p_entry:
     return
 
@@ -58,34 +76,59 @@ def adjust_pfx_min_max(p_entry: Box, m_kw: str, af: str, p_name: str, node: Box)
     return                                        # ... so we can just pop the unnecessary entry
 
   m_value = p_entry[m_kw].get(af,None)
-  if m_value < 0:                                 
+  if m_value < min_pfx_len:                                 
     log.error(
-      f'Prefix filter {m_kw} value should be >= 0 (policy {p_name}#{p_entry.sequence} on node {node.name})',
+      f'Prefix filter {af}.{m_kw} value should be >= {min_pfx_len} (limited by {p_entry[af]})',
+      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
       category=log.IncorrectValue,
       module='routing')
-    return
 
-  m_max = 32 if af == 'ipv4' else 128
-  if m_value > m_max:
+  if m_value > max_pfx_len:
     log.error(
-      f'Prefix filter {af}.{m_kw} value should be <= {m_max} (policy {p_name}#{p_entry.sequence} on node {node.name})',
+      f'Prefix filter {af}.{m_kw} value should be <= {max_pfx_len} (limited by address family)',
+      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
       category=log.IncorrectValue,
       module='routing')
-    return
 
   p_entry[m_kw] = m_value                         # Replace the min/max dict with per-AF value
 
-"""
-create_af_entry: create AF-specific prefix-list entry
-"""
-def create_pfx_af_entry(p_entry: Box, af: str, p_name: str, node: Box) -> Box:
+def create_pfx_af_entry(p_entry: Box, af: str, p_name: str, node: Box, min_strict: bool = False) -> Box:
+  """
+  create_af_entry: create AF-specific prefix-list entry
+
+  Arguments:
+  - p_entry: Original prefix list entry
+  - af: Address family we're focusing on
+  - p_name: Prefix list name (for error messages)
+  - node: Node data (needed for error messages)
+  - min_strict: Is device enforcing strict min/max rules (min/max have to be greater than prefix length)?
+  """
   af_p_entry = get_new_box(p_entry)                         # Create a copy of the current p_entry
   for af_x in ('ipv4','ipv6'):                              # ... remove all other address families
     if af_x in p_entry and af_x != af:
       af_p_entry.pop(af_x,None)
 
+  pfx_max = 32 if af == 'ipv4' else 128
+  pfx_len = ipaddress.ip_network(p_entry[af]).prefixlen
+
   for m_kw in ('min','max'):
-    adjust_pfx_min_max(af_p_entry,m_kw,af,p_name,node)
+    if pfx_len == pfx_max:
+      log.error(
+        f'Cannot use prefix filter {m_kw} keyword with prefix {p_entry[af]}',
+        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+        category=log.IncorrectValue,
+        module='routing')
+      return af_p_entry
+    else:
+      pfx_min = pfx_len + 1 if min_strict else pfx_len
+      adjust_pfx_min_max(af_p_entry,m_kw,af,p_name,node,min_pfx_len=pfx_min,max_pfx_len=pfx_max)
+
+  if 'min' in af_p_entry and 'max' in af_p_entry and af_p_entry.min > af_p_entry.max:
+    log.error(
+      f'Prefix filter {af}.min should be <= {af}.max',
+      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+      category=log.IncorrectValue,
+      module='routing')
 
   return af_p_entry
 
@@ -108,12 +151,14 @@ def expand_prefix_list(p_name: str,o_name: str,node: Box,topology: Box) -> typin
     node.routing[o_name][p_name][p_idx] = expand_prefix_entry(node.routing[o_name][p_name][p_idx],topology)
 
   node.routing[o_name][p_name] = sorted(node.routing[o_name][p_name],key=lambda O: O.get('sequence',10))
+  features = a_devices.get_device_features(node,topology.defaults)
+  min_strict = features.get('routing.prefix.strict',False)
   af_prefix: dict = {}                                      # Prepare dictionary of per-AF prefix lists
   for af in ('ipv4','ipv6'):                                # Iterate over address families (sorry, no CLNS or IPX)
     af_prefix[af] = []                                      # Start with an emtpy per-AF list
     for p_entry in node.routing[o_name][p_name]:            # Iterate over prefix list entries
       if af in p_entry:                                     # Is the current AF in the prefix list entry?
-        af_p_entry = create_pfx_af_entry(p_entry,af,p_name,node)
+        af_p_entry = create_pfx_af_entry(p_entry,af,p_name,node,min_strict=min_strict)
         af_prefix[af].append(af_p_entry)                    # create af-specific entry and append it to per-AF list
 
     if af_prefix[af]:                                       # Do we have a non-empty per-AF prefix list?

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -76,12 +76,19 @@ def adjust_pfx_min_max(
     return                                        # ... so we can just pop the unnecessary entry
 
   m_value = p_entry[m_kw].get(af,None)
-  if m_value < min_pfx_len:                                 
-    log.error(
-      f'Prefix filter {af}.{m_kw} value should be >= {min_pfx_len} (limited by {p_entry[af]})',
-      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
-      category=log.IncorrectValue,
-      module='routing')
+  if m_value < min_pfx_len:                       # The minimum prefix length is too low
+    if min_pfx_len > max_pfx_len:                 # Is this caused by /32 (or /128) prefix on an IOS-like device?
+      log.error(
+        f'Cannot use prefix filter {m_kw} keyword with prefix {p_entry[af]}',
+        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+        category=log.IncorrectValue,
+        module='routing')
+    else:
+      log.error(
+        f'Prefix filter {af}.{m_kw} value should be >= {min_pfx_len} (limited by {p_entry[af]})',
+        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+        category=log.IncorrectValue,
+        module='routing')
 
   if m_value > max_pfx_len:
     log.error(
@@ -112,16 +119,8 @@ def create_pfx_af_entry(p_entry: Box, af: str, p_name: str, node: Box, min_stric
   pfx_len = ipaddress.ip_network(p_entry[af]).prefixlen
 
   for m_kw in ('min','max'):
-    if m_kw in p_entry and pfx_len == pfx_max:
-      log.error(
-        f'Cannot use prefix filter {m_kw} keyword with prefix {p_entry[af]}',
-        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
-        category=log.IncorrectValue,
-        module='routing')
-      return af_p_entry
-    else:
-      pfx_min = pfx_len + 1 if min_strict else pfx_len
-      adjust_pfx_min_max(af_p_entry,m_kw,af,p_name,node,min_pfx_len=pfx_min,max_pfx_len=pfx_max)
+    pfx_min = pfx_len + 1 if min_strict else pfx_len
+    adjust_pfx_min_max(af_p_entry,m_kw,af,p_name,node,min_pfx_len=pfx_min,max_pfx_len=pfx_max)
 
   if 'min' in af_p_entry and 'max' in af_p_entry and af_p_entry.min > af_p_entry.max:
     log.error(

--- a/tests/errors/prefix-list-min-max.log
+++ b/tests/errors/prefix-list-min-max.log
@@ -4,8 +4,6 @@ IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited
 ... Node r1 (device frr) policy test_1 sequence# 1
 IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
 ... Node r1 (device frr) policy test_1 sequence# 2
-IncorrectValue in routing: Cannot use prefix filter min keyword with prefix 172.17.3.4/32
-... Node r1 (device frr) policy test_1 sequence# 3
 IncorrectValue in routing: Prefix filter ipv4.min value should be >= 9 (limited by 10.0.0.0/8)
 ... Node r2 (device iol) policy test_1 sequence# 1
 IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited by address family)
@@ -13,6 +11,8 @@ IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited
 IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
 ... Node r2 (device iol) policy test_1 sequence# 2
 IncorrectValue in routing: Cannot use prefix filter min keyword with prefix 172.17.3.4/32
+... Node r2 (device iol) policy test_1 sequence# 3
+IncorrectValue in routing: Cannot use prefix filter max keyword with prefix 172.17.3.4/32
 ... Node r2 (device iol) policy test_1 sequence# 3
 IncorrectValue in routing: Prefix filter ipv4.min value should be >= 17 (limited by 172.16.0.0/16)
 ... Node r2 (device iol) policy test_1 sequence# 4

--- a/tests/errors/prefix-list-min-max.log
+++ b/tests/errors/prefix-list-min-max.log
@@ -1,0 +1,23 @@
+IncorrectValue in routing: Prefix filter ipv4.min value should be >= 8 (limited by 10.0.0.0/8)
+... Node r1 (device frr) policy test_1 sequence# 1
+IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited by address family)
+... Node r1 (device frr) policy test_1 sequence# 1
+IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
+... Node r1 (device frr) policy test_1 sequence# 2
+IncorrectValue in routing: Cannot use prefix filter min keyword with prefix 172.17.3.4/32
+... Node r1 (device frr) policy test_1 sequence# 3
+IncorrectValue in routing: Prefix filter ipv4.min value should be >= 9 (limited by 10.0.0.0/8)
+... Node r2 (device iol) policy test_1 sequence# 1
+IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited by address family)
+... Node r2 (device iol) policy test_1 sequence# 1
+IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
+... Node r2 (device iol) policy test_1 sequence# 2
+IncorrectValue in routing: Cannot use prefix filter min keyword with prefix 172.17.3.4/32
+... Node r2 (device iol) policy test_1 sequence# 3
+IncorrectValue in routing: Prefix filter ipv4.min value should be >= 17 (limited by 172.16.0.0/16)
+... Node r2 (device iol) policy test_1 sequence# 4
+IncorrectValue in routing: Prefix filter ipv4.min value should be >= 25 (limited by 192.168.0.0/24)
+... Node r2 (device iol) policy test_1 sequence# 5
+IncorrectValue in routing: Prefix filter ipv4.max value should be >= 25 (limited by 192.168.0.0/24)
+... Node r2 (device iol) policy test_1 sequence# 5
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/prefix-list-min-max.yml
+++ b/tests/errors/prefix-list-min-max.yml
@@ -35,6 +35,8 @@ routing.prefix:
     min: 25
     max: 29
     sequence: 7
+  - ipv4: 172.17.3.5/32      # Should work everywhere
+    sequence: 8
 
 nodes:
   r1:
@@ -43,5 +45,5 @@ nodes:
     routing.prefix.test_1:    # Import prefix list
   r2:
     device: iol
-    box: non
+    box: none
     routing.prefix.test_1:

--- a/tests/errors/prefix-list-min-max.yml
+++ b/tests/errors/prefix-list-min-max.yml
@@ -1,0 +1,47 @@
+---
+message: |
+  The topology tests prefix list min/max error handling
+
+provider: clab                # To make IOL work
+module: [ routing ]
+
+routing.prefix:
+  test_1:
+  - ipv4: 10.0.0.0/8          # Fails everywhere
+    min: 7                    # Incorrect, must be >= 8
+    max: 33                   # Incorrect, must be <= 32
+    sequence: 1
+  - ipv4: 172.17.0.0/16       # Fails everywhere
+    min: 18
+    max: 17                   # Incorrect must be >= 18
+    sequence: 2
+  - ipv4: 172.17.3.4/32       # Fails everywhere
+    min: 32
+    max: 32                   # Cannot use min/max on maximum-length prefix
+    sequence: 3
+  - ipv4: 172.16.0.0/16       # Fails on IOS
+    min: 16
+    max: 18
+    sequence: 4
+  - ipv4: 192.168.0.0/24      # Fails on IOS
+    min: 24
+    max: 24
+    sequence: 5
+  - ipv4: 192.168.1.0/24      # Should work everywhere
+    min: 25
+    max: 25
+    sequence: 6
+  - ipv4: 192.168.2.0/24      # Should work everywhere
+    min: 25
+    max: 29
+    sequence: 7
+
+nodes:
+  r1:
+    device: frr
+    box: none                 # To ensure idempotence when images change
+    routing.prefix.test_1:    # Import prefix list
+  r2:
+    device: iol
+    box: non
+    routing.prefix.test_1:

--- a/tests/errors/prefix-list-min-max.yml
+++ b/tests/errors/prefix-list-min-max.yml
@@ -15,7 +15,7 @@ routing.prefix:
     min: 18
     max: 17                   # Incorrect must be >= 18
     sequence: 2
-  - ipv4: 172.17.3.4/32       # Fails everywhere
+  - ipv4: 172.17.3.4/32       # Fails on IOS
     min: 32
     max: 32                   # Cannot use min/max on maximum-length prefix
     sequence: 3


### PR DESCRIPTION
The min/max attributes specified in a prefix-list entry are checked to be greater than (or equal) to the specified prefix length and less than the maximum allowed by the address family. Furthermore, the max value must be greater than or equal than the min value.

The checks also enforce stricter min/max requirements for Cisco IOS where the min/max value must be strictly greater than the prefix len.