### PR TITLE
FortiOS: OSPF route import and default-route origination

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -64,7 +64,7 @@ The following table describes the per-platform support of individual router-leve
 | Dell OS10 ([❗](caveats-os10)) | ✅| ✅| ✅| ✅| ✅|
 | Cumulus Linux 5.x (NVUE) | ✅| ✅| ❌ | ✅ | ✅|
 | Extreme Networks EXOS    | ✅| ✅| ✅| ❌ | ❌ | 
-| Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ✅ | ❌ | ❌ |
+| Fortinet FortiOS         |[❗](caveats-fortios)| ✅ | ✅ | ✅ | ✅ |
 | FRR                      | ✅| ✅| ✅| ✅| ✅|
 | Junos[^Junos]            | ✅| ✅| ✅| ✅| ❌ |
 | Mikrotik RouterOS 6      | ✅| ❌ | ❌ | ❌ | ❌ |

--- a/netsim/ansible/templates/ospf/fortios.j2
+++ b/netsim/ansible/templates/ospf/fortios.j2
@@ -67,6 +67,24 @@ config router {{ proto }}
 {%   endfor %}
     end
 {% endif %}
+{#
+  default-origination and redistribution use the same keywords under 'ospf' and
+  'ospf6', so no AF fork; route-map/policy is skipped to match bgp/fortios.j2.
+#}
+{% if ospf.default is defined %}
+    set default-information-originate {{ 'always' if ospf.default.always|default(False) else 'enable' }}
+{%   if ospf.default.cost|default(0) %}
+    set default-information-metric {{ ospf.default.cost }}
+{%   endif %}
+{%   if ospf.default.type|default('') %}
+    set default-information-metric-type {{ ospf.default.type.replace('e','') }}
+{%   endif %}
+{% endif %}
+{% for proto in ospf.import|default({}) %}
+    config redistribute "{{ proto }}"
+        set status enable
+    end
+{% endfor %}
 end
 {% endmacro %}
 {% if multi_vdom %}

--- a/netsim/devices/fortios.yml
+++ b/netsim/devices/fortios.yml
@@ -52,6 +52,8 @@ features:
     gr:                        # No helper-only mode: FortiOS either advertises the full
       valid: [ enable, disable ]   # restart capability or stays silent
   ospf:
+    default: true
+    import: [ bgp, connected, static ]
     password: true
     priority: true
     timers: true


### PR DESCRIPTION
## Summary

Makes two router-level OSPF features functional on Fortinet FortiOS, for both OSPFv2
and OSPFv3, building on the FortiOS BGP support merged in #3482:

- **`ospf.import`** — redistribution of BGP, connected, and static routes into OSPF;
- **`ospf.default`** — origination of an external default route.

## Design notes for reviewers

- **One block, both address families.** The redistribution and default-origination
  keyword sets are identical under `config router ospf` and `config router ospf6`, so a
  single block in the shared `ospf_config` macro serves both families without an
  address-family fork. OSPFv3 uses `config redistribute` (not `redistribute6`), because
  the stanza already sits inside `config router ospf6`. The keywords were confirmed
  against the FortiOS 8.0.0 CLI Reference.
- **Redistribution mirrors the inverse of `bgp/fortios.j2`.** It reuses the idiom the
  BGP template already proved on a live device — `config redistribute "<protocol>"` /
  `set status enable` / `end` — which selects a predefined, read-only entry without an
  `edit`.
- **Default origination** emits `set default-information-originate always` when
  `ospf.default.always` is set and `enable` otherwise, followed by
  `set default-information-metric` and `set default-information-metric-type` derived from
  `ospf.default.cost` and `ospf.default.type` (`e1`/`e2` mapping to `1`/`2`). The guards
  read the sub-keys defensively, so both a bare `ospf.default: true` and a full dictionary
  render correctly.
- **Route map and policy are intentionally omitted** from both redistribution and default
  origination, matching the existing FortiOS BGP redistribution: _netlab_ does not yet
  generate route-map objects on FortiOS, so referencing one would emit configuration the
  device cannot resolve. Accordingly the device declares
  `features.ospf.import: [ bgp, connected, static ]` (without a policy capability) and
  `features.ospf.default: true`.

## Testing

**Transformation.** The transformation suite passes; `docs/module/ospf.md` marks the
FortiOS "Route import" and "Default route" cells as supported.

**Live integration on FortiOS.** Executed against FortiOS virtual machines (libvirt
provider) with FRR validation probes (containerlab). The two topologies that exercise
this change directly passed on both address families:

- `ospf/ospfv2/10-import` and `ospf/ospfv3/10-import` — redistribution of BGP and static
  routes into OSPF, confirmed on the FRR probe;
- `ospf/ospfv2/20-default` and `ospf/ospfv3/20-default` — external default origination in
  both the unconditional (`always`) and BGP-conditional forms, with metric and metric-type.

The broader eligible OSPF suite (`01-network`, `02-areas`, `03-cost`, `04-passive`,
`30-timers`, `31-priority`, `32-password`, and the OSPFv3 `06-lb-prefix`) also passed.

## Scope and limitations

The route-map policy variants (`11-import-policy`, `21-default-policy`) are out of scope
and are skipped at pre-flight, consistent with the absence of route-map generation on
FortiOS. This change does not modify any Python code.
