### PR TITLE
Feature/frr GRE tunnel support

### DIFF
--- a/docs/plugins/tunnel.gre.md
+++ b/docs/plugins/tunnel.gre.md
@@ -10,6 +10,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Operating system    | GRE over<br>IPv4 | GRE over<br>IPv6 | Transport<br>VRF |
 |--------------|:-:|:-:|:-:|
 | Cisco IOS/XE[^18v] |✅|✅|✅|
+| FRR                 |✅|✅|✅|
 
 [^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
 

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -188,6 +188,8 @@ features:
   stp:
     supported_protocols: [ stp ]  # Implementation uses a separate bridge per VLAN
     enable_per_port: False
+  tunnel:
+    gre: [ vrf ]
   vlan:
     mixed_trunk: true
     model: router

--- a/netsim/extra/tunnel.gre/defaults.yml
+++ b/netsim/extra/tunnel.gre/defaults.yml
@@ -1,10 +1,6 @@
 # GRE tunnels attributes and defaults
 #
 ---
-devices:
-  frr:
-    features.tunnel.gre: [ vrf ]
-
 providers:
   clab:
     kmods:
@@ -14,7 +10,7 @@ attributes:
   link:
     tunnel:
       af:                     # Transport address family
-        { type: str, valid_values: [ ipv4, ipv6] }
+        { type: str, valid_values: [ ipv4, ipv6 ] }
       mode:                   # Every tunnel plugin must define tunnel.mode link attribute
         _required: True
         type: str

--- a/netsim/extra/tunnel.gre/defaults.yml
+++ b/netsim/extra/tunnel.gre/defaults.yml
@@ -1,6 +1,15 @@
 # GRE tunnels attributes and defaults
 #
 ---
+devices:
+  frr:
+    features.tunnel.gre: [ vrf ]
+
+providers:
+  clab:
+    kmods:
+      tunnel@gre: [ ip_gre, ip6_gre ]
+
 attributes:
   link:
     tunnel:

--- a/netsim/extra/tunnel.gre/frr.j2
+++ b/netsim/extra/tunnel.gre/frr.j2
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+set -e
+#
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
+{%   set af = intf.tunnel.af|default('ipv4') %}
+{%   set gre_mode = 'ip6gre' if af == 'ipv6' else 'gre' %}
+ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
+  local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
+  dev {{ intf.tunnel._source.ifname }} ttl 255
+ip link set dev {{ intf.ifname }} up
+{% endfor %}
+exit 0

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -109,11 +109,16 @@ def load_kmods(topology: Box) -> None:
 
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules
     #
-    for m in (['initial']+ndata.get('module',[])):          # Now iterate over all the netlab modules the node uses
-      if m not in kdata:                                    # ... and if the netlab modules does not need kernel modules
-        continue                                            # ... move on
-      for kmod in kdata[m]:                                 # Next, add individual kernel modules in the kdata entry
-        append_to_list(kmod_list,m,kmod)                    # ... to the module-specific list of kernel mdules
+    for m in (['initial']+ndata.get('module',[])+ndata.get('config',[])):
+      if m in kdata:
+        kmods = kdata[m]
+      else:
+        kmod_key = m.replace('.','@')                       # For modules like bgp.session, use the @-as-. hack  
+        if kmod_key not in kdata:
+          continue
+        kmods = kdata[kmod_key]
+      for kmod in kmods:
+        append_to_list(kmod_list,m,kmod)
 
   # Now we have lists of kernel modules that have to be loaded based on netlab modules used in lab topology
   # Next step: for every netlab module, load the missing kernel modules

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -87,6 +87,21 @@ def get_loaded_kernel_modules() -> list:
   return [ line.split(' ')[0] for line in mod_list ]
 
 '''
+load_plugin_kmods: Collect kernel modules required by lab plugins
+'''
+def load_plugin_kmods(topology: Box, clab_kmods: Box, kmod_list: Box) -> None:
+  for p in topology.get('plugin',[]):
+    if p in clab_kmods:
+      kmods = clab_kmods[p]
+    else:
+      kmod_key = p.replace('.','@')   # For modules like bgp.session, use the @-as-. hack  
+      if kmod_key not in clab_kmods:
+        continue
+      kmods = clab_kmods[kmod_key]
+    for kmod in kmods:
+      append_to_list(kmod_list,p,kmod)
+
+'''
 load_kmods: Load kernel modules before starting containers
 
 The kernel modules needed for individual netlab modules are defined in provider- or device 'kmods'
@@ -97,6 +112,8 @@ def load_kmods(topology: Box) -> None:
   defs = topology.defaults
   clab_kmods = defs.providers.clab.kmods
   kmod_list  = get_empty_box()
+
+  load_plugin_kmods(topology,clab_kmods,kmod_list)
 
   for ndata in topology.nodes.values():                     # Iterate over all nodes
     if ndata.get('provider') != 'clab':                     # The node is not using clab provider, move on
@@ -109,16 +126,11 @@ def load_kmods(topology: Box) -> None:
 
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules
     #
-    for m in (['initial']+ndata.get('module',[])+ndata.get('config',[])):
-      if m in kdata:
-        kmods = kdata[m]
-      else:
-        kmod_key = m.replace('.','@')                       # For modules like bgp.session, use the @-as-. hack  
-        if kmod_key not in kdata:
-          continue
-        kmods = kdata[kmod_key]
-      for kmod in kmods:
-        append_to_list(kmod_list,m,kmod)
+    for m in (['initial']+ndata.get('module',[])):          # Now iterate over all the netlab modules the node uses
+      if m not in kdata:                                    # ... and if the netlab modules does not need kernel modules
+        continue                                            # ... move on
+      for kmod in kdata[m]:                                 # Next, add individual kernel modules in the kdata entry
+        append_to_list(kmod_list,m,kmod)                    # ... to the module-specific list of kernel mdules
 
   # Now we have lists of kernel modules that have to be loaded based on netlab modules used in lab topology
   # Next step: for every netlab module, load the missing kernel modules

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -94,7 +94,7 @@ def load_plugin_kmods(topology: Box, clab_kmods: Box, kmod_list: Box) -> None:
     if p in clab_kmods:
       kmods = clab_kmods[p]
     else:
-      kmod_key = p.replace('.','@')   # For modules like bgp.session, use the @-as-. hack  
+      kmod_key = p.replace('.','@')   # For modules like bgp.session, use the @-as-. hack
       if kmod_key not in clab_kmods:
         continue
       kmods = clab_kmods[kmod_key]

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -110,14 +110,10 @@ def load_kmods(topology: Box) -> None:
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules
     #
     for m in (['initial']+ndata.get('module',[])+ndata.get('config',[])):  # Now iterate over all the netlab modules the node uses
-      if m in kdata:
-        kmods = kdata[m]
-      else:
-        kmod_key = m.replace('.','@')                       # For plugins like tunnel.gre, use the @-as-. hack
-        if kmod_key not in kdata:                           # ... and if the netlab modules does not need kernel modules
-          continue                                          # ... move on
-        kmods = kdata[kmod_key]
-      for kmod in kmods:                                    # Next, add individual kernel modules in the kdata entry
+      kmod_key = m.replace('.','@')                         # Module names have no dots, plugins like tunnel.gre need to use @-as-.
+      if kmod_key not in kdata:                             # The netlab module does not need any kernel modules
+        continue                                            # ... move on
+      for kmod in kdata[kmod_key]:                          # Next, add individual kernel modules in the kdata entry
         append_to_list(kmod_list,m,kmod)                    # ... to the module-specific list of kernel mdules
 
   # Now we have lists of kernel modules that have to be loaded based on netlab modules used in lab topology

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -87,21 +87,6 @@ def get_loaded_kernel_modules() -> list:
   return [ line.split(' ')[0] for line in mod_list ]
 
 '''
-load_plugin_kmods: Collect kernel modules required by lab plugins
-'''
-def load_plugin_kmods(topology: Box, clab_kmods: Box, kmod_list: Box) -> None:
-  for p in topology.get('plugin',[]):
-    if p in clab_kmods:
-      kmods = clab_kmods[p]
-    else:
-      kmod_key = p.replace('.','@')   # For modules like bgp.session, use the @-as-. hack
-      if kmod_key not in clab_kmods:
-        continue
-      kmods = clab_kmods[kmod_key]
-    for kmod in kmods:
-      append_to_list(kmod_list,p,kmod)
-
-'''
 load_kmods: Load kernel modules before starting containers
 
 The kernel modules needed for individual netlab modules are defined in provider- or device 'kmods'
@@ -112,8 +97,6 @@ def load_kmods(topology: Box) -> None:
   defs = topology.defaults
   clab_kmods = defs.providers.clab.kmods
   kmod_list  = get_empty_box()
-
-  load_plugin_kmods(topology,clab_kmods,kmod_list)
 
   for ndata in topology.nodes.values():                     # Iterate over all nodes
     if ndata.get('provider') != 'clab':                     # The node is not using clab provider, move on
@@ -126,10 +109,15 @@ def load_kmods(topology: Box) -> None:
 
     # At this point, we have device-specific dictionary mapping netlab modules into kernel modules
     #
-    for m in (['initial']+ndata.get('module',[])):          # Now iterate over all the netlab modules the node uses
-      if m not in kdata:                                    # ... and if the netlab modules does not need kernel modules
-        continue                                            # ... move on
-      for kmod in kdata[m]:                                 # Next, add individual kernel modules in the kdata entry
+    for m in (['initial']+ndata.get('module',[])+ndata.get('config',[])):  # Now iterate over all the netlab modules the node uses
+      if m in kdata:
+        kmods = kdata[m]
+      else:
+        kmod_key = m.replace('.','@')                       # For plugins like tunnel.gre, use the @-as-. hack
+        if kmod_key not in kdata:                           # ... and if the netlab modules does not need kernel modules
+          continue                                          # ... move on
+        kmods = kdata[kmod_key]
+      for kmod in kmods:                                    # Next, add individual kernel modules in the kdata entry
         append_to_list(kmod_list,m,kmod)                    # ... to the module-specific list of kernel mdules
 
   # Now we have lists of kernel modules that have to be loaded based on netlab modules used in lab topology


### PR DESCRIPTION
Building out the GRE tunnel support #3554, couple of highlights:

* First plugin that requires a kernel module for Linux devices (with .-key issues); code adds a check for config keys such that kernel modules are only loaded if the plugin is actually used by at least 1 node
* ipv6 support anticipated, not tested yet