### PR TITLE
Fix BIRD inconsistencies

### DIFF
--- a/docs/dev/config/deploy.md
+++ b/docs/dev/config/deploy.md
@@ -1,18 +1,18 @@
 (dev-config-deploy)=
 # Deploying Device Configurations
 
-*netlab* Ansible playbooks deploy configurations through device-specific task lists and templates. Linux-based containers (including daemons such as Bird or dnsmasq, and routers such as FRRouting or VyOS) can also be configured using shell scripts.
+*netlab* Ansible playbooks deploy configurations through device-specific task lists and templates. Linux-based containers (including daemons such as BIRD or dnsmasq, and routers such as FRRouting or VyOS) can also be configured using shell scripts.
 
 When adding a new device type, you'll have to create either:
 
 * A generic _deploy configuration_ task list and a bunch of configuration templates
 * A module-specific task list for an individual module, plus the associated initial configuration templates (which could be empty)
 * Linux scripts that can be mapped into container files and executed within the container network namespace on the _netlab_ host or within the container itself
-* Daemon configuration files for container-based daemons (for example, Bird).
+* Daemon configuration files for container-based daemons (for example, BIRD).
 
 You can also mix and match the approaches. For example, several devices have a generic *deploy configuration* task list, but use a separate list of tasks for the initial configuration.
 
-You could also use Linux scripts for some configuration modules, Daemon configuration files for other tasks, and an Ansible task list + template for the rest of the tasks (or custom templates). For example, Bird daemon uses configuration files to configure BGP and OSPF, shell scripts (inherited from the Linux device) to configure interfaces, VLANs, and link aggregation groups, and an Ansible task list (also inherited from the Linux device) to deploy custom configuration templates.
+You could also use Linux scripts for some configuration modules, Daemon configuration files for other tasks, and an Ansible task list + template for the rest of the tasks (or custom templates). For example, BIRD daemon uses configuration files to configure BGP and OSPF, shell scripts (inherited from the Linux device) to configure interfaces, VLANs, and link aggregation groups, and an Ansible task list (also inherited from the Linux device) to deploy custom configuration templates.
 
 ```eval_rst
 .. contents:: Table of Contents
@@ -197,9 +197,9 @@ Unfortunately, the Nexus 9300v linecards become active almost a minute after com
 (dev-config-daemon)=
 ## Daemon Configuration Files
 
-You can use Jinja2 templates to create *daemon configuration files* mapped into daemon containers. These files are present in the container file system when the container starts and can be used to configure the daemon (e.g., Bird or dnsmasq) running in the container.
+You can use Jinja2 templates to create *daemon configuration files* mapped into daemon containers. These files are present in the container file system when the container starts and can be used to configure the daemon (e.g., BIRD or dnsmasq) running in the container.
 
-The daemon configuration files are specified in the **daemon_config** device parameter. These are the configuration files used by the Bird daemon:
+The daemon configuration files are specified in the **daemon_config** device parameter. These are the configuration files used by the BIRD daemon:
 
 ```
 daemon_config:

--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -55,6 +55,7 @@ The following table describes the per-platform support of individual router-leve
 | ------------------------ |:-:|:-:|:-:|:-:|:-:|
 | Arista EOS               | ✅| ✅| ✅| ✅| ✅|
 | Aruba AOS-CX             | ✅| ✅| ✅| ✅| ✅|
+| BIRD                     | ✅| ✅| ✅| ✅| ❌ | 
 | Cisco ASAv               | ✅| ✅| ❌ | ❌ | ✅|
 | Cisco IOSv/IOSvL2        | ✅| ✅| ✅| ✅| ✅|
 | Cisco IOS XE[^18v]       | ✅| ✅| ✅| ✅| ✅|
@@ -93,6 +94,7 @@ The following devices support BFD with OSPF:
 | ------------------------ | :--: | :--: |
 | Arista EOS               |  ✅  |  ❌   |
 | Aruba AOS-CX             |  ✅  |  ❌   |
+| BIRD                     |  ✅  |  ❌   |
 | Cisco IOS                |  ✅  |  ❌   |
 | Cisco IOS XE[^18v]       |  ✅  |  ❌   |
 | Cisco Nexus OS           |  ✅  |  ❌   |
@@ -118,12 +120,6 @@ The following devices support OSPF graceful restart:
 See [OSPFv2](https://release.netlab.tools/_html/coverage.ospf.ospfv2) and [OSPFv3](https://release.netlab.tools/_html/coverage.ospf.ospfv3) Integration Tests Results for more details.
 ```
 
-OSPF is also supported on these [routing daemons](platform-daemons):
-
-| Operating system         | Areas | Reference<br/>bandwidth | OSPFv3 | BFD  | BFD<br/>Strict-Mode |
-| ------------------------ |:--:|:--:|:--:|:--:|:--:|
-| BIRD                     | ✅ | ❌  | ✅ | ❌  | ❌  |
-
 (ospf-interface-support)=
 The following table documents the common interface-level OSPF features:
 
@@ -131,6 +127,7 @@ The following table documents the common interface-level OSPF features:
 | ------------------------ |:--:|:--:|:--:|:--:|
 | Arista EOS               | ✅ | ✅ | ✅ | ✅ |
 | Aruba AOS-CX             | ✅ | ✅ | ✅  | ✅ |
+| BIRD                     | ✅ | ✅ | ✅(*) | ✅ |
 | Cisco ASAv               | ✅ | [❗](caveats-asav) | ❌  | ✅ |
 | Cisco IOS                | ✅ | ✅ | ❌  | ✅ |
 | Cisco IOS XE[^18v]       | ✅ | ✅ | ✅ | ✅ |
@@ -153,16 +150,8 @@ The following table documents the common interface-level OSPF features:
 **Notes:**
 * Arista EOS, Cisco Nexus OS, SR Linux, and Dell OS10 support point-to-point and broadcast network types. Other network types will not be configured.
 * SR OS supports point-to-point, broadcast, and non-broadcast network types. It will not configure a point-to-multipoint network type.
-
-OSPF routing daemons support these interface-level features:
-
-| Operating system         | Cost  | Network<br />type | Unnumbered<br />IPv4 interfaces | Passive<br />interfaces |
-| ------------------------ |:--:|:--:|:--:|:--:|
-| BIRD                     | ✅ | ✅ | ✅(*) | ✅ |
-
-**Notes:**
-* Routing daemons usually have a single interface. Running OSPF on them seems frivolous unless you need OSPF to get paths toward remote endpoints of IBGP sessions.
-* Unnumbered IPv4 interface support requires a single unnumbered peer 
+* Control-plane daemons like BIRD usually have a single interface. Running OSPF on them seems frivolous unless you need OSPF to get paths toward remote endpoints of IBGP sessions.
+* Unnumbered IPv4 interfaces on BIRD require a single unnumbered peer 
 
 (ospf-interface-optional-support)=
 These devices also support optional OSPF interface attributes:
@@ -171,6 +160,7 @@ These devices also support optional OSPF interface attributes:
 | ------------------------ |:--:|:--:|:--:|:--:|
 | Arista EOS               | ✅ | ✅ | ✅ | ❌  |
 | Aruba AOS-CX             | ✅ | ✅ | ✅ | ❌  |
+| BIRD                     | ✅ | ✅ | ✅ | ❌ |
 | Cisco ASAv               | ✅ | ✅ | ✅ | ❌  |
 | Cisco IOSv/IOSvL2        | ✅ | ✅ | ✅ | ❌  |
 | Cisco IOS XE[^18v]       | ✅ | ✅ | ✅ | ❌  |
@@ -182,12 +172,6 @@ These devices also support optional OSPF interface attributes:
 | Extreme Networks EXOS    | ✅ | ✅ | ❌  | ❌  |
 | Junos[^Junos]            | ✅ | ✅ | ✅ | ❌  | 
 | OpenBSD                  | ✅ | ✅ | ✅ | ❌  |
-
-OSPF routing daemons support these optional OSPF interface attributes:
-
-| Operating system         | Interface<br>timers | Router<br />priority | Cleartext<br>password | MD5<br>digest |
-| ------------------------ |:--:|:--:|:--:|:--:|
-| BIRD                     | ✅ | ✅ | ✅ | ❌ |
 
 (ospf-node-parameters)=
 ## Node Parameters

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -82,7 +82,7 @@ Most devices behave as routers (or layer-3 switches); the following devices can 
 | Device | router | host | bridge |
 |-----------------------|:--:|:--:| :--:|
 | Arista EOS            | ✅ | ✅ | ✅ |
-| Bird                  | ✅ | ✅ | ❌  |
+| BIRD                  | ✅ | ✅ | ❌  |
 | Cisco IOS/IOS XE[^18v]| ✅ | ✅ | ✅ |
 | dnsmasq               | ❌  | ✅ | ❌  |
 | FRRouting             | ✅ | ✅ | ✅ |
@@ -241,7 +241,7 @@ _netlab_ uses Ansible playbooks and device-specific task lists to deploy device 
 
 [^LBS]: Initial device configurations, static routes, VLANs, and interface bonding are configured with host-side scripts executed in the container namespace. Custom configuration templates are assumed to be Linux scripts executed within the container ([more details](generic-linux-devices)).
 
-[^BBS]: Initial device configurations, VLANs, and link aggregation are configured with **bash** scripts. All other features are configured with the Bird configuration files.
+[^BBS]: Initial device configurations, VLANs, and link aggregation are configured with **bash** scripts. All other features are configured with the BIRD configuration files.
 
 [^DBS]: Initial device configurations, VLANs, static routes, and link aggregation are configured with **bash** scripts. All other features are configured with the dnsmasq configuration files.
 
@@ -386,6 +386,7 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | --------------------- | :--: | :--: | :--: | :--: | :--: |
 | Arista EOS            | ✅   |  ✅  |   ❌  |  ✅  |  ✅  |
 | Aruba AOS-CX          | ✅   |  ❌   |   ❌  |  ✅  |   ❌  |
+| BIRD Internet Routing Daemon | ✅ [❗](caveats-bird) | ❌ | ❌ | ✅ [❗](caveats-bird) | ❌ |
 | Cisco ASAv            | ✅ [❗](caveats-asav) | ✅ [❗](caveats-asav) | ❌ | ✅ | ❌ |
 | Cisco IOS/IOS XE[^18v]| ✅   |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco IOS XR[^XR]     | ✅   |  ✅  |   ❌  |  ✅  |   ❌  |
@@ -404,12 +405,6 @@ Routing protocol [configuration modules](module-reference.md) are supported on t
 | OpenBSD               | ✅   |   ❌   |   ❌  | ✅   | ✅   |
 | Sonic                 |  ❌   |   ❌   |   ❌  | ✅  |   ❌  |
 | VyOS                  | ✅   |  ✅   |   ❌  | ✅  |   ❌  |
-
-Routing protocol [configuration modules](module-reference.md) are also supported on these daemons:
-
-| Operating system      | [OSPF](module/ospf.md) | [IS-IS](module/isis.md) | [BGP](module/bgp.md) | [RIPv2/ng](module/ripv2.md) |
-|------------------------------|:--:|:--:|:--:|:--:|
-| BIRD Internet Routing Daemon | ✅ [❗](caveats-bird) | ❌ | ✅ [❗](caveats-bird) | ❌ |
 
 These devices support additional control-plane protocols or BGP address families:
 
@@ -494,15 +489,10 @@ Network services [configuration modules](module-reference.md) are supported on t
 | Operating system      | [DHCP](module/dhcp.md) | [DHCPv6](module/dhcp.md) |
 | --------------------- | :--: | :--: |
 | Arista EOS            | ✅   |  ✅  |
+| dnsmasq               | ✅   |  ✅  |
 | Cisco CSR 1000v       | ✅   |  ✅  |
 | Cisco IOSv/IOSvL2     | ✅   |  ✅  |
 | Cumulus Linux         | ✅   |  ✅  |
-
-Network services [configuration modules](module-reference.md) are also supported on these daemons:
-
-| Operating system      | [DHCP](module/dhcp.md) | [DHCPv6](module/dhcp.md) |
-| --------------------- | :--: | :--: |
-| dnsmasq               | ✅   |  ✅  |
 
 ```{tip}
 See [integration test results](https://release.netlab.tools/) for more details.
@@ -516,6 +506,7 @@ Core *netlab* functionality and all multi-protocol routing protocol configuratio
 | --------------------- |:--:|:--:|:--:|:--:|:--:|
 | Arista EOS            | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Aruba AOS-CX          | ✅ | ❌ | ❌ | ✅ | ❌ |
+| BIRD                  | ✅ | ❌ | ❌ | ✅ | ❌ |
 | Cisco ASAv            | ❌ | ✅ | ❌ | ✅ | ❌ |
 | Cisco IOS/IOS XE[^18v]| ✅ | ✅ | ✅ | ✅ | ❌ |
 | Cisco IOS XR[^XR]     | ✅ | ✅ | ❌ | ✅ | ✅ |

--- a/docs/plugins/bgp.session.md
+++ b/docs/plugins/bgp.session.md
@@ -63,6 +63,7 @@ The plugin implements generic BGP session features for the following platforms:
 | ------------------- | :--: | :--: | :--: | :--: | :--: |
 | Arista EOS          |  ✅  |  ✅  |  ✅  |  ✅  | ✅  |
 | Aruba AOS-CX        |  ✅  |  ✅  |  ✅  |   ❌  |  ❌  |
+| BIRD                |  ✅  |  ✅  |  ✅  |  ✅  |  ❌  |
 | Cisco IOSv/IOSvL2   |  ✅  |  ✅  |  ✅  |  ✅  |  ❌  |
 | Cisco IOS XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |  ❌  |
 | Cisco IOS XR[^XR]   |  ✅  |  ✅  |   ❌  |  ✅  |  ❌  |
@@ -88,12 +89,6 @@ The plugin implements generic BGP session features for the following platforms:
 * Arista EOS supports TCP-AO only when running as a virtual machine
 * _netlab_ always configures HMAC-SHA1-96 as the cryptographic algorithm on IOS XE
 
-BGP session features are also available on these daemons:
-
-| Operating system    | default<br>originate | BGP<br>timers |  BFD | Passive<br>peer |
-| ------------------- | :--: | :--: | :--: | :--: |
-| BIRD                |  ✅  |  ✅  |   ✅  |  ✅  |
-
 (bgp-session-security)=
 BGP session security features are available on these platforms:
 
@@ -101,6 +96,7 @@ BGP session security features are available on these platforms:
 | ------------------- | :------: | :-: | :-:  |
 | Arista EOS          |    ✅    | ✅  |  ✅ |
 | Aruba AOS-CX        |    ✅    | ✅  |  ❌  |
+| BIRD                |    ✅    | ✅   | ❌   |
 | Cisco IOSv/IOSvL2   |    ✅    | ✅  |  ❌  |
 | Cisco IOS XE[^18v]  |    ✅    | ✅  |  ✅ |
 | Cisco IOS XR[^XR]   |    ✅    | ✅  |  ✅ |
@@ -115,12 +111,6 @@ BGP session security features are available on these platforms:
 | Nokia SR OS         |    ✅    | ❌  |  ✅  |
 | OpenBSD             |    ✅    | ✅  |  ❌  |
 
-BGP session security features are also available on these daemons:
-
-| Operating system    | password | GTSM | TCP-AO |
-| ------------------- | :------: | :-: | :-: |
-| BIRD                |    ✅    | ✅   | ❌   |
-
 (bgp-session-as-path)=
 The plugin implements AS-path-mangling nerd knobs for the following platforms:
 
@@ -128,7 +118,7 @@ The plugin implements AS-path-mangling nerd knobs for the following platforms:
 | ------------------- | :--: | :--: | :--: | :--: | :--: |
 | Arista EOS          |  ✅  |  ✅  |  ✅  |   ❌  |  ✅  |
 | Aruba AOS-CX        |  ✅  |  ❌   |  ✅  |   ❌  |   ❌  |
-| Bird                |   ❌  |   ❌  |   ✅  |  ✅  |  ✅  |
+| BIRD                |   ❌  |   ❌  |   ✅  |  ✅  |  ✅  |
 | Cisco IOSv/IOSvL2   |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco IOS XE[^18v]  |  ✅  |  ✅  |  ✅  |  ✅  |  ✅  |
 | Cisco IOS XR[^XR]   |  ✅  |  ✅  |  ✅  |   ❌  |  ✅  |

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -20,7 +20,7 @@ daemon_config:
   evpn: /etc/bird/evpn.mod.conf
 clab:
   group_vars:
-    netlab_show_command: [ birdc, 'show $@' ]
+    netlab_show_command: [ birdcl, 'show $@' ]
     docker_shell: bash -il
     netlab_config_mode: sh
     netlab_start_daemon: "/usr/sbin/bird -d -c /etc/bird/bird.conf"


### PR DESCRIPTION
* BIRD capitalization should be either 'BIRD' for product name or 'bird' for device name.
* BIRD CLI interface has been renamed from 'birdc' to 'birdcl'
* Removed a separate 'daemons' part of various platform support tables and added BIRD (or dnsmasq) to the main table.

Fixes #3505