### PR TITLE
Fix vMX SSH-readiness timeout regression (#3483)

### DIFF
--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -14,6 +14,8 @@ group_vars:
   ansible_connection: netconf
   netlab_console_connection: ssh
   netlab_ready: [ ansible ]
+  netlab_check_retries: 60
+  netlab_check_delay: 10
 
 features:
   initial:

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -32,7 +32,5 @@ clab:
   group_vars:
     ansible_user: admin
     ansible_ssh_pass: admin@123
-    netlab_check_retries: 60
-    netlab_check_delay: 10
 
 graphite.icon: router

--- a/netsim/devices/vmx.yml
+++ b/netsim/devices/vmx.yml
@@ -9,7 +9,6 @@ group_vars:
   ansible_user: admin
   ansible_ssh_pass: "admin@123"
   netlab_device_type: vmx
-  netlab_check_retries: 20
   netlab_license_url: https://www.juniper.net/content/dam/www/assets/dm/us/en/E421992502.txt
 
 features:

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -44,7 +44,5 @@ clab:
   group_vars:
     ansible_user: admin
     ansible_ssh_pass: "admin@123"
-    netlab_check_retries: 60
-    netlab_check_delay: 10
 
 graphite.icon: firewall


### PR DESCRIPTION
This one was only verified by in memory transform without live tests,
as I don't have any Junos uploaded on netlab server.
What could possibly go wrong?

## Problem

After upgrading from 25.11 to 26.06, vMX nodes fail during `netlab up` with:

```
SSH server on node <name> (device vmx) is not ready after 102.5 seconds
```

## Root cause

Moving the SSH readiness check from the Ansible `until` loop
(`netsim/ansible/tasks/readiness-check/ssh.yml`) to internal Python code
(`netsim/cli/initial/ready.py`, introduced by #3049) changed how
`netlab_check_retries` and `netlab_check_delay` are interpreted. The per-device
values were never altered — only their meaning.

| | 25.11 (Ansible loop) | 26.06 (Python check) |
|---|---|---|
| total budget | ≈ `retries × (per-attempt + delay)` | flat cap `retries × delay` (`ready.py:61`, `ready.py:115`) |
| per-attempt timeout | fixed 10 s (`timeout -k 10s 10s`) | `delay` seconds (`ready.py:98`) |

vMX carried `netlab_check_retries: 20` with the default `delay` of 5. Under the
old semantics that allowed roughly 250–300 s of wall-clock time; under the new
flat cap it yields exactly `20 × 5 = 100 s`, which is below the boot time of a
full vMX (VCP + VFP). vMX was the only Juniper virtual device whose effective
budget fell close enough to its real boot time to start failing — its tuning
was anomalously low relative to its siblings (vsrx/vjunos-router at 60/10,
vjunos-switch/vptx at 40/10).

## Fix

- Establish a **60/10 readiness floor (600 s)** in `junos.yml` top-level
  `group_vars`, so the whole Juniper virtual family inherits a sane budget.
- Remove vMX's stale `netlab_check_retries: 20` so it picks up that floor.
- Remove the now-redundant `60/10` overrides from `vsrx` and `vjunos-router`;
  they continue to resolve to 60/10 through inheritance.
- `vjunos-switch` and `vptx` deliberately set `40/10` in their `clab` blocks,
  which still overrides the floor, so they are left unchanged.

Raising vMX's `delay` to 10 s also restores a 10 s per-attempt probe timeout,
matching the old `timeout -k 10s 10s` behaviour rather than halving it.

## Provider paths

These timers only govern the **clab** readiness path. The two providers differ:

- **clab (vrnetlab):** `netlab_ready: [ ssh, ansible ]`. The internal SSH check
  in `ready.py` runs and consumes `netlab_check_retries`/`netlab_check_delay` —
  this is the path that regressed and the path this PR fixes.
- **libvirt (native VM):** `netlab_ready: [ ansible ]`. The internal SSH check
  does not run, so `netlab_check_*` are resolved but never consulted. Readiness
  is governed solely by `tasks/readiness-check/junos.yml`, which hardcodes
  `interval: 5`, `retries: 60` (≈300 s). The libvirt path was identical in
  25.11 and 26.06 and was never affected by the regression.

Two notes follow. First, vMX is **clab-only**: neither `vmx.yml` nor the
`junos` parent defines a `libvirt` block, so vMX runs exclusively under
vrnetlab — exactly the reporter's path. Second, under libvirt `vjunos-switch`
and `vptx` resolve to the 60/10 floor rather than their `clab`-block 40/10,
but since the timers are unused on that path the difference is immaterial.

## Verification

Transformed in-memory topologies and resolved the values through the same
`get_node_group_var` path that `ready.py` uses.

**clab** (one node per device) — the path that governs the SSH check:

| node | device | retries | delay | wait | status |
|---|---|---|---|---|---|
| r_vmx | vmx | 60 | 10 | **600 s** | inherits junos floor (was 100 s) |
| r_vsrx | vsrx | 60 | 10 | 600 s | inherits junos (override removed) |
| r_vjr | vjunos-router | 60 | 10 | 600 s | inherits via vmx → junos (override removed) |
| r_vjs | vjunos-switch | 40 | 10 | 400 s | own clab override still wins |
| r_vptx | vptx | 40 | 10 | 400 s | unchanged |

**libvirt** (vMX excluded — no libvirt support) — confirms the SSH check is
not active and the timers are not consulted:

| node | device | netlab_ready | (timers unused) |
|---|---|---|---|
| r_vsrx | vsrx | `[ ansible ]` | readiness via hardcoded junos check |
| r_vjr | vjunos-router | `[ ansible ]` | readiness via hardcoded junos check |
| r_vjs | vjunos-switch | `[ ansible ]` | readiness via hardcoded junos check |
| r_vptx | vptx | `[ ansible ]` | readiness via hardcoded junos check |

`yamllint` passes on all four changed files.

Fixes #3483.

