### PR TITLE
Filter static node next hops by link when present

### DIFF
--- a/docs/module/routing-static.txt
+++ b/docs/module/routing-static.txt
@@ -46,6 +46,8 @@ A static route entry's **nexthop** attribute specifies the next hop used to reac
 * **node** -- The next hop is the specified node. The node name will be resolved into a list of directly connected next-hops or the control-plane endpoint of a distant node (allowing you to specify recursive static routes).
 * **discard** -- The static route is a *discard* (aka *blackhole*) route pointing to the *null* interface (or an equivalent).
 
+When using **nexthop.node** with a directly connected node, you can use **nexthop.link** to select a named link to that next-hop node. Without **nexthop.link**, _netlab_ creates one static route per matching connected link.
+
 ```{tip}
 * You can combine **‌ipv4** and **‌ipv6** next hops in the same static route entry. **gateway** and **node** next-hop attributes are exclusive and can specify both IPv4 and IPv6 next hops.
 * Static route entries with an **‌ipv4** prefix must have an **‌ipv4** next hop (and likewise for **‌ipv6**). _netlab_ does not support IPv6 next hops for IPv4 routes.

--- a/netsim/modules/routing/static.py
+++ b/netsim/modules/routing/static.py
@@ -209,6 +209,7 @@ of the 'nexthop' data structure.
 def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
   nh = data.get_empty_box()
   nh_vrf = sr_data.nexthop.vrf if 'vrf' in sr_data.nexthop else sr_data.get('vrf',None)
+  nh_link = sr_data.nexthop.get('link',None)
 
   node_found = False
   for intf in node.interfaces:
@@ -219,6 +220,10 @@ def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
         continue
 
       node_found = True
+      if nh_link:
+        intf_link = topology.links[intf.linkindex - 1]
+        if nh_link != intf_link.get('name',None):
+          continue
       if intf.get('vrf',None) != nh_vrf:
         continue
 

--- a/netsim/modules/routing/static.py
+++ b/netsim/modules/routing/static.py
@@ -220,9 +220,9 @@ def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
         continue
 
       node_found = True
-      if nh_link and nh_link != intf.get('name',None):
+      if intf.get('vrf',None) != nh_vrf:
         continue
-      if nh_vrf and nh_vrf != intf.get('vrf',None):
+      if nh_link and nh_link != intf.get('name',None):
         continue
 
       ngb_addr = extract_af_info(ngb,keep_prefix=False)

--- a/netsim/modules/routing/static.py
+++ b/netsim/modules/routing/static.py
@@ -220,11 +220,9 @@ def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
         continue
 
       node_found = True
-      if nh_link:
-        intf_link = topology.links[intf.linkindex - 1]
-        if nh_link != intf_link.get('name',None):
-          continue
-      if intf.get('vrf',None) != nh_vrf:
+      if nh_link and nh_link != intf.get('name',None):
+        continue
+      if nh_vrf and nh_vrf != intf.get('vrf',None):
         continue
 
       ngb_addr = extract_af_info(ngb,keep_prefix=False)
@@ -232,7 +230,7 @@ def resolve_node_nexthop(sr_data: Box, node: Box, topology: Box) -> Box:
 
       if nh_data:
         data.append_to_list(nh,'nhlist',nh_data)
-  
+
   if nh:
     extract_nh_from_list(nh)
   else:

--- a/tests/topology/expected/rp-static.yml
+++ b/tests/topology/expected/rp-static.yml
@@ -33,7 +33,6 @@ links:
     ipv6: 2001:db8:1:1::2/64
     node: p
   linkindex: 2
-  name: c-p-backup
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -45,35 +44,54 @@ links:
     ifname: eth3
     ipv4: 10.1.0.9/30
     ipv6: 2001:db8:1:2::1/64
-    node: p
-  - ifindex: 1
-    ifname: eth1
+    node: c
+  - ifindex: 3
+    ifname: eth3
     ipv4: 10.1.0.10/30
     ipv6: 2001:db8:1:2::2/64
-    node: x
+    node: p
   linkindex: 3
+  name: c-p-backup
   node_count: 2
   prefix:
     ipv4: 10.1.0.8/30
     ipv6: 2001:db8:1:2::/64
   type: p2p
-- _linkname: vrfs.red.links[1]
+- _linkname: links[4]
   interfaces:
-  - ifindex: 3
-    ifname: eth3
-    ipv4: 10.1.0.13/30
-    ipv6: 2001:db8:1:3::1/64
-    node: c
   - ifindex: 4
     ifname: eth4
+    ipv4: 10.1.0.13/30
+    ipv6: 2001:db8:1:3::1/64
+    node: p
+  - ifindex: 1
+    ifname: eth1
     ipv4: 10.1.0.14/30
     ipv6: 2001:db8:1:3::2/64
-    node: p
+    node: x
   linkindex: 4
   node_count: 2
   prefix:
     ipv4: 10.1.0.12/30
     ipv6: 2001:db8:1:3::/64
+  type: p2p
+- _linkname: vrfs.red.links[1]
+  interfaces:
+  - ifindex: 4
+    ifname: eth4
+    ipv4: 10.1.0.17/30
+    ipv6: 2001:db8:1:4::1/64
+    node: c
+  - ifindex: 5
+    ifname: eth5
+    ipv4: 10.1.0.18/30
+    ipv6: 2001:db8:1:4::2/64
+    node: p
+  linkindex: 5
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.16/30
+    ipv6: 2001:db8:1:4::/64
   type: p2p
   vrf: red
 module:
@@ -109,7 +127,7 @@ nodes:
       ipv4: 10.1.0.5/30
       ipv6: 2001:db8:1:1::1/64
       linkindex: 2
-      name: c-p-backup
+      name: c -> p
       neighbors:
       - ifname: eth2
         ipv4: 10.1.0.6/30
@@ -118,14 +136,26 @@ nodes:
       type: p2p
     - ifindex: 3
       ifname: eth3
-      ipv4: 10.1.0.13/30
-      ipv6: 2001:db8:1:3::1/64
-      linkindex: 4
+      ipv4: 10.1.0.9/30
+      ipv6: 2001:db8:1:2::1/64
+      linkindex: 3
+      name: c-p-backup
+      neighbors:
+      - ifname: eth3
+        ipv4: 10.1.0.10/30
+        ipv6: 2001:db8:1:2::2/64
+        node: p
+      type: p2p
+    - ifindex: 4
+      ifname: eth4
+      ipv4: 10.1.0.17/30
+      ipv6: 2001:db8:1:4::1/64
+      linkindex: 5
       name: c -> p
       neighbors:
-      - ifname: eth4
-        ipv4: 10.1.0.14/30
-        ipv6: 2001:db8:1:3::2/64
+      - ifname: eth5
+        ipv4: 10.1.0.18/30
+        ipv6: 2001:db8:1:4::2/64
         node: p
         vrf: red
       type: p2p
@@ -187,12 +217,18 @@ nodes:
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
+      - ipv4: 0.0.0.0/0
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.1.0.10
+          ipv6: 2001:db8:1:2::2
       - ipv4: 192.0.2.0/24
         nexthop:
           idx: 0
-          intf: eth2
-          ipv4: 10.1.0.6
-          ipv6: 2001:db8:1:1::2
+          intf: eth3
+          ipv4: 10.1.0.10
+          ipv6: 2001:db8:1:2::2
       - ipv4: 10.0.0.3/32
         nexthop:
           idx: 0
@@ -205,6 +241,12 @@ nodes:
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
+      - ipv4: 10.0.0.3/32
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.1.0.10
+          ipv6: 2001:db8:1:2::2
       - ipv6: 2001:db8:0:3::/64
         nexthop:
           idx: 0
@@ -217,12 +259,18 @@ nodes:
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
+      - ipv6: 2001:db8:0:3::/64
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.1.0.10
+          ipv6: 2001:db8:1:2::2
       - ipv4: 172.16.0.0/16
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 10.1.0.14
-          ipv6: 2001:db8:1:3::2
+          intf: eth4
+          ipv4: 10.1.0.18
+          ipv6: 2001:db8:1:4::2
         vrf: red
       - ipv4: 172.17.0.0/16
         nexthop:
@@ -238,14 +286,22 @@ nodes:
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
+          vrf: null
+        vrf: red
+      - ipv4: 172.17.0.0/16
+        nexthop:
+          idx: 2
+          intf: eth3
+          ipv4: 10.1.0.10
+          ipv6: 2001:db8:1:2::2
           vrf: null
         vrf: red
       - ipv4: 172.18.0.0/16
         nexthop:
           idx: 0
-          intf: eth3
-          ipv4: 10.1.0.14
-          ipv6: 2001:db8:1:3::2
+          intf: eth4
+          ipv4: 10.1.0.18
+          ipv6: 2001:db8:1:4::2
           vrf: red
     vrf:
       as: 65000
@@ -289,7 +345,7 @@ nodes:
       ipv4: 10.1.0.6/30
       ipv6: 2001:db8:1:1::2/64
       linkindex: 2
-      name: c-p-backup
+      name: p -> c
       neighbors:
       - ifname: eth2
         ipv4: 10.1.0.5/30
@@ -298,26 +354,38 @@ nodes:
       type: p2p
     - ifindex: 3
       ifname: eth3
-      ipv4: 10.1.0.9/30
-      ipv6: 2001:db8:1:2::1/64
+      ipv4: 10.1.0.10/30
+      ipv6: 2001:db8:1:2::2/64
       linkindex: 3
-      name: p -> x
+      name: c-p-backup
       neighbors:
-      - ifname: eth1
-        ipv4: 10.1.0.10/30
-        ipv6: 2001:db8:1:2::2/64
-        node: x
+      - ifname: eth3
+        ipv4: 10.1.0.9/30
+        ipv6: 2001:db8:1:2::1/64
+        node: c
       type: p2p
     - ifindex: 4
       ifname: eth4
-      ipv4: 10.1.0.14/30
-      ipv6: 2001:db8:1:3::2/64
+      ipv4: 10.1.0.13/30
+      ipv6: 2001:db8:1:3::1/64
       linkindex: 4
+      name: p -> x
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.14/30
+        ipv6: 2001:db8:1:3::2/64
+        node: x
+      type: p2p
+    - ifindex: 5
+      ifname: eth5
+      ipv4: 10.1.0.18/30
+      ipv6: 2001:db8:1:4::2/64
+      linkindex: 5
       name: p -> c
       neighbors:
-      - ifname: eth3
-        ipv4: 10.1.0.13/30
-        ipv6: 2001:db8:1:3::1/64
+      - ifname: eth4
+        ipv4: 10.1.0.17/30
+        ipv6: 2001:db8:1:4::1/64
         node: c
         vrf: red
       type: p2p
@@ -362,14 +430,14 @@ nodes:
     interfaces:
     - ifindex: 1
       ifname: eth1
-      ipv4: 10.1.0.10/30
-      ipv6: 2001:db8:1:2::2/64
-      linkindex: 3
+      ipv4: 10.1.0.14/30
+      ipv6: 2001:db8:1:3::2/64
+      linkindex: 4
       name: x -> p
       neighbors:
-      - ifname: eth3
-        ipv4: 10.1.0.9/30
-        ipv6: 2001:db8:1:2::1/64
+      - ifname: eth4
+        ipv4: 10.1.0.13/30
+        ipv6: 2001:db8:1:3::1/64
         node: p
       type: p2p
     loopback:

--- a/tests/topology/expected/rp-static.yml
+++ b/tests/topology/expected/rp-static.yml
@@ -33,6 +33,7 @@ links:
     ipv6: 2001:db8:1:1::2/64
     node: p
   linkindex: 2
+  name: c-p-backup
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
@@ -108,7 +109,7 @@ nodes:
       ipv4: 10.1.0.5/30
       ipv6: 2001:db8:1:1::1/64
       linkindex: 2
-      name: c -> p
+      name: c-p-backup
       neighbors:
       - ifname: eth2
         ipv4: 10.1.0.6/30
@@ -183,6 +184,12 @@ nodes:
       - ipv4: 0.0.0.0/0
         nexthop:
           idx: 1
+          intf: eth2
+          ipv4: 10.1.0.6
+          ipv6: 2001:db8:1:1::2
+      - ipv4: 192.0.2.0/24
+        nexthop:
+          idx: 0
           intf: eth2
           ipv4: 10.1.0.6
           ipv6: 2001:db8:1:1::2
@@ -282,7 +289,7 @@ nodes:
       ipv4: 10.1.0.6/30
       ipv6: 2001:db8:1:1::2/64
       linkindex: 2
-      name: p -> c
+      name: c-p-backup
       neighbors:
       - ifname: eth2
         ipv4: 10.1.0.5/30

--- a/tests/topology/input/rp-static.yml
+++ b/tests/topology/input/rp-static.yml
@@ -58,6 +58,7 @@ nodes:
 
 links:
 - c-p
+- c-p
 - name: c-p-backup
   interfaces: [ c, p ]
 - p-x

--- a/tests/topology/input/rp-static.yml
+++ b/tests/topology/input/rp-static.yml
@@ -28,6 +28,9 @@ nodes:
     routing.static:
     - ipv4: 0.0.0.0/0         # Expand into NH-list
       nexthop.node: p
+    - ipv4: 192.0.2.0/24      # Node next-hop filtered by link name
+      nexthop.node: p
+      nexthop.link: c-p-backup
     - pool: loopback          # Checking pool prefix and remote nexthop
       nexthop.node: x
     - node: x                 # Checking static route to node CP endpoint
@@ -55,5 +58,6 @@ nodes:
 
 links:
 - c-p
-- c-p
+- name: c-p-backup
+  interfaces: [ c, p ]
 - p-x


### PR DESCRIPTION
Honor ```nexthop.link``` when resolving static routes via a node so topologies with parallel links can select the intended adjacency.

The current data schema already allows ```nexthop.link``` but doesn't seem to use it?

I need this for a topology involving VPN tunnels across uplinks, to filter out the duplicate routes and only select one.