### PR TITLE
Fix anycast-check crash when device lacks gateway.protocol

### DIFF
--- a/tests/integration/evpn/anycast-check/plugin.py
+++ b/tests/integration/evpn/anycast-check/plugin.py
@@ -22,7 +22,7 @@ def pre_transform(topology: Box) -> None:
   node = get_box({'device': def_device})
   features = get_device_features(node,topology.defaults)
 
-  if 'anycast' in features.get('gateway.protocol'):
+  if 'anycast' in features.get('gateway.protocol', []):
     topology.validate.pop('anycast',None)
     return
 


### PR DESCRIPTION
## Summary
- Default `features.get('gateway.protocol')` to `[]` in the EVPN anycast-check test plugin
- Prevents `TypeError` when `netlab create -d <device>` uses a default device without gateway features (for example, bird)

## Test plan
- [x] `netlab create -d bird -p clab evpn/02-vxlan-asymmetric-irb.yml` no longer crashes in `anycast-check` pre_transform (fails later on missing gateway module, as expected)


Made with [Cursor](https://cursor.com)