### PR TITLE
Set IPv6 loopbacks to /128 similar to IPv4, unless otherwise told

### DIFF
--- a/netsim/augment/addressing.py
+++ b/netsim/augment/addressing.py
@@ -113,6 +113,8 @@ def setup_pools(addr_pools: typing.Optional[Box] = None, defaults: typing.Option
     clean_pfx = normalize_prefix(addrs[pool])
     if 'ipv4' in clean_pfx and not 'prefix' in clean_pfx:
       clean_pfx.prefix = 32 if 'loopback' in pool else 24
+    if 'ipv6' in clean_pfx and not 'prefix6' in clean_pfx:
+      clean_pfx.prefix6 = 128 if 'loopback' in pool else 64
     addrs[pool] = clean_pfx
 
   return addrs

--- a/tests/integration/ospf/ospfv3/06-lb-prefix.yml
+++ b/tests/integration/ospf/ospfv3/06-lb-prefix.yml
@@ -35,4 +35,4 @@ validate:
     wait: ospfv3_spf
     wait_msg: Waiting for DUT and SPF to do their magic
     nodes: [ x1 ]
-    plugin: ospf6_prefix('2001:db8:1:1::1/128')
+    plugin: ospf6_prefix(nodes.dut.loopback.ipv6)


### PR DESCRIPTION
This fixes issues with different routing platforms giving different routing advertisements for ipv6 loopbacks.

OpenBSD for one, always considers loopbacks to be ipv4 /32 or ipv6 /128, though it will display the prefix length of 64 via ifconfig that is not what is configured.

This showed up when trying to run a new test for OSPFv3 route and trying to just use the loopback's IPv6 address.

Mention #3632 
