### PR TITLE
OSPFv3 default route integration tests must be run with routers

### DIFF
--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -23,7 +23,7 @@ protocol static ospf_default_{{ proto_suffix }}_{{ ver }} {
 {%   set dfd = odata.default %}
 {%   set mtype = dfd.type|default('e2') %}
 {%   set mcost = dfd.cost|default(20) %}
-      if net = {{ ospf_default_pfx(af) }} then {
+      if net = {{ ospf_default_pfx(af) }} && source != RTS_DEVICE then {
         ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
         accept;
       }

--- a/netsim/daemons/bird/vrf-table.j2
+++ b/netsim/daemons/bird/vrf-table.j2
@@ -27,7 +27,7 @@ protocol kernel kernel_vrf_{{ vname }}_{{ _af }} {
   {{ _af }} {
     table {{ vrf_table(vname,_af) }};
     export all;
-    import filter vrf_{{ vname }}_tag;
+#    import filter vrf_{{ vname }}_tag;
   };
 }
 {%   endfor %}

--- a/tests/integration/ospf/ospfv3/20-default.yml
+++ b/tests/integration/ospf/ospfv3/20-default.yml
@@ -16,12 +16,14 @@ groups:
 
 nodes:
   dut_a:
+    role: router
     id: 1
     ospf.default:
       always: True
       type: e2
       cost: 40
   dut_c:
+    role: router
     id: 2
     module: [ ospf, bgp ]
     bgp.as: 65000

--- a/tests/integration/ospf/ospfv3/21-default-policy.yml
+++ b/tests/integration/ospf/ospfv3/21-default-policy.yml
@@ -21,6 +21,7 @@ routing:
 
 nodes:
   dut:
+    role: router
     module: [ ospf, bgp, routing ]
     bgp.as: 65000
     id: 1

--- a/tests/integration/ospf/ospfv3/22-default-vrf.yml
+++ b/tests/integration/ospf/ospfv3/22-default-vrf.yml
@@ -15,16 +15,15 @@ groups:
 
 vrfs:
   d1:
-    role: router
     ospf.default.always: True
     links: [ dut-p1 ]
   d2:
-    role: router
     ospf.default: True
     links: [ dut-p2, dut-xf ]
 
 nodes:
   dut:
+    role: router
     id: 1
     module: [ ospf, bgp, vrf ]
     bgp.as: 65000

--- a/tests/integration/ospf/ospfv3/22-default-vrf.yml
+++ b/tests/integration/ospf/ospfv3/22-default-vrf.yml
@@ -15,9 +15,11 @@ groups:
 
 vrfs:
   d1:
+    role: router
     ospf.default.always: True
     links: [ dut-p1 ]
   d2:
+    role: router
     ospf.default: True
     links: [ dut-p2, dut-xf ]
 


### PR DESCRIPTION
Some devices require a default route in their routing table to originate an OSPF default route. If we decide to add a static default route to support that functionality, then it's better to make it a floating static route (so a real default route can take over).

However, in the IPv6 world, a "better" default route could be the RA default route, so we have to set 'role: router' on tested devices to ensure they do NOT listen to RA updates.