### PR TITLE
Support per-module DP script + CP config for daemons

### DIFF
--- a/netsim/ansible/templates/vrf/bird.j2
+++ b/netsim/ansible/templates/vrf/bird.j2
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+set -e
+#
+# Placeholder: VRF data-plane configuration for BIRD
+#
+touch /var/run/vrf.done

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -31,7 +31,9 @@ clab:
     initial:
       roles: [ host, router ]
       config_mode: [ sh ]
-      dataplane_config: [ vxlan ]
+      dataplane_config: [ vxlan, vrf ]
+      extra_daemon_config:
+        vrf: /etc/bird/vrf.mod.conf
 libvirt:                        # Not yet available on libvirt or virtualbox
   image:
 virtualbox:
@@ -81,3 +83,4 @@ features:
     roles: [ host, router ]
   vxlan:
     vtep6: true
+  vrf: {}                           # Placeholder, has to be replaced with the real VRF code

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -83,4 +83,4 @@ features:
     roles: [ host, router ]
   vxlan:
     vtep6: true
-  vrf: {}                           # Placeholder, has to be replaced with the real VRF code
+#  vrf: {}                           # Placeholder, has to be replaced with the real VRF code

--- a/netsim/daemons/bird/vrf-daemon.j2
+++ b/netsim/daemons/bird/vrf-daemon.j2
@@ -1,0 +1,3 @@
+#
+# Placeholder: BIRD daemon config for VRFs
+#

--- a/netsim/devices/_common.py
+++ b/netsim/devices/_common.py
@@ -34,6 +34,10 @@ def check_daemon_dataplane_config(node: Box, topology: Box) -> None:
   If such a module is found, the function puts plumbing in place to ensure the control-plane
   daemon is started only when the dataplane configuration is finished. It is assumed that
   the '/etc/dataplane-wait.sh' script is available on the device.
+
+  Some modules require a data-plane and control-plane (daemon) config. The 'extra_daemon_config'
+  feature must he set for such modules to generate extra entries in _daemon_config (for inclusion
+  into daemon configuration) and config_templates (to generate the config files).
   """
   features = a_devices.get_device_features(node,topology.defaults)    # Get device features
   dp_config = features.initial.get('dataplane_config',[])             # Do we have to take care of dataplane configs?
@@ -50,3 +54,10 @@ def check_daemon_dataplane_config(node: Box, topology: Box) -> None:
     node=node,
     quirk='dataplane_config',
     info=True)
+
+  cp_config = features.initial.get('extra_daemon_config',{})          # Finally, check whether we need extra daemon config files
+  for k,v in cp_config.items():
+    if k not in dp_module:                                            # Skip irrelevant modules
+      continue
+    node._daemon_config[k+'-daemon'] = v                              # This will include the config file into daemon config
+    n_clab.config_templates[k+'-daemon'] = v                          # ... and generate the config file from -daemon template

--- a/netsim/devices/_common.py
+++ b/netsim/devices/_common.py
@@ -36,7 +36,7 @@ def check_daemon_dataplane_config(node: Box, topology: Box) -> None:
   the '/etc/dataplane-wait.sh' script is available on the device.
 
   Some modules require a data-plane and control-plane (daemon) config. The 'extra_daemon_config'
-  feature must he set for such modules to generate extra entries in _daemon_config (for inclusion
+  feature must be set for such modules to generate extra entries in _daemon_config (for inclusion
   into daemon configuration) and config_templates (to generate the config files).
   """
   features = a_devices.get_device_features(node,topology.defaults)    # Get device features


### PR DESCRIPTION
Some modules (VRF, EVPN) require data-plane scripts to configure new interfaces or routing tables and control-plane (daemon) configuration

This commit adds that functionality demonstrated with placeholder files for BIRD VRF support.

A module with DP/CP configuration should be listed in:

* features.initial.dataplane_config list (to ensure the data plane config is done before the daemon is started)
* features.extra_daemon_config dictionary to create an extra config entry/bind

The data-plane configuration template MUST be in the module directory of ansible/templates tree (named _device_.j2); the control-plane template MUST be in daemons/_device_ directory named _mod_-daemon.j2.