### PR TITLE
Exit device-module-test early if we detect other running netlab instances

### DIFF
--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -284,6 +284,9 @@ def check_no_running_labs() -> None:
     return  # No default lab detected.. continue testing
 
   directory = default_lab.get('dir','')
+  if len(directory) > 50:
+      directory = '...' + directory[-47:]
+
   lab_status = default_lab.get('status','')
   providers = ', '.join(default_lab.get('providers',[]))
 

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 import typing
+import json
 
 from box import Box
 
@@ -255,6 +256,44 @@ def print_ok(step: str) -> None:
   _strings.print_colored_text(f"{step}(ok)",color="bright_green")
   print(" ",end="",flush=True)
 
+def check_no_running_labs() -> None:
+  status = subprocess.run(
+    ['netlab','status','--all','--format','json'],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True)
+
+  try:
+    status_data = json.loads(status.stdout or '{}')
+  except json.JSONDecodeError:
+    print(status.stdout)
+    log.fatal("Cannot parse netlab status --all JSON output")
+
+  if status.returncode == 1 and status_data.get('warning') == 'No netlab-managed labs':
+      return  # No running labs detected.. continue testing
+
+  if status.returncode != 0:
+    if status.stdout:
+      print(status.stdout)
+    if status.stderr:
+      print(status.stderr)
+    log.fatal("Cannot check running netlab labs")
+
+
+  print("Running netlab lab instance(s) detected:")
+  print("Active lab instance(s)\n")
+  print(f"{'id':<12} {'directory':<50} {'status':<10} providers")
+  print(f"{'-' * 12} {'-' * 50} {'-' * 10} {'-' * 20}")
+
+  for lab_id, lab_data in status_data.items():
+    directory = lab_data.get('dir','')
+    lab_status = lab_data.get('status','')
+    providers = ', '.join(lab_data.get('providers',[]))
+
+  print(f"{lab_id:<12} {directory:<50} {lab_status:<10} {providers}\n")
+
+  log.fatal("Refusing to launch integration test while another netlab lab is running")
+
 def run_test(test: str, args: argparse.Namespace,first: bool) -> None:
   test_path = os.path.abspath(test)
   os.makedirs(args.workdir,exist_ok=True)
@@ -410,6 +449,8 @@ def main() -> None:
 
       log_result(test,None)                       # Clean up the results from previous test runs
       try:
+        if "up" in args.steps:
+          check_no_running_labs()
         run_test(test,args,first_test)
         first_test = False
       except KeyboardInterrupt:

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -279,20 +279,21 @@ def check_no_running_labs() -> None:
       print(status.stderr)
     log.fatal("Cannot check running netlab labs")
 
+  default_lab = status_data.get('default')
+  if not default_lab:
+    return  # No default lab detected.. continue testing
+
+  directory = default_lab.get('dir','')
+  lab_status = default_lab.get('status','')
+  providers = ', '.join(default_lab.get('providers',[]))
 
   print("Running netlab lab instance(s) detected:")
   print("Active lab instance(s)\n")
   print(f"{'id':<12} {'directory':<50} {'status':<10} providers")
   print(f"{'-' * 12} {'-' * 50} {'-' * 10} {'-' * 20}")
+  print(f"{'default':<12} {directory:<50} {lab_status:<10} {providers}\n")
 
-  for lab_id, lab_data in status_data.items():
-    directory = lab_data.get('dir','')
-    lab_status = lab_data.get('status','')
-    providers = ', '.join(lab_data.get('providers',[]))
-
-  print(f"{lab_id:<12} {directory:<50} {lab_status:<10} {providers}\n")
-
-  log.fatal("Refusing to launch integration test while another netlab lab is running")
+  log.fatal("Refusing to launch integration test while another 'default' netlab lab is running")
 
 def run_test(test: str, args: argparse.Namespace,first: bool) -> None:
   test_path = os.path.abspath(test)

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -287,7 +287,7 @@ def check_no_running_labs() -> None:
   lab_status = default_lab.get('status','')
   providers = ', '.join(default_lab.get('providers',[]))
 
-  print("Running netlab lab instance(s) detected:")
+  print("Running netlab lab 'default' instance detected:")
   print("Active lab instance(s)\n")
   print(f"{'id':<12} {'directory':<50} {'status':<10} providers")
   print(f"{'-' * 12} {'-' * 50} {'-' * 10} {'-' * 20}")

--- a/tests/integration/device-module-test
+++ b/tests/integration/device-module-test
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import time
 import typing
-import json
 
 from box import Box
 
@@ -23,6 +22,7 @@ from netsim.utils import files as _files
 from netsim.utils import log
 from netsim.utils import read as _read
 from netsim.utils import strings as _strings
+from netsim.utils import status as _status
 
 
 def test_parse(args: typing.List[str], topology: Box) -> argparse.Namespace:
@@ -256,47 +256,30 @@ def print_ok(step: str) -> None:
   _strings.print_colored_text(f"{step}(ok)",color="bright_green")
   print(" ",end="",flush=True)
 
-def check_no_running_labs() -> None:
-  status = subprocess.run(
-    ['netlab','status','--all','--format','json'],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    text=True)
+def check_test_lab_instance(topology: Box) -> None:
+  lab_id = _status.get_lab_id(topology)
+  lab_states = _status.read_status(topology)
 
-  try:
-    status_data = json.loads(status.stdout or '{}')
-  except json.JSONDecodeError:
-    print(status.stdout)
-    log.fatal("Cannot parse netlab status --all JSON output")
+  if lab_id not in lab_states:
+    return
 
-  if status.returncode == 1 and status_data.get('warning') == 'No netlab-managed labs':
-      return  # No running labs detected.. continue testing
+  lab_state = lab_states[lab_id]
+  directory = lab_state.get('dir','unknown')
+  lab_status = lab_state.get('status','unknown')
 
-  if status.returncode != 0:
-    if status.stdout:
-      print(status.stdout)
-    if status.stderr:
-      print(status.stderr)
-    log.fatal("Cannot check running netlab labs")
-
-  default_lab = status_data.get('default')
-  if not default_lab:
-    return  # No default lab detected.. continue testing
-
-  directory = default_lab.get('dir','')
-  if len(directory) > 50:
-      directory = '...' + directory[-47:]
-
-  lab_status = default_lab.get('status','')
-  providers = ', '.join(default_lab.get('providers',[]))
-
-  print("Running netlab lab 'default' instance detected:")
-  print("Active lab instance(s)\n")
-  print(f"{'id':<12} {'directory':<50} {'status':<10} providers")
-  print(f"{'-' * 12} {'-' * 50} {'-' * 10} {'-' * 20}")
-  print(f"{'default':<12} {directory:<50} {lab_status:<10} {providers}\n")
-
-  log.fatal("Refusing to launch integration test while another 'default' netlab lab is running")
+  log.error(
+    text=f"Netlab instance '{lab_id}' is already active",
+    category=log.FatalError,
+    module='',
+    more_data=[
+      f"Directory: {directory}",
+      f"Status: {lab_status}",
+    ],
+    more_hints=(
+      f"Stop the integration-test instance with "
+      f"'netlab status -i {lab_id} --cleanup'"
+    ))
+  log.exit_on_error()
 
 def run_test(test: str, args: argparse.Namespace,first: bool) -> None:
   test_path = os.path.abspath(test)
@@ -453,8 +436,8 @@ def main() -> None:
 
       log_result(test,None)                       # Clean up the results from previous test runs
       try:
-        if "up" in args.steps:
-          check_no_running_labs()
+        if first_test and "up" in args.steps:
+          check_test_lab_instance(topology)
         run_test(test,args,first_test)
         first_test = False
       except KeyboardInterrupt:


### PR DESCRIPTION
This provides a early escape when trying to run tests and you have another 'default' netlab lab already running.

Mentioned in #3604 

Conditional that it only cares if user is trying to run the `up` case where it would clash with an existing lab.

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p clab -d frr  --steps create bgp
Pre-test cleanup:
17:09:48 bgp/01-ebgp-session.yml: create(ok) up(skip) config(skip) validate(skip) cleanup(ok)
17:09:49 bgp/02-ibgp-ebgp-session.yml: create(ok) up(skip) config(skip) validate(skip) cleanup(ok)
```

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p clab -d frr  bgp
Running netlab lab 'default' instance detected:
Active lab instance(s)

id           directory                                    status     providers
------------ -------------------------------------------- ---------- --------------------
default      ...me/netlab/snuffy-netlab/tests/integration started    clab

[FATAL]   Refusing to launch integration test while another 'default' netlab lab is running
```