### PR TITLE
Add OSPF graceful restart config with initial support for FRR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,6 @@ With the Box settings used in the topology data structure:
 
 * The interim dictionaries are created automatically: `a.b.c=1` works even when `a.b` does not exist yet.
 * The dotted paths can be used in indices (for example, `a['b.c'] = 1`) and in **in** tests (for example `'b.c' in a`)
-* Prefer `box.get('dotted.path', default)` over nested existence checks like `'gr' in box and box.gr.get('state', ...)`
-* When testing whether an optional feature is active, default to "off" (e.g. `'disable'`), not to an enabled state. Do not add `.get()` defaults for `_required` attributes — validation guarantees they are set when the parent object is present.
 
 IMPORTANT -- the Box objects must have the default_box and box_dots flags set to work as expected:
 
@@ -119,7 +117,6 @@ IMPORTANT -- the Box objects must have the default_box and box_dots flags set to
 - YAML files for configuration and topology definitions
 - Jinja2 templates for configuration generation
 - Global settings in `netsim/defaults/`
-- In module/plugin YAML (`netsim/modules/*.yml`, `netsim/extra/*/defaults.yml`), define user-defined attribute types only when the same structure is reused in multiple places. Inline `{ type: ..., valid_values: ... }` (and similar constraints) for single-use attributes instead of adding a named type in `_top` or `attributes`. See `docs/dev/validation.md` (User-Defined Data Types).
 
 ### Documentation
 - Docstrings follow Google style (not strictly enforced but preferred)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ With the Box settings used in the topology data structure:
 
 * The interim dictionaries are created automatically: `a.b.c=1` works even when `a.b` does not exist yet.
 * The dotted paths can be used in indices (for example, `a['b.c'] = 1`) and in **in** tests (for example `'b.c' in a`)
+* Prefer `box.get('dotted.path', default)` over nested existence checks like `'gr' in box and box.gr.get('state', ...)`
+* When testing whether an optional feature is active, default to "off" (e.g. `'disable'`), not to an enabled state. Do not add `.get()` defaults for `_required` attributes — validation guarantees they are set when the parent object is present.
 
 IMPORTANT -- the Box objects must have the default_box and box_dots flags set to work as expected:
 
@@ -117,6 +119,7 @@ IMPORTANT -- the Box objects must have the default_box and box_dots flags set to
 - YAML files for configuration and topology definitions
 - Jinja2 templates for configuration generation
 - Global settings in `netsim/defaults/`
+- In module/plugin YAML (`netsim/modules/*.yml`, `netsim/extra/*/defaults.yml`), define user-defined attribute types only when the same structure is reused in multiple places. Inline `{ type: ..., valid_values: ... }` (and similar constraints) for single-use attributes instead of adding a named type in `_top` or `attributes`. See `docs/dev/validation.md` (User-Defined Data Types).
 
 ### Documentation
 - Docstrings follow Google style (not strictly enforced but preferred)

--- a/docs/dev/config/ospf.md
+++ b/docs/dev/config/ospf.md
@@ -67,7 +67,7 @@ These parameters are set in the node or VRF **ospf** dictionary:
 
 * **ospf.router_id** -- OSPF router ID (always present, should be an IPv4 address). Always set the OSPF router ID for OSPFv3 routing processes to ensure we have a usable router ID in IPv6-only deployments
 * **ospf.reference_bandwidth** -- reference bandwidth (optional)
-* **ospf.gr** -- graceful restart settings. **restart** can be `true` or a dictionary with **grace_period** (integer, 1–1800 seconds). **helper** can be `true` or a dictionary with **grace_period** (integer, 10–1800 seconds). A boolean **ospf.gr** value is a shortcut for **ospf.gr.restart**.
+* **ospf.gr** -- graceful restart settings. **restart** can be `true` or a dictionary with **grace_period** (integer, 1–1800 seconds). **helper** can be `true` or a dictionary with **grace_period** (integer, 10–1800 seconds). `true` values are normalized into a **grace_period** value of 300 seconds. A boolean **ospf.gr** value is a shortcut for **ospf.gr.restart**.
 * **ospf.unnumbered** -- OSPF is ran on at least one unnumbered IPV4 interface (optional)
 * **ospf.area** -- default OSPF area (always present)
 

--- a/docs/dev/config/ospf.md
+++ b/docs/dev/config/ospf.md
@@ -67,7 +67,7 @@ These parameters are set in the node or VRF **ospf** dictionary:
 
 * **ospf.router_id** -- OSPF router ID (always present, should be an IPv4 address). Always set the OSPF router ID for OSPFv3 routing processes to ensure we have a usable router ID in IPv6-only deployments
 * **ospf.reference_bandwidth** -- reference bandwidth (optional)
-* **ospf.gr** -- graceful restart settings: **state** (`enable`, `disable`, or `helper`) and optional **grace_period** (integer, 1–1800 seconds)
+* **ospf.gr** -- graceful restart settings. **restart** can be `true` or a dictionary with **grace_period** (integer, 1–1800 seconds). **helper** can be `true` or a dictionary with **grace_period** (integer, 10–1800 seconds). A boolean **ospf.gr** value is a shortcut for **ospf.gr.restart**.
 * **ospf.unnumbered** -- OSPF is ran on at least one unnumbered IPV4 interface (optional)
 * **ospf.area** -- default OSPF area (always present)
 

--- a/docs/dev/config/ospf.md
+++ b/docs/dev/config/ospf.md
@@ -29,6 +29,7 @@ You can use the following device **features.ospf** [device features](dev-device-
 * **timers** -- OSPF timers
 * **priority** -- DR election priority
 * **password** -- Simple OSPFv2 authentication
+* **gr** -- OSPF graceful restart (OSPFv2 only)
 
 (dev-ospf-af)=
 ## Supporting Multiple Address Families
@@ -66,6 +67,7 @@ These parameters are set in the node or VRF **ospf** dictionary:
 
 * **ospf.router_id** -- OSPF router ID (always present, should be an IPv4 address). Always set the OSPF router ID for OSPFv3 routing processes to ensure we have a usable router ID in IPv6-only deployments
 * **ospf.reference_bandwidth** -- reference bandwidth (optional)
+* **ospf.gr** -- graceful restart settings: **state** (`enable`, `disable`, or `helper`) and optional **grace_period** (integer, 1–1800 seconds)
 * **ospf.unnumbered** -- OSPF is ran on at least one unnumbered IPV4 interface (optional)
 * **ospf.area** -- default OSPF area (always present)
 

--- a/docs/dev/config/ospf.md
+++ b/docs/dev/config/ospf.md
@@ -29,7 +29,7 @@ You can use the following device **features.ospf** [device features](dev-device-
 * **timers** -- OSPF timers
 * **priority** -- DR election priority
 * **password** -- Simple OSPFv2 authentication
-* **gr** -- OSPF graceful restart (OSPFv2 only)
+* **gr** -- OSPF graceful restart. A list of supported address families (`ipv4` for OSPFv2, `ipv6` for OSPFv3).
 
 (dev-ospf-af)=
 ## Supporting Multiple Address Families

--- a/docs/dev/config/ospf.md
+++ b/docs/dev/config/ospf.md
@@ -66,9 +66,10 @@ Use something similar to the following example as the stub template:
 These parameters are set in the node or VRF **ospf** dictionary:
 
 * **ospf.router_id** -- OSPF router ID (always present, should be an IPv4 address). Always set the OSPF router ID for OSPFv3 routing processes to ensure we have a usable router ID in IPv6-only deployments
-* **ospf.reference_bandwidth** -- reference bandwidth (optional)
-* **ospf.gr** -- graceful restart settings. **restart** can be `true` or a dictionary with **grace_period** (integer, 1–1800 seconds). **helper** can be `true` or a dictionary with **grace_period** (integer, 10–1800 seconds). `true` values are normalized into a **grace_period** value of 300 seconds. A boolean **ospf.gr** value is a shortcut for **ospf.gr.restart**.
-* **ospf.unnumbered** -- OSPF is ran on at least one unnumbered IPV4 interface (optional)
+* **ospf.reference_bandwidth** (optional) -- reference bandwidth
+* **ospf.gr.restart** (optional) -- Configure GR functionality when **ospf.gr.restart** is defined. Configure the grace period when **ospf.gr.restart.grace_period** is defined (integer, 1–1800 seconds).
+* **ospf.gr.helper** (optional) -- Configure GR Helper functionality when **ospf.gr.helper** is defined. Configure the grace period when **ospf.gr.helper.grace_period** is defined (integer, 1–1800 seconds).
+* **ospf.unnumbered** (optional) -- OSPF is ran on at least one unnumbered IPV4 interface
 * **ospf.area** -- default OSPF area (always present)
 
 Cisco IOS OSPFv2 example:

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -196,7 +196,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 * **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
-* **ospf.gr** -- OSPF graceful restart settings. **ospf.gr.restart** can be `true` or a dictionary with **grace_period** (1–1800 seconds). **ospf.gr.helper** can be `true` or a dictionary with **grace_period** (10–1800 seconds). You can also set **ospf.gr** to a boolean value as a shortcut for **ospf.gr.restart**.
+* **ospf.gr** -- OSPF graceful restart settings. **ospf.gr.restart** can be `true` or a dictionary with **grace_period** (1–1800 seconds). **ospf.gr.helper** can be `true` or a dictionary with **grace_period** (10–1800 seconds). `true` values are normalized into a **grace_period** value of 300 seconds. You can also set **ospf.gr** to a boolean value as a shortcut for **ospf.gr.restart**.
 * **ospf.default** -- External default route origination ([more details](ospf-default))
 * **ospf.digest** -- default OSPFv2 digest authentication parameters. Applies to all interfaces without an explicit **ospf.digest** setting.
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -32,6 +32,7 @@ Supported OSPF features:
 * [Route import](routing_import) (redistribution)
 * [Default route origination](ospf-default)
 * BFD (optionally with RFC9355 strict mode)
+* Graceful Restart (OSPFv2 only)
 * VRF OSPFv2 instances (on platforms with [VRF support](module-vrf-platform-support))
 * Stub and NSSA areas (implemented in a separate [ospf.areas plugin](plugin-ospf-areas))
 
@@ -105,6 +106,15 @@ The following devices support BFD with OSPF:
 
 **Notes:**
 * Mikrotik RouterOS and VyOS support BFD on OSPF only with the system default values for interval and multiplier.
+
+The following devices support OSPF graceful restart:
+
+| Operating system | Graceful<br/>Restart |
+| ---------------- | :--: |
+| FRR              |  ✅  |
+
+**Notes:**
+* OSPF graceful restart applies to OSPFv2 instances only.
 
 ```{tip}
 See [OSPFv2](https://release.netlab.tools/_html/coverage.ospf.ospfv2) and [OSPFv3](https://release.netlab.tools/_html/coverage.ospf.ospfv3) Integration Tests Results for more details.
@@ -189,6 +199,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 * **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
+* **ospf.gr** -- OSPF graceful restart (OSPFv2 only). A dictionary with **ospf.gr.state** (`enable`, `disable`, or `helper`) and optional **ospf.gr.grace_period** (1–1800 seconds). You can also set **ospf.gr** to one of the **state** string values.
 * **ospf.default** -- External default route origination ([more details](ospf-default))
 * **ospf.digest** -- default OSPFv2 digest authentication parameters. Applies to all interfaces without an explicit **ospf.digest** setting.
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.
@@ -203,7 +214,7 @@ You can specify most node parameters as global values (top-level topology elemen
 
 ## VRF Parameters
 
-* You can use most OSPF node parameters (for example, **area**, **digest**, **password**, or **timers**) in VRF definitions to change the VRF OSPF instance configuration.
+* You can use most OSPF node parameters (for example, **area**, **digest**, **gr**, **password**, or **timers**) in VRF definitions to change the VRF OSPF instance configuration.
 * By default, _netlab_ redistributes BGP- and connected routes into VRF OSPF instances on all network devices. You can change that on devices supporting configurable route import with the **[ospf.import](routing_import)** VRF parameter.
 * You can change the [router ID](routing_router_id) of a VRF OSPF instance with **ospf.router_id** parameter. Use this parameter when building back-to-back links between VRFs on the same node.
 * Set **ospf.active** to *True* to force a VRF to use OSPF even when no routers are attached to the VRF interfaces.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -32,7 +32,7 @@ Supported OSPF features:
 * [Route import](routing_import) (redistribution)
 * [Default route origination](ospf-default)
 * BFD (optionally with RFC9355 strict mode)
-* Graceful Restart (OSPFv2 only)
+* Graceful Restart
 * VRF OSPFv2 instances (on platforms with [VRF support](module-vrf-platform-support))
 * Stub and NSSA areas (implemented in a separate [ospf.areas plugin](plugin-ospf-areas))
 
@@ -109,12 +109,9 @@ The following devices support BFD with OSPF:
 
 The following devices support OSPF graceful restart:
 
-| Operating system | Graceful<br/>Restart |
-| ---------------- | :--: |
-| FRR              |  ✅  |
-
-**Notes:**
-* OSPF graceful restart applies to OSPFv2 instances only.
+| Operating system | OSPFv2 | OSPFv3 |
+| ---------------- | :--: | :--: |
+| FRR              |  ✅  |  ✅  |
 
 ```{tip}
 See [OSPFv2](https://release.netlab.tools/_html/coverage.ospf.ospfv2) and [OSPFv3](https://release.netlab.tools/_html/coverage.ospf.ospfv3) Integration Tests Results for more details.
@@ -199,7 +196,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 * **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
-* **ospf.gr** -- OSPF graceful restart (OSPFv2 only). A dictionary with **ospf.gr.state** (`enable`, `disable`, or `helper`) and optional **ospf.gr.grace_period** (1–1800 seconds). You can also set **ospf.gr** to one of the **state** string values.
+* **ospf.gr** -- OSPF graceful restart. A dictionary with **ospf.gr.state** (`enable`, `disable`, or `helper`) and optional **ospf.gr.grace_period** (1–1800 seconds). You can also set **ospf.gr** to one of the **state** string values. Device support is per address family (OSPFv2 and/or OSPFv3).
 * **ospf.default** -- External default route origination ([more details](ospf-default))
 * **ospf.digest** -- default OSPFv2 digest authentication parameters. Applies to all interfaces without an explicit **ospf.digest** setting.
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -196,7 +196,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 * **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
-* **ospf.gr** -- OSPF graceful restart settings. **ospf.gr.restart** can be `true` or a dictionary with **grace_period** (1–1800 seconds). **ospf.gr.helper** can be `true` or a dictionary with **grace_period** (10–1800 seconds). `true` values are normalized into a **grace_period** value of 300 seconds. You can also set **ospf.gr** to a boolean value as a shortcut for **ospf.gr.restart**.
+* **ospf.gr** -- OSPF graceful restart settings. **ospf.gr.restart** can be `true` (enable GR with default settings) or a dictionary with **grace_period** (1–1800 seconds). **ospf.gr.helper** can be `true` (enable GR helper with default settings) or a dictionary with **grace_period** (10–1800 seconds). You can also set **ospf.gr** to a boolean value as a shortcut for **ospf.gr.restart**.
 * **ospf.default** -- External default route origination ([more details](ospf-default))
 * **ospf.digest** -- default OSPFv2 digest authentication parameters. Applies to all interfaces without an explicit **ospf.digest** setting.
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -196,7 +196,7 @@ OSPF routing daemons support these optional OSPF interface attributes:
 * **ospf.area** -- default OSPF area (default: 0.0.0.0). Used on links/interfaces (including the loopback interface) without an explicit OSPF area.
 * **ospf.bfd** -- enable BFD for OSPF (default: False)
 * **ospf.bfd.strict** enables RFC9355 BFD Strict-Mode (default: False)
-* **ospf.gr** -- OSPF graceful restart. A dictionary with **ospf.gr.state** (`enable`, `disable`, or `helper`) and optional **ospf.gr.grace_period** (1–1800 seconds). You can also set **ospf.gr** to one of the **state** string values. Device support is per address family (OSPFv2 and/or OSPFv3).
+* **ospf.gr** -- OSPF graceful restart settings. **ospf.gr.restart** can be `true` or a dictionary with **grace_period** (1–1800 seconds). **ospf.gr.helper** can be `true` or a dictionary with **grace_period** (10–1800 seconds). You can also set **ospf.gr** to a boolean value as a shortcut for **ospf.gr.restart**.
 * **ospf.default** -- External default route origination ([more details](ospf-default))
 * **ospf.digest** -- default OSPFv2 digest authentication parameters. Applies to all interfaces without an explicit **ospf.digest** setting.
 * **ospf.import** -- [import (redistribute) routes](routing_import) into the global OSPF instance. By default, no routes are redistributed into the global OSPF instance.

--- a/netsim/ansible/templates/ospf/frr.gr.j2
+++ b/netsim/ansible/templates/ospf/frr.gr.j2
@@ -1,0 +1,14 @@
+{% if ospf_data.gr is defined %}
+{%   if ospf_data.gr.restart is defined %}
+ graceful-restart
+{%     if ospf_data.gr.restart.grace_period is defined %}
+ graceful-restart grace-period {{ ospf_data.gr.restart.grace_period }}
+{%     endif %}
+{%   endif %}
+{%   if ospf_data.gr.helper is defined %}
+ graceful-restart helper enable
+{%     if ospf_data.gr.helper.grace_period is defined %}
+ graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
+{%     endif %}
+{%   endif %}
+{% endif %}

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,7 +15,10 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% include 'frr.gr.j2' %}
+{% if ospf_data.gr is defined %}
+ capability opaque
+{%   include 'frr.gr.j2' %}
+{% endif %}
  timers throttle spf 10 50 500
  timers throttle lsa all 100
  timers lsa min-arrival 100

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,8 +15,8 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% if ospf_data.gr is defined and ospf_data.gr.state|default('enable') != 'disable' %}
-{%   set gr_state = ospf_data.gr.state|default('enable') %}
+{% if ospf_data.get('gr.state','disable') != 'disable' %}
+{%   set gr_state = ospf_data.gr.state %}
 {%   if gr_state == 'enable' %}
 {%     if ospf_data.gr.grace_period is defined %}
  graceful-restart grace-period {{ ospf_data.gr.grace_period }}

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,6 +15,21 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
+{% if ospf_data.gr is defined and ospf_data.gr.state|default('enable') != 'disable' %}
+{%   set gr_state = ospf_data.gr.state|default('enable') %}
+{%   if gr_state == 'enable' %}
+{%     if ospf_data.gr.grace_period is defined %}
+ graceful-restart grace-period {{ ospf_data.gr.grace_period }}
+{%     else %}
+ graceful-restart
+{%     endif %}
+{%   elif gr_state == 'helper' %}
+ graceful-restart helper enable
+{%     if ospf_data.gr.grace_period is defined %}
+ graceful-restart helper supported-grace-time {{ ospf_data.gr.grace_period }}
+{%     endif %}
+{%   endif %}
+{% endif %}
  timers throttle spf 10 50 500
  timers throttle lsa all 100
  timers lsa min-arrival 100

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,7 +15,7 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% if ospf_data.get('gr.state','disable') != 'disable' %}
+{% if ospf_data.gr.state|default('disable') != 'disable' %}
 {%   set gr_state = ospf_data.gr.state %}
 {%   if gr_state == 'enable' %}
 {%     if ospf_data.gr.grace_period is defined %}

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -16,14 +16,12 @@ router ospf
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
 {% if ospf_data.gr is defined %}
-{%   if ospf_data.gr.restart is true or ospf_data.gr.restart.grace_period is defined %}
- graceful-restart{{ " grace-period " ~ ospf_data.gr.restart.grace_period if ospf_data.gr.restart.grace_period is defined else "" }}
+{%   if ospf_data.gr.restart.grace_period is defined %}
+ graceful-restart grace-period {{ ospf_data.gr.restart.grace_period }}
 {%   endif %}
-{%   if ospf_data.gr.helper is true or ospf_data.gr.helper.grace_period is defined %}
+{%   if ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper enable
-{%     if ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
-{%     endif %}
 {%   endif %}
 {% endif %}
  timers throttle spf 10 50 500

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,18 +15,14 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% if ospf_data.gr.state|default('disable') != 'disable' %}
-{%   set gr_state = ospf_data.gr.state %}
-{%   if gr_state == 'enable' %}
-{%     if ospf_data.gr.grace_period is defined %}
- graceful-restart grace-period {{ ospf_data.gr.grace_period }}
-{%     else %}
- graceful-restart
-{%     endif %}
-{%   elif gr_state == 'helper' %}
+{% if ospf_data.gr is defined %}
+{%   if ospf_data.gr.restart is true or ospf_data.gr.restart.grace_period is defined %}
+ graceful-restart{{ " grace-period " ~ ospf_data.gr.restart.grace_period if ospf_data.gr.restart.grace_period is defined else "" }}
+{%   endif %}
+{%   if ospf_data.gr.helper is true or ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper enable
-{%     if ospf_data.gr.grace_period is defined %}
- graceful-restart helper supported-grace-time {{ ospf_data.gr.grace_period }}
+{%     if ospf_data.gr.helper.grace_period is defined %}
+ graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
 {%     endif %}
 {%   endif %}
 {% endif %}

--- a/netsim/ansible/templates/ospf/frr.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv2.j2
@@ -15,15 +15,7 @@ router ospf
 {% if ospf_data.reference_bandwidth is defined %}
  auto-cost reference-bandwidth {{ ospf_data.reference_bandwidth }}
 {% endif %}
-{% if ospf_data.gr is defined %}
-{%   if ospf_data.gr.restart.grace_period is defined %}
- graceful-restart grace-period {{ ospf_data.gr.restart.grace_period }}
-{%   endif %}
-{%   if ospf_data.gr.helper.grace_period is defined %}
- graceful-restart helper enable
- graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
-{%   endif %}
-{% endif %}
+{% include 'frr.gr.j2' %}
  timers throttle spf 10 50 500
  timers throttle lsa all 100
  timers lsa min-arrival 100

--- a/netsim/ansible/templates/ospf/frr.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv3.j2
@@ -43,6 +43,21 @@ router ospf6 vrf {{ ospf_vrf }}
 router ospf6
 {% endif %}
  ospf6 router-id {{ ospf_data.router_id }}
+{% if ospf_data.get('gr.state','disable') != 'disable' %}
+{%   set gr_state = ospf_data.gr.state %}
+{%   if gr_state == 'enable' %}
+{%     if ospf_data.gr.grace_period is defined %}
+ graceful-restart grace-period {{ ospf_data.gr.grace_period }}
+{%     else %}
+ graceful-restart
+{%     endif %}
+{%   elif gr_state == 'helper' %}
+ graceful-restart helper enable
+{%     if ospf_data.gr.grace_period is defined %}
+ graceful-restart helper supported-grace-time {{ ospf_data.gr.grace_period }}
+{%     endif %}
+{%   endif %}
+{% endif %}
  timers lsa min-arrival 100
  timers throttle spf 10 50 500
 {{ ospf_default.config(ospf_data,'ipv6') }}

--- a/netsim/ansible/templates/ospf/frr.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv3.j2
@@ -43,18 +43,14 @@ router ospf6 vrf {{ ospf_vrf }}
 router ospf6
 {% endif %}
  ospf6 router-id {{ ospf_data.router_id }}
-{% if ospf_data.get('gr.state','disable') != 'disable' %}
-{%   set gr_state = ospf_data.gr.state %}
-{%   if gr_state == 'enable' %}
-{%     if ospf_data.gr.grace_period is defined %}
- graceful-restart grace-period {{ ospf_data.gr.grace_period }}
-{%     else %}
- graceful-restart
-{%     endif %}
-{%   elif gr_state == 'helper' %}
+{% if ospf_data.gr is defined %}
+{%   if ospf_data.gr.restart is true or ospf_data.gr.restart.grace_period is defined %}
+ graceful-restart{{ " grace-period " ~ ospf_data.gr.restart.grace_period if ospf_data.gr.restart.grace_period is defined else "" }}
+{%   endif %}
+{%   if ospf_data.gr.helper is true or ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper enable
-{%     if ospf_data.gr.grace_period is defined %}
- graceful-restart helper supported-grace-time {{ ospf_data.gr.grace_period }}
+{%     if ospf_data.gr.helper.grace_period is defined %}
+ graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
 {%     endif %}
 {%   endif %}
 {% endif %}

--- a/netsim/ansible/templates/ospf/frr.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv3.j2
@@ -43,15 +43,7 @@ router ospf6 vrf {{ ospf_vrf }}
 router ospf6
 {% endif %}
  ospf6 router-id {{ ospf_data.router_id }}
-{% if ospf_data.gr is defined %}
-{%   if ospf_data.gr.restart.grace_period is defined %}
- graceful-restart grace-period {{ ospf_data.gr.restart.grace_period }}
-{%   endif %}
-{%   if ospf_data.gr.helper.grace_period is defined %}
- graceful-restart helper enable
- graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
-{%   endif %}
-{% endif %}
+{% include 'frr.gr.j2' %}
  timers lsa min-arrival 100
  timers throttle spf 10 50 500
 {{ ospf_default.config(ospf_data,'ipv6') }}

--- a/netsim/ansible/templates/ospf/frr.ospfv3.j2
+++ b/netsim/ansible/templates/ospf/frr.ospfv3.j2
@@ -44,14 +44,12 @@ router ospf6
 {% endif %}
  ospf6 router-id {{ ospf_data.router_id }}
 {% if ospf_data.gr is defined %}
-{%   if ospf_data.gr.restart is true or ospf_data.gr.restart.grace_period is defined %}
- graceful-restart{{ " grace-period " ~ ospf_data.gr.restart.grace_period if ospf_data.gr.restart.grace_period is defined else "" }}
+{%   if ospf_data.gr.restart.grace_period is defined %}
+ graceful-restart grace-period {{ ospf_data.gr.restart.grace_period }}
 {%   endif %}
-{%   if ospf_data.gr.helper is true or ospf_data.gr.helper.grace_period is defined %}
+{%   if ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper enable
-{%     if ospf_data.gr.helper.grace_period is defined %}
  graceful-restart helper supported-grace-time {{ ospf_data.gr.helper.grace_period }}
-{%     endif %}
 {%   endif %}
 {% endif %}
  timers lsa min-arrival 100

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -146,6 +146,7 @@ features:
     unnumbered: true
     import: [ bgp, ripv2, isis, connected, static, vrf ]
     default: true
+    gr: true
     password: true
     priority: true
     timers: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -146,7 +146,7 @@ features:
     unnumbered: true
     import: [ bgp, ripv2, isis, connected, static, vrf ]
     default: true
-    gr: true
+    gr: [ ipv4, ipv6 ]
     password: true
     priority: true
     timers: true

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -97,6 +97,7 @@ features:
     unnumbered: True
     import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true
+    gr: True
     password: true
     priority: true
     timers: true

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -97,7 +97,7 @@ features:
     unnumbered: True
     import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true
-    gr: True
+    gr: [ ipv4, ipv6 ]
     password: true
     priority: true
     timers: true

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -140,21 +140,19 @@ def adjust_interface_timers(node: Box) -> None:
         category=log.IncorrectValue)
 
 def check_gr_support(node: Box, features: Box) -> None:
+  gr_af = features.get('ospf.gr', [])
+
   for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
-    if 'gr' not in o_data or o_data.gr.get('state','enable') == 'disable':
+    if o_data.get('gr.state', 'disable') == 'disable':
       continue
 
     vrf_info = f' in VRF {vrf}' if vrf else ''
-    if 'ipv4' not in o_data.af:
-      log.error(
-        f'OSPF graceful restart requires OSPFv2 (ipv4){vrf_info} on node {node.name}',
-        log.IncorrectValue,
-        'ospf')
-    if not features.get('ospf.gr',False):
-      log.error(
-        f'Device {node.device} does not support ospf.gr{vrf_info} on node {node.name}',
-        log.IncorrectValue,
-        'ospf')
+    for af in o_data.af:
+      if af not in gr_af:
+        log.error(
+          f'Device {node.device} does not support ospf.gr for {af}{vrf_info} on node {node.name}',
+          log.IncorrectValue,
+          'ospf')
 
 class OSPF(_Module):
 

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -139,6 +139,23 @@ def adjust_interface_timers(node: Box) -> None:
         module='ospf',
         category=log.IncorrectValue)
 
+def check_gr_support(node: Box, features: Box) -> None:
+  for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
+    if 'gr' not in o_data or o_data.gr.get('state','enable') == 'disable':
+      continue
+
+    vrf_info = f' in VRF {vrf}' if vrf else ''
+    if not o_data.get('af',{}).get('ipv4'):
+      log.error(
+        f'OSPF graceful restart requires OSPFv2 (ipv4){vrf_info} on node {node.name}',
+        log.IncorrectValue,
+        'ospf')
+    if not features.get('ospf.gr',False):
+      log.error(
+        f'Device {node.device} does not support ospf.gr{vrf_info} on node {node.name}',
+        log.IncorrectValue,
+        'ospf')
+
 class OSPF(_Module):
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
@@ -182,6 +199,7 @@ class OSPF(_Module):
     _routing.check_vrf_protocol_support(node,'ospf','ipv4','ospfv2',topology)
     _routing.check_vrf_protocol_support(node,'ospf','ipv6','ospfv3',topology)
     _routing.check_intf_support(node,'ospf',topology)
-    
+    check_gr_support(node,features)
+
     # Collect OSPF areas from interfaces (similar to ospf.areas plugin but without extra attributes)
     collect_ospf_areas(node)

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -145,7 +145,7 @@ def check_gr_support(node: Box, features: Box) -> None:
       continue
 
     vrf_info = f' in VRF {vrf}' if vrf else ''
-    if not o_data.get('af',{}).get('ipv4'):
+    if 'ipv4' not in o_data.af:
       log.error(
         f'OSPF graceful restart requires OSPFv2 (ipv4){vrf_info} on node {node.name}',
         log.IncorrectValue,

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -128,25 +128,36 @@ def adjust_interface_timers(node: Box) -> None:
 
     if 'hello' in timers and 'dead' not in timers:
       timers.dead = timers.hello * 4                  # Missing dead timer: 4 times the hello timer
-    
+
     if 'dead' in timers and 'hello' not in timers:    # Missing hello timer?
       timers.hello = max(round(timers.dead / 4),1)    # ... a quarter of the dead timer, but at least one
 
     if timers.hello >= timers.dead:                   # Sanity check...
       log.error(                                      # ... Dead timer must be higher than the hello timer
-        f'OSPF interface hello timer is greater or equal to dead timer',
+        'OSPF interface hello timer is greater or equal to dead timer',
         more_data=f'Node {node.name} interface {intf.ifname} ({intf.name})',
         module='ospf',
         category=log.IncorrectValue)
 
-def check_gr_support(node: Box, features: Box) -> None:
+def check_gr(node: Box, features: Box) -> None:
+  """
+  Check device support for OSPF Graceful Restart when restart or helper mode is configured.
+  """
   gr_af = features.get('ospf.gr', [])
 
   for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
-    if o_data.get('gr.state', 'disable') == 'disable':
+    if 'gr' not in o_data:
+      continue
+
+    restart = o_data.gr.get('restart',False)
+    helper = o_data.gr.get('helper',False)
+    restart_configured = restart is True or 'restart.grace_period' in o_data.gr
+    helper_configured = helper is True or 'helper.grace_period' in o_data.gr
+    if not restart_configured and not helper_configured:
       continue
 
     vrf_info = f' in VRF {vrf}' if vrf else ''
+
     for af in o_data.af:
       if af not in gr_af:
         log.error(
@@ -161,7 +172,7 @@ class OSPF(_Module):
     adjust_interface_timers(node)
 
     _routing.router_id(node,'ospf',topology.pools)
-    
+
     # If strict BFD is requested, check if the node supports it
     if isinstance(node.get('ospf.bfd',None),Box) and node.get('ospf.bfd.strict',False):
       if features.get('ospf.strict_bfd',False):
@@ -197,7 +208,7 @@ class OSPF(_Module):
     _routing.check_vrf_protocol_support(node,'ospf','ipv4','ospfv2',topology)
     _routing.check_vrf_protocol_support(node,'ospf','ipv6','ospfv3',topology)
     _routing.check_intf_support(node,'ospf',topology)
-    check_gr_support(node,features)
+    check_gr(node,features)
 
     # Collect OSPF areas from interfaces (similar to ospf.areas plugin but without extra attributes)
     collect_ospf_areas(node)

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -7,7 +7,7 @@ import ipaddress
 from box import Box
 
 from ..augment import devices
-from ..data import append_to_list
+from ..data import append_to_list, get_box
 from ..utils import log
 from ..utils import routing as _ospf
 from . import _Module, _routing, bfd
@@ -144,11 +144,16 @@ def check_gr(node: Box, features: Box) -> None:
   Check device support for OSPF Graceful Restart when restart or helper mode is configured.
   """
   gr_af = features.get('ospf.gr', [])
-  if len(gr_af) == 2:                                 # Both IPv4 and IPv6 are supported -> ok
-    return
 
   for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
     if 'gr' not in o_data:
+      continue
+
+    for gr_action in ('restart','helper'):
+      if o_data.gr.get(gr_action,None) is True:
+        o_data.gr[gr_action] = get_box({ 'grace_period': 300 })
+
+    if len(gr_af) == 2:                               # Both IPv4 and IPv6 are supported -> ok
       continue
 
     vrf_info = f' in VRF {vrf}' if vrf else ''

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -7,7 +7,7 @@ import ipaddress
 from box import Box
 
 from ..augment import devices
-from ..data import append_to_list, get_box
+from ..data import append_to_list
 from ..utils import log
 from ..utils import routing as _ospf
 from . import _Module, _routing, bfd
@@ -148,10 +148,6 @@ def check_gr(node: Box, features: Box) -> None:
   for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
     if 'gr' not in o_data:
       continue
-
-    for gr_action in ('restart','helper'):
-      if o_data.gr.get(gr_action,None) is True:
-        o_data.gr[gr_action] = get_box({ 'grace_period': 300 })
 
     if len(gr_af) == 2:                               # Both IPv4 and IPv6 are supported -> ok
       continue

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -144,23 +144,18 @@ def check_gr(node: Box, features: Box) -> None:
   Check device support for OSPF Graceful Restart when restart or helper mode is configured.
   """
   gr_af = features.get('ospf.gr', [])
+  if len(gr_af) == 2:                                 # Both IPv4 and IPv6 are supported -> ok
+    return
 
   for (o_data,_,vrf) in _ospf.rp_data(node,'ospf'):
     if 'gr' not in o_data:
       continue
 
-    restart = o_data.gr.get('restart',False)
-    helper = o_data.gr.get('helper',False)
-    restart_configured = restart is True or 'restart.grace_period' in o_data.gr
-    helper_configured = helper is True or 'helper.grace_period' in o_data.gr
-    if not restart_configured and not helper_configured:
-      continue
-
     vrf_info = f' in VRF {vrf}' if vrf else ''
 
     for af in o_data.af:
-      if af not in gr_af:
-        log.error(
+      if af not in gr_af:                             # Technically it could be gr.restart: False
+        log.error(                                    # ... but we still call foul on that
           f'Device {node.device} does not support OSPF Graceful Restart for {af} (node {node.name}{vrf_info})',
           log.IncorrectValue,
           'ospf')

--- a/netsim/modules/ospf.py
+++ b/netsim/modules/ospf.py
@@ -150,7 +150,7 @@ def check_gr_support(node: Box, features: Box) -> None:
     for af in o_data.af:
       if af not in gr_af:
         log.error(
-          f'Device {node.device} does not support ospf.gr for {af}{vrf_info} on node {node.name}',
+          f'Device {node.device} does not support OSPF Graceful Restart for {af} (node {node.name}{vrf_info})',
           log.IncorrectValue,
           'ospf')
 

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -1,13 +1,6 @@
 # OSPFv2/OSPFv3 default settings and attributes
 #
 ---
-_top:
-  attributes:
-    ospf_gr_state:
-      type: str
-      valid_values: [ enable, disable, helper ]
-      _required: True
-
 area: 0.0.0.0
 transform_after: [ vlan, vrf ]
 config_after: [ vlan, dhcp, routing ]
@@ -49,7 +42,7 @@ attributes:
     gr:
       type: dict
       _keys:
-        state: ospf_gr_state
+        state: { type: str, valid_values: [ enable, disable, helper ], _required: True }
         grace_period: { type: int, min_value: 1, max_value: 1800 }
       _value_to_dict:
         state: '{value}'

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -40,15 +40,21 @@ attributes:
         type: { type: str, valid_values: [ e1, e2 ] }
     digest: { type: dict }
     gr:
-      _alt_types: [ bool ]
+      _remove_when_false: True
       _value_to_dict:
         restart: '{value}'
       restart:
-        _alt_types: [ bool ]
-        grace_period: { type: int, min_value: 1, max_value: 1800 }
+        type: dict
+        _keys:
+          grace_period: { type: int, min_value: 1, max_value: 1800 }
+        true_value: {}
+        _remove_when_false: True
       helper:
-        _alt_types: [ bool ]
-        grace_period: { type: int, min_value: 10, max_value: 1800 }
+        type: dict
+        _keys:
+          grace_period: { type: int, min_value: 10, max_value: 1800 }
+        true_value: {}
+        _remove_when_false: True
     import: _r_import
     passive:
     password: { copy: global }

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -1,6 +1,13 @@
 # OSPFv2/OSPFv3 default settings and attributes
 #
 ---
+_top:
+  attributes:
+    ospf_gr_state:
+      type: str
+      valid_values: [ enable, disable, helper ]
+      _required: True
+
 area: 0.0.0.0
 transform_after: [ vlan, vrf ]
 config_after: [ vlan, dhcp, routing ]
@@ -39,6 +46,13 @@ attributes:
         cost: int
         type: { type: str, valid_values: [ e1, e2 ] }
     digest: { type: dict }
+    gr:
+      type: dict
+      _keys:
+        state: ospf_gr_state
+        grace_period: { type: int, min_value: 1, max_value: 1800 }
+      _value_to_dict:
+        state: '{value}'
     import: _r_import
     passive:
     password: { copy: global }
@@ -51,7 +65,7 @@ attributes:
   node_copy: [ area, passive, digest, password, priority, timers ]
 
   vrf_aware: [ area ]
-  vrf_copy: [ area, router_id, reference_bandwidth ]
+  vrf_copy: [ area, router_id, reference_bandwidth, gr ]
   vrf:
     active: bool
     af: { copy: global }
@@ -59,6 +73,7 @@ attributes:
     import: _r_import
     default: { copy: node }
     digest: { copy: node }
+    gr: { copy: node }
     passive: bool
     password: { copy: global }
     router_id: { copy: node }
@@ -86,6 +101,7 @@ attributes:
 features:
   default: Originate external default route
   digest: MD5 authentication
+  gr: OSPF graceful restart (restarting router and helper)
   import: Import routes from other routing protocols
   password: Cleartext authentication
   priority: Router priority

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -40,12 +40,15 @@ attributes:
         type: { type: str, valid_values: [ e1, e2 ] }
     digest: { type: dict }
     gr:
-      type: dict
-      _keys:
-        state: { type: str, valid_values: [ enable, disable, helper ], _required: True }
-        grace_period: { type: int, min_value: 1, max_value: 1800 }
+      _alt_types: [ bool ]
       _value_to_dict:
-        state: '{value}'
+        restart: '{value}'
+      restart:
+        _alt_types: [ bool ]
+        grace_period: { type: int, min_value: 1, max_value: 1800 }
+      helper:
+        _alt_types: [ bool ]
+        grace_period: { type: int, min_value: 10, max_value: 1800 }
     import: _r_import
     passive:
     password: { copy: global }
@@ -94,7 +97,7 @@ attributes:
 features:
   default: Originate external default route
   digest: MD5 authentication
-  gr: OSPF graceful restart (restarting router and helper)
+  gr: OSPF graceful restart (restart and helper)
   import: Import routes from other routing protocols
   password: Cleartext authentication
   priority: Router priority

--- a/tests/integration/ospf/ospfv2/41-gr.yml
+++ b/tests/integration/ospf/ospfv2/41-gr.yml
@@ -10,50 +10,51 @@ groups:
   probes:
     device: frr
     provider: clab
-    members: [ x1 ]
+    members: [ xgr, xp ]
     module: [ ospf ]
 
 nodes:
   dut:
     ospf.gr:
       helper:
-        grace_period: 123
-  x1:
+        grace_period: 600
+  xgr:
     ospf.gr:
       restart:
         grace_period: 60
+  xp:
+
+ospf.timers:
+  hello: 1
+  dead: 3
 
 links:
-- dut:
-  x1:
-  # Keep the GR retention test short: route_during_gr waits past this dead timer.
-  ospf.timers:
-    hello: 1
-    dead: 3
+- dut-xgr
+- dut-xp
 
 validate:
   adj:
-    description: Check OSPF adjacency with X1
+    description: Check OSPF adjacency with DUT
     wait_msg: Waiting for OSPF adjacency process to complete
     wait: ospfv2_adj_p2p
-    nodes: [ x1 ]
+    nodes: [ xgr, xp ]
     plugin: ospf_neighbor(nodes.dut.ospf.router_id)
-  route_before:
-    description: Check X1 loopback route on DUT
+  xgr_present:
+    description: Check XGR loopback route on XP
     wait_msg: Waiting for SPF to complete
     wait: ospfv2_spf
-    nodes: [ dut ]
-    plugin: ospf_prefix(nodes.x1.loopback.ipv4)
+    nodes: [ xp ]
+    plugin: ospf_prefix(nodes.xgr.loopback.ipv4)
   gr_stop:
-    description: Start planned OSPF graceful restart on X1
-    nodes: [ x1 ]
+    description: Start planned OSPF graceful restart on XGR
+    nodes: [ xgr ]
     devices: [ frr ]
     exec: >-
       vtysh -c "graceful-restart prepare ip ospf" && kill -STOP $(pidof ospfd)
   wait_gr:
-    description: Wait for the graceful restart to start
-    wait: 5
-  route_during_gr:
-    description: Check X1 loopback route on DUT during graceful restart
-    nodes: [ dut ]
-    plugin: ospf_prefix(nodes.x1.loopback.ipv4)
+    description: Wait a long while to ensure SPF has been run
+    wait: ospfv2_spf_long
+  gr_helper:
+    description: Check XGR loopback during graceful restart
+    nodes: [ xp ]
+    plugin: ospf_prefix(nodes.xgr.loopback.ipv4)

--- a/tests/integration/ospf/ospfv2/41-gr.yml
+++ b/tests/integration/ospf/ospfv2/41-gr.yml
@@ -1,0 +1,50 @@
+---
+message: |
+  This lab tests OSPF graceful restart configuration. The device under test runs
+  OSPFv2 with graceful restart enabled; an FRR probe runs in helper mode.
+
+defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
+module: [ ospf ]
+
+groups:
+  probes:
+    device: frr
+    provider: clab
+    members: [ x1, x2 ]
+    module: [ ospf ]
+
+nodes:
+  dut:
+    ospf.gr:
+      state: enable
+      grace_period: 60
+  x1:
+  x2:
+    ospf.gr: helper
+
+links:
+- dut:
+  x1:
+- dut:
+  x2:
+
+validate:
+  adj_x1:
+    description: Check OSPF adjacency with X1
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: ospfv2_adj_p2p
+    nodes: [ x1 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+  adj_x2:
+    description: Check OSPF adjacency with X2
+    wait_msg: Waiting for OSPF adjacency process to complete
+    wait: ospfv2_adj_p2p
+    nodes: [ x2 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+  gr_helper:
+    description: Check OSPF GR helper configuration on probe
+    nodes: [ x2 ]
+    show:
+      frr: ip ospf graceful-restart helper json
+    valid:
+      frr: result.helperSupport == "Enabled"

--- a/tests/integration/ospf/ospfv2/41-gr.yml
+++ b/tests/integration/ospf/ospfv2/41-gr.yml
@@ -58,3 +58,9 @@ validate:
     description: Check XGR loopback during graceful restart
     nodes: [ xp ]
     plugin: ospf_prefix(nodes.xgr.loopback.ipv4)
+  gr_resume:
+    description: Resume OSPF on XGR
+    nodes: [ xgr ]
+    devices: [ frr ]
+    exec: kill -CONT $(pidof ospfd) || true
+    pass: OSPF daemon resumed on XGR

--- a/tests/integration/ospf/ospfv2/README.md
+++ b/tests/integration/ospf/ospfv2/README.md
@@ -16,7 +16,7 @@ You can run the following tests:
 * `03-cost.yml` -- Tests interface costs
 * `04-passive.yml` -- Tests passive and stub OSPF interfaces
 * `05-unnumbered.yml` -- Tests OSPF on unnumbered IPv4 interfaces.
-* `41-gr.yml` -- Tests OSPF graceful restart (restarting router and helper mode)
+* `41-gr.yml` -- Tests OSPF graceful restart helper route retention
 
 Each test includes a validation suite that can be run with the `netlab validate` command.
 

--- a/tests/integration/ospf/ospfv2/README.md
+++ b/tests/integration/ospf/ospfv2/README.md
@@ -16,6 +16,7 @@ You can run the following tests:
 * `03-cost.yml` -- Tests interface costs
 * `04-passive.yml` -- Tests passive and stub OSPF interfaces
 * `05-unnumbered.yml` -- Tests OSPF on unnumbered IPv4 interfaces.
+* `41-gr.yml` -- Tests OSPF graceful restart (restarting router and helper mode)
 
 Each test includes a validation suite that can be run with the `netlab validate` command.
 

--- a/tests/integration/ospf/ospfv3/41-gr.yml
+++ b/tests/integration/ospf/ospfv3/41-gr.yml
@@ -1,7 +1,7 @@
 ---
 message: |
-  This lab tests OSPFv3 graceful restart helper behavior. The device under test
-  should retain the FRR probe loopback route during a planned OSPFv3 restart.
+  This lab tests OSPF graceful restart helper behavior. The device under test
+  should retain the FRR probe loopback route during a planned OSPF restart.
 
 defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
 module: [ ospf ]
@@ -10,50 +10,51 @@ groups:
   probes:
     device: frr
     provider: clab
-    members: [ x1 ]
+    members: [ xgr, xp ]
     module: [ ospf ]
 
 nodes:
   dut:
     ospf.gr:
       helper:
-        grace_period: 123
-  x1:
+        grace_period: 600
+  xgr:
     ospf.gr:
       restart:
         grace_period: 60
+  xp:
+
+ospf.timers:
+  hello: 1
+  dead: 3
 
 links:
-- dut:
-  x1:
-  # Keep the GR retention test short: route_during_gr waits past this dead timer.
-  ospf.timers:
-    hello: 1
-    dead: 3
+- dut-xgr
+- dut-xp
 
 validate:
   adj:
-    description: Check OSPFv3 adjacency with X1
+    description: Check OSPF adjacency with DUT
     wait_msg: Waiting for OSPFv3 adjacency process to complete
     wait: ospfv3_adj_p2p
-    nodes: [ x1 ]
+    nodes: [ xgr, xp ]
     plugin: ospf6_neighbor(nodes.dut.ospf.router_id)
-  route_before:
-    description: Check X1 loopback route on DUT
+  xgr_present:
+    description: Check XGR loopback route on XP
     wait_msg: Waiting for SPF to complete
     wait: ospfv3_spf
-    nodes: [ dut ]
-    plugin: ospf6_prefix(nodes.x1.loopback.ipv6)
+    nodes: [ xp ]
+    plugin: ospf6_prefix(nodes.xgr.loopback.ipv6)
   gr_stop:
-    description: Start planned OSPFv3 graceful restart on X1
-    nodes: [ x1 ]
+    description: Start planned OSPFv3 graceful restart on XGR
+    nodes: [ xgr ]
     devices: [ frr ]
     exec: >-
       vtysh -c "graceful-restart prepare ipv6 ospf" && kill -STOP $(pidof ospf6d)
   wait_gr:
-    description: Wait for the graceful restart to start
-    wait: 5
-  route_during_gr:
-    description: Check X1 loopback route on DUT during graceful restart
-    nodes: [ dut ]
-    plugin: ospf6_prefix(nodes.x1.loopback.ipv6)
+    description: Wait a long while to ensure SPF has been run
+    wait: ospfv3_spf_long
+  gr_helper:
+    description: Check XGR loopback during graceful restart
+    nodes: [ xp ]
+    plugin: ospf6_prefix(nodes.xgr.loopback.ipv6)

--- a/tests/integration/ospf/ospfv3/41-gr.yml
+++ b/tests/integration/ospf/ospfv3/41-gr.yml
@@ -1,7 +1,7 @@
 ---
 message: |
-  This lab tests OSPF graceful restart helper behavior. The device under test
-  should retain the FRR probe loopback route during a planned OSPF restart.
+  This lab tests OSPFv3 graceful restart helper behavior. The device under test
+  should retain the FRR probe loopback route during a planned OSPFv3 restart.
 
 defaults.sources.extra: [ ../../wait_times.yml, ../../warnings.yml ]
 module: [ ospf ]
@@ -33,27 +33,27 @@ links:
 
 validate:
   adj:
-    description: Check OSPF adjacency with X1
-    wait_msg: Waiting for OSPF adjacency process to complete
-    wait: ospfv2_adj_p2p
+    description: Check OSPFv3 adjacency with X1
+    wait_msg: Waiting for OSPFv3 adjacency process to complete
+    wait: ospfv3_adj_p2p
     nodes: [ x1 ]
-    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+    plugin: ospf6_neighbor(nodes.dut.ospf.router_id)
   route_before:
     description: Check X1 loopback route on DUT
     wait_msg: Waiting for SPF to complete
-    wait: ospfv2_spf
+    wait: ospfv3_spf
     nodes: [ dut ]
-    plugin: ospf_prefix(nodes.x1.loopback.ipv4)
+    plugin: ospf6_prefix(nodes.x1.loopback.ipv6)
   gr_stop:
-    description: Start planned OSPF graceful restart on X1
+    description: Start planned OSPFv3 graceful restart on X1
     nodes: [ x1 ]
     devices: [ frr ]
     exec: >-
-      vtysh -c "graceful-restart prepare ip ospf" && kill -STOP $(pidof ospfd)
+      vtysh -c "graceful-restart prepare ipv6 ospf" && kill -STOP $(pidof ospf6d)
   wait_gr:
     description: Wait for the graceful restart to start
     wait: 5
   route_during_gr:
     description: Check X1 loopback route on DUT during graceful restart
     nodes: [ dut ]
-    plugin: ospf_prefix(nodes.x1.loopback.ipv4)
+    plugin: ospf6_prefix(nodes.x1.loopback.ipv6)

--- a/tests/integration/ospf/ospfv3/41-gr.yml
+++ b/tests/integration/ospf/ospfv3/41-gr.yml
@@ -58,3 +58,9 @@ validate:
     description: Check XGR loopback during graceful restart
     nodes: [ xp ]
     plugin: ospf6_prefix(nodes.xgr.loopback.ipv6)
+  gr_resume:
+    description: Resume OSPFv3 on XGR
+    nodes: [ xgr ]
+    devices: [ frr ]
+    exec: kill -CONT $(pidof ospf6d) || true
+    pass: OSPFv3 daemon resumed on XGR

--- a/tests/integration/ospf/ospfv3/README.md
+++ b/tests/integration/ospf/ospfv3/README.md
@@ -16,6 +16,7 @@ You can run the following tests:
 * `03-cost.yml` -- Tests OSPFv3 interface costs
 * `04-passive.yml` -- Tests passive and stub OSPFv3 interfaces
 * `05-unnumbered.yml` -- Tests OSPFv3 on IPv6 LLA interfaces.
+* `41-gr.yml` -- Tests OSPFv3 graceful restart helper route retention
 
 Each test includes a validation suite that can be run with the `netlab validate` command.
 


### PR DESCRIPTION
## Summary - a minimal proposal to add GR support for OSPF as part of ospf module

- Add `ospf.gr` to the OSPF module with `state` (`enable`, `disable`, `helper`) and optional `grace_period` (BGP-style string shorthand supported)
- Render FRR OSPF/VRF graceful restart configuration
- Add OSPFv2 integration test `41-gr.yml` and minimal documentation
- updated AGENTS.md based on feedback, hoping to improve future PRs

Addresses https://github.com/ipspace/netlab/discussions/3488

## Test plan

- [x] `netlab up tests/integration/ospf/ospfv2/41-gr.yml` with `NETLAB_DEVICE=frr NETLAB_PROVIDER=clab`
- [x] `netlab validate` — adjacency and helper GR checks on FRR probes


Made with [Cursor](https://cursor.com)