### PR TITLE
Fix: Tested device in VRF integration tests must be a router

### DIFF
--- a/tests/integration/vrf/01-multi-vrf.yml
+++ b/tests/integration/vrf/01-multi-vrf.yml
@@ -16,14 +16,14 @@ groups:
     device: linux
     provider: clab
   routers:
-    members: [ rtr ]
+    members: [ dut ]
     module: [ vrf ]
 
 vrfs:
   red:
-    links: [ rtr-h1, rtr-h3 ]
+    links: [ dut-h1, dut-h3 ]
   blue:
-    links: [ rtr-h2, rtr-h4 ]
+    links: [ dut-h2, dut-h4 ]
 
 validate:
   red:

--- a/tests/integration/vrf/02-multi-vrf-ipv6.yml
+++ b/tests/integration/vrf/02-multi-vrf-ipv6.yml
@@ -16,14 +16,14 @@ groups:
     device: linux
     provider: clab
   routers:
-    members: [ rtr ]
+    members: [ dut ]
     module: [ vrf ]
 
 vrfs:
   red:
-    links: [ rtr-h1, rtr-h3 ]
+    links: [ dut-h1, dut-h3 ]
   blue:
-    links: [ rtr-h2, rtr-h4 ]
+    links: [ dut-h2, dut-h4 ]
 
 validate:
   ra:

--- a/tests/integration/vrf/topology-defaults.yml
+++ b/tests/integration/vrf/topology-defaults.yml
@@ -1,0 +1,4 @@
+groups:
+  tested:
+    members: [ dut ]
+    role: router


### PR DESCRIPTION
Also: rename 'rtr' to 'dut' in initial VRF tests for consistency

Closes #3506