### PR TITLE
Fix features of 'none' device

### DIFF
--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -92,6 +92,7 @@ features:
     vpn: True
     6pe: True
   ospf:
+    areas: true
     unnumbered: True
     import: [ bgp, isis, ripv2, connected, static, vrf ]
     default.policy: true


### PR DESCRIPTION
The changes made in #3532 fixed the CI/CD harness that checks the integration tests against the 'none' device. As more tests being run, we have to update the device features to pass this expanded set of tests.