### PR TITLE
Fix: Cleanup BIRD VRF config (part 1)

### DIFF
--- a/netsim/daemons/bird/bgp.macros.j2
+++ b/netsim/daemons/bird/bgp.macros.j2
@@ -163,9 +163,7 @@ protocol bgp bgp_{{ ('vrf_' + vrf_name + '_') if vrf_name else '' }}{{ n.name }}
   {{ _af }} {
 {%       if vrf_name %}
     table vrf_{{ vrf_name }}_{{ _af }};
-    import filter {
-{{         tag_vrf_route(vrf_data) }}
-    };
+    import filter vrf_{{ vrf_name }}_tag;
 {%       else %}
     import all;
 {%       endif %}

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -24,9 +24,7 @@ protocol ospf {{ ver }} ospf_{{ proto_suffix }}_{{ ver }} {
   {{ af }} {
 {%     if vrf_name %}
     table vrf_{{ vrf_name }}_{{ af }};
-    import filter {
-{{ tag_vrf_route(vrf_data) }}
-    };
+    import filter vrf_{{ vrf_name }}_tag;
 {%     endif %}
 {%     if import_list %}
     export filter {

--- a/netsim/daemons/bird/vrf-daemon.j2
+++ b/netsim/daemons/bird/vrf-daemon.j2
@@ -11,24 +11,19 @@ vrf_{{ vname }}_{{ af }}
 {%- endmacro %}
 
 {#
- # rt_value: Return a BIRD extended community route-target tuple from a netlab RT string.
- #}
-{% macro rt_value(rt) -%}
-(rt, {{ rt.split(':')[0] }}, {{ rt.split(':')[1] }})
-{%- endmacro %}
-
-{#
  # tag_vrf_route: Tag an imported VRF route with all export route targets configured on the VRF.
  #}
 {% macro tag_vrf_route(vdata) %}
       netlab_vrf_rt.empty;
-{%   for rt in vdata.export|default([]) %}
-      netlab_vrf_rt.add({{ rt_value(rt) }});
+{%   for rt in vdata._bird_export|default([]) %}
+      netlab_vrf_rt.add({{ rt }});
 {%   endfor %}
       accept;
 {% endmacro -%}
 
 attribute eclist netlab_vrf_rt;
+attribute string netlab_vrf_name;
+
 {% for vname,vdata in vrfs|default({})|dictsort %}
 
 #
@@ -38,14 +33,21 @@ attribute eclist netlab_vrf_rt;
 {{ _af }} table {{ vrf_table(vname,_af) }};
 {%   endfor %}
 
+filter vrf_{{ vname }}_tag {
+  netlab_vrf_name = "{{ vname }}";
+  netlab_vrf_rt.empty;
+{%   for rt in vdata._bird_export|default([]) %}
+  netlab_vrf_rt.add({{ rt }});
+{%   endfor %}
+  accept;
+}
+
 {%   for _af in ['ipv4','ipv6'] if _af in vdata.af %}
 protocol direct direct_vrf_{{ vname }}_{{ _af }} {
   vrf "{{ vname }}";
   {{ _af }} {
     table {{ vrf_table(vname,_af) }};
-    import filter {
-{{ tag_vrf_route(vdata) }}
-    };
+    import filter vrf_{{ vname }}_tag;
   };
 }
 
@@ -56,9 +58,7 @@ protocol kernel kernel_vrf_{{ vname }}_{{ _af }} {
   {{ _af }} {
     table {{ vrf_table(vname,_af) }};
     export all;
-    import filter {
-{{ tag_vrf_route(vdata) }}
-    };
+    import filter vrf_{{ vname }}_tag;
   };
 }
 {%   endfor %}
@@ -69,9 +69,7 @@ protocol kernel kernel_vrf_{{ vname }}_{{ _af }} {
 protocol static static_vrf_{{ vname }}_{{ sr_af }} {
   {{ sr_af }} {
     table {{ vrf_table(vname,sr_af) }};
-    import filter {
-{{ tag_vrf_route(vdata) }}
-    };
+    import filter vrf_{{ vname }}_tag;
   };
   check link;
 {%       endif %}
@@ -122,16 +120,15 @@ protocol static static_vrf_leak_{{ vname }}_{{ dst_name }}_{{ sr_af }} {
 {# Route leaking between VRF tables based on transformed import/export route targets #}
 {% for src_name,src_data in vrfs|default({})|dictsort %}
 {%   for dst_name,dst_data in vrfs|default({})|dictsort if dst_name != src_name %}
-{%     set import_rt = dst_data.import|default([])|select('in',src_data.export|default([]))|list %}
+{%     set import_rt = dst_data._bird_import|default([])|select('in',src_data._bird_export|default([]))|list %}
 {%     if import_rt %}
-{%       set bird_import_rt = import_rt|map('replace',':',', ')|join('), (rt, ') %}
 {%       for _af in src_data.af if _af in dst_data.af %}
 
 protocol pipe pipe_vrf_{{ src_name }}_{{ dst_name }}_{{ _af }} {
   table {{ vrf_table(dst_name,_af) }};
   peer table {{ vrf_table(src_name,_af) }};
   import filter {
-    if netlab_vrf_rt ~ [ (rt, {{ bird_import_rt }}) ] then accept;
+    if netlab_vrf_rt ~ [ {{ import_rt|join(',') }} ] then accept;
     reject;
   };
   export none;

--- a/netsim/devices/bird.py
+++ b/netsim/devices/bird.py
@@ -7,9 +7,30 @@ from . import _Quirks
 from ._common import check_daemon_dataplane_config, check_indirect_static_routes
 
 
+def bird_vrf_rt(node: Box) -> None:
+  '''
+  Convert standard route targets into (rt,a,b) format used by Bird configuration
+  '''
+  for vdata in node.get('vrfs',{}).values():                # Iterate over all VRFs
+    for kw in ('import','export'):                          # Process import and export RTs
+      if kw not in vdata:                                   # Not relevant? Cool ;)
+        continue
+
+      '''
+      The magic of the following line explained for people who don't want to study it ;)
+
+      * Iterate over all route targets in the import/export list
+      * Split the original route target (asn:rt or ip:rt) into its components
+      * Rejoin the RT components separated by commas (OK, I could have used replace, but this
+        is way cooler :-P )
+      * Add (rt,) around the RT components
+      '''
+      vdata[f'_bird_{kw}'] = [ '(rt,'+','.join(rt.split(':'))+')' for rt in vdata[kw]]
+
 class Bird(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     check_indirect_static_routes(node)
     check_daemon_dataplane_config(node,topology)
+    bird_vrf_rt(node)

--- a/netsim/devices/bird.py
+++ b/netsim/devices/bird.py
@@ -16,15 +16,14 @@ def bird_vrf_rt(node: Box) -> None:
       if kw not in vdata:                                   # Not relevant? Cool ;)
         continue
 
-      '''
-      The magic of the following line explained for people who don't want to study it ;)
-
-      * Iterate over all route targets in the import/export list
-      * Split the original route target (asn:rt or ip:rt) into its components
-      * Rejoin the RT components separated by commas (OK, I could have used replace, but this
-        is way cooler :-P )
-      * Add (rt,) around the RT components
-      '''
+      # The magic of the following line explained for people who don't want to study it ;)
+      #
+      # - Iterate over all route targets in the import/export list
+      # - Split the original route target (asn:rt or ip:rt) into its components
+      # - Rejoin the RT components separated by commas (OK, I could have used replace, but this
+      #   is way cooler :-P )
+      # - Add (rt,) around the RT components
+      #
       vdata[f'_bird_{kw}'] = [ '(rt,'+','.join(rt.split(':'))+')' for rt in vdata[kw]]
 
 class Bird(_Quirks):


### PR DESCRIPTION
* Create a common per-VRF tagging filter that replaces the per-proto tagging code
* Add VRF name to VRF routes (that will make inter-VRF route leaking easier)
* Convert import/export RTs to BIRD syntax in device quirk and use the BIRD-formatted values in Jinja2 templates