### PR TITLE
Fix: Use BGP _source_intf when configuring BIRD IBGP sessions

### DIFF
--- a/netsim/daemons/bird/bgp.macros.j2
+++ b/netsim/daemons/bird/bgp.macros.j2
@@ -88,8 +88,8 @@ protocol bgp bgp_{{ ('vrf_' + vrf_name + '_') if vrf_name else '' }}{{ n.name }}
   router id {{ vrf_data.bgp.router_id }};
 {%       endif %}
 {%     endif %}
-{%     set local_if = bgp_interfaces|selectattr('ifindex','eq',n.ifindex)|first if n.type != 'ibgp' else loopback %}
-  local {{ local_if[af]|ansible.utils.ipaddr('address') }} as {{ n.local_as|default(bgp_data.as|default(bgp.as)) }};
+  local {{ n._source_intf[af]|ansible.utils.ipaddr('address') if n._source_intf[af] is defined else ''
+          }} as {{ n.local_as|default(bgp_data.as|default(bgp.as)) }};
 {%     if bgp_data.confederation is defined %}
   confederation {{ bgp_data.confederation.as }};
 {%       if n.type == 'confed_ebgp' %}

--- a/tests/integration/bgp/02-ibgp-ebgp-session.yml
+++ b/tests/integration/bgp/02-ibgp-ebgp-session.yml
@@ -3,6 +3,9 @@ message: |
   Use this topology to test the baseline IPv4 IBGP and EBGP implementation
   and next-hop-self on IBGP sessions.
 
+  DUT has the default device role (router or host) and thus might have to
+  establish IBGP session from the LAN interface.
+
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 defaults.paths.prepend.plugin: [ "topology:../plugin" ]
 
@@ -29,7 +32,6 @@ groups:
 
 nodes:
   dut:
-    role: router
   x1:
     bgp.passive: True
     bgp.session.apply.ibgp: [ passive ]


### PR DESCRIPTION
The BIRD BGP configuration template was created before we had the BGP neighbor _source_intf attribute and thus used weird logic to figure out the source IP address of a BGP session, causing crashes in certain scenarios where the device was used as host.

With this change, the template uses ngb._source_intf attribute when it's defined and leaves the source IP address empty when it's not (so it becomes the IP address of the outgoing interface).

The IBGP/EBGP integration test was (re)adjusted to test this scenario.