### PR TITLE
Add '_expect_fail' parameter to validation tests

### DIFF
--- a/netsim/cli/validate/plugin.py
+++ b/netsim/cli/validate/plugin.py
@@ -198,6 +198,7 @@ def execute_validation_plugin(
       report.log_progress(msg,topology)
       report.increase_pass_count(v_entry)
     elif report_error:
-      report.increase_fail_count(v_entry)
+      if not v_entry.get('_expect_fail',False):
+        report.increase_fail_count(v_entry)
 
   return OK if OK is None else bool(OK)

--- a/netsim/cli/validate/report.py
+++ b/netsim/cli/validate/report.py
@@ -100,7 +100,8 @@ def p_test_fail(n_name: str, v_entry: Box, topology: Box, fail_msg: str = '') ->
   if v_entry.get('level') == 'warning':
     log_failure(err,topology,f_status='WARNING',f_color='bright_yellow')
   else:
-    log_failure(err,topology)
+    f_color = 'bright_yellow' if v_entry.get('_expect_fail',False) else 'bright_red'
+    log_failure(err,topology,f_color=f_color)
 
 # Print "test passed"
 #

--- a/netsim/cli/validate/tests.py
+++ b/netsim/cli/validate/tests.py
@@ -260,6 +260,14 @@ def execute_validation_test(
         wait_time += 15                           # ... and it will happen after 15 seconds
       time.sleep(1)
 
+  if v_entry.get('_expect_fail',False):           # Do we expect the test to fail (used for plugin validation)
+    if ret_value:
+      report.log_failure('The test did not fail as expected',topology)
+      return False
+    else:
+      report.p_test_pass(v_entry,topology)
+      return True
+
   if ret_value:                                   # If we got to 'True'
     report.log_info(
       f'Test succeeded in { round(time.time() - start_time,1) } seconds',

--- a/netsim/cli/validate/tests.py
+++ b/netsim/cli/validate/tests.py
@@ -263,9 +263,11 @@ def execute_validation_test(
   if v_entry.get('_expect_fail',False):           # Do we expect the test to fail (used for plugin validation)
     if ret_value:
       report.log_failure('The test did not fail as expected',topology)
+      report.increase_fail_count(v_entry)
       return False
     else:
       report.p_test_pass(v_entry,topology)
+      report.increase_pass_count(v_entry)
       return True
 
   if ret_value:                                   # If we got to 'True'

--- a/netsim/cli/validate/tests.py
+++ b/netsim/cli/validate/tests.py
@@ -261,14 +261,16 @@ def execute_validation_test(
       time.sleep(1)
 
   if v_entry.get('_expect_fail',False):           # Do we expect the test to fail (used for plugin validation)
-    if ret_value:
+    if ret_value is True:
       report.log_failure('The test did not fail as expected',topology)
       report.increase_fail_count(v_entry)
       return False
-    else:
+    elif ret_value is False:
       report.p_test_pass(v_entry,topology)
       report.increase_pass_count(v_entry)
       return True
+    else:
+      return ret_value
 
   if ret_value:                                   # If we got to 'True'
     report.log_info(

--- a/tests/platform-integration/validate/00-expect-logic.yml
+++ b/tests/platform-integration/validate/00-expect-logic.yml
@@ -1,0 +1,59 @@
+message: |
+  Check the 'ping' validation plugin
+
+plugin: [ files ]
+
+defaults.netlab.integration:
+  validate: bash validate_logic.sh
+
+# Node device type set via default groups
+#
+nodes: [ dut_frr, h1 ]
+
+links: [ dut_frr-h1 ]
+
+validate:
+  ping_OK:
+    nodes: [ dut_frr ]
+    plugin: ping('h1')
+  ping_FAIL:
+    nodes: [ dut_frr ]
+    plugin: ping('172.42.42.42')
+  ping_WARN:
+    nodes: [ dut_frr ]
+    plugin: ping('172.42.42.42')
+    level: warning
+  ping_EXPECT:
+    nodes: [ dut_frr ]
+    plugin: ping('172.42.42.42')
+    _expect_fail: True
+
+files:
+  validate_logic.sh: |
+    if ! netlab validate ping_OK -q; then           # OK should succeed
+      echo "OK test failed"
+      exit 1
+    fi
+    echo "OK test completed"
+    echo ""
+    #
+    if ! netlab validate ping_EXPECT -q; then       # EXPECT (to fail) should also succeed
+      echo "EXPECT-to-fail test did not succeed"
+      exit 1
+    fi
+    echo "EXPECT-to-fail test completed"
+    echo ""
+    if netlab validate ping_FAIL; then              # FAIL should FAIL
+      echo "A test that should fail did not"
+      exit 1
+    fi
+    echo "FAIL test failed as expected"
+    echo ""
+    netlab validate ping_WARN
+    WARN_EXIT=$?
+    if [ $WARN_EXIT -ne 3 ]; then                   # WARN should fail with error code 3
+      echo "A test that should generate a warning did not return exit code 3 (got $WARN_EXIT)"
+      exit 1
+    fi
+    echo "WARN test behaved as expected"
+    echo ""

--- a/tests/platform-integration/validate/00-expect-logic.yml
+++ b/tests/platform-integration/validate/00-expect-logic.yml
@@ -27,33 +27,30 @@ validate:
     nodes: [ dut_frr ]
     plugin: ping('172.42.42.42')
     _expect_fail: True
+  ping_XP_NF:
+    nodes: [ dut_frr ]
+    plugin: ping('h1')
+    _expect_fail: True
 
 files:
   validate_logic.sh: |
-    if ! netlab validate ping_OK -q; then           # OK should succeed
-      echo "OK test failed"
-      exit 1
-    fi
-    echo "OK test completed"
-    echo ""
-    #
-    if ! netlab validate ping_EXPECT -q; then       # EXPECT (to fail) should also succeed
-      echo "EXPECT-to-fail test did not succeed"
-      exit 1
-    fi
-    echo "EXPECT-to-fail test completed"
-    echo ""
-    if netlab validate ping_FAIL; then              # FAIL should FAIL
-      echo "A test that should fail did not"
-      exit 1
-    fi
-    echo "FAIL test failed as expected"
-    echo ""
-    netlab validate ping_WARN
-    WARN_EXIT=$?
-    if [ $WARN_EXIT -ne 3 ]; then                   # WARN should fail with error code 3
-      echo "A test that should generate a warning did not return exit code 3 (got $WARN_EXIT)"
-      exit 1
-    fi
-    echo "WARN test behaved as expected"
-    echo ""
+    check_validate() {
+      netlab validate -q $1                         # execute a test
+      EXIT_CODE=$?
+      if [ $EXIT_CODE -ne $2 ]; then                # did we get the expected exit code?
+        echo "===================================================================="
+        echo "FAIL: $1 scenario returned exit code $EXIT_CODE (expected $2)"
+        echo "===================================================================="
+        exit 1
+      fi
+      echo "===================================================================="
+      echo "SUCCESS: $1 passed with exit code $2"
+      echo "===================================================================="
+      echo
+    }
+
+    check_validate ping_OK 0
+    check_validate ping_EXPECT 0
+    check_validate ping_FAIL 1
+    check_validate ping_WARN 3
+    check_validate ping_XP_NF 1

--- a/tests/platform-integration/validate/topology-defaults.yml
+++ b/tests/platform-integration/validate/topology-defaults.yml
@@ -1,0 +1,18 @@
+provider: clab
+
+groups:
+  grp_eos:
+    members: [ dut_eos ]
+    device: eos
+  grp_frr:
+    members: [ dut_frr ]
+    device: frr
+  grp_linux:
+    members: [ dut_linux ]
+    device: linux
+  grp_linux_probes:
+    members: [ h1, h2, h3 ]
+    device: linux
+  grp_frr_probes:
+    members: [ r1, r2, r3 ]
+    device: frr


### PR DESCRIPTION
If we want to thoroughly check validation plugin behavior, we need a mechanism to say 'this test should fail'. That's the role of the '_export_fail' parameter -- it disables 'failed test' reporting, changes reported color to yellow (to indicate something funky is going on) and reverses the 'did we pass' logic.

The platform validation test checks all expected test result behaviors