### PR TITLE
Fix: Write FRR device log to /var/log/frr instead of /tmp/logging

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -401,7 +401,7 @@ ansible_httpapi_port: 80
 * Many FRR configuration templates are not idempotent -- you cannot run **netlab initial** multiple times. Non-idempotent templates include VLAN and VRF configurations.
 * You can change the FRR default profile with the **netlab_frr_defaults** node parameter (`traditional` or `datacenter`, default is `datacenter`).
 * **netlab collect** downloads FRR configuration but not Linux interface configuration.
-* FRR has no default logging destinations. The initial device configuration adds file logging to `/tmp/logging`.
+* FRR has no default logging destinations. The initial device configuration adds file logging to `/var/log/frr/frr.log`.
 * _netlab_ automatically enables FRR daemons required by the _netlab_ modules you use on individual nodes in the `/etc/frr/daemons` FRRouting configuration file. Use the **frr.daemons** node attribute to enable additional FRRouting daemons.
 
 **FRR-Specific Node Attributes:**

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -128,12 +128,22 @@ echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 
 {% if not netlab_initial_reload|default(False) %}
 #
+# Ensure FRR's log directory exists before enabling file logging
+#
+mkdir -p /var/log/frr && chown frr:frr /var/log/frr
+#
 # Rest of initial configuration done through VTYSH
 #
 cat >/tmp/config <<CONFIG
 hostname {{ inventory_hostname }}
 !
-log file /tmp/logging
+{#
+  Log to /var/log/frr, FRR's canonical log directory. A /tmp destination is
+  rejected by the host AppArmor bgpd/staticd profiles (shipped in the apparmor
+  package), which permit /var/log/frr/* but deny /tmp; on FRR 10.4 that rejection
+  is fatal and aborts initial configuration.
+#}
+log file /var/log/frr/frr.log
 {% from '_debug_commands.j2' import enable_debugging %}
 {{ enable_debugging(frr.debug,prefix='debug') }}
 !


### PR DESCRIPTION
On **Ubuntu 26.04** AppArmor is enabled by default with `bgpd` and `staticd` profiles restricting access to `/tmp`.
AppArmor policy is global and pathname-based, so the confinement reaches into the container and as result
`netlab initial` fails on `frr:10.4.1`, and on `frr:10.6.1` logging configuration fails with a warning.

## Fix

Log to `/var/log/frr/frr.log`, FRR's "canonical" log directory, which
`abstractions/frr` already permits — so **no AppArmor change is required**.
The stock FRR image ships no `/var/log/frr`, so the template creates it
(owned by `frr`) before the daemons open the file. The directory is created
by the unconfined initial shell, not the confined daemon.

Files changed:

- `netsim/ansible/templates/initial/frr.j2` — new log path + `mkdir`/`chown`,
  with a Jinja comment recording the AppArmor rationale.
- `docs/caveats.md` — the current-state note now cites `/var/log/frr/frr.log`.

The log path was never a shared contract: a repo-wide sweep found no reader of
the old destination (only the template wrote it). The historical
`docs/release/25.09.md` note is left untouched, as it correctly records what
25.09 shipped. No release note is added here; release notes in this project are
curated at release time.

## Testing

`tests/integration/bgp.session/10-timers.yml`, device `frr`, provider `clab`,
probe pinned to `frr:10.4.1` (the previously-fatal version):

- `netlab up` now completes `initial,bgp,bgp.session` on both nodes (the probe
  previously failed `initial`).
- `netlab validate` → `[SUCCESS] Tests passed: 4` (session_v4, session_v6,
  timers_v4, timers_v6).
- On the 10.4.1 node, the confined `bgpd` and `staticd` daemons now write to
  `/var/log/frr/frr.log` (BGP and STATIC log lines present); no `/tmp/logging`
  is created — confirming logging is functional, not merely non-fatal.
