### PR TITLE
OpenBSD does not support advertising IPv6 loopbacks with /64, force to /128

### DIFF
--- a/netsim/devices/openbsd.py
+++ b/netsim/devices/openbsd.py
@@ -58,10 +58,40 @@ def check_ospf6_quirks(node: Box) -> None:
       category=Warning,
       node=node)
 
+def adjust_ipv6_loopback_prefix(node: Box) -> None:
+  '''
+  OpenBSD wants to have /128 IPv6 prefix on the system loopback interface lets not pretend it supports /64
+  '''
+  v6lb = node.get('loopback.ipv6',None)
+  if not v6lb:                                    # No IPv6 on system loopback, no problem
+    return
+
+  (v6ad,v6pf) = v6lb.split('/')                   # Get address and prefix
+  if v6pf == '128':                               # Prefix already /128?
+    return                                        # Cool, let's get out of here
+
+  node.loopback.ipv6 = f'{v6ad}/128'              # Change the prefix length on the loopback interface
+  report_quirk(
+    text=f'Loopback prefix {v6lb} on node {node.name} was changed to {node.loopback.ipv6}',
+    more_hints=[ f'The IPv6 prefix configured on OpenBSD system (loopback) interface should be /128' ],
+    quirk='loopback_ipv6',
+    node=node,
+    category=Warning)
+
+  if 'bgp.advertise' not in node:                 # Do we have to patch the bgp.advertise list?
+    return
+
+  v6lb_pfx = str(ipaddress.ip_network(v6lb,strict=False))
+  for pfx in node.bgp.advertise:                  # Iterate over advertised prefixes
+    if pfx.get('ipv6',None) == v6lb_pfx:          # Did we find the original loopback prefix?
+      pfx.ipv6 = node.loopback.ipv6               # Replace it with node loopback IPv6 (with /128 prefix)
+      break                                       # ... and get out of the loop, we're done.
+
 class OpenBSD(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     check_loopback(node,topology)
     check_indirect_static_routes(node)
+    adjust_ipv6_loopback_prefix(node)
     check_ospf6_quirks(node)


### PR DESCRIPTION
While you can set OpenBSD to have a IPv6 loopback  /64, it treats it as a /128, the /64 is just metadata within the ifconfig output.

This can cause problems during tests that expect to see both a /128 and /64 being advertised to them like OSPFv3.

My choice was to add quirk to set it to /128, then any device searching for it would only be looking for the /128 route.

I had looked into changing it during deployment to /128 and then adding a static blackhole route for the /64 to ::1.
But then it required doing redistribution of that special static route in OSPFv3

Shamelessly steal from SR implementation

The tests now do show more 'warnings' due to this change, the overall test pass rate did not change.

<details><summary> OSPFv3 Tests</summary>

```
 ./device-module-test -p libvirt -d openbsd ospf/ospfv3/
Pre-test cleanup:
21:02:41 ospf/ospfv3/01-network.yml: create(WARNING) up(ok) config(ok) validate(ok) cleanup(ok) OK
21:04:28 ospf/ospfv3/02-areas.yml: create(FAIL)
21:04:29 ospf/ospfv3/03-cost.yml: create(WARNING) up(ok) config(ok) validate(ok) cleanup(ok) OK
21:05:36 ospf/ospfv3/04-passive.yml: create(WARNING) up(ok) config(ok)
[c_p1]       Check cost of IPv6 prefix on passive interface on DUT [ node(s): x1 ]
[FAIL]       Node x1: Invalid OSPF end-to-end cost for prefix 2001:db8:cafe:1::/64: expected 25 actual 200

[c_x2]       Check cost of IPv6 prefix on stub interface on DUT [ node(s): x1 ]
[FAIL]       Node x1: Invalid OSPF end-to-end cost for prefix 2001:db8:cafe:2::/64: expected 35 actual 65545
cleanup(ok)
21:06:52 ospf/ospfv3/05-unnumbered.yml: create(WARNING) up(ok) config(ok) validate(ok) cleanup(ok) OK
21:07:53 ospf/ospfv3/06-lb-prefix.yml: create(WARNING) up(ok) config(ok) validate(ok) cleanup(ok) OK
21:08:53 ospf/ospfv3/07-vlan-mtu.yml: create(WARNING) up(ok) config(ok) validate(ok) cleanup(ok) OK
21:09:58 ospf/ospfv3/08-dual-stack.yml: create(FAIL)
21:09:58 ospf/ospfv3/10-import.yml: create(FAIL)
21:09:58 ospf/ospfv3/11-import-policy.yml: create(FAIL)
21:09:59 ospf/ospfv3/20-default.yml: create(FAIL)
21:09:59 ospf/ospfv3/21-default-policy.yml: create(FAIL)
21:09:59 ospf/ospfv3/22-default-vrf.yml: create(FAIL)
21:10:00 ospf/ospfv3/30-timers.yml: create(WARNING) up(ok) config(ok)
[v_warning]  Starting test
[WARNING]    Device openbsd does support VRFs, skipping VRF-specific tests
validate(WARNING) cleanup(ok) OK
21:10:51 ospf/ospfv3/31-priority.yml: create(WARNING) up(ok) config(ok)
[v_warning]  Starting test
[WARNING]    Device openbsd does support VRFs, skipping VRF-specific tests
validate(WARNING) cleanup(ok) OK
21:12:23 ospf/ospfv3/40-area-parameters.yml: create(FAIL)
21:12:24 ospf/ospfv3/41-gr.yml: create(FAIL)
21:12:24 ospf/ospfv3/42-bfd.yml: create(FAIL)
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```
</details>