### PR TITLE
Fix VyOS BFD profile configuration

### DIFF
--- a/netsim/ansible/templates/bfd/vyos.j2
+++ b/netsim/ansible/templates/bfd/vyos.j2
@@ -1,3 +1,3 @@
-set bfd profile netsim interval multiplier {{ bfd.multiplier|default(3) }}
-set bfd profile netsim interval receive {{ bfd.min_rx|default(500) }}
-set bfd profile netsim interval transmit {{ bfd.min_tx|default(500) }}
+set protocols bfd profile netsim interval multiplier {{ bfd.multiplier|default(3) }}
+set protocols bfd profile netsim interval receive {{ bfd.min_rx|default(500) }}
+set protocols bfd profile netsim interval transmit {{ bfd.min_tx|default(500) }}


### PR DESCRIPTION
For whatever reason, we have to use 'set protocols bfd' instead of 'set bfd' in VyOS configuration