### PR TITLE
Set missing BIRD VRF feature flags

### DIFF
--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -46,6 +46,7 @@ features:
     ipv6_lla: false             # Bird supports dynamic neighbors using 'range', but not active discovery based on RAs
     rfc8950: true
     local_as: true
+    vrf_local_as: true
     local_as_ibgp: true
     community:
       standard: [ standard, large ]

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -65,7 +65,7 @@ features:
     confederation: true
     timers: true
   ospf:
-    import: [ bgp, connected, static ]
+    import: [ bgp, connected, static, vrf ]
     password: true
     priority: true
     timers: true

--- a/tests/integration/vrf/15-multi-vrf-mixed.yml
+++ b/tests/integration/vrf/15-multi-vrf-mixed.yml
@@ -41,10 +41,8 @@ nodes:
     vrfs:
       red:
         ospf.router_id: 10.100.0.1
-        ospf.import: [ bgp, connected ]
       blue:
         ospf.router_id: 10.101.0.1
-        ospf.import: [ bgp, connected ]
   r1:
   r2:
     bgp.as: 65100

--- a/tests/integration/vrf/15-multi-vrf-mixed.yml
+++ b/tests/integration/vrf/15-multi-vrf-mixed.yml
@@ -41,8 +41,10 @@ nodes:
     vrfs:
       red:
         ospf.router_id: 10.100.0.1
+        ospf.import: [ bgp, connected ]
       blue:
         ospf.router_id: 10.101.0.1
+        ospf.import: [ bgp, connected ]
   r1:
   r2:
     bgp.as: 65100


### PR DESCRIPTION
Now that BIRD supports VRFs, we should be explicit about its capabilities.

TBD which integration test would catch these, if any