### PR TITLE
FRR: Unify Linux interface sysctl settings

### DIFF
--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -1,4 +1,5 @@
 {% from "initial/linux/create-bond.j2" import create_bond_dev %}
+{% from "initial/linux/intf-sysctl.j2" import linux_intf_sysctl with context %}
 #!/bin/bash
 #
 set -e
@@ -105,21 +106,12 @@ if [ ! -e /sys/class/net/{{ i.ifname }} ]; then
 fi
 {% endfor %}
 
-# Disable IPv6 (for IPv4-only interfaces) or SLAAC (if the device is a router)
+# Set Linux interface sysctl parameters: Disable IPv6 (for IPv4-only interfaces)
+# or SLAAC (if the device is a router)
 #
 {% for i in interfaces if i.type in ['lan','p2p','stub','lag','bond'] %}
 ip link set {{ i.ifname }} down
-{%   if i.ipv6 is not defined %}
-sysctl -qw net.ipv6.conf.{{ i.ifname }}.disable_ipv6=1
-{%   else %}
-{%     set ra_flag = '0' if role == 'router' else '1' %}
-sysctl -qw net.ipv6.conf.{{ i.ifname }}.autoconf={{ ra_flag }}
-sysctl -qw net.ipv6.conf.{{ i.ifname }}.accept_ra={{ ra_flag }}
-{%   endif %}
-{%   if i.mtu is defined %}
-ip link set dev {{ i.ifname }} mtu {{ i.mtu }}
-{%   endif %}
-ip link set {{ i.ifname }} {{ "down" if i.shutdown|default(False) else "up" }}
+{{ linux_intf_sysctl(i,role|default('router')) }}
 {% endfor %}
 
 #

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -1,5 +1,5 @@
 {% from "initial/linux/create-bond.j2" import create_bond_dev %}
-{% from "initial/linux/intf-sysctl.j2" import linux_intf_sysctl with context %}
+{% from "initial/linux/intf-sysctl.j2" import linux_intf_sysctl %}
 #!/bin/bash
 #
 set -e
@@ -111,7 +111,7 @@ fi
 #
 {% for i in interfaces if i.type in ['lan','p2p','stub','lag','bond'] %}
 ip link set {{ i.ifname }} down
-{{ linux_intf_sysctl(i,role|default('router')) }}
+{{ linux_intf_sysctl(i,role) }}
 {% endfor %}
 
 #

--- a/netsim/ansible/templates/initial/linux/intf-sysctl.j2
+++ b/netsim/ansible/templates/initial/linux/intf-sysctl.j2
@@ -1,0 +1,26 @@
+{#
+    Some Linux interface sysctl parameters have to be set based on
+    whether a device uses IPv6 (IPv6 is enabled by default on Linux)
+    and whether it's a router (so it should not listen to RAs).
+
+    The same macro also sets the interface MTU
+#}
+{% macro linux_intf_sysctl(intf,role='router',activate=True) %}
+# Linux interface parameters for {{ intf.ifname }}
+#
+{%   if intf.ipv6 is not defined %}
+sysctl -qw net/ipv6/conf/{{ intf.ifname }}/disable_ipv6=1
+{%   else %}
+sysctl -qw net/ipv6/conf/{{ intf.ifname }}/keep_addr_on_down=1
+{%     set ra_flag = '0' if role == 'router' else '1' %}
+sysctl -qw net/ipv6/conf/{{ intf.ifname }}/autoconf={{ ra_flag }}
+sysctl -qw net/ipv6/conf/{{ intf.ifname }}/accept_ra={{ ra_flag }}
+sysctl -w net/ipv6/conf/{{ intf.ifname }}/addr_gen_mode=3
+{%   endif %}
+{%   if intf.mtu is defined %}
+ip link set dev {{ intf.ifname }} mtu {{ intf.mtu }}
+{%   endif %}
+{%   if activate %}
+ip link set {{ intf.ifname }} {{ "down" if intf.shutdown|default(False) else "up" }}
+{%   endif %}
+{% endmacro %}

--- a/netsim/ansible/templates/initial/linux/intf-sysctl.j2
+++ b/netsim/ansible/templates/initial/linux/intf-sysctl.j2
@@ -15,7 +15,7 @@ sysctl -qw net/ipv6/conf/{{ intf.ifname }}/keep_addr_on_down=1
 {%     set ra_flag = '0' if role == 'router' else '1' %}
 sysctl -qw net/ipv6/conf/{{ intf.ifname }}/autoconf={{ ra_flag }}
 sysctl -qw net/ipv6/conf/{{ intf.ifname }}/accept_ra={{ ra_flag }}
-sysctl -w net/ipv6/conf/{{ intf.ifname }}/addr_gen_mode=3
+sysctl -qw net/ipv6/conf/{{ intf.ifname }}/addr_gen_mode=3
 {%   endif %}
 {%   if intf.mtu is defined %}
 ip link set dev {{ intf.ifname }} mtu {{ intf.mtu }}

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -20,7 +20,7 @@ if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   ip link set {{ i.ifname }} type bridge stp_state 1
 {%   endif %}
   ip addr flush dev {{ i.ifname }}
-{{   linux_intf_sysctl(i,role|default('router'),activate=False)|indent(2,first=True) }}
+{{   linux_intf_sysctl(i,role,activate=False)|indent(2,first=True) }}
 fi
 {% endfor %}
 

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -20,7 +20,7 @@ if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   ip link set {{ i.ifname }} type bridge stp_state 1
 {%   endif %}
   ip addr flush dev {{ i.ifname }}
-{{   linux_intf_sysctl(i,role|default('router'))|indent(2,first=True) }}
+{{   linux_intf_sysctl(i,role|default('router'),activate=False)|indent(2,first=True) }}
 fi
 {% endfor %}
 

--- a/netsim/ansible/templates/vlan/frr.j2
+++ b/netsim/ansible/templates/vlan/frr.j2
@@ -1,3 +1,4 @@
+{% from "initial/linux/intf-sysctl.j2" import linux_intf_sysctl with context %}
 #!/bin/bash
 #
 set -e # Exit immediately when any command fails
@@ -15,19 +16,11 @@ if [ ! -e /sys/devices/virtual/net/{{ i.ifname }} ]; then
   ip link add {{ i.ifname }} type bridge
   ip link set dev {{ i.ifname }} address {{ i.mac_address|ansible.utils.hwaddr('linux') }}
 {# If STP is required, enable it before bringing up the bridge device to avoid any forwarding loops #}
-{%  if 'stp' in module|default([]) and (i.stp|default(stp)).enable|default(True) %}
+{%   if 'stp' in module|default([]) and (i.stp|default(stp)).enable|default(True) %}
   ip link set {{ i.ifname }} type bridge stp_state 1
-{%  endif %}
-
-{%   if i.mtu is defined %}
-  ip link set dev {{ i.ifname }} mtu {{ i.mtu }}
 {%   endif %}
   ip addr flush dev {{ i.ifname }}
-{%   if 'ipv6' in i %}
-  sysctl -w net.ipv6.conf.{{ i.ifname }}.addr_gen_mode=3
-{%   else %}
-  sysctl -w net.ipv6.conf.{{ i.ifname }}.disable_ipv6=1
-{%   endif %}
+{{   linux_intf_sysctl(i,role|default('router'))|indent(2,first=True) }}
 fi
 {% endfor %}
 

--- a/netsim/defaults/paths.yml
+++ b/netsim/defaults/paths.yml
@@ -20,6 +20,8 @@ custom:                         # Custom configuration templates
   - "~/.netlab"
   - "/etc/netlab"
   - "package:extra"
+  extra_dirs:
+  - "package:ansible/templates" # Give custom configs access to main configuration macros
   files:                        # ... potential file names
   - "{{custom_config}}/{{inventory_hostname}}.{{netlab_device_type}}-{{node_provider}}.j2"
   - "{{custom_config}}/{{inventory_hostname}}.{{netlab_device_type}}.j2"

--- a/netsim/extra/tunnel/gre/frr.j2
+++ b/netsim/extra/tunnel/gre/frr.j2
@@ -9,6 +9,6 @@ set -e
 ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
   local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
   dev {{ intf.tunnel._source.ifname }} ttl 255
-{{ linux_intf_sysctl(intf,role|default('router')) }}
+{{ linux_intf_sysctl(intf,role) }}
 {% endfor %}
 exit 0

--- a/netsim/extra/tunnel/gre/frr.j2
+++ b/netsim/extra/tunnel/gre/frr.j2
@@ -1,3 +1,4 @@
+{% from "initial/linux/intf-sysctl.j2" import linux_intf_sysctl with context %}
 #!/bin/bash
 #
 set -e
@@ -9,5 +10,6 @@ ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
   local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
   dev {{ intf.tunnel._source.ifname }} ttl 255
 ip link set dev {{ intf.ifname }} up
+{{ linux_intf_sysctl(intf,role|default('router')) }}
 {% endfor %}
 exit 0

--- a/netsim/extra/tunnel/gre/frr.j2
+++ b/netsim/extra/tunnel/gre/frr.j2
@@ -9,7 +9,6 @@ set -e
 ip tunnel add {{ intf.ifname }} mode {{ gre_mode }} \
   local {{ intf.tunnel._source[af] }} remote {{ intf.tunnel._destination[af] }} \
   dev {{ intf.tunnel._source.ifname }} ttl 255
-ip link set dev {{ intf.ifname }} up
 {{ linux_intf_sysctl(intf,role|default('router')) }}
 {% endfor %}
 exit 0

--- a/netsim/utils/templates.py
+++ b/netsim/utils/templates.py
@@ -182,11 +182,17 @@ def config_template_paths(
       node: Box,
       fname: str,
       topology: Box,
-      provider_path: typing.Optional[str] = None) -> list:
+      provider_path: typing.Optional[str] = None,
+      jinja_extra_include: bool = False) -> list:
   if fname in node.get('config',[]):                    # Are we dealing with extra-config template?
-    path_prefix = topology.defaults.paths.custom.dirs
-    if topology.defaults.paths.custom.extra_dirs:       # Extra search directories are needed to include config macros
-      path_prefix.extend(topology.defaults.paths.custom.extra_dirs)
+    path_prefix = list(topology.defaults.paths.custom.dirs)
+
+    # Extra search directories are needed to include config macros. However, we
+    # should not add these same directors when finding files; they should only
+    # affect Jinja2 include directives
+    #
+    if topology.defaults.paths.custom.extra_dirs and jinja_extra_include:
+      path_prefix += list(topology.defaults.paths.custom.extra_dirs)
     path_suffix = [ fname ]
   else:
     path_suffix = [ node.device ]
@@ -327,7 +333,8 @@ def render_config_template(
                     node=node,
                     fname=template_id,
                     topology=topology,
-                    provider_path=provider_path)
+                    provider_path=provider_path,
+                    jinja_extra_include=True)
     node_dict['netlab_config_mode'] = config_mode
     write_template(
       in_folder=os.path.dirname(template_path),

--- a/netsim/utils/templates.py
+++ b/netsim/utils/templates.py
@@ -185,6 +185,8 @@ def config_template_paths(
       provider_path: typing.Optional[str] = None) -> list:
   if fname in node.get('config',[]):                    # Are we dealing with extra-config template?
     path_prefix = topology.defaults.paths.custom.dirs
+    if topology.defaults.paths.custom.extra_dirs:       # Extra search directories are needed to include config macros
+      path_prefix.extend(topology.defaults.paths.custom.extra_dirs)
     path_suffix = [ fname ]
   else:
     path_suffix = [ node.device ]


### PR DESCRIPTION
FRR configuration templates applied inconsistent interface sysctl settings to physical and VLAN interfaces (and none to gre tunnels).

This commit creates a shared macro that sets Linux interface sysctl parameters (primarily IPv6), MTU, and interface state. That macro can be used by all Linux-based devices (BIRD, FRR, Linux) in the future (its current use is limited to FRR).

Also:
* Had to change the search paths for the custom config templates to include the main config templates, or the custom configs (plugins) wouldn't be able to use macros from the main templates.