### PR TITLE
Add Validation functions BGP BFD for FRR/EOS

### DIFF
--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -78,7 +78,7 @@ def valid_bgp_neighbor(
 
   return f'Neighbor {n_addr} ({n_id}) is in state {data[n_addr].peerState}'
 
-def show_bgp_neighbor_details(ngb: list, n_id: str, af: str='ipv4', *, activate: str = '', bfd: bool = False, **kwargs: typing.Any) -> str:
+def show_bgp_neighbor_details(ngb: list, n_id: str, af: str='ipv4', *, activate: str = '', **kwargs: typing.Any) -> str:
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
   global af_lookup
   if not activate:
@@ -125,7 +125,7 @@ def valid_bgp_neighbor_details(
 
   result = f'The neighbor {n_addr} ({n_id}){act_err} is in BFD state {found.bfdState}'
   if not found.bfdState == 3:
-      raise Exception(f'{result} ( expected 3 - Up )')
+      raise Exception(f'{result} (expected 3 - Up)')
 
   return result
 

--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -78,6 +78,57 @@ def valid_bgp_neighbor(
 
   return f'Neighbor {n_addr} ({n_id}) is in state {data[n_addr].peerState}'
 
+def show_bgp_neighbor_details(ngb: list, n_id: str, af: str='ipv4', *, activate: str = '', bfd: bool = False, **kwargs: typing.Any) -> str:
+  n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
+  global af_lookup
+  if not activate:
+    return f'bgp neighbors {n_addr} | json'
+
+  if activate not in af_lookup:
+    raise Exception(f'Unsupported address family {activate}')
+
+  return f'bgp {af_lookup[activate]} neighbors {n_addr} | json'
+
+def valid_bgp_neighbor_details(
+      ngb: list,
+      n_id: str,
+      af: str = 'ipv4',
+      state: str = 'Established',
+      vrf: str = 'default',
+      activate: str = '',
+      intf: str = '',
+      bfd: bool = False) -> str:
+  _result = global_vars.get_result_dict('_result')
+  n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
+
+  data = check_vrf_data(_result,vrf,'peerList','BGP peers')
+
+  act_err = f' in address family {activate}' if activate else ''
+  found = next(item for item in data if item.peerAddress == n_addr)
+
+  if not found:
+    result = f'The router has no BGP neighbor with {af} address {n_addr} ({n_id}){act_err}'
+    if state == 'missing':
+      return result
+    else:
+      raise Exception(result)
+
+  if not state == found.state:
+    result = f'The neighbor {n_addr} ({n_id}){act_err} is in state {found.state}'
+    if state == 'missing' and data[0].state != 'Established':
+      return result
+    else:
+      raise Exception(f'{result} (expected {state})')
+
+  if not bfd:
+    return result
+
+  result = f'The neighbor {n_addr} ({n_id}){act_err} is in BFD state {found.bfdState}'
+  if not found.bfdState == 3:
+      raise Exception(f'{result} ( expected 3 - Up )')
+
+  return result
+
 """
 BGP prefix checks, starting with 'get a BGP prefix from JSON results'
 """

--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -95,7 +95,7 @@ def valid_bgp_neighbor_details(
 
   data = check_vrf_data(_result,vrf,'peerList','BGP peers')
 
-  found = next(item for item in data if item.peerAddress == n_addr)
+  found = next((item for item in data if item.peerAddress == n_addr),None)
   if not found:
     raise Exception(f'The router has no BGP neighbor with {af} address {n_addr} ({n_id})')
 
@@ -104,6 +104,8 @@ def valid_bgp_neighbor_details(
   if bfd is not None:
     bfd_state = 3 if bfd else 2
     bfd_s_txt = 'Up' if bfd else 'Down'
+    if 'bfdState' not in found:
+      raise Exception(f'We are not running BFD with neighbor {n_addr} ({n_id})')
     if found.bfdState != bfd_state:
       raise Exception(f'The neighbor {n_addr} ({n_id}) is in BFD state {found.bfdState}' +\
                       f' (expected {bfd_state} - {bfd_s_txt})')

--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -78,54 +78,35 @@ def valid_bgp_neighbor(
 
   return f'Neighbor {n_addr} ({n_id}) is in state {data[n_addr].peerState}'
 
-def show_bgp_neighbor_details(ngb: list, n_id: str, af: str='ipv4', *, activate: str = '', **kwargs: typing.Any) -> str:
+def show_bgp_neighbor_details(ngb: list, n_id: str, af: str='ipv4', **kwargs: typing.Any) -> str:
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
-  global af_lookup
-  if not activate:
-    return f'bgp neighbors {n_addr} | json'
-
-  if activate not in af_lookup:
-    raise Exception(f'Unsupported address family {activate}')
-
-  return f'bgp {af_lookup[activate]} neighbors {n_addr} | json'
+  return f'bgp neighbors {n_addr} | json'
 
 def valid_bgp_neighbor_details(
       ngb: list,
       n_id: str,
       af: str = 'ipv4',
-      state: str = 'Established',
-      vrf: str = 'default',
-      activate: str = '',
-      intf: str = '',
-      bfd: bool = False) -> str:
+      bfd: typing.Optional[bool] = None,
+      **kwargs: typing.Any) -> str:
+
+  vrf = 'default'
   _result = global_vars.get_result_dict('_result')
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
 
   data = check_vrf_data(_result,vrf,'peerList','BGP peers')
 
-  act_err = f' in address family {activate}' if activate else ''
   found = next(item for item in data if item.peerAddress == n_addr)
-
   if not found:
-    result = f'The router has no BGP neighbor with {af} address {n_addr} ({n_id}){act_err}'
-    if state == 'missing':
-      return result
-    else:
-      raise Exception(result)
+    raise Exception(f'The router has no BGP neighbor with {af} address {n_addr} ({n_id})')
 
-  if not state == found.state:
-    result = f'The neighbor {n_addr} ({n_id}){act_err} is in state {found.state}'
-    if state == 'missing' and data[0].state != 'Established':
-      return result
-    else:
-      raise Exception(f'{result} (expected {state})')
+  result = f'All specified BGP neighbor parameters have the expected values'
 
-  if not bfd:
-    return result
-
-  result = f'The neighbor {n_addr} ({n_id}){act_err} is in BFD state {found.bfdState}'
-  if not found.bfdState == 3:
-      raise Exception(f'{result} (expected 3 - Up)')
+  if bfd is not None:
+    bfd_state = 3 if bfd else 2
+    bfd_s_txt = 'Up' if bfd else 'Down'
+    if found.bfdState != bfd_state:
+      raise Exception(f'The neighbor {n_addr} ({n_id}) is in BFD state {found.bfdState}' +\
+                      f' (expected {bfd_state} - {bfd_s_txt})')
 
   return result
 

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -106,9 +106,9 @@ def valid_bgp_neighbor_details(
   if bfd:
     if data.peerBfdInfo:
       if data.peerBfdInfo.status != 'Up':
-        raise Exception(f'{k} expected value UP actual {data.peerBfdInfo.status}')
+        raise Exception(f'BGP {k} expected value UP actual {data.peerBfdInfo.status}')
     else:
-      raise Exception(f'Neighbor data structure does not contain attribute peerBfdInfo')
+      raise Exception(f'No BFD information for BGP peer {n_id}')
 
   return f'All specified BGP neighbor parameters have the expected values'
 

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -90,7 +90,7 @@ def valid_bgp_neighbor_details(
       ngb: list,
       n_id: str,
       af: str = 'ipv4',
-      bfd: bool = False,
+      bfd: typing.Optional[bool] = None,
       **kwargs: typing.Any) -> str:
   _result = global_vars.get_result_dict('_result')
 
@@ -103,12 +103,13 @@ def valid_bgp_neighbor_details(
     if data[k] != v:
       raise Exception(f'{k} expected value {v} actual {data[k]}')
 
-  if bfd:
-    if data.peerBfdInfo:
-      if data.peerBfdInfo.status != 'Up':
-        raise Exception(f'BGP {k} expected value UP actual {data.peerBfdInfo.status}')
-    else:
+  if bfd is not None:
+    if not data.peerBfdInfo:
       raise Exception(f'No BFD information for BGP peer {n_id}')
+    else:
+      expected = 'Up' if bfd else 'Down'
+      if data.peerBfdInfo.status != expected:
+        raise Exception(f'BGP BFD expected value {expected} actual {data.peerBfdInfo.status}')
 
   return f'All specified BGP neighbor parameters have the expected values'
 

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -104,8 +104,8 @@ def valid_bgp_neighbor_details(
       raise Exception(f'{k} expected value {v} actual {data[k]}')
 
   if bfd is not None:
-    if not data.peerBfdInfo:
-      raise Exception(f'No BFD information for BGP peer {n_id}')
+    if 'peerBfdInfo' not in data:
+      raise Exception(f'We are not running BFD with neighbor {n_addr} ({n_id})')
     else:
       expected = 'Up' if bfd else 'Down'
       if data.peerBfdInfo.status != expected:

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -82,14 +82,16 @@ def valid_bgp_neighbor(
 
   return f'Neighbor {n_addr} ({n_id}) is in state {data[n_addr].state}'
 
-def show_bgp_neighbor_details(ngb: list, n_id: str, af: str = 'ipv4', **kwargs: typing.Any) -> str:
+def show_bgp_neighbor_details(ngb: list, n_id: str, af: str = 'ipv4', bfd: bool = False, **kwargs: typing.Any) -> str:
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
   return f'bgp neighbor {n_addr} json'
 
 def valid_bgp_neighbor_details(
       ngb: list,
       n_id: str,
-      af: str = 'ipv4',**kwargs: typing.Any) -> str:
+      af: str = 'ipv4',
+      bfd: bool = False,
+      **kwargs: typing.Any) -> str:
   _result = global_vars.get_result_dict('_result')
 
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
@@ -100,6 +102,13 @@ def valid_bgp_neighbor_details(
       raise Exception(f'Neighbor data structure does not contain attribute {k}')
     if data[k] != v:
       raise Exception(f'{k} expected value {v} actual {data[k]}')
+
+  if bfd:
+    if data.peerBfdInfo:
+      if data.peerBfdInfo.status != "Up":
+        raise Exception(f'{k} expected value UP actual {data.peerBfdInfo.status}')
+    else:
+      raise Exception(f'Neighbor data structure does not contain attribute peerBfdInfo')
 
   return f'All specified BGP neighbor parameters have the expected values'
 

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -82,7 +82,7 @@ def valid_bgp_neighbor(
 
   return f'Neighbor {n_addr} ({n_id}) is in state {data[n_addr].state}'
 
-def show_bgp_neighbor_details(ngb: list, n_id: str, af: str = 'ipv4', bfd: bool = False, **kwargs: typing.Any) -> str:
+def show_bgp_neighbor_details(ngb: list, n_id: str, af: str = 'ipv4', **kwargs: typing.Any) -> str:
   n_addr = _common.get_bgp_neighbor_id(ngb,n_id,af)
   return f'bgp neighbor {n_addr} json'
 
@@ -105,7 +105,7 @@ def valid_bgp_neighbor_details(
 
   if bfd:
     if data.peerBfdInfo:
-      if data.peerBfdInfo.status != "Up":
+      if data.peerBfdInfo.status != 'Up':
         raise Exception(f'{k} expected value UP actual {data.peerBfdInfo.status}')
     else:
       raise Exception(f'Neighbor data structure does not contain attribute peerBfdInfo')

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -17,14 +17,14 @@ defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
 groups:
   probes:
-    device: frr
+    device: eos
     provider: clab
     members: [ x1 ]
 
 nodes:
   dut:
     bgp.as: 65000
-    bgp.bfd: True
+    config: [ static_bfd ]
   x1:
     bgp.as: 65100
     bgp.bfd: True
@@ -60,20 +60,6 @@ validate:
     valid:
       eos: >-
         vrfs.default.ipv4Neighbors["10.1.0.1"].peers.Ethernet1.types.normal.peerStats["10.1.0.2"].status == "up"
-      frr: >-
-        result[0].status == "up"
-
-  bfd_v4_dut:
-    description: Check BFD peer on DUT
-    wait_msg: Waiting for BFD to start
-    wait: bfd_init
-    nodes: [ dut ]
-    show:
-      eos: "bfd peers | json"
-      frr: "bfd peers json"
-    valid:
-      eos: >-
-        vrfs.default.ipv4Neighbors["10.1.0.2"].peers.Ethernet1.types.normal.peerStats["10.1.0.1"].status == "up"
       frr: >-
         result[0].status == "up"
 

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -2,14 +2,6 @@ message: |
   This lab tests the BGP BFD functionality. The EBGP session between the probe
   and the lab device should trigger a BFD session between them.
 
-  The final test disables BFD on the probe to verify that the BGP session is
-  promptly torn down when BFD fails. It catches the FRR 10.5.1 regression that
-  kept BGP sessions with default timers Established for 30 seconds after BFD
-  failure. To run the test against FRR 10.5.1:
-
-    netlab up tests/integration/bgp.session/13-bfd.yml --validate \
-      --set defaults.devices.frr.clab.image=quay.io/frrouting/frr:10.5.1
-
 plugin: [ bgp.session ]
 module: [ bgp, bfd ]
 
@@ -24,13 +16,13 @@ groups:
 nodes:
   dut:
     bgp.as: 65000
-    config: [ static_bfd ]
   x1:
     bgp.as: 65100
-    bgp.bfd: True
+    config: [ static_bfd ]
 
 links:
 - dut:
+    bgp.bfd: True
   x1:
   pool: p2p  # Force addressing to come from the p2p pool, else with host devices like bird it becomes a lan
 
@@ -42,13 +34,6 @@ validate:
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
-  bgp_bfd_v4:
-    description: Check IPv4 EBGP sessions with DUT
-    wait_msg: Waiting for BFD EBGP session data
-    wait: ebgp_session
-    nodes: [ x1 ]
-    plugin: bgp_neighbor_details(node.bgp.neighbors,'dut',bfd='True')
-
   bfd_v4:
     description: Check BFD peer on X1
     wait_msg: Waiting for BFD to start
@@ -56,32 +41,6 @@ validate:
     nodes: [ x1 ]
     show:
       eos: "bfd peers | json"
-      frr: "bfd peers json"
     valid:
       eos: >-
         vrfs.default.ipv4Neighbors["10.1.0.1"].peers.Ethernet1.types.normal.peerStats["10.1.0.2"].status == "up"
-      frr: >-
-        result[0].status == "up"
-
-  drop_bfd_x1:
-    description: Disable BFD on X1 BGP neighbor
-    nodes: [ x1 ]
-    devices: [ frr ]
-    exec: >-
-      vtysh -c "configure terminal" -c "router bgp 65100" -c "no neighbor 10.1.0.1 bfd"
-    pass: BFD disabled on X1 BGP neighbor
-
-  bfd_bgp_down:
-    description: BGP session should go down promptly after BFD failure
-    wait_msg: Waiting for BFD failure to tear down BGP
-    wait: bfd_init
-    nodes: [ x1 ]
-    plugin: bgp_neighbor(node.bgp.neighbors,'dut',state=['Idle','Active','Connect'])
-
-  restore_bfd_x1:
-    description: Restore BFD on X1 BGP neighbor
-    nodes: [ x1 ]
-    devices: [ frr ]
-    exec: >-
-      vtysh -c "configure terminal" -c "router bgp 65100" -c "neighbor 10.1.0.1 bfd"
-    pass: BFD restored on X1 BGP neighbor

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -9,20 +9,20 @@ defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
 groups:
   probes:
-    device: eos
+    device: frr
     provider: clab
     members: [ x1 ]
 
 nodes:
   dut:
     bgp.as: 65000
+    bgp.bfd: True
   x1:
     bgp.as: 65100
-    config: [ static_bfd ]
+    bgp.bfd: True
 
 links:
 - dut:
-    bgp.bfd: True
   x1:
   pool: p2p  # Force addressing to come from the p2p pool, else with host devices like bird it becomes a lan
 
@@ -34,6 +34,13 @@ validate:
     nodes: [ x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
+  bgp_bfd_v4:
+    description: Check IPv4 EBGP sessions with DUT
+    wait_msg: Waiting for BFD EBGP session data
+    wait: ebgp_session
+    nodes: [ x1 ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'dut',bfd='True')
+
   bfd_v4:
     description: Check BFD peer on X1
     wait_msg: Waiting for BFD to start
@@ -41,6 +48,23 @@ validate:
     nodes: [ x1 ]
     show:
       eos: "bfd peers | json"
+      frr: "bfd peers json"
     valid:
       eos: >-
         vrfs.default.ipv4Neighbors["10.1.0.1"].peers.Ethernet1.types.normal.peerStats["10.1.0.2"].status == "up"
+      frr: >-
+        result[0].status == "up"
+
+  bfd_v4_dut:
+    description: Check BFD peer on DUT
+    wait_msg: Waiting for BFD to start
+    wait: bfd_init
+    nodes: [ dut ]
+    show:
+      eos: "bfd peers | json"
+      frr: "bfd peers json"
+    valid:
+      eos: >-
+        vrfs.default.ipv4Neighbors["10.1.0.2"].peers.Ethernet1.types.normal.peerStats["10.1.0.1"].status == "up"
+      frr: >-
+        result[0].status == "up"

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -2,6 +2,14 @@ message: |
   This lab tests the BGP BFD functionality. The EBGP session between the probe
   and the lab device should trigger a BFD session between them.
 
+  The final test disables BFD on the probe to verify that the BGP session is
+  promptly torn down when BFD fails. It catches the FRR 10.5.1 regression that
+  kept BGP sessions with default timers Established for 30 seconds after BFD
+  failure. To run the test against FRR 10.5.1:
+
+    netlab up tests/integration/bgp.session/13-bfd.yml --validate \
+      --set defaults.devices.frr.clab.image=quay.io/frrouting/frr:10.5.1
+
 plugin: [ bgp.session ]
 module: [ bgp, bfd ]
 
@@ -68,3 +76,26 @@ validate:
         vrfs.default.ipv4Neighbors["10.1.0.2"].peers.Ethernet1.types.normal.peerStats["10.1.0.1"].status == "up"
       frr: >-
         result[0].status == "up"
+
+  drop_bfd_x1:
+    description: Disable BFD on X1 BGP neighbor
+    nodes: [ x1 ]
+    devices: [ frr ]
+    exec: >-
+      vtysh -c "configure terminal" -c "router bgp 65100" -c "no neighbor 10.1.0.1 bfd"
+    pass: BFD disabled on X1 BGP neighbor
+
+  bfd_bgp_down:
+    description: BGP session should go down promptly after BFD failure
+    wait_msg: Waiting for BFD failure to tear down BGP
+    wait: bfd_init
+    nodes: [ x1 ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'dut',state=['Idle','Active','Connect'])
+
+  restore_bfd_x1:
+    description: Restore BFD on X1 BGP neighbor
+    nodes: [ x1 ]
+    devices: [ frr ]
+    exec: >-
+      vtysh -c "configure terminal" -c "router bgp 65100" -c "neighbor 10.1.0.1 bfd"
+    pass: BFD restored on X1 BGP neighbor

--- a/tests/platform-integration/validate/11-bgp-neighbor-details.yml
+++ b/tests/platform-integration/validate/11-bgp-neighbor-details.yml
@@ -72,11 +72,11 @@ validate:
   bgp_r3_ipv4:
     nodes: [ dut_eos, dut_frr ]
     wait: ebgp_session
-    plugin: bgp_neighbor(node.bgp.neighbors,'r2')
+    plugin: bgp_neighbor(node.bgp.neighbors,'r3')
   bgp_r3_ipv6:
     nodes: [ dut_eos, dut_frr ]
     wait: ebgp_session
-    plugin: bgp_neighbor(node.bgp.neighbors,'r2',af='ipv6')
+    plugin: bgp_neighbor(node.bgp.neighbors,'r3',af='ipv6')
   bgp_r4_ipv4:
     nodes: [ dut_eos, dut_frr ]
     wait: ebgp_session
@@ -102,10 +102,6 @@ validate:
     description: R3 does not run BFD
     nodes: [ dut_eos, dut_frr ]
     plugin: bgp_neighbor_details(node.bgp.neighbors,'r3',af='ipv4',bfd=False)
-  bfd_r4:
-    description: BFD for BGP is not used with R4
-    nodes: [ dut_eos, dut_frr ]
-    plugin: bgp_neighbor_details(node.bgp.neighbors,'r3',af='ipv4',bfd=False)
 
   fail_bfd_r1:
     description: R1 is running BFD
@@ -116,4 +112,9 @@ validate:
     description: R2 is not running BFD
     nodes: [ dut_eos, dut_frr ]
     plugin: bgp_neighbor_details(node.bgp.neighbors,'r2',af='ipv6',bfd=True)
+    _expect_fail: True
+  fail_bfd_r4:
+    description: BFD for BGP is not used with R4
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r4',af='ipv4',bfd=False)
     _expect_fail: True

--- a/tests/platform-integration/validate/11-bgp-neighbor-details.yml
+++ b/tests/platform-integration/validate/11-bgp-neighbor-details.yml
@@ -1,0 +1,119 @@
+message: |
+  Check the 'bgp_neighbor_details' validation plugin. The VRF part of the test
+  is not implemented yet as the bgp_neighbor_details plugin is not yet VRF-aware
+
+defaults.sources.extra: [ ../../integration/wait_times.yml ]
+plugin: [ bgp.session ]
+
+module: [ bgp, bfd, vrf ]
+groups:
+  probes:
+    members: [ r1, r2, r3, r4, vr1, vr2, vr3 ]
+    module: [ bgp ]
+    device: frr
+  probes_bfd:
+    members: [ r1, r2, vr1, vr2 ]
+    module: [ bgp, bfd ]
+
+vrfs:
+  tenant:
+    links:
+    - interfaces: [ dut_eos, dut_frr, vr1, vr3 ]
+      prefix.ipv4: 172.16.2.0/24
+    - interfaces: [ dut_eos, dut_frr, vr2, vr3 ]
+      prefix.ipv6: 2001:db8:0:2::/64
+
+# Node device type for DUT devices set via default groups
+#
+nodes:
+  dut_eos.bgp.as: 65001
+  dut_frr.bgp.as: 65002
+  r1.bgp.as: 65101
+  r2.bgp.as: 65102
+  r3.bgp.as: 65103
+  r4.bgp.as: 65104
+
+  vr1.bgp.as: 65201
+  vr2.bgp.as: 65202
+  vr3:
+    module: [ bgp ]               # VR3 is not running BFD
+    bgp.as: 65203
+
+links:
+- dut_eos.bgp.bfd: True
+  dut_frr.bgp.bfd: True
+  r1.bgp.bfd: True
+  r2:
+  r3:
+  prefix:
+    ipv4: 172.16.1.0/24
+    ipv6: 2001:db8:0:1::/64
+- interfaces: [ dut_eos, dut_frr, r4 ]        # No BFD on this link
+
+validate:
+  # Check BGP sessions that are expected to be up (global + VRF)
+  #
+  bgp_r1_ipv4:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r1')
+  bgp_r1_ipv6:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r1',af='ipv6')
+  bgp_r2_ipv4:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r2')
+  bgp_r2_ipv6:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r2',af='ipv6')
+  bgp_r3_ipv4:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r2')
+  bgp_r3_ipv6:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r2',af='ipv6')
+  bgp_r4_ipv4:
+    nodes: [ dut_eos, dut_frr ]
+    wait: ebgp_session
+    plugin: bgp_neighbor(node.bgp.neighbors,'r4')
+
+  det_r1_none:
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r1',af='ipv4')
+  det_r2_none:
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r2',af='ipv6')
+
+  # Check BFD detection
+  bfd_r1:
+    description: BFD is enabled on R1
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r1',af='ipv4',bfd=True)
+  bfd_r2:
+    description: BFD for BGP is not configured on R2
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r2',af='ipv6',bfd=False)
+  bfd_r3:
+    description: R3 does not run BFD
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r3',af='ipv4',bfd=False)
+  bfd_r4:
+    description: BFD for BGP is not used with R4
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r3',af='ipv4',bfd=False)
+
+  fail_bfd_r1:
+    description: R1 is running BFD
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r1',af='ipv4',bfd=False)
+    _expect_fail: True
+  fail_bfd_r2:
+    description: R2 is not running BFD
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor_details(node.bgp.neighbors,'r2',af='ipv6',bfd=True)
+    _expect_fail: True


### PR DESCRIPTION
Made the validation plugin be able to take BFD information similar to the OSPF one.

Works with both EOS and FRR.

Not entirely sure if is correct how I made change to the DUT with enabling BFD in the topology.


```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/bgp.session$ netlab validate
[WARNING] Topology source file(s) have changed since the lab has started
[INFO]    Reading validation tests from /home/netlab/snuffy-netlab/tests/integration/bgp.session/13-bfd.yml
[session_v4] Check IPv4 EBGP sessions with DUT [ node(s): x1 ]
[PASS]       x1: Neighbor 10.1.0.1 (dut) is in state Established
[PASS]       Test succeeded in 0.1 seconds

[bgp_bfd_v4] Check IPv4 EBGP sessions with DUT [ node(s): x1 ]
[PASS]       x1: All specified BGP neighbor parameters have the expected values
[PASS]       Test succeeded in 0.1 seconds

[bfd_v4]     Check BFD peer on X1 [ node(s): x1 ]
[PASS]       Validation succeeded on x1
[PASS]       Test succeeded in 0.1 seconds

[bfd_v4_dut] Check BFD peer on DUT [ node(s): dut ]
[PASS]       Validation succeeded on dut
[PASS]       Test succeeded in 0.2 seconds

[SUCCESS]    Tests passed: 4
```