### PR TITLE
Fix: FortiOS config collection fails with HTTP 405 on current FortiOS

### DIFF
--- a/netsim/ansible/tasks/fetch-config/fortios.yml
+++ b/netsim/ansible/tasks/fetch-config/fortios.yml
@@ -1,9 +1,14 @@
-# fetch Fortinet FortiOS configuration using fortios_monitor_fact module
+# fetch Fortinet FortiOS configuration using the fortios_monitor module
 #
+# The config-backup monitor endpoint changed verb across FortiOS releases:
+# the FNDN API reference shows GET on 6.4 (6.4.16) and POST on 7.0 (7.0.17)
+# and later. The legacy fortios_monitor_fact/system_config_backup issues GET,
+# which returns HTTP 405 on current releases (verified on FortiOS 8.0.0).
+# fortios_monitor + backup.system.config issues the required POST.
 ---
 - name: save fortios config
-  fortinet.fortios.fortios_monitor_fact:
-    selector: 'system_config_backup'
+  fortinet.fortios.fortios_monitor:
+    selector: 'backup.system.config'
     vdom: "{{ vdom }}"
     params:
       scope: 'global'


### PR DESCRIPTION
## Problem

`netlab collect` collects no configuration for FortiOS nodes on current
FortiOS releases; the FortiOS hosts fail their collection task with an
HTTP 405 error:

```
http_status: 405, action: backup, path: system, status: error
```

The collection task (`netsim/ansible/tasks/fetch-config/fortios.yml`) used
`fortinet.fortios.fortios_monitor_fact` with selector `system_config_backup`,
which issues `GET /api/v2/monitor/system/config/backup`. The config-backup
monitor endpoint changed HTTP verb across FortiOS releases: per the FNDN API
reference it is **GET on FortiOS 6.4** (6.4.16) but **POST on FortiOS 7.0**
(7.0.17) and later. On a release that expects POST, the GET request is
rejected with **405 Method Not Allowed**. The FortiOS hosts then collect no
`.cfg` file; other devices in the lab are unaffected and collect normally,
but the failed hosts make the run exit with a non-zero status.

## Fix

Switch the task to `fortinet.fortios.fortios_monitor` with selector
`backup.system.config`. This targets the same
`/api/v2/monitor/system/config/backup` URL but issues the POST request the
endpoint now expects. The POST response continues to expose the raw
configuration at `meta.raw`, so the `ansible_net_config` extraction is
unchanged.

## Validation

Verified live against a running FortiGate cluster (FGCP HA, **FortiOS
v8.0.0 build 167**) plus FRR/Linux nodes:

- Before: `netlab collect` on a FortiOS node returns `http_status: 405`,
  no config file written, playbook aborts.
- After: full `netlab collect` over the lab completes with `failed=0` for
  every node; both FGCP HA members and all FRR routers collect cleanly. The
  FortiOS backups are well-formed (≈16.9k-line configurations).

The exact FortiOS release in which the verb changed was not bisected; the
GET→POST transition is bracketed by the FNDN API reference (GET on 6.4.16,
POST on 7.0.17), and the 405 failure was reproduced directly on 8.0.0.

## References

- FNDN API reference: config-backup monitor endpoint is documented as GET on
  FortiOS 6.4.16 and POST on FortiOS 7.0.17 (Fortinet Developer Network,
  authentication required).
- FortiOS 8.0 configuration backup documentation:
  https://docs.fortinet.com/document/fortigate/8.0.0/administration-guide/702257/configuration-backups-and-reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
