### PR TITLE
Fix 3312: L3VNI in VyOS

### DIFF
--- a/netsim/ansible/templates/evpn/vyos.j2
+++ b/netsim/ansible/templates/evpn/vyos.j2
@@ -35,7 +35,6 @@ set protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
 set vrf name {{ n }} protocols bgp address-family ipv4-unicast redistribute connected
 set vrf name {{ n }} protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
 set vrf name {{ n }} vni '{{l3vni}}'
-set vrf name {{ n }} protocols bgp address-family l2vpn-evpn vni {{ l3vni }}
 
 set vrf name {{ n }} protocols bgp address-family l2vpn-evpn rd {{ v.rd }}
 set vrf name {{ n }} protocols bgp address-family l2vpn-evpn route-target import "{{ v.import|join(' ') }}"

--- a/tests/integration/evpn/05-vxlan-l3only.yml
+++ b/tests/integration/evpn/05-vxlan-l3only.yml
@@ -41,8 +41,8 @@ links:
   mtu: 1600
 
 _adjust:
-- nodes: [ dut ]              # Do not test the second VRF on vyos (broken) or NXOS (unknown)
-  devices: [ vyos, nxos ]
+- nodes: [ dut ]              # Do not test the second VRF on NXOS (unknown)
+  devices: [ nxos ]
   warning: The device does not work correctly with multiple L3VRFs
   remove:
   - validate.ping_other

--- a/tests/integration/evpn/21-bgp-ce-router.yml
+++ b/tests/integration/evpn/21-bgp-ce-router.yml
@@ -48,8 +48,8 @@ links:
   mtu: 1600
 
 _adjust:
-- nodes: [ dut ]              # Do not test the second VRF on vyos (broken) or NXOS (unknown)
-  devices: [ vyos, nxos ]
+- nodes: [ dut ]              # Do not test the second VRF or NXOS (unknown)
+  devices: [ nxos ]
   warning: The device does not work correctly with multiple L3VRFs
   remove:
   - validate.ping_ce4


### PR DESCRIPTION
Fix #3312 

Configuration of `vni` under the VRF BGP L2VPN EVPN stanza refers to the VNIs to announce (and not to the L3VNI itself, which is declared directly on the vrf configuration).
The explicit configuration of the VNI to announce for the VRF clashes with the configuration `advertise-all-vni`.

Failed test is now passing:

```
Results of configuration script deployments
================================================================================================================================================================================================================================
hr1              Script:  initial,routing
hr2              Script:  initial,routing
hb1              Script:  initial,routing
hb2              Script:  initial,routing
s2               Script:  initial,vlan,ospf,bgp,vrf,vxlan,evpn


[SUCCESS] Lab devices configured


The device under test is a VLAN-to-VXLAN layer-3 switch between an access
interface and an EVPN transit VNI.

Hosts should be able to ping each other.

Please note it might take a while for the lab to work due to STP learning
phase.

[ospf_adj]   Check OSPF adjacencies with DUT [ node(s): s2 ]
[PASS]       s2: OSPFv2 neighbor 10.0.0.5 is in state Full/-
[PASS]       Test succeeded in 0.2 seconds

[ibgp_adj]   Check IBGP adjacencies with DUT [ node(s): s2 ]
[PASS]       s2: Neighbor 10.0.0.5 (dut) is in state Established
[PASS]       Test succeeded in 0.2 seconds

[ping_gw]    Pinging default gateway [ node(s): hr1,hb1 ]
[PASS]       hr1: Ping to 172.16.0.5 succeeded
[PASS]       hb1: Ping to 172.16.2.5 succeeded
[PASS]       Test succeeded in 0.4 seconds

[ping_cust]  End-to-end reachability in Customer VRF [ node(s): hr1 ]
[PASS]       hr1: Ping to hr2 (172.16.1.2) succeeded
[PASS]       Test succeeded in 1.2 seconds

[ping_other] End-to-end reachability in other VRF [ node(s): hb1 ]
[PASS]       hb1: Ping to hb2 (172.16.3.4) succeeded
[PASS]       Test succeeded in 0.2 seconds

[SUCCESS]    Tests passed: 6
```
