### PR TITLE
Fix: Recognize a.b or a/b in included VyOS dataplane templates

### DIFF
--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -13,8 +13,18 @@ set system host-name 'vyos-{{ inventory_hostname | replace("_","-") }}'
 {% if vlans is defined %}
 {% include 'vyos.vlan.j2' %}
 {% endif %}
+{#
+    Include interface-related parts of plugin configuration
+#}
 {% for x_dp in config|default([]) %}
-{%  include x_dp + '/vyos.initial.j2' ignore missing %}
+{#
+    With the restructuring of plugin directories, we have to try
+    plugin name with '.' and '/'. Fortunately, Jinja2 provides a
+    nifty mechanism to do that.
+#}
+{%  set dp_initial = x_dp + '/vyos.initial.j2' %}
+{%  set dp_alt = x_dp.replace('.','/') + '/vyos.initial.j2' %}
+{%  include [ dp_initial, dp_alt ] ignore missing %}
 {% endfor %}
 
 {% if loopback.ipv4 is defined %}


### PR DESCRIPTION
VyOS initial device configuration includes interface configuration code from plugin configuration templates. The plugin name in the node data is sometimes in 'a.b' format (for example, 'tunnel.gre'), whereas the new directory structure uses slashes (i.e. 'tunnel/gre').

This fix tries both names to allow users to override plugin dataplane templates in their own 'tunnel.gre' directory.