### PR TITLE
Log FRR container output to docker logs

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -415,18 +415,19 @@ ansible_httpapi_port: 80
 * The **frr.logfile** attribute specifies the path to the FRR logging file (default: `/var/log/frr/frr.log`)
 * You can specify a list of additional FRRouting daemons you want to have enabled in the **frr.daemons** node attribute.
 
-**FRR VM caveats:**
+**FRR VM Caveats:**
 
 * The VM version of FRR is a Debian VM. The FRR package is downloaded and installed during **vagrant up** processing in the libvirt environment. To postpone the FRR installation to the initial configuration process, set the node variable **netlab_quick_start** to `true`.
 * You can [build a custom FRR VM](build-frr) with a preinstalled **frr** package to speed up the **vagrant up** processing.
 
-**FRR container caveats:**
+**FRR Container Features and Caveats:**
 
+* FRR logging messages are copied to the container *stdout*. You can always inspect them with **docker logs _containername_** (which you can find with the **netlab status** command).
 * FRR containers need host kernel modules (drivers) to implement the data-plane functionality of *vrf*, *mpls*, and *vxlan* netlab modules. The kernel modules are automatically loaded (when available) during the **netlab up** processing.
 * VRF and VXLAN kernel modules are usually bundled with a Linux distribution. If your Ubuntu distribution does not include the MPLS drivers, try installing them with `sudo apt install linux-generic`.
 * You cannot load kernel modules in GitHub Codespaces and thus cannot use *vrf*, *mpls*, or *vxlan* modules on FRRouting nodes in that environment.
 * FRR containers have a management VRF. Use `ip vrf exec mgmt <command>` to run a CLI command that needs access to the outside world through the management interface. To disable the management VRF, set the **netlab_mgmt_vrf** node parameter to *False*.
-* FRR initial container configuration might fail if your Ubuntu distribution does not include the VRF kernel module. Install the VRF kernel module with the `sudo apt install linux-generic` and reboot the server.
+* FRR initial container configuration might fail if your Ubuntu distribution does not include the VRF kernel module. Install the VRF kernel module with `sudo apt install linux-generic`, then reboot the server.
 
 **FRR Implementation Caveats:**
 

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -232,7 +232,6 @@ vtysh -f /tmp/config
 # Redirect FRR's log to the container's stdout so 'docker logs' works
 #
 DOCKER_LOGS_STDOUT="/proc/1/fd/1"
-touch {{ frr_log_path }} && chown frr:frr {{ frr_log_path }}
 tail -n 0 -F {{ frr_log_path }} >${DOCKER_LOGS_STDOUT} 2>&1 &
 {% endif %}
 !

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -131,6 +131,14 @@ echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 # Ensure FRR's log directory exists before enabling file logging
 #
 mkdir -p /var/log/frr && chown frr:frr /var/log/frr
+{% if clab is defined %}
+#
+# Redirect FRR's log to the container's stdout so 'docker logs' works
+#
+FRR_LOG_OUTPUT="/proc/$(pgrep -f '^/bin/bash /usr/lib/frr/docker-start$')/fd/1"
+touch /var/log/frr/frr.log && chown frr:frr /var/log/frr/frr.log
+tail -n 0 -F /var/log/frr/frr.log >${FRR_LOG_OUTPUT} 2>&1 &
+{% endif %}
 #
 # Rest of initial configuration done through VTYSH
 #
@@ -143,7 +151,8 @@ hostname {{ inventory_hostname }}
   package), which permit /var/log/frr/* but deny /tmp; on FRR 10.4 that rejection
   is fatal and aborts initial configuration.
 #}
-log file {{ frr.logfile|default('/var/log/frr/frr.log') }}
+{% set frr_log_level = 'debugging' if frr.debug|default([]) else 'informational' %}
+log file {{ frr.logfile|default('/var/log/frr/frr.log') }} {{ frr_log_level }}
 {% from '_debug_commands.j2' import enable_debugging %}
 {{ enable_debugging(frr.debug,prefix='debug') }}
 !

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -126,19 +126,12 @@ ip link set {{ i.ifname }} {{ "down" if i.shutdown|default(False) else "up" }}
 # Add vtysh.conf file
 echo "service integrated-vtysh-config" >/etc/frr/vtysh.conf
 
+{% set frr_log_path = frr.logfile|default('/var/log/frr/frr.log') %}
 {% if not netlab_initial_reload|default(False) %}
 #
 # Ensure FRR's log directory exists before enabling file logging
 #
 mkdir -p /var/log/frr && chown frr:frr /var/log/frr
-{% if clab is defined %}
-#
-# Redirect FRR's log to the container's stdout so 'docker logs' works
-#
-FRR_LOG_OUTPUT="/proc/$(pgrep -f '^/bin/bash /usr/lib/frr/docker-start$')/fd/1"
-touch /var/log/frr/frr.log && chown frr:frr /var/log/frr/frr.log
-tail -n 0 -F /var/log/frr/frr.log >${FRR_LOG_OUTPUT} 2>&1 &
-{% endif %}
 #
 # Rest of initial configuration done through VTYSH
 #
@@ -152,7 +145,7 @@ hostname {{ inventory_hostname }}
   is fatal and aborts initial configuration.
 #}
 {% set frr_log_level = 'debugging' if frr.debug|default([]) else 'informational' %}
-log file {{ frr.logfile|default('/var/log/frr/frr.log') }} {{ frr_log_level }}
+log file {{ frr_log_path }} {{ frr_log_level }}
 {% from '_debug_commands.j2' import enable_debugging %}
 {{ enable_debugging(frr.debug,prefix='debug') }}
 !
@@ -233,5 +226,14 @@ do write
 CONFIG
 vtysh -f /tmp/config
 {% endif %}{# not netlab_initial_reload #}
+
+{% if clab is defined %}
+#
+# Redirect FRR's log to the container's stdout so 'docker logs' works
+#
+DOCKER_LOGS_STDOUT="/proc/1/fd/1"
+touch {{ frr_log_path }} && chown frr:frr {{ frr_log_path }}
+tail -n 0 -F {{ frr_log_path }} >${DOCKER_LOGS_STDOUT} 2>&1 &
+{% endif %}
 !
 exit 0


### PR DESCRIPTION
Relay FRR file logging to the container stdout stream for clab Docker nodes, enabling debugging when ```frr.debug``` is set

Sample use case:
```
netlab up bgp.session/13-bfd.yml -d frr -p clab -s nodes.dut.clab.image=quay.io/frrouting/frr:10.5.1 -s frr.debug="bfd peer"
```

With this PR, ```docker logs clab-bgpsession-dut``` shows the BFD events working for 10.6.1 but failing for 10.5.1