### PR TITLE
Fix: Use overall packet length in ping validation plugins

### DIFF
--- a/netsim/validate/eos.py
+++ b/netsim/validate/eos.py
@@ -17,8 +17,8 @@ def exec_ping(
       pkt_len: typing.Optional[int] = None,
       **kwargs: typing.Any) -> str:
 
-  if pkt_len is not None and pkt_len < 36:
-    raise Exception('Minimum ping packet size is 36 bytes')
+  if pkt_len is not None and pkt_len < 64:
+    raise Exception('Minimum IP packet size for ping plugin is 64 bytes')
 
   host = _rp_utils.try_intf_address(host)
   cmd = 'enable\nping ' + ('ip' if af is None or af == 'ipv4' else af) + ' ' + host

--- a/netsim/validate/eos.py
+++ b/netsim/validate/eos.py
@@ -17,6 +17,9 @@ def exec_ping(
       pkt_len: typing.Optional[int] = None,
       **kwargs: typing.Any) -> str:
 
+  if pkt_len is not None and pkt_len < 36:
+    raise Exception('Minimum ping packet size is 36 bytes')
+
   host = _rp_utils.try_intf_address(host)
   cmd = 'enable\nping ' + ('ip' if af is None or af == 'ipv4' else af) + ' ' + host
   if src:
@@ -51,6 +54,11 @@ def valid_ping(
         return msg+' failed as expected'
     raise Exception(msg+' did not fail')
   else:
-    if f"{ pkt_len + 8 if pkt_len else 80 } bytes from" in _result.stdout:
+    if pkt_len:
+      pkt_exp = pkt_len - (40 if af == 'ipv6' else 20)
+      OK_result = f"{ pkt_exp } bytes from"
+    else:
+      OK_result = " bytes from"
+    if OK_result in _result.stdout:
       return msg+' succeeded'
     raise Exception(msg+' failed')

--- a/netsim/validate/linux.py
+++ b/netsim/validate/linux.py
@@ -16,6 +16,9 @@ def exec_ping(
       pkt_len: typing.Optional[int] = None,
       expect: typing.Optional[str] = None) -> str:
 
+  if pkt_len is not None and pkt_len < 36:
+    raise Exception('Minimum ping packet size is 36 bytes')
+
   host = host.split('/')[0]
   cmd = f'ping -c {count} -W 1 -A'
   if af == 'ipv6':
@@ -23,7 +26,7 @@ def exec_ping(
   elif af == 'ipv4':
     cmd += ' -4'
   if pkt_len:
-    cmd += f' -s {pkt_len}'
+    cmd += f' -s {pkt_len - (28 if af == "ipv4" else 48)}'
   if src:
     cmd += ' -I '+src.split('/')[0]
 
@@ -70,7 +73,8 @@ def valid_ping(
         return msg+' failed as expected'
     raise Exception(msg+' did not fail')
   else:
-    if f"{ pkt_len + 8 if pkt_len else 64 } bytes from" in _result.stdout:
+    pkt_len_adj = 20 if af == 'ipv4' else 40
+    if f"{ pkt_len - pkt_len_adj if pkt_len else 64 } bytes from" in _result.stdout:
       return msg+' succeeded'
     raise Exception(msg+' failed')
 

--- a/netsim/validate/linux.py
+++ b/netsim/validate/linux.py
@@ -16,8 +16,8 @@ def exec_ping(
       pkt_len: typing.Optional[int] = None,
       expect: typing.Optional[str] = None) -> str:
 
-  if pkt_len is not None and pkt_len < 36:
-    raise Exception('Minimum ping packet size is 36 bytes')
+  if pkt_len is not None and pkt_len < 64:
+    raise Exception('Minimum IP packet size for ping plugin is 64 bytes')
 
   host = host.split('/')[0]
   cmd = f'ping -c {count} -W 1 -A'
@@ -26,7 +26,7 @@ def exec_ping(
   elif af == 'ipv4':
     cmd += ' -4'
   if pkt_len:
-    cmd += f' -s {pkt_len - (28 if af == "ipv4" else 48)}'
+    cmd += f' -s {pkt_len - (48 if af == "ipv6" else 28)}'
   if src:
     cmd += ' -I '+src.split('/')[0]
 
@@ -73,7 +73,7 @@ def valid_ping(
         return msg+' failed as expected'
     raise Exception(msg+' did not fail')
   else:
-    pkt_len_adj = 20 if af == 'ipv4' else 40
+    pkt_len_adj = 40 if af == 'ipv6' else 20
     if f"{ pkt_len - pkt_len_adj if pkt_len else 64 } bytes from" in _result.stdout:
       return msg+' succeeded'
     raise Exception(msg+' failed')

--- a/tests/platform-integration/validate/01-ping.yml
+++ b/tests/platform-integration/validate/01-ping.yml
@@ -1,0 +1,45 @@
+message: |
+  Check the 'ping' validation plugin
+
+# Node device type set via default groups
+#
+nodes: [ dut_eos, dut_frr, dut_linux, h1, h2 ]
+
+links:
+- interfaces: [ dut_eos, dut_frr, dut_linux, h1 ]
+  prefix.ipv4: 172.16.1.0/24
+- interfaces: [ dut_eos, dut_frr, dut_linux, h2 ]
+  prefix.ipv6: 2001:db8:0:1::/64
+- interfaces: [ dut_eos, dut_frr, dut_linux ]
+  prefix.ipv4: 172.16.2.0/24
+  prefix.ipv6: 2001:db8:0:2::/64
+
+validate:
+  ping_v4_OK:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h1',af='ipv4')
+  ping_v6_OK:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h2',af='ipv6')
+  ping_v4_len:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h1',af='ipv4',pkt_len=80,count=1)
+  ping_v6_len:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h2',af='ipv6',pkt_len=80,count=1)
+  ping_v4_nh:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h2',af='ipv4')
+    _expect_fail: True
+  ping_v6_nh:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('h1',af='ipv6')
+    _expect_fail: True
+  ping_v4_nr:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('172.16.2.42',count=2)
+    _expect_fail: True
+  ping_v6_nr:
+    nodes: [ dut_eos, dut_frr, dut_linux ]
+    plugin: ping('2001:db8:0:2::42/64',af='ipv6',count=2)
+    _expect_fail: True

--- a/tests/platform-integration/validate/01-ping.yml
+++ b/tests/platform-integration/validate/01-ping.yml
@@ -1,6 +1,8 @@
 message: |
   Check the 'ping' validation plugin
 
+defaults.sources.extra: [ ../../integration/wait_times.yml ]
+
 # Node device type set via default groups
 #
 nodes: [ dut_eos, dut_frr, dut_linux, h1, h2 ]
@@ -17,9 +19,11 @@ links:
 validate:
   ping_v4_OK:
     nodes: [ dut_eos, dut_frr, dut_linux ]
+    wait: ping
     plugin: ping('h1',af='ipv4')
   ping_v6_OK:
     nodes: [ dut_eos, dut_frr, dut_linux ]
+    wait: ping
     plugin: ping('h2',af='ipv6')
   ping_v4_len:
     nodes: [ dut_eos, dut_frr, dut_linux ]
@@ -43,3 +47,12 @@ validate:
     nodes: [ dut_eos, dut_frr, dut_linux ]
     plugin: ping('2001:db8:0:2::42/64',af='ipv6',count=2)
     _expect_fail: True
+
+#
+#  It would be nice to test the ping sizes, but an error in the 'show_x' part of the
+#  plugin processing is not yet considering the '_expect_fail' parameter. TBD...
+#
+#  ping_size:
+#    nodes: [ dut_eos, dut_frr, dut_linux ]
+#    plugin: ping('h1',pkt_len=32)
+#    _expect_fail: True


### PR DESCRIPTION
Various 'ping' implementations treat the specified 'packet size' parameter differently, and report the returned packet size as payload size, ICMP packet size, or overall packet size.

This change unifies the 'ping' validation plugin behavior -- the specified packet length (pkt_len) is the IP packet size, and the plugin code deals with implementation- and IPv4/IPv6 differences.

As no integration test used the 'pkt_len' parameter, the change does not affect existing integration tests.