### PR TITLE
Refactor initial tunnel implementation

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -21,6 +21,61 @@ from . import addressing, devices
 VIRTUAL_INTERFACE_TYPES: typing.Final[typing.List[str]] = [
   'loopback', 'tunnel', 'lag', 'svi' ]
 
+# Utility functions
+#
+# - get_link_by_index: returns a link given its linkindex
+# - get_linkname: returns a link name given its linkindex
+# - get_next_linkindex: returns a unique linkindex for a new link
+# - set_linkindex: Assign unique linkindex to every link
+# - set_linkname: Assign names to all links without them
+
+def get_link_by_index(topology: Box, idx: int) -> typing.Optional[Box]:
+  '''
+  Find a link from its linkindex
+  '''
+  for link in topology.links:
+    if link.linkindex == idx:
+      return link
+  return None
+
+def get_linkname(topology: Box, linkindex: int) -> str:
+  '''
+  Get the name of a link referenced in an interface.
+
+  Always returns string ('unknown' when the link cannot be found)
+  '''
+  link = get_link_by_index(topology,linkindex)
+  return link._linkname if link is not None else 'unknown'
+
+def get_next_linkindex(topology: Box) -> int:
+  '''
+  Get a new linkindex -- either the last linkindex + 1 or default value
+  '''
+  if not topology.links:
+    topology.links = []
+    return topology.defaults.get('link_index',1)
+
+  return topology.links[-1].linkindex + 1
+
+def set_linkindex(topology: Box) -> None:
+  '''
+  set_linkindex -- set link index for each link
+  '''
+  linkindex = topology.defaults.get('link_index',1)
+  for link in topology.links:
+    link.linkindex = linkindex
+    linkindex = linkindex + 1
+
+def set_linknames(topology: Box) -> None:
+  '''
+  set_linknames -- set link name if not defined
+  '''
+  for cnt,link in enumerate(topology.links):
+    if link.get('group'):
+      link._linkname = f'links[{link.group}]'
+    elif not '_linkname' in link:
+      link._linkname = f'links[{cnt+1}]'
+
 '''
 We cannot definitely say whether a node name is valid before the component
 expansion is complete. We can, however, do basic sanity checks.
@@ -1224,45 +1279,6 @@ def set_node_af(nodes: Box) -> None:
         if af in l:
           n.af[af] = True
           continue
-
-'''
-Link index utility functions:
-
-* get_next_linkindex: get last linkindex+1 or default value
-* get_link_by_index: given a link index, return the link
-'''
-
-def get_next_linkindex(topology: Box) -> int:
-  if not topology.links:
-    topology.links = []
-    return topology.defaults.get('link_index',1)
-
-  return topology.links[-1].linkindex + 1
-
-def get_link_by_index(topology: Box, idx: int) -> typing.Optional[Box]:
-  for link in topology.links:
-    if link.linkindex == idx:
-      return link
-  return None
-
-'''
-set_linknames -- set link name if not defined
-'''
-def set_linknames(topology: Box) -> None:
-  for cnt,link in enumerate(topology.links):
-    if link.get('group'):
-      link._linkname = f'links[{link.group}]'
-    elif not '_linkname' in link:
-      link._linkname = f'links[{cnt+1}]'
-
-'''
-set_linkindex -- set link index for each link
-'''
-def set_linkindex(topology: Box) -> None:
-  linkindex = topology.defaults.get('link_index',1)
-  for link in topology.links:
-    link.linkindex = linkindex
-    linkindex = linkindex + 1
 
 '''
 check_duplicate_address: Check whether any two nodes on the link got duplicate IP

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -27,7 +27,7 @@ VIRTUAL_INTERFACE_TYPES: typing.Final[typing.List[str]] = [
 # - get_linkname: returns a link name given its linkindex
 # - get_next_linkindex: returns a unique linkindex for a new link
 # - set_linkindex: Assign unique linkindex to every link
-# - set_linkname: Assign names to all links without them
+# - set_linknames: Assign names to all links without them
 
 def get_link_by_index(topology: Box, idx: int) -> typing.Optional[Box]:
   '''

--- a/netsim/extra/tunnel/__init__.py
+++ b/netsim/extra/tunnel/__init__.py
@@ -62,7 +62,7 @@ def get_tunnel_source(ndata: Box, t_intf: Box, topology: Box) -> typing.List[Box
   '''
   Find the tunnel source interface using (in descending order) tunnel.type,
   tunnel.vrf, and various tunnel.source parameters. Viable interface(s) are
-  also checked for desired transport AF. The first viable interface is returned
+  also checked for desired transport AF. Returns the list of viable interfaces.
   '''
   t_vrf  = t_intf.get('tunnel.vrf',None)
   t_type = t_intf.get('tunnel.source.type',None)
@@ -121,15 +121,18 @@ def set_tunnel_source(t_intf: Box, u_iflist: list, ndata: Box, topology: Box) ->
     t_intf.tunnel._source.ifname = u_intf.ifname
     t_af = t_intf.get('tunnel.af',None)
     for af in log.AF_LIST:
-      if t_af is None or af == t_af:
-        t_intf.tunnel._source[af] = str(ipaddress.ip_interface(u_intf[af]).ip)
+      if (t_af is None or af == t_af) and af in u_intf:
+        if isinstance(u_intf[af],str):                      # We need just IP addresses for numbered interfaces
+          t_intf.tunnel._source[af] = str(ipaddress.ip_interface(u_intf[af]).ip)
+        else:                                               # Or 'True' for unnumbered ones (if supported)
+          t_intf.tunnel._source[af] = u_intf[af]
 
     return True
 
   msg_af = t_intf.tunnel.af + ' ' if 'tunnel.af' in t_intf else ''
   linkname = _links.get_linkname(topology,t_intf.linkindex)
   t_src = get_empty_box()
-  if 'vrf' in t_intf:
+  if 'vrf' in t_intf.tunnel:
     t_src.vrf = t_intf.vrf
   if 'tunnel.source' in t_intf:
     t_src += t_intf.tunnel.source

--- a/netsim/extra/tunnel/__init__.py
+++ b/netsim/extra/tunnel/__init__.py
@@ -7,11 +7,18 @@ import typing
 
 from box import Box
 
-from ..augment import devices as a_devices
-from ..augment import links as _links
-from ..data import get_box, global_vars
-from . import log
+from ...augment import devices as a_devices
+from ...augment import links as _links
+from ...data import get_empty_box, global_vars
+from ...utils import log
 
+
+def init(topology: Box) -> typing.NoReturn:
+  '''
+  Just in case someone has a great idea to use the 'tunnel' plugin, we
+  have to set them straight
+  '''
+  log.fatal("You cannot use the 'tunnel' plugin. Use a plugin for the tunnel mode you're interested in")
 
 def set_tunnel_type(topology: Box) -> None:
   """
@@ -51,7 +58,7 @@ def interfaces(node: Box, tunnel_type: str) -> typing.Generator:
     if intf.get('tunnel.mode',None) == tunnel_type:
       yield intf
 
-def get_tunnel_source(ndata: Box, t_intf: Box, topology: Box) -> typing.Optional[Box]:
+def get_tunnel_source(ndata: Box, t_intf: Box, topology: Box) -> typing.List[Box]:
   '''
   Find the tunnel source interface using (in descending order) tunnel.type,
   tunnel.vrf, and various tunnel.source parameters. Viable interface(s) are
@@ -61,11 +68,13 @@ def get_tunnel_source(ndata: Box, t_intf: Box, topology: Box) -> typing.Optional
   t_type = t_intf.get('tunnel.source.type',None)
   t_name = t_intf.get('tunnel.source.link.name',None)
   t_role = t_intf.get('tunnel.source.link.role',None)
-  t_af   = t_intf.get('tunnel.af','ipv4')
+  t_af   = t_intf.get('tunnel.af',None)
 
   iflist = ndata.get('interfaces',[])
   if 'loopback' in ndata and t_type == 'loopback' and t_vrf is None:
     iflist = iflist + [ ndata.loopback ]
+
+  underlay_iflist = []
 
   for intf in iflist:
     if t_type is None:                            # No type means 'not loopback or tunnel'
@@ -90,17 +99,52 @@ def get_tunnel_source(ndata: Box, t_intf: Box, topology: Box) -> typing.Optional
       else:                                       # No interface role, let's check link role
         link = _links.get_link_by_index(topology,intf.linkindex)
         if link is None or t_role != link.get('role',None):
-          continue                                  # Mismatch in link role
+          continue                                # Mismatch in link role
 
-    if t_af not in intf:                          # Is the interface enabled for the desired tunnel transport AF
-      continue
+    if t_af:
+      if t_af not in intf:                        # Is the interface enabled for the desired tunnel transport AF
+        continue
+      if not isinstance(intf[t_af],str):          # Cannot run tunnels from unnumbered interfaces
+        continue
 
-    if not isinstance(intf[t_af],str):            # Cannot run tunnels from unnumbered interfaces
-      continue
+    underlay_iflist.append(intf)
 
-    return get_box({'ifname': intf.ifname, t_af: str(ipaddress.ip_interface(intf[t_af]).ip) })
+  return underlay_iflist
 
-  return None
+def set_tunnel_source(t_intf: Box, u_iflist: list, ndata: Box, topology: Box) -> bool:
+  '''
+  Set the tunnel interface _source parameters (ifname, optional AF)
+  or report an error
+  '''
+  if u_iflist:
+    u_intf = u_iflist[0]
+    t_intf.tunnel._source.ifname = u_intf.ifname
+    t_af = t_intf.get('tunnel.af',None)
+    for af in log.AF_LIST:
+      if t_af is None or af == t_af:
+        t_intf.tunnel._source[af] = str(ipaddress.ip_interface(u_intf[af]).ip)
+
+    return True
+
+  msg_af = t_intf.tunnel.af + ' ' if 'tunnel.af' in t_intf else ''
+  linkname = _links.get_linkname(topology,t_intf.linkindex)
+  t_src = get_empty_box()
+  if 'vrf' in t_intf:
+    t_src.vrf = t_intf.vrf
+  if 'tunnel.source' in t_intf:
+    t_src += t_intf.tunnel.source
+
+  log.error(
+    f'Cannot get {msg_af}tunnel source for link {linkname} on node {ndata.name}',
+    more_data=f'Tunnel source data: {t_src or "none"}',
+    category=log.MissingDependency,
+    module='tunnel')
+
+  return False
+
+def set_tunnel_name(intf: Box, t_mode: str) -> None:
+  if 'name' in intf and '->' in intf.name and t_mode not in intf.name:
+    intf.name += f' [{t_mode} tunnel]'
 
 def check_feature(
       ndata: Box,

--- a/netsim/extra/tunnel/__init__.py
+++ b/netsim/extra/tunnel/__init__.py
@@ -129,11 +129,11 @@ def set_tunnel_source(t_intf: Box, u_iflist: list, ndata: Box, topology: Box) ->
 
     return True
 
-  msg_af = t_intf.tunnel.af + ' ' if 'tunnel.af' in t_intf else ''
+  msg_af = f'{t_intf.tunnel.af} ' if t_intf.get('tunnel.af',None) else ''
   linkname = _links.get_linkname(topology,t_intf.linkindex)
   t_src = get_empty_box()
   if 'vrf' in t_intf.tunnel:
-    t_src.vrf = t_intf.vrf
+    t_src.vrf = t_intf.tunnel.vrf
   if 'tunnel.source' in t_intf:
     t_src += t_intf.tunnel.source
 

--- a/netsim/extra/tunnel/_p2p.py
+++ b/netsim/extra/tunnel/_p2p.py
@@ -1,0 +1,117 @@
+'''
+Utility functions for point-to-point tunnels
+'''
+
+import typing
+
+from box import Box
+
+from ... import api
+from ...augment import links as _links
+from ...augment import nodes as _nodes
+from ...utils import log
+from .. import tunnel as _tunnel
+
+
+def init(topology: Box) -> None:
+  '''
+  This module is a utility module. Nothing to see here, please move on ;)
+  '''
+  log.fatal("You cannot use the 'tunnel._p2p' plugin. Use a plugin for the tunnel mode you're interested in")
+
+def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
+  '''
+  Check whether the devices using tunnels support them. Returns a dictionary
+  of nodes using the specified tunnel technology
+  '''
+  node_iflist: dict = {}
+
+  for node,ndata in topology.nodes.items():
+    node_iflist[node] = []
+
+    # Initial interface pass: collect tunnel interfaces
+    #
+    node_iflist[node] = [ intf for intf in _tunnel.interfaces(ndata,'gre') ]
+    if not node_iflist:                                     # No GRE interfaces on this node?
+      continue                                              # Cool, move on
+
+    if not _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=t_desc):
+      continue                                              # Device does not support GRE features, move on
+
+    VRF_OK = True
+    for intf in node_iflist[node]:                          # Next check: VRF features
+      if not 'tunnel.vrf' in intf:                          # Tunnel does not use transport VRF? Cool, move on
+        continue
+      VRF_OK = _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=f'VRF {t_desc}',f_value='vrf')
+      break
+
+    if not VRF_OK:                                          # If VRF check failed, move to next node
+      continue
+
+    api.node_config(ndata,f'tunnel.{t_mode}')               # Remember that we need to configure tunnels
+
+  return node_iflist
+
+def tunnel_source(
+      topology: Box,
+      node_iflist: dict,
+      default_af: typing.Optional[str] = None,
+      t_name: str = '') -> None:
+  '''
+  Iterate over nodes using tunnels and figures out the source interfaces
+  for all tunnel interfaces
+
+  - node_iflist: contains lists of tunnel interfaces (returned by tunnel_feature_check)
+  - default_af:  has to be set for tunnels that are not dual-stack-aware
+  - t_name:      the string to add to interface description once we know it's a valid tunnel
+  '''
+  for node in node_iflist.keys():
+    ndata = topology.nodes[node]
+    for intf in node_iflist[node]:
+      if 'tunnel.af' not in intf and default_af:
+        intf.tunnel.af = default_af                         # Set the default AF for the tunnel
+
+      u_iflist = _tunnel.get_tunnel_source(ndata,intf,topology)
+      if not _tunnel.set_tunnel_source(intf,u_iflist,ndata,topology):
+        continue
+
+      if t_name:
+        _tunnel.set_tunnel_name(intf,t_name)
+
+def tunnel_destination(
+      topology: Box,
+      node_iflist: dict,
+      t_mode: str) -> None:
+  '''
+  All nodes with tunnel interfaces should have tunnel._source interface
+  values by now. Iterate over those nodes and use the neighbor
+  tunnel._source values to set interface tunnel._destination.
+  '''
+  for node in node_iflist:                                  # Process only nodes with tunnel interfaces
+    for intf in node_iflist[node]:                          # ... and only tunnel interfaces
+      if len(intf.neighbors) != 1:
+        linkname = _links.get_linkname(topology,intf.linkindex)
+        log.error(
+          f'Tunnel interface should have exactly one neighbor (found {len(intf.neighbors)})',
+          more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {linkname}',
+          module=f'tunnel.{t_mode}',
+          category=log.IncorrectValue)
+        continue
+      ngb = intf.neighbors[0]
+      ngb_intf = _nodes.get_node_interface(topology.nodes[ngb.node],ifname=ngb.ifname)
+      if not ngb_intf:
+        log.error(
+          f'Internal error: Cannot find the remote tunnel interface for interface {intf.ifname} on {node}',
+          category=log.FatalError,
+          module=f'tunnel.{t_mode}')
+        continue
+      if 'tunnel._source' not in ngb_intf:
+        linkname = _links.get_linkname(topology,intf.linkindex)
+        log.error(
+          f'Cannot find tunnel destination for node {ngb.node}',
+          more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {linkname}',
+          module='tunnel.gre',
+          category=log.MissingDependency)
+        continue
+
+      intf.tunnel._destination = ngb_intf.tunnel._source

--- a/netsim/extra/tunnel/_p2p.py
+++ b/netsim/extra/tunnel/_p2p.py
@@ -27,16 +27,13 @@ def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
   node_iflist: dict = {}
 
   for node,ndata in topology.nodes.items():
-    node_iflist[node] = []
-
-    # Initial interface pass: collect tunnel interfaces
-    #
-    node_iflist[node] = [ intf for intf in _tunnel.interfaces(ndata,'gre') ]
-    if not node_iflist:                                     # No GRE interfaces on this node?
+    t_iflist = [ intf for intf in _tunnel.interfaces(ndata,t_mode) ]
+    if not t_iflist:                                        # No tunnel interfaces on this node?
       continue                                              # Cool, move on
 
+    node_iflist[node] = t_iflist
     if not _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=t_desc):
-      continue                                              # Device does not support GRE features, move on
+      continue                                              # Device does not support tunnel features, move on
 
     VRF_OK = True
     for intf in node_iflist[node]:                          # Next check: VRF features
@@ -110,7 +107,7 @@ def tunnel_destination(
         log.error(
           f'Cannot find tunnel destination for node {ngb.node}',
           more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {linkname}',
-          module='tunnel.gre',
+          module='tunnel.{t_mode}',
           category=log.MissingDependency)
         continue
 

--- a/netsim/extra/tunnel/_p2p.py
+++ b/netsim/extra/tunnel/_p2p.py
@@ -31,12 +31,11 @@ def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
     if not t_iflist:                                        # No tunnel interfaces on this node?
       continue                                              # Cool, move on
 
-    node_iflist[node] = t_iflist
     if not _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=t_desc):
       continue                                              # Device does not support tunnel features, move on
 
     VRF_OK = True
-    for intf in node_iflist[node]:                          # Next check: VRF features
+    for intf in t_iflist:                                   # Next check: VRF features
       if not 'tunnel.vrf' in intf:                          # Tunnel does not use transport VRF? Cool, move on
         continue
       VRF_OK = _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=f'VRF {t_desc}',f_value='vrf')
@@ -45,6 +44,7 @@ def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
     if not VRF_OK:                                          # If VRF check failed, move to next node
       continue
 
+    node_iflist[node] = t_iflist
     api.node_config(ndata,f'tunnel.{t_mode}')               # Remember that we need to configure tunnels
 
   return node_iflist
@@ -107,7 +107,7 @@ def tunnel_destination(
         log.error(
           f'Cannot find tunnel destination for node {ngb.node}',
           more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {linkname}',
-          module='tunnel.{t_mode}',
+          module=f'tunnel.{t_mode}',
           category=log.MissingDependency)
         continue
 

--- a/netsim/extra/tunnel/gre/__init__.py
+++ b/netsim/extra/tunnel/gre/__init__.py
@@ -1,9 +1,6 @@
 
 from box import Box
 
-from netsim import api
-from netsim.augment import links as _links
-from netsim.augment import nodes as _nodes
 from netsim.utils import log
 
 from ... import tunnel as _tunnel

--- a/netsim/extra/tunnel/gre/__init__.py
+++ b/netsim/extra/tunnel/gre/__init__.py
@@ -5,7 +5,9 @@ from netsim import api
 from netsim.augment import links as _links
 from netsim.augment import nodes as _nodes
 from netsim.utils import log
-from netsim.utils import tunnel as _tunnel
+
+from ... import tunnel as _tunnel
+from .. import _p2p
 
 _config_name = 'tunnel.gre'
 
@@ -21,92 +23,17 @@ def pre_link_transform(topology: Box) -> None:
         category=log.IncorrectAttr,
         module='tunnel.gre')
 
-def get_linkname(topology: Box, linkindex: int) -> str:
-  '''
-  Utility function: get the name of a link referenced in an interface.
-  Return 'unknown' when the link cannot be found
-  '''
-  link = _links.get_link_by_index(topology,linkindex)
-  return link._linkname if link is not None else 'unknown'
-
 def post_transform(topology: Box) -> None:
   '''
   post_transform hook: check device support, set tunnel interface source/destination
   '''
-  node_iflist: dict = {}
 
-  # First pass, check feature support and set source interfaces
+  # Use shared P2P tunnel function to check feature support
   #
-  for node,ndata in topology.nodes.items():
-    first = True
-    vrf_check = False
-    node_iflist[node] = []
-
-    # Initial interface pass: collect tunnel interfaces, check features
-    #
-    for intf in _tunnel.interfaces(ndata,'gre'):
-      if first:
-        first = False
-        if not _tunnel.check_feature(ndata,topology,f_name='gre',f_desc='GRE tunnels'):
-          break
-        api.node_config(ndata,_config_name)
-
-      if not vrf_check and 'tunnel.vrf' in intf:
-        vrf_check = True
-        if not _tunnel.check_feature(ndata,topology,f_name='gre',f_desc='VRF GRE tunnels',f_value='vrf'):
-          break
-
-      node_iflist[node].append(intf)
-
-    # Process tunnel interfaces: set transport AF, tunnel name, and tunnel source
-    #
-    for intf in node_iflist[node]:
-      if 'tunnel.af' not in intf:
-        intf.tunnel.af = 'ipv4'                             # Assume IPv4 tunnel
-
-      src_intf = _tunnel.get_tunnel_source(ndata,intf,topology)
-      if src_intf:
-        intf.tunnel._source = src_intf
-      else:
-        log.error(
-          f'Cannot get {intf.tunnel.af} tunnel source for link {get_linkname(topology,intf.linkindex)} on node {node}',
-          more_data=f'Tunnel source data: {intf.tunnel.source if "tunnel.source" in intf else "none"}',
-          category=log.MissingDependency,
-          module='tunnel')
-        continue
-
-      if 'name' in intf and '->' in intf.name and 'GRE' not in intf.name:
-        intf.name += ' [GRE tunnel]'
+  node_iflist = _p2p.feature_check(topology,t_mode='gre',t_desc='GRE tunnels')
+  _p2p.tunnel_source(topology,node_iflist,default_af='ipv4',t_name='GRE')
 
   if log.get_error_count():                                 # Has someone reported an error?
     return                                                  # Might have been us, no reason to continue
 
-  # Second pass -- after computing tunnel source for all GRE interfaces, set tunnel destinations
-  #
-  for node in node_iflist:                                  # Process only nodes with tunnel interfaces
-    ndata = topology.nodes[node]                            # Get node data (we might need it)
-    for intf in node_iflist[node]:                          # ... and only tunnel interfaces
-      if len(intf.neighbors) != 1:
-        log.error(
-          f'GRE tunnel interface should have exactly one neighbor (found {len(intf.neighbors)})',
-          more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {get_linkname(topology,intf.linkindex)}',
-          module='tunnel.gre',
-          category=log.IncorrectValue)
-        continue
-      ngb = intf.neighbors[0]
-      ngb_intf = _nodes.get_node_interface(topology.nodes[ngb.node],ifname=ngb.ifname)
-      if not ngb_intf:
-        log.error(
-          f'Internal error: Cannot find the remote tunnel interface for interface {intf.ifname} on {node}',
-          category=log.FatalError,
-          module='tunnel.gre')
-        continue
-      if 'tunnel._source' not in ngb_intf:
-        log.error(
-          f'Cannot find tunnel destination for node {ngb.node}',
-          more_data=f'node {node} interface {intf.ifname} ({intf.name}) link {get_linkname(topology,intf.linkindex)}',
-          module='tunnel.gre',
-          category=log.MissingDependency)
-        continue
-
-      intf.tunnel._destination = ngb_intf.tunnel._source
+  _p2p.tunnel_destination(topology,node_iflist,t_mode='gre')


### PR DESCRIPTION
* Move utils/tunnel.py to extra/tunnel/__init__.py
* Return interface list from 'select source interface' function, making if useful in environments with additional requirements
* Make tunnel.af check optional to support dual-stack-capable tunnels
* Move most of GRE processing to _p2p.py utility function, assuming it can be used (or adapted) to other tunnel implementations.

Also:

* Move all link-related utility functions to augment/links and move them to the top of that module