### PR TITLE
Generic 'include module/plugin config into initial config' framework

### DIFF
--- a/netsim/ansible/templates/initial/_extra_initial.j2
+++ b/netsim/ansible/templates/initial/_extra_initial.j2
@@ -31,7 +31,7 @@
 #}
 {% 
    macro extra_module_initial() %}
-{%   for m in module %}
+{%   for m in module|default([]) %}
 {%     include [ 
          m + '/' + netlab_device_type + '.initial.j2',
          m + '/' + ansible_network_os + '.initial.j2' ]

--- a/netsim/ansible/templates/initial/_extra_initial.j2
+++ b/netsim/ansible/templates/initial/_extra_initial.j2
@@ -1,0 +1,58 @@
+{#
+    While most network devices can use interfaces as soon as they're mentioned,
+    some devices have to explicitely create or even configure them before using
+    them in device configurations. Notable examples: VyOS and BIRD.
+
+    However, even some traditional network devices refuse to create interfaces
+    without having underlying data objects. For example, in many cases you have
+    to create VLANs before you can mention an SVI/VLAN interface.
+
+    Traditionally, we moved parts of module-specific device configuration (for
+    example, VLAN definition) into 'initial' directory and include it from there.
+    This set of macros allows you to have the module-specific parts of the
+    initial device configuration in the module directory
+
+    IMPORTANT: This file must be imported WITH CONTEXT to get access to the node
+    module, config, and other variables.
+#}
+{% 
+   macro extra_initial() %}
+{{   extra_module_initial() }}
+{{   extra_plugin_initial() }}
+{% endmacro +%}
+{#
+    When including module initial configurations, we have to consider the device
+    type (for example, CSR has a device-specific VLAN configuration) and the
+    network OS (most Cisco IOS or Junos devices use the same VLAN
+    configuration).
+
+    Please note that we're using a list in the "include" directive, which means
+    that at most one template will be included.
+#}
+{% 
+   macro extra_module_initial() %}
+{%   for m in module %}
+{%     include [ 
+         m + '/' + netlab_device_type + '.initial.j2',
+         m + '/' + ansible_network_os + '.initial.j2' ]
+         ignore missing %}
+{%   endfor %}
+{% endmacro +%}
+{#
+    When including plugin initial configurations, we have to consider device
+    type and network OS (as above), but also the possibility that a plugin
+    resides in a subdirectory of the 'extra' directory (for example, tunnel.gre
+    plugin is in tunnel/gre directory), which forces us to try the directory
+    name with dot replaced by slash.
+#}
+{% 
+   macro extra_plugin_initial() %}
+{%   for c in config|default([]) %}
+{%     include [ 
+         c + '/' + netlab_device_type + '.initial.j2',
+         c.replace('.','/') + '/' + netlab_device_type + '.initial.j2',
+         c + '/' + ansible_network_os + '.initial.j2',
+         c.replace('.','/') + '/' + ansible_network_os + '.initial.j2' ]
+         ignore missing %}
+{%    endfor %}
+{% endmacro +%}

--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -1,3 +1,4 @@
+{% from '_extra_initial.j2' import extra_initial with context %}
 {#
 It seems VyOS has some problems in handling hostnames with only one letter in it.
 #}
@@ -7,25 +8,11 @@ set system host-name '{{ inventory_hostname | replace("_","-") }}'
 set system host-name 'vyos-{{ inventory_hostname | replace("_","-") }}'
 {% endif %}
 
-{% if vrfs is defined %}
-{% include 'vyos.vrf.j2' %}
-{% endif %}
-{% if vlans is defined %}
-{% include 'vyos.vlan.j2' %}
-{% endif %}
 {#
-    Include interface-related parts of plugin configuration
+    Include interface-related parts of module/plugin configuration, including
+    VLANs, VRFs, and tunnels
 #}
-{% for x_dp in config|default([]) %}
-{#
-    With the restructuring of plugin directories, we have to try
-    plugin name with '.' and '/'. Fortunately, Jinja2 provides a
-    nifty mechanism to do that.
-#}
-{%  set dp_initial = x_dp + '/vyos.initial.j2' %}
-{%  set dp_alt = x_dp.replace('.','/') + '/vyos.initial.j2' %}
-{%  include [ dp_initial, dp_alt ] ignore missing %}
-{% endfor %}
+{{ extra_initial() }}
 
 {% if loopback.ipv4 is defined %}
 set interfaces dummy dum0 address {{ loopback.ipv4 }}

--- a/netsim/ansible/templates/initial/vyos.vlan.j2
+++ b/netsim/ansible/templates/initial/vyos.vlan.j2
@@ -1,7 +1,0 @@
-
-set interfaces bridge br0 description 'Global Switch Bridge'
-set interfaces bridge br0 enable-vlan
-
-{% for vname,vdata in vlans.items() if vdata.mode is defined and vdata.mode != 'route' and vdata.id != 1 %}
-set interfaces bridge br0 vif {{ vdata.id }}
-{% endfor +%}

--- a/netsim/ansible/templates/initial/vyos.vrf.j2
+++ b/netsim/ansible/templates/initial/vyos.vrf.j2
@@ -1,3 +1,0 @@
-{% for vname,vdata in vrfs.items() %}
-set vrf name {{ vname }} table {{ vdata.vrfidx }}
-{% endfor %}

--- a/netsim/ansible/templates/vlan/vyos.initial.j2
+++ b/netsim/ansible/templates/vlan/vyos.initial.j2
@@ -1,0 +1,11 @@
+{% if vlans is defined %}
+#
+# Create VLAN bridge and VLAN interfaces as part of initial configuration
+#
+set interfaces bridge br0 description 'Global Switch Bridge'
+set interfaces bridge br0 enable-vlan
+
+{%   for vname,vdata in vlans.items() if vdata.mode is defined and vdata.mode != 'route' and vdata.id != 1 %}
+set interfaces bridge br0 vif {{ vdata.id }}
+{%   endfor +%}
+{% endif %}

--- a/netsim/ansible/templates/vrf/vyos.initial.j2
+++ b/netsim/ansible/templates/vrf/vyos.initial.j2
@@ -1,0 +1,8 @@
+{% if vrfs is defined %}
+#
+# Create VRF tables as part of initial device configuration
+#
+{%   for vname,vdata in vrfs.items() %}
+set vrf name {{ vname }} table {{ vdata.vrfidx }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
Some devices need VLANs, VRFs, and tunnels defined before configuring routing protocols and such. This PR provides a unified framework in which a single macro call in the 'initial' config template includes .initial.j2 templates from all modules and plugins used by a node.

Sample implementation: VyOS VLAN, VRF, and GRE tunnel configuration