### PR TITLE
Add VTEP6 support for RouterOS7

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -37,7 +37,7 @@ The following table describes the per-platform support of individual VXLAN featu
 | Cumulus 5.x (NVUE) | ✅  | ✅  |  ❌  |
 | Dell OS10          | ✅  | ✅  |  ❌  |
 | FRR                | ✅  | ✅  | ✅  |
-| Mikrotik RouterOS 7 | ✅  | ✅  |  ❌ |
+| Mikrotik RouterOS 7 | ✅  | ✅  | ✅ |
 | Nokia SR Linux     | ✅ [❗](caveats-srlinux)  |  ❌  |  ❌  |
 | Nokia SR OS[^SROS] | ✅  |  ❌  |  ❌  |
 | vJunos-switch      | ✅  | ✅  |  ❌ |

--- a/netsim/ansible/templates/vxlan/routeros7.j2
+++ b/netsim/ansible/templates/vxlan/routeros7.j2
@@ -2,7 +2,7 @@
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
 {%    set learning="no" if vxlan.flooding|default("") == "evpn" else "yes" %}
 {%    set v= vlans[vname] %}
-/interface/vxlan add bridge=switch bridge-pvid={{ v.id }} local-address={{ vxlan.vtep }} name=vxlan-{{ v.vni }} vni={{ v.vni }} learning={{ learning }}
+/interface/vxlan add bridge=switch bridge-pvid={{ v.id }} local-address={{ vxlan.vtep }} name=vxlan-{{ v.vni }} vni={{ v.vni }} learning={{ learning }} checksum=yes
 {%     if v.vtep_list is defined %}
 {%       for remote_vtep in v.vtep_list %}
 /interface/vxlan/vtep add interface=vxlan-{{ v.vni }} remote-ip={{ remote_vtep }}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -43,7 +43,8 @@ features:
   vrf:
     ospfv2: True
     bgp: True
-  vxlan: True
+  vxlan:
+    vtep6: True
 clab:
   image: vrnetlab/mikrotik_routeros:7.21.4
   build: https://containerlab.dev/manual/kinds/vr-ros/


### PR DESCRIPTION
Fix the last issue for RouterOS7 and VTEP6 support.
We needed to enable checksums

Successfully runs `07-vxlan-bridging-v6only.yml` VXLAN integration test
```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/vxlan$ netlab up -d routeros7 -p clab 

(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/vxlan$ netlab validate
[ospf6_adj] Check OSPFv3 adjacencies [ node(s): s2 ]
[PASS]      s2: OSPFv3 neighbor 10.0.0.4 is in state Full
[PASS]      Test succeeded in 0.1 seconds

[stp_red]   Waiting for STP to enable ports in red VLAN [ node(s): h1 ]
[PASS]      h1: Ping to h1a succeeded
[PASS]      Test succeeded in 0.1 seconds

[ping]      Ping-based reachability test in VLAN red [ node(s): h1 ]
[PASS]      h1: Ping to h2 succeeded
[PASS]      Test succeeded in 0.1 seconds

[SUCCESS]   Tests passed: 3
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/vxlan$
```