### PR TITLE
Fix: Do not use default routes in single-VRF GRE tests

### DIFF
--- a/tests/integration/tunnel/01-gre.yml
+++ b/tests/integration/tunnel/01-gre.yml
@@ -6,6 +6,10 @@ message: |
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
+addressing:
+  core:
+    ipv4: 172.22.0.0/16
+
 plugin: [ tunnel.gre ]
 
 groups:
@@ -16,7 +20,7 @@ groups:
   ce:
     members: [ dut_r1, dut_r2 ]
     routing.static:
-    - ipv4: 0.0.0.0/0
+    - pool: core
       nexthop.node: core
 
 module: [ ospf, routing ]
@@ -32,6 +36,7 @@ links:
 - group: core
   ospf: False
   role: core
+  pool: core
   members: [ dut_r1-core, dut_r2-core ]
 - group: site
   members: [ dut_r2-r3 ]


### PR DESCRIPTION
Closes #3563