### PR TITLE
Use node/group variables for OpenBSD username/password

### DIFF
--- a/netsim/templates/provider/libvirt/openbsd-domain.j2
+++ b/netsim/templates/provider/libvirt/openbsd-domain.j2
@@ -1,8 +1,8 @@
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
 
     {{ name }}.ssh.insert_key = false
-    {{ name }}.ssh.username = "openbsd"
-    {{ name }}.ssh.password = "vagrant"
+    {{ name }}.ssh.username = "{{ n.ansible_user }}"
+    {{ name }}.ssh.password = "{{ n.ansible_ssh_pass }}"
     {{ name }}.vm.guest = :openbsd
 
     {{ name }}.vm.provider :libvirt do |domain|


### PR DESCRIPTION
Allow for users to have different  `ansible_ssh_user`  and `ansible_ssh_pass`  for OpenBSD Vagrant image.