### PR TITLE
Add the v6 addressing and check for the containerlab instance in dual stack integration test

### DIFF
--- a/tests/platform-integration/cli/13-status-mgmt-dual-stack.yml
+++ b/tests/platform-integration/cli/13-status-mgmt-dual-stack.yml
@@ -23,6 +23,7 @@ nodes:
   ctr:
     provider: clab
     mgmt.ipv4: 192.168.121.32
+    mgmt.ipv6: 2001:db8:121::32
 
 links: [ vm-ctr ]
 
@@ -35,6 +36,7 @@ files:
     grep "192.168.121.31" status.out >/dev/null
     grep "2001:db8:121::31" status.out >/dev/null
     grep "192.168.121.32" status.out >/dev/null
+    grep "2001:db8:121::32" status.out >/dev/null
     grep "graphite" status.out >/dev/null
     netlab status --format json >status.json
     python3 - <<'PY'
@@ -46,6 +48,7 @@ files:
     assert nodes["vm"]["mgmt"] == "192.168.121.31"
     assert nodes["vm"]["mgmt6"] == "2001:db8:121::31"
     assert nodes["ctr"]["mgmt"] == "192.168.121.32"
+    assert nodes["ctr"]["mgmt6"] == "2001:db8:121::32"
     assert nodes["graphite"]["device"] == "(tool)"
     assert "mgmt" not in nodes["graphite"]
     assert "mgmt6" not in nodes["graphite"]


### PR DESCRIPTION
This dropped off the dual stack integration test while re-working it in the original fix.

**// Current**

```
> $ ../netlab status                                                                            [±enhancement/add_dualstack_mgmt_address_support_to_status ●]
Lab default in /home/adrian/code/forks/netlab/tests
  status:      started
  topology:    platform-integration/cli/13-status-mgmt-dual-stack.yml
  provider(s): libvirt,clab

┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ node     ┃ device ┃ image              ┃ mgmt IP          ┃ connection ┃ provider ┃ VM/container ┃ status        ┃
┡━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ vm       │ linux  │ bento/ubuntu-24.04 │ 192.168.121.31   │ paramiko   │ libvirt  │ cli_vm       │ running       │
│          │        │                    │ 2001:db8:121::31 │            │          │              │               │
├──────────┼────────┼────────────────────┼──────────────────┼────────────┼──────────┼──────────────┼───────────────┤
│ ctr      │ linux  │ python:3.13-alpine │ 192.168.121.32   │ docker     │ clab     │ clab-cli-ctr │ Up 31 seconds │
├──────────┼────────┼────────────────────┼──────────────────┼────────────┼──────────┼──────────────┼───────────────┤
│ graphite │ (tool) │                    │                  │ docker     │ clab     │ cli_graphite │ Not running   │
└──────────┴────────┴────────────────────┴──────────────────┴────────────┴──────────┴──────────────┴───────────────┘
```

**// After**

```
> $ ../netlab status                                                                                  [±improvement/dual-stack-integration-test_status_fix ●]
Lab default in /home/adrian/code/forks/netlab/tests
  status:      started
  topology:    platform-integration/cli/13-status-mgmt-dual-stack.yml
  provider(s): libvirt,clab

┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ node     ┃ device ┃ image              ┃ mgmt IP          ┃ connection ┃ provider ┃ VM/container ┃ status            ┃
┡━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ vm       │ linux  │ bento/ubuntu-24.04 │ 192.168.121.31   │ paramiko   │ libvirt  │ cli_vm       │ running           │
│          │        │                    │ 2001:db8:121::31 │            │          │              │                   │
├──────────┼────────┼────────────────────┼──────────────────┼────────────┼──────────┼──────────────┼───────────────────┤
│ ctr      │ linux  │ python:3.13-alpine │ 192.168.121.32   │ docker     │ clab     │ clab-cli-ctr │ Up About a minute │
│          │        │                    │ 2001:db8:121::32 │            │          │              │                   │
├──────────┼────────┼────────────────────┼──────────────────┼────────────┼──────────┼──────────────┼───────────────────┤
│ graphite │ (tool) │                    │                  │ docker     │ clab     │ cli_graphite │ Not running       │
└──────────┴────────┴────────────────────┴──────────────────┴────────────┴──────────┴──────────────┴───────────────────┘

```