### PR TITLE
Add BIRD OSPF default route origination support.

### DIFF
--- a/docs/module/ospf.md
+++ b/docs/module/ospf.md
@@ -55,7 +55,7 @@ The following table describes the per-platform support of individual router-leve
 | ------------------------ |:-:|:-:|:-:|:-:|:-:|
 | Arista EOS               | ✅| ✅| ✅| ✅| ✅|
 | Aruba AOS-CX             | ✅| ✅| ✅| ✅| ✅|
-| BIRD                     | ✅| ✅| ✅| ✅| ❌ | 
+| BIRD                     | ✅| ✅| ✅| ✅| ✅|
 | Cisco ASAv               | ✅| ✅| ❌ | ❌ | ✅|
 | Cisco IOSv/IOSvL2        | ✅| ✅| ✅| ✅| ✅|
 | Cisco IOS XE[^18v]       | ✅| ✅| ✅| ✅| ✅|

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -68,6 +68,7 @@ features:
     timers: true
   ospf:
     import: [ bgp, connected, static, vrf ]
+    default: true
     password: true
     priority: true
     timers: true

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -6,14 +6,14 @@
 {% for af in ['ipv4','ipv6'] if af in ospf.af and ospf.default is defined and ospf.default.always|default(false) %}
 {%   set ver = 'v2' if af == 'ipv4' else 'v3' %}
 protocol static ospf_default_{{ proto_suffix }}_{{ ver }} {
-{%   if vrf_name %}
   {{ af }} {
+{%   if vrf_name %}
     table vrf_{{ vrf_name }}_{{ af }};
     import filter vrf_{{ vrf_name }}_tag;
-  };
-{%   else %}
-  {{ af }};
 {%   endif %}
+    # Low preference so any real default (BGP/OSPF/static) is preferred in the FIB
+    preference 1;
+  };
   route {{ ospf_default_pfx(af) }} unreachable;
 }
 {% endfor %}

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -1,5 +1,44 @@
+{% macro ospf_default_pfx(af) -%}
+{{ '0.0.0.0/0' if af == 'ipv4' else '::/0' }}
+{%- endmacro %}
+
+{% macro ospf_default_static(ospf,proto_suffix,vrf_name) %}
+{% for af in ['ipv4','ipv6'] if af in ospf.af and ospf.default is defined and ospf.default.always|default(false) %}
+{%   set ver = 'v2' if af == 'ipv4' else 'v3' %}
+protocol static ospf_default_{{ proto_suffix }}_{{ ver }} {
+{%   if vrf_name %}
+  {{ af }} {
+    table vrf_{{ vrf_name }}_{{ af }};
+    import filter vrf_{{ vrf_name }}_tag;
+  };
+{%   else %}
+  {{ af }};
+{%   endif %}
+  route {{ ospf_default_pfx(af) }} unreachable;
+}
+{% endfor %}
+{% endmacro %}
+
+{% macro ospf_default_export(odata,af) %}
+{%   set dfd = odata.default %}
+{%   set mtype = dfd.type|default('e2') %}
+{%   set mcost = dfd.cost|default(20) %}
+      if net = {{ ospf_default_pfx(af) }} then {
+{%     if dfd.always|default(false) %}
+        ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
+        accept;
+{%     else %}
+        if source ~ [ RTS_BGP, RTS_STATIC, RTS_STATIC_DEVICE ] then {
+          ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
+          accept;
+        }
+{%     endif %}
+      }
+{% endmacro %}
+
 {% macro ospf_config(ospf,proto_suffix,vrf_name,ospf_interfaces,vrf_data) %}
 {% set KW_NETWORK_TYPE = { 'broadcast': 'bcast', 'point-to-point': 'ptp','point-to-multipoint': 'ptmp', 'non-broadcast': 'nbma' } %}
+{{ ospf_default_static(ospf,proto_suffix,vrf_name) }}
 {% for af in ['ipv4','ipv6'] if af in ospf.af %}
 {%   set import_list = ospf.import|default(['bgp','connected','static'] if vrf_name else []) %}
 {%   set ver = 'v2' if af == 'ipv4' else 'v3' %}
@@ -10,24 +49,29 @@ protocol ospf {{ ver }} ospf_{{ proto_suffix }}_{{ ver }} {
   router id {{ ospf.router_id }};
 {%     endif %}
 {%   endif %}
-{%   if import_list or vrf_name %}
+{%   if import_list or vrf_name or ospf.default is defined %}
   {{ af }} {
 {%     if vrf_name %}
     table vrf_{{ vrf_name }}_{{ af }};
     import filter vrf_{{ vrf_name }}_tag;
 {%     endif %}
-{%     if import_list %}
+{%     if import_list or ospf.default is defined %}
     export filter {
+{%       if ospf.default is defined %}
+{{         ospf_default_export(ospf,af) }}
+{%       endif %}
 {%       if vrf_name and vrf_data.import|default([]) %}
       if netlab_vrf_rt ~ [ {{ vrf_data._bird_import|join(',') }} ] then {
         ospf_metric2 = 20;
         accept;
       }
 {%       endif %}
+{%       if import_list %}
       if source ~ [ {% for p in import_list %}{{ netlab_import_map[p] }}{% if not loop.last %},{% endif %}{% endfor %} ] then {
         ospf_metric2 = 20;
         accept;
       }
+{%       endif %}
       reject;
    };
 {%     endif %}

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -24,15 +24,8 @@ protocol static ospf_default_{{ proto_suffix }}_{{ ver }} {
 {%   set mtype = dfd.type|default('e2') %}
 {%   set mcost = dfd.cost|default(20) %}
       if net = {{ ospf_default_pfx(af) }} then {
-{%     if dfd.always|default(false) %}
         ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
         accept;
-{%     else %}
-        if source ~ [ RTS_BGP, RTS_STATIC, RTS_STATIC_DEVICE ] then {
-          ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
-          accept;
-        }
-{%     endif %}
       }
 {% endmacro %}
 


### PR DESCRIPTION
Export default routes via OSPF filters with E1/E2 metrics, use static routes for always-originate, and restrict conditional origination to BGP and static sources to avoid re-advertising OSPF-learned defaults.