### PR TITLE
Fix validation of non-v4/v6 BGP AF activation

### DIFF
--- a/netsim/validate/bgp/eos.py
+++ b/netsim/validate/bgp/eos.py
@@ -39,13 +39,18 @@ def show_bgp_neighbor(
       activate: str = '', **kwargs: typing.Any) -> str:
   global af_lookup
   if not activate:
-    bgp_cmd = 'bgp summary'
+    return f'bgp summary vrf {vrf} | json'
   elif activate not in af_lookup:
     raise Exception(f'Unsupported address family {activate}')
-  else:
-    bgp_cmd = f'bgp {af_lookup[activate]} summary'
 
-  return f'{bgp_cmd} vrf {vrf} | json'
+  bgp_cmd = f'bgp {af_lookup[activate]} summary'
+  if vrf != 'default':
+    if 'unicast' in bgp_cmd:
+      bgp_cmd += f' vrf {vrf}'
+    else:
+      raise Exception(f'Cannot check {activate} BGP AF in VRF {vrf}')
+
+  return f'{bgp_cmd} | json'
 
 def valid_bgp_neighbor(
       ngb: list,

--- a/netsim/validate/bgp/frr.py
+++ b/netsim/validate/bgp/frr.py
@@ -43,7 +43,12 @@ def show_bgp_neighbor(
   if activate not in af_lookup:
     raise Exception(f'Unsupported address family {activate}')
 
-  return f"bgp vrf {vrf} {af_kw[activate]} json"
+  if activate not in ['ipv4','ipv6']:
+    if vrf != 'default':
+      raise Exception(f'Cannot check {activate} BGP AF in VRF {vrf}')
+    return f"bgp {af_kw[activate]} json"
+  else:
+    return f"bgp vrf {vrf} {af_kw[activate]} json"
 
 def valid_bgp_neighbor(
       ngb: list,
@@ -72,7 +77,7 @@ def valid_bgp_neighbor(
   if 'peers' in _result:
     data = _result.peers
   elif struct_name not in _result:
-    raise Exception(f'There are no BGP peers in address family {activate}')
+    _common.report_state(f'There are no BGP peers in address family {activate}',state=='missing')
   else:
     data = _result[struct_name].peers
 

--- a/tests/platform-integration/validate/10-bgp-neighbor.yml
+++ b/tests/platform-integration/validate/10-bgp-neighbor.yml
@@ -3,12 +3,14 @@ message: |
 
 defaults.sources.extra: [ ../../integration/wait_times.yml ]
 
-module: [ bgp, vrf ]
 groups:
   probes:
     members: [ r1, r2, r3, vr1, vr2, vr3 ]
     module: [ bgp ]
     device: frr
+  duts:
+    module: [ bgp, vrf, vlan, vxlan, evpn ]
+    members: [ dut_eos, dut_frr ]
 
 vrfs:
   tenant:
@@ -17,6 +19,9 @@ vrfs:
       prefix.ipv4: 172.16.2.0/24
     - interfaces: [ dut_eos, dut_frr, vr2, vr3 ]
       prefix.ipv6: 2001:db8:0:2::/64
+
+evpn.session: [ ebgp ]
+bgp.community: [ standard, extended ]
 
 # Node device type for DUT devices set via default groups
 #
@@ -94,6 +99,18 @@ validate:
     wait: ebgp_session
     plugin: bgp_neighbor(node.bgp.neighbors,'r2',af='ipv6',activate='ipv4',state='missing')
 
+  # Check non-IP AFs
+  #
+  evpn_eos:
+    nodes: [ dut_eos ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'dut_frr',af='ipv4',activate='evpn')
+  evpn_frr:
+    nodes: [ dut_frr ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'dut_eos',af='ipv4',activate='evpn')
+  act_vpnv4:
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'r1',af='ipv4',activate='vpnv4',state='missing')
+
   # Check matching explicit states
   #
   state_ipv4:
@@ -125,4 +142,8 @@ validate:
   fail_act_ipv4:
     nodes: [ dut_eos, dut_frr ]
     plugin: bgp_neighbor(node.bgp.neighbors,'r2',af='ipv6',activate='ipv4')
+    _expect_fail: True
+  fail_act_vpnv4:
+    nodes: [ dut_eos, dut_frr ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'r1',af='ipv4',activate='vpnv4')
     _expect_fail: True


### PR DESCRIPTION
Changes made in #3580 broke the AF activation validation for non-IP BGP address families (which cannot be run in VRFs). This commit fixes that, adds extra checks for non-IP AF tests in non-default VRF, and extends the platform integration test with non-IP scenarios.