### PR TITLE
Fix: Do not use BIRD kernel routes to originate OSPF defaults

### DIFF
--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -23,7 +23,7 @@ protocol static ospf_default_{{ proto_suffix }}_{{ ver }} {
 {%   set dfd = odata.default %}
 {%   set mtype = dfd.type|default('e2') %}
 {%   set mcost = dfd.cost|default(20) %}
-      if net = {{ ospf_default_pfx(af) }} then {
+      if net = {{ ospf_default_pfx(af) }} && source != RTS_DEVICE then {
         ospf_metric{{ mtype.replace('e', '') }} = {{ mcost }};
         accept;
       }


### PR DESCRIPTION
The BIRD OSPF default route can be based on any BIRD-derived route, but not on the kernel default routes. Add the 'source != RTS_DEVICE' condition to the default route origination.