### PR TITLE
Correct ospf/fortios.j2 control-tag indentation post #3451

### DIFF
--- a/netsim/ansible/templates/ospf/fortios.j2
+++ b/netsim/ansible/templates/ospf/fortios.j2
@@ -10,63 +10,63 @@
 {% set passive_intfs = intf_list|selectattr('ospf.passive', 'defined')|selectattr('ospf.passive')|map(attribute='ifname')|list %}
 config router {{ proto }}
     set router-id {{ ospf.router_id }}
-{%  if ospf.reference_bandwidth is defined %}
+{% if ospf.reference_bandwidth is defined %}
     set auto-cost-ref-bandwidth {{ ospf.reference_bandwidth }}
-{%  endif %}
-{%  if passive_intfs|length > 0 %}
+{% endif %}
+{% if passive_intfs|length > 0 %}
     set passive-interface {{ passive_intfs|join(' ') }}
-{%  endif %}
+{% endif %}
 
     config area
-{%  for area_data in ospf.areas|default([]) %}
+{% for area_data in ospf.areas|default([]) %}
         edit {{ area_data.area }}
         next
-{%  endfor %}
+{% endfor %}
     end
-{%  if intf_list|length > 0 %}
+{% if intf_list|length > 0 %}
 
     config {{ intf_stanza }}
-{%      for intf in intf_list %}
+{%   for intf in intf_list %}
         edit "{{ intf.ifname }}"
             set interface "{{ intf.ifname }}"
-{%          if proto == 'ospf6' %}
+{%     if proto == 'ospf6' %}
             set area-id {{ intf.ospf.area }}
-{%          endif %}
-{%          if intf.ospf.network_type is defined %}
+{%     endif %}
+{%     if intf.ospf.network_type is defined %}
             set network-type {{ intf.ospf.network_type }}
-{%          endif %}
-{%          if intf.ospf.cost is defined %}
+{%     endif %}
+{%     if intf.ospf.cost is defined %}
             set cost {{ intf.ospf.cost }}
-{%          endif %}
-{%          if intf.ospf.timers.hello is defined %}
+{%     endif %}
+{%     if intf.ospf.timers.hello is defined %}
             set hello-interval {{ intf.ospf.timers.hello }}
-{%          endif %}
-{%          if intf.ospf.timers.dead is defined %}
+{%     endif %}
+{%     if intf.ospf.timers.dead is defined %}
             set dead-interval {{ intf.ospf.timers.dead }}
-{%          endif %}
-{%          if intf.ospf.priority is defined %}
+{%     endif %}
+{%     if intf.ospf.priority is defined %}
             set priority {{ intf.ospf.priority }}
-{%          endif %}
-{%          if proto == 'ospf' and intf.ospf.password is defined %}
+{%     endif %}
+{%     if proto == 'ospf' and intf.ospf.password is defined %}
             set authentication text
             set authentication-key {{ intf.ospf.password }}
-{%          endif %}
+{%     endif %}
             set status enable
         next
-{%      endfor %}
+{%   endfor %}
     end
-{%  endif %}
-{%  if proto == 'ospf' %}
+{% endif %}
+{% if proto == 'ospf' %}
 
     config network
-{%      for intf in intf_list if intf.ospf.area is defined %}
+{%   for intf in intf_list if intf.ospf.area is defined %}
         edit {{ loop.index }}
             set prefix {{ intf.ipv4|ansible.utils.ipaddr('subnet') }}
             set area {{ intf.ospf.area }}
         next
-{%      endfor %}
+{%   endfor %}
     end
-{%  endif %}
+{% endif %}
 end
 {% endmacro %}
 {% if multi_vdom %}


### PR DESCRIPTION
This is control-tag indentation cleanup only PR.
It can be ignored, but then we will be dragging the exception forever, or till the next change
and then that change will get the commit which after being squashed will obscure the intent. 
It should be noted that I wasn't able to find any rule for Jinja endorsed in the repo,
so the "1/3/5/7..." rule was rather inferred from the majority of other template files.
Sorry for the mess.

## What

Re-indents the Jinja control tags in `netsim/ansible/templates/ospf/fortios.j2`
to match the repository-wide convention for `.j2` templates: flush-left `{%`,
one space of inside-padding at the outermost level, and +2 per enclosing
`if`/`for` (1/3/5/7…).
## Why

The file, rewritten recently in #3451, mixed two indentation schemes:

- `{% set %}` tags used the canonical one-space inside-padding;
- the `{% if %}`/`{% for %}` ladder used a base-2, +4-per-level scheme (2/6/10).

As a result, sibling tags at the same nesting depth disagreed — for instance a
`set` at 1 space sitting directly next to an `if` at 2. This commit makes the
whole file uniform on the 1/3/5 convention used by the mature templates
(`bgp/frr.j2`, `bgp/eos.j2`, and the large majority of `.j2` files), which keeps
future diffs on this file clean.

## Render-equivalence

This is a whitespace-only change with no effect on rendered output:

- Inside-padding lives between `{%` and the keyword, so it can never reach the
  generated configuration.
- `trim_blocks` / `lstrip_blocks` (set in `netsim/utils/templates.py`) strip the
  whitespace around the tags anyway.

`git diff -w` against the prior revision is empty; the diff is purely the
re-padding of 28 control-tag lines.

## Testing

No behavioural change, so no new tests. Verified render-equivalence via
`git diff -w` (empty).
