### PR TITLE
[FRR] Bugfix log redirect only when debug options are set

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -411,7 +411,7 @@ ansible_httpapi_port: 80
 
 **FRR-Specific Node Attributes:**
 
-* The **frr.debug** global- or node attribute to [enables debugging](node-debug-attribute) during the initial device configuration.
+* The **frr.debug** global- or node attribute [enables debugging](node-debug-attribute) during the initial device configuration. On FRR containers, it also relays log file output to container *stdout* so you can inspect it with **docker logs** (see below).
 * The **frr.logfile** attribute specifies the path to the FRR logging file (default: `/var/log/frr/frr.log`)
 * You can specify a list of additional FRRouting daemons you want to have enabled in the **frr.daemons** node attribute.
 
@@ -422,7 +422,7 @@ ansible_httpapi_port: 80
 
 **FRR Container Features and Caveats:**
 
-* FRR logging messages are copied to the container *stdout*. You can always inspect them with **docker logs _containername_** (which you can find with the **netlab status** command).
+* FRR logging messages are written to the log file (default: `/var/log/frr/frr.log`; see **frr.logfile**). When **frr.debug** is enabled, they are also copied to the container *stdout* so you can inspect them with **docker logs _containername_** (which you can find with the **netlab status** command). The log relay can trigger SELinux denials on the host and is therefore disabled by default.
 * FRR containers need host kernel modules (drivers) to implement the data-plane functionality of *vrf*, *mpls*, and *vxlan* netlab modules. The kernel modules are automatically loaded (when available) during the **netlab up** processing.
 * VRF and VXLAN kernel modules are usually bundled with a Linux distribution. If your Ubuntu distribution does not include the MPLS drivers, try installing them with `sudo apt install linux-generic`.
 * You cannot load kernel modules in GitHub Codespaces and thus cannot use *vrf*, *mpls*, or *vxlan* modules on FRRouting nodes in that environment.

--- a/docs/dev/debugging.md
+++ b/docs/dev/debugging.md
@@ -119,7 +119,7 @@ nodes:
 ```
 
 ### FRRouting
-Enable debug conditions:
+Enable debug conditions. On containerlab deployments, this also relays FRR log file output to container *stdout* (visible via **docker logs**):
 ```yaml
 nodes:
   router1:

--- a/docs/node/debug.md
+++ b/docs/node/debug.md
@@ -47,6 +47,7 @@ Finally, you might be worried that the symptoms you're experiencing depend on th
 * The contents of the **_device_.debug** attribute are device-specific. *netlab* currently does not have multi-vendor **debug** capabilites.
 * The values of the **_device_.debug** attribute are not checked. They must be relevant to the underlying network device, or you'll get configuration errors during the initial configuration
 * The initial device configuration template supplies the mandatory prefix (for example, **do debug**). You only have to list the debugging conditions, for example:
+* On FRR containers, setting **frr.debug** also relays log file output to container *stdout* (visible via **docker logs**).
 
 ```
 nodes:

--- a/docs/node/debug.md
+++ b/docs/node/debug.md
@@ -47,7 +47,6 @@ Finally, you might be worried that the symptoms you're experiencing depend on th
 * The contents of the **_device_.debug** attribute are device-specific. *netlab* currently does not have multi-vendor **debug** capabilites.
 * The values of the **_device_.debug** attribute are not checked. They must be relevant to the underlying network device, or you'll get configuration errors during the initial configuration
 * The initial device configuration template supplies the mandatory prefix (for example, **do debug**). You only have to list the debugging conditions, for example:
-* On FRR containers, setting **frr.debug** also relays log file output to container *stdout* (visible via **docker logs**).
 
 ```
 nodes:

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -227,9 +227,10 @@ CONFIG
 vtysh -f /tmp/config
 {% endif %}{# not netlab_initial_reload #}
 
-{% if clab is defined %}
+{% if clab is defined and frr.debug|default([]) %}
 #
 # Redirect FRR's log to the container's stdout so 'docker logs' works
+# Note that this may trigger SELinux denials on the host.
 #
 DOCKER_LOGS_STDOUT="/proc/1/fd/1"
 tail -n 0 -F {{ frr_log_path }} >${DOCKER_LOGS_STDOUT} 2>&1 &


### PR DESCRIPTION
To avoid issues with SELinux deny policies, only redirect when debugging options are set (i.e. off by default)

Addresses #3574 