### PR TITLE
OpenBSD VXLAN support

### DIFF
--- a/docs/module/vxlan.md
+++ b/docs/module/vxlan.md
@@ -40,6 +40,7 @@ The following table describes the per-platform support of individual VXLAN featu
 | Mikrotik RouterOS 7 | ✅  | ✅  |  ❌ |
 | Nokia SR Linux     | ✅ [❗](caveats-srlinux)  |  ❌  |  ❌  |
 | Nokia SR OS[^SROS] | ✅  |  ❌  |  ❌  |
+| OpenBSD            | ✅  | ✅  | ✅  |
 | vJunos-switch      | ✅  | ✅  |  ❌ |
 | vJunos-router      | ✅  | ✅  |  ❌ |
 | VyOS               | ✅  | ✅  | ✅  |

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -481,7 +481,7 @@ The data plane [configuration modules](module-reference.md) are supported on the
 | Mikrotik RouterOS 7   | ✅ | ✅ | ✅ | ✅ |  ❌ |  ❌ |
 | Nokia SR Linux        | ✅ | ✅ | ✅ | ✅ | ✅ |  ❌ |
 | Nokia SR OS[^SROS]    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| OpenBSD               | ✅ | ❌ | ❌ | ❌  | ❌ |
+| OpenBSD               | ✅ | ❌ | ✅ | ❌  | ❌ |
 | VyOS                  | ✅ | ✅ | ✅ | ✅ |  ❌ |  ❌ |
 
 (platform-services-support)=

--- a/netsim/ansible/templates/initial/openbsd.j2
+++ b/netsim/ansible/templates/initial/openbsd.j2
@@ -3,9 +3,9 @@
   This script configures an OpenBSD host
 #}
 #!/bin/sh
-#
-set -e
-set -x
+
+set -e # Exit immediately when any command fails
+set -x # Track commands for troubleshooting
 
 hostname {{ inventory_hostname.replace("_","-") }}
 {% include 'linux/hosts.j2' +%}

--- a/netsim/ansible/templates/vlan/openbsd.j2
+++ b/netsim/ansible/templates/vlan/openbsd.j2
@@ -3,10 +3,9 @@
   This script configures OpenBSD VLANs
 #}
 #!/bin/sh
-#
+
 set -e # Exit immediately when any command fails
 set -x # Track commands for troubleshooting
-#
 
 {% for ifdata in interfaces if ifdata.vlan is defined %}
 {% if ifdata.type == 'vlan_member' %}

--- a/netsim/ansible/templates/vlan/openbsd.j2
+++ b/netsim/ansible/templates/vlan/openbsd.j2
@@ -14,15 +14,15 @@ ifconfig {{ ifdata.ifname }} parent {{ ifdata.parent_ifname }} vnetid {{ ifdata.
 {% endif %}
 {{ ifconfig(ifdata) }}
 {% if ifdata.vlan.access is defined %}
-ifconfig bridge{{ vlans[ifdata.vlan.access].id }} add {{ ifdata.ifname }} up
+ifconfig veb{{ vlans[ifdata.vlan.access].id }} add {{ ifdata.ifname }} up
 {% endif %}
 {% if ifdata.vlan.native is defined %}
-ifconfig bridge{{ vlans[ifdata.vlan.native].id }} add {{ ifdata.ifname }} up
+ifconfig veb{{ vlans[ifdata.vlan.native].id }} add {{ ifdata.ifname }} up
 {% endif %}
 {% if ifdata.type=='svi' %}
 {%   for vname,vdata in vlans.items() %}
 {%     if ifdata.vlan.name == vname %}
-ifconfig bridge{{ vdata.id }} add {{ ifdata.ifname }} up
+ifconfig veb{{ vdata.id }} add {{ ifdata.ifname }} up
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/vxlan/openbsd.j2
+++ b/netsim/ansible/templates/vxlan/openbsd.j2
@@ -1,12 +1,14 @@
 {#
-    We only need data-plane VXLAN configuration. Bird configuration is thus (almost)
-    identical to the FRR one; we just need to set the "we're done" flag.
+  This will setup VXLAN tunnels on OpenBSD
 #}
-touch /home/openbsd/blanket
+#!/bin/sh
+
+set -e # Exit immediately when any command fails
+set -x # Track commands for troubleshooting
+
 {% if vxlan.vlans is defined %}
 {%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
-{%    set tun_type="" if vxlan.flooding|default("") == "evpn" else "yes" %}
-{%    set v= vlans[vname] %}
+{%    set v = vlans[vname] %}
 {%     if v.vtep_list is defined %}
 {%       for remote_vtep in v.vtep_list %}
 ifconfig vxlan{{ v.vni }}{{ loop.index }} vnetid {{ v.vni }} tunnel {{ vxlan.vtep }} {{ remote_vtep }}

--- a/netsim/ansible/templates/vxlan/openbsd.j2
+++ b/netsim/ansible/templates/vxlan/openbsd.j2
@@ -9,8 +9,8 @@ touch /home/openbsd/blanket
 {%    set v= vlans[vname] %}
 {%     if v.vtep_list is defined %}
 {%       for remote_vtep in v.vtep_list %}
-ifconfig vxlan{{ v.vni }}{{ loop.index }} vnetid {{ v.vni }} tunnel {{ vxlan.vtep }} {{ remote_vtep }} 
-ifconfig veb{{vlans[vname].id}} add vxlan{{ v.vni }}{{ loop.index }} 
+ifconfig vxlan{{ v.vni }}{{ loop.index }} vnetid {{ v.vni }} tunnel {{ vxlan.vtep }} {{ remote_vtep }}
+ifconfig veb{{vlans[vname].id}} add vxlan{{ v.vni }}{{ loop.index }}
 ifconfig vxlan{{ v.vni}}{{ loop.index }} up
 {%       endfor %}
 {%     endif %}

--- a/netsim/ansible/templates/vxlan/openbsd.j2
+++ b/netsim/ansible/templates/vxlan/openbsd.j2
@@ -1,0 +1,18 @@
+{#
+    We only need data-plane VXLAN configuration. Bird configuration is thus (almost)
+    identical to the FRR one; we just need to set the "we're done" flag.
+#}
+touch /home/openbsd/blanket
+{% if vxlan.vlans is defined %}
+{%   for vname in vxlan.vlans if vlans[vname].vni is defined %}
+{%    set tun_type="" if vxlan.flooding|default("") == "evpn" else "yes" %}
+{%    set v= vlans[vname] %}
+{%     if v.vtep_list is defined %}
+{%       for remote_vtep in v.vtep_list %}
+ifconfig vxlan{{ v.vni }}{{ loop.index }} vnetid {{ v.vni }} tunnel {{ vxlan.vtep }} {{ remote_vtep }} 
+ifconfig veb{{vlans[vname].id}} add vxlan{{ v.vni }}{{ loop.index }} 
+ifconfig vxlan{{ v.vni}}{{ loop.index }} up
+{%       endfor %}
+{%     endif %}
+{%   endfor %}
+{% endif %}

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -51,9 +51,11 @@ features:
   vlan:
     model: router
     subif_name: 'vlan{vlan.access_id}{ifname[-1]}'
-    svi_interface_name: vether{vlan}
+    svi_interface_name: vport{vlan}
     mixed_trunk: true
     native_routed: true
+  vxlan:
+    vtep6: True
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd


### PR DESCRIPTION
This adds VXLAN support to OpenBSD.

* Allows IPv4 and IPv6 VTEP
* Switch from `bridge + vether` to `veb + vport`

Only VXLAN integration tests failing are due to missing VRF support:
* 04-vxlan-irb-ospf.yml
* 05-vxlan-router-stick.yml

Only VLAN integration test failed is the same as before the `bridge` to `veb` change due to missing VRF support:
* 52-vlan-vrf-lite.yml

<details><summary> VXLAN test integration outputs</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p libvirt -d openbsd vxlan
Pre-test cleanup:
02:45:54 vxlan/01-vxlan-bridging.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
02:47:18 vxlan/02-vxlan-bridging-multinode.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
02:48:54 vxlan/03-vxlan-irb.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
02:50:08 vxlan/04-vxlan-irb-ospf.yml: create(FAIL)
02:50:08 vxlan/05-vxlan-router-stick.yml: create(FAIL)
02:50:09 vxlan/07-vxlan-bridging-v6only.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
02:51:20 vxlan/08-vxlan-alt-vtep.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```
</details>

<details><summary> VLAN test integration outputs</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p libvirt -d openbsd vlan/
Pre-test cleanup:
10:01:41 vlan/01-vlan-bridge-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:02:25 vlan/02-vlan-bridge-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:03:14 vlan/21-vlan-irb-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:04:00 vlan/22-vlan-irb-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:04:46 vlan/23-vlan-mixed-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:05:35 vlan/31-vlan-bridge-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:05:38 vlan/32-vlan-bridge-trunk-router.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:06:32 vlan/33-vlan-irb-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:06:35 vlan/41-vlan-bridge-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:06:38 vlan/42-vlan-irb-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:06:41 vlan/51-vlan-routed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:08:24 vlan/52-vlan-vrf-lite.yml: create(FAIL)
10:08:24 vlan/61-vlan-routed-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:10:13 vlan/62-vlan-mixed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:12:16 vlan/63-vlan-mixed-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
10:15:31 vlan/70-vlan-1-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
```
</details>