### PR TITLE
[FRR] Move FRR GRE tunnel netdev setup into plugin initial templates

### DIFF
--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -89,6 +89,10 @@ fi
 #
 sysctl -w net.ipv4.conf.all.arp_announce=2
 
+{% for x_dp in config|default([]) %}
+{%   include x_dp|replace('.','/') + '/frr.initial.j2' ignore missing %}
+{% endfor %}
+
 #
 # Create loopbacks, stub and lag/bond devices
 #
@@ -107,7 +111,7 @@ fi
 
 # Disable IPv6 (for IPv4-only interfaces) or SLAAC (if the device is a router)
 #
-{% for i in interfaces if i.type in ['lan','p2p','stub','lag','bond'] %}
+{% for i in interfaces if i.type in ['lan','p2p','stub','lag','bond','tunnel'] %}
 ip link set {{ i.ifname }} down
 {%   if i.ipv6 is not defined %}
 sysctl -qw net.ipv6.conf.{{ i.ifname }}.disable_ipv6=1

--- a/netsim/extra/tunnel/gre/frr.initial.j2
+++ b/netsim/extra/tunnel/gre/frr.initial.j2
@@ -1,0 +1,12 @@
+{# Create GRE tunnel interfaces during initial device configuration #}
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
+if [ ! -e /sys/class/net/{{ intf.ifname }} ]; then
+  if [ ! -e /sys/devices/virtual/net/{{ intf.ifname }} ]; then
+{%   set af = intf.tunnel.af|default('ipv4') %}
+{%   set gre_mode = 'ip6gre' if af == 'ipv6' else 'gre' %}
+    ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
+      local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
+      dev {{ intf.tunnel._source.ifname }} ttl 255
+  fi
+fi
+{% endfor %}

--- a/netsim/extra/tunnel/gre/frr.j2
+++ b/netsim/extra/tunnel/gre/frr.j2
@@ -1,13 +1,1 @@
-#!/bin/bash
-#
-set -e
-#
-{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
-{%   set af = intf.tunnel.af|default('ipv4') %}
-{%   set gre_mode = 'ip6gre' if af == 'ipv6' else 'gre' %}
-ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
-  local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
-  dev {{ intf.tunnel._source.ifname }} ttl 255
-ip link set dev {{ intf.ifname }} up
-{% endfor %}
-exit 0
+# GRE tunnel interfaces are created during initial FRR device configuration


### PR DESCRIPTION
Include tunnel plugin frr.initial.j2 snippets from the FRR initial config, create GRE interfaces there instead of the module deploy script, and apply IPv6 sysctl settings to tunnel interfaces during initial configuration.

Mirrors the VyOS pattern, preparing for #3569

```./device-module-test -d frr tunnel``` still passes for both clab and libvirt