### PR TITLE
Fix: Check returned STDERR and STDOUT in validation tests

### DIFF
--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -8,7 +8,7 @@ import sys
 import typing
 from enum import IntEnum
 
-from .external_commands import run_command
+from .external_commands import get_combined_output, run_command
 
 
 class LogLevel(IntEnum):
@@ -131,7 +131,11 @@ def ssh_connect(
 
   sys.stderr.flush()
   need_output = 'output' in p_args and p_args.output
-  return run_command(c_args,check_result=need_output,return_stdout=need_output,ignore_errors=True)
+  status = run_command(c_args,check_result=need_output,return_stdout=need_output,ignore_errors=True)
+  if not need_output:
+    return status
+  else:
+    return get_combined_output()
 
 def quote_list(args: list) -> list:
   return [ f'"{arg}"' if " " in arg else arg for arg in args ]

--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -132,10 +132,9 @@ def ssh_connect(
   sys.stderr.flush()
   need_output = 'output' in p_args and p_args.output
   status = run_command(c_args,check_result=need_output,return_stdout=need_output,ignore_errors=True)
-  if not need_output:
+  if not need_output or status is False:
     return status
-  else:
-    return get_combined_output()
+  return get_combined_output()
 
 def quote_list(args: list) -> list:
   return [ f'"{arg}"' if " " in arg else arg for arg in args ]

--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -77,6 +77,11 @@ def log_command(cmd: typing.Union[str,list], status: str) -> None:
 CAPTURED_STDOUT: str = ''
 CAPTURED_STDERR: str = ''
 
+def get_combined_output() -> str:
+  global CAPTURED_STDOUT, CAPTURED_STDERR
+  stderr = CAPTURED_STDERR.strip() + "\n" if CAPTURED_STDERR else ""
+  return stderr + CAPTURED_STDOUT
+
 def run_command(
     cmd : typing.Union[str,list],
     check_result : bool = False,


### PR DESCRIPTION
Some versions of Arista EOS return error messages on stderr. SSH client sends those messages to (local) stderr, and the validation code did not get them. This fix combines stderr and stdout returned by SSH (or docker exec) into a single string that can be checked by the validation code.

Fixes #3496