### PR TITLE
Fix: VXLAN integration tests run only with 'role: router'

### DIFF
--- a/tests/integration/vxlan/01-vxlan-bridging.yml
+++ b/tests/integration/vxlan/01-vxlan-bridging.yml
@@ -23,6 +23,7 @@ groups:
   switches:
     members: [ dut, s2 ]
     module: [ vlan, vxlan, ospf ]
+    role: router
   probes:
     members: [ s2 ]
     device: frr

--- a/tests/integration/vxlan/02-vxlan-bridging-multinode.yml
+++ b/tests/integration/vxlan/02-vxlan-bridging-multinode.yml
@@ -22,6 +22,7 @@ groups:
   switches:
     members: [ s1, s2, s3 ]
     module: [ vlan, vxlan, ospf ]
+    role: router
   probes:
     members: [ s3 ]
     device: frr

--- a/tests/integration/vxlan/03-vxlan-irb.yml
+++ b/tests/integration/vxlan/03-vxlan-irb.yml
@@ -21,6 +21,7 @@ groups:
   switches:
     members: [ dut, s2 ]
     module: [ vlan, vxlan, ospf ]
+    role: router
   probes:
     members: [ s2 ]
     device: frr

--- a/tests/integration/vxlan/04-vxlan-irb-ospf.yml
+++ b/tests/integration/vxlan/04-vxlan-irb-ospf.yml
@@ -26,6 +26,7 @@ groups:
   switches:
     members: [ dut, s2 ]
     module: [ vlan, vxlan, vrf, ospf ]
+    role: router
   probes:
     members: [ s2 ]
     device: frr

--- a/tests/integration/vxlan/05-vxlan-router-stick.yml
+++ b/tests/integration/vxlan/05-vxlan-router-stick.yml
@@ -54,14 +54,14 @@ validate:
     wait_msg: Waiting for OSPF adjacency process to complete
     wait: ospfv2_adj_p2p
     nodes: [ l2sw ]
-    plugin: ospf_neighbor(nodes.ros.ospf.router_id)
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
     stop_on_error: True
   ping_gw:
     description: Host-to-router ping-based reachability tests
     wait_msg: Waiting for OSPF to do its magic
     wait: vxlan_ping
     nodes: [ h1, h2 ]
-    plugin: ping(nodes.ros.vrfs.tenant.loopback_address.ipv4)
+    plugin: ping(nodes.dut.vrfs.tenant.loopback_address.ipv4)
   ping_e2e:
     description: Host-to-host ping-based reachability tests
     wait_msg: We might have to wait a bit longer

--- a/tests/integration/vxlan/05-vxlan-router-stick.yml
+++ b/tests/integration/vxlan/05-vxlan-router-stick.yml
@@ -18,11 +18,11 @@ groups:
 vlans:
   red:
     vrf: tenant
-    links: [ s1-h1 ]
+    links: [ l2sw-h1 ]
     vni: 5000
   blue:
     vrf: tenant
-    links: [ s1-h2 ]
+    links: [ l2sw-h2 ]
     vni: 5001
 
 vrfs:
@@ -31,20 +31,21 @@ vrfs:
     ospf: False
 
 nodes:
-  s1:
+  dut:
+    module: [ vlan, vxlan, ospf, vrf ]
+    role: router
+    vlans:                                      # Bring VLANs to ROS (until we agree on a better solution)
+      red:
+      blue:
+  l2sw:
     module: [ vlan, vxlan, ospf ]
     vlan.mode: bridge
     device: frr
     provider: clab
-  ros:
-    module: [ vlan, vxlan, ospf, vrf ]
-    vlans:                                      # Bring VLANs to ROS (until we agree on a better solution)
-      red:
-      blue:
 
 links:
-- s1:
-  ros:
+- dut:
+  l2sw:
   mtu: 1600
 
 validate:
@@ -52,7 +53,7 @@ validate:
     description: Check OSPF adjacencies
     wait_msg: Waiting for OSPF adjacency process to complete
     wait: ospfv2_adj_p2p
-    nodes: [ s1 ]
+    nodes: [ l2sw ]
     plugin: ospf_neighbor(nodes.ros.ospf.router_id)
     stop_on_error: True
   ping_gw:
@@ -70,10 +71,10 @@ validate:
 
 _fixup:
   arubacx:
-    nodes.s1.device: eos
+    nodes.l2sw.device: eos
     validate.warning:
       wait: 0
       level: warning
       fail: VXLAN-encapsulated ARP packets sent by Aruba CX have invalid IP packet length
     _delete:
-      nodes.s1.provider:
+      nodes.l2sw.provider:

--- a/tests/integration/vxlan/07-vxlan-bridging-v6only.yml
+++ b/tests/integration/vxlan/07-vxlan-bridging-v6only.yml
@@ -23,6 +23,7 @@ groups:
   switches:
     members: [ dut, s2 ]
     module: [ vlan, vxlan, ospf ]
+    role: router
   probes:
     members: [ s2 ]
     device: frr

--- a/tests/integration/vxlan/08-vxlan-alt-vtep.yml
+++ b/tests/integration/vxlan/08-vxlan-alt-vtep.yml
@@ -21,6 +21,7 @@ groups:
   switches:
     members: [ dut, s2 ]
     module: [ vlan, vxlan, ospf ]
+    role: router
   probes:
     members: [ s2 ]
     device: frr


### PR DESCRIPTION
VXLAN needs the system loopback interface, and the easiest way to get it is to set the device role to 'router'

Also: renamed s1/ros in router-on-stick test to 'l2sw' and 'dut' to match the common 'device under test' name