### PR TITLE
Fix: Install procps in BIRD containers

### DIFF
--- a/netsim/daemons/bird/Dockerfile.j2
+++ b/netsim/daemons/bird/Dockerfile.j2
@@ -1,6 +1,6 @@
 {%- set _sw_version = sw_version|default("v3") -%}
 {%- set _base_image = "debian:trixie-slim" -%}
-{%- set _runtime_tools = "iputils-ping net-tools iproute2" -%}
+{%- set _runtime_tools = "iputils-ping net-tools iproute2 procps" -%}
 {%- set _is_bird2 = _sw_version == "v2" -%}
 {%- set _is_bird3 = _sw_version == "v3" -%}
 {%- set _from_source = not (_is_bird2 or _is_bird3) -%}


### PR DESCRIPTION
When using anycast gateway on bird, the scripts use ```sysctl```

This is one way to fix, another option might be to use ns provisioning