### PR TITLE
Fix: Add "VLAN 1 cannot be tagged" quirk to OS10 and EXOS

### DIFF
--- a/netsim/devices/dellos10.py
+++ b/netsim/devices/dellos10.py
@@ -4,7 +4,7 @@
 from box import Box, BoxList
 
 from ..utils import routing as _rp_utils
-from . import _Quirks, need_ansible_collection, report_quirk
+from . import _common, _Quirks, need_ansible_collection, report_quirk
 
 
 def check_vlan_ospf(node: Box, iflist: BoxList, vname: str) -> None:
@@ -132,6 +132,9 @@ class OS10(_Quirks):
     if 'gateway' in mods:
       if 'anycast' in node.get('gateway',{}):
         check_anycast_gateways(node)
+
+    if 'vlan' in mods:
+      _common.check_tagged_vlan_1(node)
 
   def check_config_sw(self, node: Box, topology: Box) -> None:
     need_ansible_collection(node,'dellemc.os10')

--- a/netsim/devices/exos.py
+++ b/netsim/devices/exos.py
@@ -1,7 +1,7 @@
 from box import Box
 
 from ..utils import log
-from . import _Quirks, need_ansible_collection, report_quirk
+from . import _common, _Quirks, need_ansible_collection, report_quirk
 
 EXOS_VLAN_1_NAME = 'Default'
 
@@ -63,6 +63,7 @@ class EXOS(_Quirks):
   def device_quirks(cls, node: Box, topology: Box) -> None:
     if 'vlan' in node.get('module',[]):
       default_vlan_1(node)
+      _common.check_tagged_vlan_1(node)
     if 'gateway' in node.get('module',[]):
       check_vrrp_address_families(node)
 


### PR DESCRIPTION
Dell OS10 and Extreme EXOS were also failing the "tagged VLAN 1" test. Use the quirk developed for Mikrotik RouterOS7 to catch that.