### PR TITLE
Fix: Unify bird Dockerfiles and logging

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -89,6 +89,7 @@ nodes:
 * _netlab_ installs BIRD software in a container image running Ubuntu 24.04 when you use the default **netlab clab build bird** target (~2.14). Other build targets install different BIRD releases — see [](build-bird).
 * BIRD supports a single router ID used for BGP and OSPF.
 * The VM or container running BIRD in host mode starts with static routes pointing to one of the adjacent routers (see [](linux-forwarding)). After establishing routing adjacencies, BIRD copies BGP and OSPF into the kernel IP routing table.
+* The **bird** container starts BIRD in foreground mode with logging messages (including debugging messages) sent to *stderr*. Use the **docker logs** command to inspect the BIRD messages.
 
 ### OSPF Caveats
 

--- a/netsim/daemons/bird/Dockerfile
+++ b/netsim/daemons/bird/Dockerfile
@@ -8,4 +8,4 @@ RUN mkdir /etc/bird && mkdir /run/bird && apt-get update && apt-get install -y i
 
 WORKDIR /root
 
-CMD [ "bird", "-c", "/etc/bird/bird.conf", "-d" ]
+CMD ["/usr/sbin/bird", "-d", "-c", "/etc/bird/bird.conf"]

--- a/netsim/daemons/bird/Dockerfile.v2_from_src.j2
+++ b/netsim/daemons/bird/Dockerfile.v2_from_src.j2
@@ -50,6 +50,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y \
     libreadline8 \
     libssh-4 \
+    iputils-ping net-tools iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy binaries and built directories from the builder stage
@@ -61,4 +62,4 @@ COPY --from=builder /etc/bird /etc/bird
 RUN mkdir -p /var/run
 
 # Run BIRD in the foreground with the default config path
-CMD ["/usr/sbin/bird", "-f", "-c", "/etc/bird/bird.conf"]
+CMD ["/usr/sbin/bird", "-d", "-c", "/etc/bird/bird.conf"]

--- a/netsim/daemons/bird/Dockerfile.v3
+++ b/netsim/daemons/bird/Dockerfile.v3
@@ -16,4 +16,4 @@ RUN apt-get update && apt-get install -y bird3
 
 WORKDIR /root
 
-CMD [ "bird", "-c", "/etc/bird/bird.conf", "-d" ]
+CMD ["/usr/sbin/bird", "-d", "-c", "/etc/bird/bird.conf"]

--- a/netsim/daemons/bird/bird.j2
+++ b/netsim/daemons/bird/bird.j2
@@ -1,5 +1,5 @@
 {% set module = module|default([]) %}
-log "/var/log/bird" all;
+log stderr all;
 
 {% include 'protocols.j2' %}
 


### PR DESCRIPTION
* Use the same command to start BIRD in all Dockerfiles
* Install the same tools into all BIRD containers
* Enable STDOUT/STDERR logging on BIRD daemon