### PR TITLE
Check device support for bgp.remove_private_as values

### DIFF
--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -55,7 +55,8 @@ features:
     gtsm: true
     passive: true
     password: true
-    remove_private_as: true
+    remove_private_as.valid: [ 'on', all, replace, ingress, ingress-replace ]
+
     rs_client: true
     tcp_ao: [ libvirt, virtualbox, external ]
     timers: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -109,7 +109,7 @@ features:
     gtsm: true
     passive: true
     password: true
-    remove_private_as: true
+    remove_private_as.valid: [ 'on', all, replace ]
     rs: true
     rs_client: true
     timers: true

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -54,7 +54,7 @@ features:
     gtsm: true
     passive: true
     password: true
-    remove_private_as: true
+    remove_private_as.valid: [ 'on', all, replace ]
     rs: true
     rs_client: true
     timers: true

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -38,7 +38,7 @@ features:
     multihop.vrf: true
     password: true
     passive: true
-    remove_private_as: true
+    remove_private_as.valid: [ 'on', all, replace ]
     timers: true
     vrf_local_as: true
     _default_locpref: false

--- a/netsim/devices/xr.yml
+++ b/netsim/devices/xr.yml
@@ -42,7 +42,7 @@ features:
     multihop.vrf: true
     passive: true
     password: true
-    remove_private_as: true
+    remove_private_as.valid: [ 'on', all, replace, ingress, ingress-all ]
     rs_client: true
     tcp_ao: true
     timers: true

--- a/netsim/extra/bgp.session/iosxr.j2
+++ b/netsim/extra/bgp.session/iosxr.j2
@@ -35,7 +35,15 @@ as-override
 default-originate
 {%     endif %}
 {%   if n.remove_private_as|default([]) %}
-remove-private-AS{{ " entire-aspath" if 'all' in n.remove_private_as else "" }}
+{%     set rpa = n.remove_private_as %}
+{%     if 'replace' in rpa %}
+replace-private-AS
+{%     elif 'on' in rpa or 'all' in rpa %}
+remove-private-AS{{ " entire-aspath" if 'all' in rpa else "" }}
+{%     endif %}
+{%     if 'ingress' in rpa or 'ingress-all' in rpa %}
+remove-private-AS inbound{{ " entire-aspath" if 'ingress-all' in rpa else "" }}
+{%     endif %}
 {%   endif %}
 {%- endmacro %}
 {% set ao_algo = { 'aes-128-cmac': 'aes-128-cmac-96', 'hmac-sha-1': 'hmac-sha1-96' } %}

--- a/netsim/extra/bgp.session/plugin.py
+++ b/netsim/extra/bgp.session/plugin.py
@@ -50,9 +50,10 @@ def apply_neighbor_attributes(node: Box, ngb: Box, intf: typing.Optional[Box], a
     if not attr_value:                                  # Attribute not defined in interface or node, move on
       continue
 
+    ngb[attr] = attr_value                              # Set neighbor attribute from interface/node value
+
     # Check that the node(device) supports the desired attribute
     OK = OK and _bgp.check_device_attribute_support(attr,node,ngb,topology,_config_name)
-    ngb[attr] = attr_value                              # Set neighbor attribute from interface/node value
     mark_plugin_config(node,ngb)                        # Remember that we have to do extra configuration
 
   return OK

--- a/netsim/utils/routing.py
+++ b/netsim/utils/routing.py
@@ -129,19 +129,60 @@ def get_device_bgp_feature(attr: str, ndata: Box, topology: Box) -> typing.Optio
   return features.bgp.get(attr,None)
 
 def check_device_attribute_support(attr: str, ndata: Box, neigh: Box, topology: Box, module: str) -> bool:
-  enabled = get_device_bgp_feature(attr,ndata,topology)
-  if not enabled:
-    log.error(
+  """
+  Check whether the specified BGP attribute is supported by the specified node.
+  The BGP neighbor data is provided mostly for error messages
+  """
+
+  def check_attr_value(value: typing.Any, enabled: Box) -> bool:
+    """
+    Given an attribute value which could be a list or a string, check whether the value(s)
+    are valid for the current device. Note that this is the "supported by the device' check.
+    Crazy values should have been filtered by the data validation code.
+    """
+    if isinstance(value,str):                               # Do we have a string value?
+      if not value in enabled.valid:                        # Easy, compare it to the list of supported values
+        inv_cache_key = f'_invalid_value.{module}.{attr}'   # Did we already report the error for this value?
+        if value in ndata.get(inv_cache_key,[]):
+          return False                                      # We did, don't do it twice, just return "failed"
+        data.append_to_list(ndata,inv_cache_key,value)      # Remember the value we reported
+        log.error(                                          # ... and report unsupported value
+          f'Node {ndata.name} (device {ndata.device}) does not support BGP attribute {attr} value {value}',
+          log.IncorrectValue,
+          module)
+        return False
+    elif isinstance(value,list):                            # Oh, the value is a list of keywords
+      for elem in value:                                    # So we have to iterate over all of them...
+        if not check_attr_value(elem,enabled):
+          return False
+
+    return True                                             # We cannot check other values, assuming they're OK
+  
+  enabled = get_device_bgp_feature(attr,ndata,topology)     # Get feature data for the attribute
+  if not enabled:                                           # No feature information or not valid?
+    log.error(                                              # Report an error
       f'Attribute {attr} used on BGP neighbor {neigh.name} is not supported by node {ndata.name} (device {ndata.device})',
       log.IncorrectValue,
       module)
     return False
 
-  if not isinstance(enabled,list):
+  if enabled is True:                                       # Unconditionally supported?
+    return True                                             # Cool
+  
+  if isinstance(enabled,Box):                               # Feature specified as a dict?
+    if 'valid' in enabled:                                  # Maybe it contains supported values?
+      n_value = neigh.get(attr,True)                        # If so, fetch the attribute value
+      return(check_attr_value(n_value,enabled))             # ... and compare it to supported values
     return True
 
-  if not topology.provider in enabled:
-    log.error(
+  if not isinstance(enabled,list):                          # The only other option is a list of supported providers
+    return True                                             # Not that, must be OK
+
+  if not devices.get_provider(ndata,topology.defaults) in enabled:
+    if ndata.get(f'_invalid_provider.{attr}',False):        # Did we already report the problem?
+      return False
+    ndata._invalid_provider[attr] = True
+    log.error(                                              # Provider used on node is not supported
       f'Node {ndata.name} (device {ndata.device}) does not support BGP attribute {attr} when running with {topology.provider} provider',
       log.IncorrectValue,
       module)

--- a/netsim/utils/routing.py
+++ b/netsim/utils/routing.py
@@ -178,12 +178,13 @@ def check_device_attribute_support(attr: str, ndata: Box, neigh: Box, topology: 
   if not isinstance(enabled,list):                          # The only other option is a list of supported providers
     return True                                             # Not that, must be OK
 
-  if not devices.get_provider(ndata,topology.defaults) in enabled:
+  n_provider = devices.get_provider(ndata,topology.defaults)
+  if n_provider not in enabled:
     if ndata.get(f'_invalid_provider.{attr}',False):        # Did we already report the problem?
       return False
     ndata._invalid_provider[attr] = True
     log.error(                                              # Provider used on node is not supported
-      f'Node {ndata.name} (device {ndata.device}) does not support BGP attribute {attr} when running with {topology.provider} provider',
+      f'Node {ndata.name} (device {ndata.device}) does not support BGP attribute {attr} when running with {n_provider} provider',
       log.IncorrectValue,
       module)
     return False

--- a/tests/errors/bgp-remove-private-as.log
+++ b/tests/errors/bgp-remove-private-as.log
@@ -1,3 +1,4 @@
 IncorrectValue in bgp.session: Node r1 (device iosv) does not support BGP attribute remove_private_as value ingress
 IncorrectValue in bgp.session: Node r2 (device iosxr) does not support BGP attribute remove_private_as value ingress-replace
+IncorrectValue in bgp.session: Node rp (device frr) does not support BGP attribute remove_private_as when running with libvirt provider
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/bgp-remove-private-as.log
+++ b/tests/errors/bgp-remove-private-as.log
@@ -1,0 +1,3 @@
+IncorrectValue in bgp.session: Node r1 (device iosv) does not support BGP attribute remove_private_as value ingress
+IncorrectValue in bgp.session: Node r2 (device iosxr) does not support BGP attribute remove_private_as value ingress-replace
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/bgp-remove-private-as.yml
+++ b/tests/errors/bgp-remove-private-as.yml
@@ -1,0 +1,40 @@
+---
+message: |
+  This topology tests device-specific value validation in 'remove private AS'
+  functionality.
+
+plugin: [ bgp.session ]
+module: [ bgp ]
+
+nodes:
+  r1:
+    device: iosv
+    bgp.as: 65000
+    box: none
+  r2:
+    device: iosxr
+    bgp.as: 65001
+    box: none
+  r3:
+    device: eos
+    bgp.as: 65002
+    box: none
+  r4:
+    device: none
+    bgp.as: 65003
+  rt:
+    device: frr
+    box: none
+    bgp.as: 65004
+
+links:
+- r1:
+    bgp.remove_private_as: [ all, ingress ]             # ingress should fail
+  r2:
+    bgp.remove_private_as: [ ingress, ingress-replace ] # ingress-replace should fail
+  r3:
+    bgp.remove_private_as: [ replace, ingress-replace ] # Should succeed
+  r4:
+    bgp.remove_private_as: [ ingress-replace ]          # Should succeed
+  rt:
+    bgp.remove_private_as: True                         # Should succeed

--- a/tests/errors/bgp-remove-private-as.yml
+++ b/tests/errors/bgp-remove-private-as.yml
@@ -26,6 +26,11 @@ nodes:
     device: frr
     box: none
     bgp.as: 65004
+  rp:
+    device: frr
+    bgp.as: 65005
+    box: none
+    _features.bgp.remove_private_as: [ external ]
 
 links:
 - r1:
@@ -36,5 +41,7 @@ links:
     bgp.remove_private_as: [ replace, ingress-replace ] # Should succeed
   r4:
     bgp.remove_private_as: [ ingress-replace ]          # Should succeed
+  rp:
+    bgp.remove_private_as: True                         # Should fail with provider error
   rt:
     bgp.remove_private_as: True                         # Should succeed


### PR DESCRIPTION
The 'check_device_attribute_support' function has been enhanced to check for the values of an enabled feature when that feature flag is a dictionary with 'valid' attribute. All other behavior is unchanged.

This addition is used to check for valid values of the bgp.remove_private_as attribute on common platforms (EOS, FRR, IOS, IOS XR, Junos).

Other changes:
* Enhanced IOS XR support
* The attribute value must be set in bgp.session plugin before the device support is checked (to give that function a value to check)

Incidentally fixes #3165