### PR TITLE
Add BFD support for RouterOS7

### DIFF
--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -18,7 +18,7 @@ BFD is supported on these platforms:
 | Dell OS10             | ✅  | ✅  |  ❌  |
 | Junos[^Junos]         | ✅[❗](caveats-junos) | ✅  | ✅  |
 | Mikrotik RouterOS 6   |  ❌  | ✅  | ✅  |
-| Mikrotik RouterOS 7   |  ❌  |  ❌  |  ❌  |
+| Mikrotik RouterOS 7   | ✅  | ✅  |  ❌  |
 | Nokia SR Linux        | ✅  | ✅  | ✅  |
 | Nokia SR OS[^SROS]    | ✅  | ✅  | ✅  |
 | VyOS                  | ✅[❗](caveats-vyos) | ✅  | ✅  |

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -99,6 +99,7 @@ The following devices support BFD with OSPF:
 | Dell OS10                |  ✅  |  ❌   |
 | Junos[^Junos]            |  ✅  |  ❌   |
 | Mikrotik RouterOS 6      |  ✅  |  ❌   |
+| Mikrotik RouterOS 7      |  ✅  |  ❌   |
 | Nokia SR Linux           |  ✅  |  ❌   |
 | Nokia SR OS[^SROS]       |  ✅  |  ✅  |
 | VyOS                     |  ✅  |  ❌   |

--- a/netsim/ansible/templates/bfd/routeros7.j2
+++ b/netsim/ansible/templates/bfd/routeros7.j2
@@ -1,0 +1,23 @@
+{% for l in interfaces|default([]) if bfd|default(False) or l.bfd|default(False) %}
+{%   set disable_bfd = l.bfd is defined and not l.bfd %}
+{%   if not disable_bfd %}
+/routing/bfd/configuration add interfaces={{ l.ifname }} min-tx {{ 
+   link_bfd.min_tx|default(bfd.min_tx)|default(500) }}ms min-rx {{ 
+   link_bfd.min_rx|default(bfd.min_rx)|default(500) }}ms multiplier {{
+   link_bfd.multiplier|default(bfd.multiplier)|default(3)
+   }}
+{%   else %}
+ /routing/bfd/configuration add interfaces={{ l.ifname }} forbid-bfd=true
+{%   endif %}
+{% endfor %}
+
+{#
+To be able to filter multi-hop sessions, addresses or address-list properties can be used to match the destination, as well as the appropriate VRF, if
+a session is not running in the "main" VRF.
+/ip firewall address-list
+add address=10.155.255.183 list=bgp_allow_bfd
+add address=10.155.255.217 list=bgp_allow_bfd
+/routing bfd configuration
+add addresses=111.111.0.0/16 vrf=vrf1
+add address-list=bgp_allow_bfd
+#}

--- a/netsim/ansible/templates/bfd/routeros7.j2
+++ b/netsim/ansible/templates/bfd/routeros7.j2
@@ -1,10 +1,10 @@
 {% for l in interfaces|default([]) if bfd|default(False) or l.bfd|default(False) %}
 {%   set disable_bfd = l.bfd is defined and not l.bfd %}
 {%   if not disable_bfd %}
-/routing/bfd/configuration add interfaces={{ l.ifname }} min-tx {{ 
-   link_bfd.min_tx|default(bfd.min_tx)|default(500) }}ms min-rx {{ 
-   link_bfd.min_rx|default(bfd.min_rx)|default(500) }}ms multiplier {{
-   link_bfd.multiplier|default(bfd.multiplier)|default(3)
+/routing/bfd/configuration add interfaces={{ l.ifname }} min-tx={{
+   l.bfd.min_tx|default(bfd.min_tx)|default(500) }}ms min-rx={{
+   l.bfd.min_rx|default(bfd.min_rx)|default(500) }}ms multiplier={{
+   l.bfd.multiplier|default(bfd.multiplier)|default(3)
    }}
 {%   else %}
  /routing/bfd/configuration add interfaces={{ l.ifname }} forbid-bfd=true

--- a/netsim/ansible/templates/ospf/routeros7.ospf-include.j2
+++ b/netsim/ansible/templates/ospf/routeros7.ospf-include.j2
@@ -1,5 +1,4 @@
 {% set KW_NETWORK_TYPE = {'point-to-point': 'ptp','point-to-multipoint': 'ptmp', 'non-broadcast': 'nbma','broadcast': 'broadcast' } %}
-
 {% set area = (ospf.area|default("0.0.0.0"))|string|ansible.utils.ipaddr('address') %}
 
 {% if ospf_router_id is defined %}
@@ -15,31 +14,22 @@
 {% endfor %}
 
 {% for l in ospf_interfaces|default([]) if 'ospf' in l and ospf_afi_check in l %}
-
 {%   if "external" in l.role|default("") %}
 ## OSPF not configured on external interface {{ l.ifname }}
 {%   else %}
-
 {%     set ospf_intf_params=[] %}
-
 {%     if l.ospf.passive|default(False) %}
 {%       set _ = ospf_intf_params.append('passive') %}
 {%     endif %}
-
 {%     if l.ospf.network_type is defined %}
 {%       set _ = ospf_intf_params.append('type='+KW_NETWORK_TYPE[l.ospf.network_type]) %}
 {%     endif %}
-
 {%     if l.ospf.cost is defined %}
 {%       set _ = ospf_intf_params.append('cost='+l.ospf.cost|string) %}
 {%     endif %}
-
 {%     if l.ospf.bfd|default(False) %}
-## BFD Currently not supported in ROS7 for OSPF
+{%       set _ = ospf_intf_params.append('use-bfd=yes') %}
 {%     endif %}
-
 /routing/ospf/interface-template add area=[/routing ospf area find area-id={{ l.ospf.area }} and instance={{instance}}] interface={{ l.ifname }} {{ ospf_intf_params|join(' ') }}
-
 {%   endif %}
-
 {% endfor %}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -33,6 +33,7 @@ features:
     ldp: true
     vpn: true
   ospf: true
+  bfd: true
   vlan:
     model: l3-switch
     svi_interface_name: "vlan{vlan}"


### PR DESCRIPTION
I saw that BFD work had mostly been done for RouterOS7 

This adds the OSPF v2/v3 support.

Will not be much extra to add for BGP if requested.

To do multihop BFD will need a little bit more effort though.

Was tested with the `bfd.yml` in the `ospfv2` and `ospfv3`

This work would follow the 7.18 to 7.21.4