### PR TITLE
Fix: Reduce BIRD inter-VRF route leaking pipes

### DIFF
--- a/netsim/daemons/bird/vrf-daemon.j2
+++ b/netsim/daemons/bird/vrf-daemon.j2
@@ -122,18 +122,21 @@ protocol static static_vrf_leak_{{ vname }}_{{ dst_name }}_{{ sr_af }} {
 {# Route leaking between VRF tables based on transformed import/export route targets #}
 {% for src_name,src_data in vrfs|default({})|dictsort %}
 {%   for dst_name,dst_data in vrfs|default({})|dictsort if dst_name != src_name %}
-{%     for rt in dst_data.import|default([]) if rt in src_data.export|default([]) %}
-{%       if loop.first %}
-{%         for _af in src_data.af if _af in dst_data.af %}
+{%     set import_rt = dst_data.import|default([])|select('in',src_data.export|default([]))|list %}
+{%     if import_rt %}
+{%       set bird_import_rt = import_rt|map('replace',':',', ')|join('), (rt, ') %}
+{%       for _af in src_data.af if _af in dst_data.af %}
 
 protocol pipe pipe_vrf_{{ src_name }}_{{ dst_name }}_{{ _af }} {
   table {{ vrf_table(dst_name,_af) }};
   peer table {{ vrf_table(src_name,_af) }};
-  import all;
+  import filter {
+    if netlab_vrf_rt ~ [ (rt, {{ bird_import_rt }}) ] then accept;
+    reject;
+  };
   export none;
 }
-{%         endfor %}
-{%       endif %}
-{%     endfor %}
+{%       endfor %}
+{%     endif %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/daemons/bird/vrf-daemon.j2
+++ b/netsim/daemons/bird/vrf-daemon.j2
@@ -130,6 +130,9 @@ filter netlab_vrf_{{ vname }}_import {
 {% endfor %}
 {% for src_name,src_data in vrfs|default({})|dictsort %}
 {%   for dst_name,dst_data in vrfs|default({})|dictsort if src_data.vrfidx < dst_data.vrfidx %}
+{%     set src_to_dst = src_data.export|default([])|select('in',dst_data.import|default([]))|list %}
+{%     set dst_to_src = dst_data.export|default([])|select('in',src_data.import|default([]))|list %}
+{%     if src_to_dst or dst_to_src %}
 {%       for _af in ['ipv4','ipv6'] if _af in src_data.af and _af in dst_data.af %}
 
 protocol pipe pipe_vrf_{{ src_name }}_{{ dst_name }}_{{ _af }} {
@@ -139,5 +142,6 @@ protocol pipe pipe_vrf_{{ src_name }}_{{ dst_name }}_{{ _af }} {
   export filter netlab_vrf_{{ dst_name }}_import;
 }
 {%       endfor %}
+{%     endif %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/daemons/bird/vrf-daemon.j2
+++ b/netsim/daemons/bird/vrf-daemon.j2
@@ -120,28 +120,20 @@ protocol static static_vrf_leak_{{ vname }}_{{ dst_name }}_{{ sr_af }} {
 {% endfor %}
 
 {# Route leaking between VRF tables based on transformed import/export route targets #}
-{% for vname,vdata in vrfs|default({})|dictsort %}
-filter netlab_vrf_{{ vname }}_import {
-{%   if vdata.import|default([]) %}
-  if netlab_vrf_rt ~ [ {% for rt in vdata.import %}{{ rt_value(rt) }}{% if not loop.last %}, {% endif %}{% endfor %} ] then accept;
-{%   endif %}
-  reject;
-}
-{% endfor %}
 {% for src_name,src_data in vrfs|default({})|dictsort %}
-{%   for dst_name,dst_data in vrfs|default({})|dictsort if src_data.vrfidx < dst_data.vrfidx %}
-{%     set src_to_dst = src_data.export|default([])|select('in',dst_data.import|default([]))|list %}
-{%     set dst_to_src = dst_data.export|default([])|select('in',src_data.import|default([]))|list %}
-{%     if src_to_dst or dst_to_src %}
-{%       for _af in ['ipv4','ipv6'] if _af in src_data.af and _af in dst_data.af %}
+{%   for dst_name,dst_data in vrfs|default({})|dictsort if dst_name != src_name %}
+{%     for rt in dst_data.import|default([]) if rt in src_data.export|default([]) %}
+{%       if loop.first %}
+{%         for _af in src_data.af if _af in dst_data.af %}
 
 protocol pipe pipe_vrf_{{ src_name }}_{{ dst_name }}_{{ _af }} {
-  table {{ vrf_table(src_name,_af) }};
-  peer table {{ vrf_table(dst_name,_af) }};
-  import filter netlab_vrf_{{ src_name }}_import;
-  export filter netlab_vrf_{{ dst_name }}_import;
+  table {{ vrf_table(dst_name,_af) }};
+  peer table {{ vrf_table(src_name,_af) }};
+  import all;
+  export none;
 }
-{%       endfor %}
-{%     endif %}
+{%         endfor %}
+{%       endif %}
+{%     endfor %}
 {%   endfor %}
 {% endfor %}

--- a/tests/integration/vrf/35-vrf-asymmetric-leaking.yml
+++ b/tests/integration/vrf/35-vrf-asymmetric-leaking.yml
@@ -1,0 +1,101 @@
+---
+message: |
+  The device under test has three VRFs with one OSPF-speaking CE router in
+  each VRF. Every VRF imports routes from exactly one other VRF:
+
+  * red imports green
+  * green imports blue
+  * blue imports red
+
+  The lab tests asymmetric inter-VRF route leaking by checking that every CE
+  router receives only the routes imported by its local VRF.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
+defaults.interfaces.mtu: 1500
+
+groups:
+  _auto_create: True
+  ce:
+    members: [ r1, r2, r3 ]
+    module: [ ospf ]
+    device: frr
+    provider: clab
+  pe:
+    members: [ dut ]
+    module: [ vrf, ospf ]
+
+vrfs:
+  red:
+    import: [ green ]
+    links: [ dut-r1 ]
+  green:
+    import: [ blue ]
+    links: [ dut-r2 ]
+  blue:
+    import: [ red ]
+    links: [ dut-r3 ]
+
+nodes:          # Set different router ID on every OSPF process
+  dut:          # ... to keep Cisco IOS happy
+    id: 1
+    vrfs:
+      red:
+        ospf.router_id: 10.100.0.100
+      green:
+        ospf.router_id: 10.100.0.101
+      blue:
+        ospf.router_id: 10.100.0.102
+
+validate:
+  red_adj:
+    description: Check OSPF adjacencies in red VRF
+    wait_msg: Waiting for OSPF adjacencies to form
+    wait: ospfv2_adj_p2p
+    nodes: [ r1 ]
+    plugin: ospf_neighbor(nodes.dut.vrfs.red.ospf.router_id)
+    stop_on_error: true
+  green_adj:
+    description: Check OSPF adjacencies in green VRF
+    wait_msg: Waiting for OSPF adjacencies to form
+    wait: ospfv2_adj_p2p
+    nodes: [ r2 ]
+    plugin: ospf_neighbor(nodes.dut.vrfs.green.ospf.router_id)
+    stop_on_error: true
+  blue_adj:
+    description: Check OSPF adjacencies in blue VRF
+    wait_msg: Waiting for OSPF adjacencies to form
+    wait: ospfv2_adj_p2p
+    nodes: [ r3 ]
+    plugin: ospf_neighbor(nodes.dut.vrfs.blue.ospf.router_id)
+    stop_on_error: true
+  red_import:
+    description: Check green route imported into red VRF
+    wait: ospf_import
+    wait_msg: Waiting for inter-VRF OSPF route leaking
+    nodes: [ r1 ]
+    plugin: ospf_prefix(nodes.r2.loopback.ipv4)
+  red_no_blue:
+    description: Check blue route is not imported into red VRF
+    nodes: [ r1 ]
+    plugin: ospf_prefix(nodes.r3.loopback.ipv4,state='missing')
+  green_import:
+    description: Check blue route imported into green VRF
+    wait: ospf_import
+    wait_msg: Waiting for inter-VRF OSPF route leaking
+    nodes: [ r2 ]
+    plugin: ospf_prefix(nodes.r3.loopback.ipv4)
+  green_no_red:
+    description: Check red route is not imported into green VRF
+    nodes: [ r2 ]
+    plugin: ospf_prefix(nodes.r1.loopback.ipv4,state='missing')
+  blue_import:
+    description: Check red route imported into blue VRF
+    wait: ospf_import
+    wait_msg: Waiting for inter-VRF OSPF route leaking
+    nodes: [ r3 ]
+    plugin: ospf_prefix(nodes.r1.loopback.ipv4)
+  blue_no_green:
+    description: Check green route is not imported into blue VRF
+    nodes: [ r3 ]
+    plugin: ospf_prefix(nodes.r2.loopback.ipv4,state='missing')


### PR DESCRIPTION
Create BIRD pipe protocols only for VRF pairs with matching import/export route targets to avoid unnecessary full-mesh route leaking configuration.

Fixes #3523 

```./device-module-test -d bird -p clab vrf``` all pass