### PR TITLE
Add Router OS 7 VXLAN / EVPN support

### DIFF
--- a/netsim/ansible/templates/evpn/routeros7.j2
+++ b/netsim/ansible/templates/evpn/routeros7.j2
@@ -1,0 +1,9 @@
+{% for n in bgp.neighbors if n.ipv4 is defined and n.evpn|default(False) %}
+{%   set neigh_id = n.ipv4|replace('.', '_')|replace(':', '_') %}
+/routing/bgp/connection set [/routing/bgp/connection find name={{ neigh_id }}] afi=evpn
+{%   if vlans is defined and 'vxlan' in module %}
+{%     for v in vlans.values() if v.evpn.evi is defined %}
+/routing/bgp/evpn add name={{ neigh_id }}-evpn disabled=no instance=main export.route-targets={{ v.evpn.export|join(',') }} import.route-targets={{ v.evpn.import|join(',') }} vni={{ v.vni }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/vxlan/routeros7.j2
+++ b/netsim/ansible/templates/vxlan/routeros7.j2
@@ -1,0 +1,12 @@
+{% if vxlan.vlans is defined %}
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%    set learning="no" if vxlan.flooding|default("") == "evpn" else "yes" %}
+{%    set v= vlans[vname] %}
+/interface/vxlan add bridge=switch bridge-pvid={{ v.id }} local-address={{ vxlan.vtep }} name=vxlan-{{ v.vni }} vni={{ v.vni }} learning={{ learning }}
+{%     if v.vtep_list is defined %}
+{%       for remote_vtep in v.vtep_list %}
+/interface/vxlan/vtep add interface=vxlan-{{ v.vni }} remote-ip={{ remote_vtep }}
+{%       endfor %}
+{%     endif %}
+{%   endfor %}
+{% endif %}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -42,6 +42,10 @@ features:
     ospfv2: True
     bgp: True
   vxlan: True
+  evpn:
+    irb: True
+    transport: [ vxlan ]
+evpn._start_transit_vlan: 3800
 clab:
   image: vrnetlab/mikrotik_routeros:7.18.2
   build: https://containerlab.dev/manual/kinds/vr-ros/

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -41,6 +41,7 @@ features:
   vrf:
     ospfv2: True
     bgp: True
+  vxlan: True
 clab:
   image: vrnetlab/mikrotik_routeros:7.18.2
   build: https://containerlab.dev/manual/kinds/vr-ros/


### PR DESCRIPTION
Add the ability to use VXLAN and VXLAN + EVPN

Tested with the `netlab-examples` repository

Seems to work for the following (when as the router):
* VXLAN/vxlan-router-stick
* VXLAN/vxlan-bridging
* EVPN/vxvlan-bridging

**NOTE**: I have not done other extensive regressions for other parts of the stack 