### PR TITLE
bug: Fix silent skipping of nested integrations tests #3532

### DIFF
--- a/tests/check-integration-tests.sh
+++ b/tests/check-integration-tests.sh
@@ -3,6 +3,7 @@
 # Run transformation code on integration tests for an additional
 # verification before merging pull requests
 #
+shopt -s globstar
 err_cnt=0
 
 for file in integration/**/[0-9]*.yml platform-integration/**/[0-9]*.yml; do


### PR DESCRIPTION
Pointed out by Copilot review here --> https://github.com/ipspace/netlab/pull/3532/changes#r3485734887

integration/**/[0-9]*.yml relies on Bash globstar; without enabling it, this script (and CI) will silently skip nested integration tests like tests/integration/ospf/ospfv2/04-passive.yml.

This PR implements the fix for that gap.