### PR TITLE
Fix: Use correct literal IPv6 addrs in tool URLs

### DIFF
--- a/netsim/cli/connect.py
+++ b/netsim/cli/connect.py
@@ -202,7 +202,11 @@ def connect_to_tool(
       need_output: bool = False) -> typing.Optional[typing.Union[bool,int,str]]:
 
   cmds = external_commands.get_tool_command(tool,'connect',topology,verbose=False)
-  topology.sys.ipaddr = external_commands.get_local_addr()
+
+  loc_addr = external_commands.get_local_addr()
+  topology.sys.ipaddr = loc_addr
+  topology.sys.ipurl = f'[{loc_addr}]' if ':' in loc_addr else loc_addr
+
   if cmds is None:
     msg = external_commands.get_tool_message(tool,topology)
     if not msg:

--- a/netsim/cli/external_commands.py
+++ b/netsim/cli/external_commands.py
@@ -293,7 +293,11 @@ def get_local_addr() -> str:
 #
 def execute_tool_commands(cmds: list, topology: Box) -> typing.Optional[str]:
   topology.sys.docker_net = ""
-  topology.sys.ipaddr = get_local_addr()
+
+  loc_addr = get_local_addr()
+  topology.sys.ipaddr = loc_addr
+  topology.sys.ipurl = f'[{loc_addr}]' if ':' in loc_addr else loc_addr
+
   if docker_is_used(topology):
     topology.sys.docker_net = f"--network={topology.addressing.mgmt.get('_network',None) or 'netlab_mgmt'}"
 

--- a/netsim/tools/edgeshark.yml
+++ b/netsim/tools/edgeshark.yml
@@ -2,7 +2,7 @@
 # Edgeshark tool
 # https://github.com/siemens/edgeshark
 #
-
+---
 runtime: docker     # Default: start in a Docker container
 docker:
   up:
@@ -56,7 +56,7 @@ docker:
         "--proxy-discovery"
 
   message:
-    Open http://{sys.ipaddr}:5001 in your browser
+    Open http://{sys.ipurl}:5001 in your browser
   down:
   - docker rm -f edgeshark
   - docker rm -f gostwire

--- a/netsim/tools/graphite.yml
+++ b/netsim/tools/graphite.yml
@@ -1,6 +1,7 @@
 #
 # Graphite tool
 #
+---
 runtime: docker     # Default: start in a Docker container
 docker:
   up:
@@ -10,8 +11,8 @@ docker:
       -p { 8080 + defaults.multilab.id if defaults.multilab.id else 8080 }:80
       --name "{name}_graphite"
       netreplica/graphite:0.4.2
-  message:
-    Open http://{sys.ipaddr}:{ 8080 + defaults.multilab.id if defaults.multilab.id else 8080 }/graphite/ in your browser
+  message: >-
+    Open http://{sys.ipurl}:{8080 + defaults.multilab.id if defaults.multilab.id else 8080}/graphite/ in your browser
   down:
     docker kill '{name}_graphite'
 config:

--- a/netsim/tools/nso.yml
+++ b/netsim/tools/nso.yml
@@ -11,7 +11,7 @@ docker:
     docker exec -it {name}-cisco-nso sed -i.backup -e "/<local-authentication>/{{n;s|<enabled>false</enabled>|<enabled>true</enabled>|}}" /etc/ncs/ncs.conf;
     docker exec -it {name}-cisco-nso sed -i.backup -e "/<webui>/a <package-upload> <enabled>true</enabled> </package-upload>" /etc/ncs/ncs.conf;
   message:
-    Open http://{sys.ipaddr}:{ 8888 + defaults.multilab.id if defaults.multilab.id else 8888 } in your browser
+    Open http://{sys.ipurl}:{ 8888 + defaults.multilab.id if defaults.multilab.id else 8888 } in your browser
     Use admin/admin for login
     Use 'netlab connect nso' to start nso CLI and type ncs_cli -C -u admin to acces cisco CLI
   connect:


### PR DESCRIPTION
When 'netlab' decides that the best way to connect to a lab tools is via an IPv6 address, it has to enclose the literal IPv6 address in square brackets according to RFC 2732.