### PR TITLE
Fix: Cross-provider links destroyed 'tunnel' link type

### DIFF
--- a/netsim/extra/tunnel/gre/__init__.py
+++ b/netsim/extra/tunnel/gre/__init__.py
@@ -8,9 +8,9 @@ from .. import _p2p
 
 _config_name = 'tunnel.gre'
 
-def pre_link_transform(topology: Box) -> None:
+def pre_transform(topology: Box) -> None:
   '''
-  pre_link_transform hook: set tunnel link type, check whether GRE tunnels are P2P
+  pre_transform hook: set tunnel link type, check whether GRE tunnels are P2P
   '''
   _tunnel.set_tunnel_type(topology)
   for link in _tunnel.links(topology,'gre'):

--- a/netsim/extra/tunnel/wireguard/__init__.py
+++ b/netsim/extra/tunnel/wireguard/__init__.py
@@ -129,9 +129,9 @@ def wireguard_intf_defaults(ndata: Box, intf: Box, topology: Box) -> bool:
   intf.tunnel._source.listen_port = intf.tunnel.listen_port
   return True
 
-def pre_link_transform(topology: Box) -> None:
+def pre_transform(topology: Box) -> None:
   '''
-  pre_link_transform hook: set tunnel link type, check whether WireGuard tunnels are P2P
+  pre_transform hook: set tunnel link type, check whether WireGuard tunnels are P2P
   '''
   _tunnel.set_tunnel_type(topology)
   for link in _tunnel.links(topology,'wireguard'):

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -285,22 +285,23 @@ class Libvirt(_Provider):
           l.libvirt.public = 'bridge'                            # ... default mode is bridge (MACVTAP)
 
       """
-      The libvirt links could be modeled as P2P links (using UDP tunnels) or
-      LAN links using a Linux bridge. It's better to use the UDP tunnels, but
-      we must us the Linux bridge if:
+      The libvirt links could be modeled as P2P links (using UDP tunnels) or LAN
+      links using a Linux bridge. It's better to use the UDP tunnels, but we
+      must us the Linux bridge if:
 
       * The link type is 'lan' or 'stub' (set/used elsewhere, also includes
         hosts connected to links)
       * The libvirt.provider attribute is set (multi-provider links or external
         connectivity)
-      * The system defaults say P2P links should be modeled as bridges
-        (used for traffic capture)
+      * The system defaults say P2P links should be modeled as bridges (used for
+        traffic capture)
       * The link or any of the interfaces has the 'tc' parameter
 
-      However, we should never set the link type for virtual links (currently,
-      tunnel links)
+      However, we should never set the link type for virtual links. Currently,
+      that would be tunnel and loopback links; cross-provider LAG member links
+      don't work (and are thus blocked) and VLAN/SVI links are created later.
       """
-      if l.get('type','') in ['tunnel']:
+      if l.get('type','') in ['tunnel','loopback']:
         continue
 
       must_be_lan = l.get('libvirt.provider',None) and 'vlan' not in l.type

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -296,7 +296,13 @@ class Libvirt(_Provider):
       * The system defaults say P2P links should be modeled as bridges
         (used for traffic capture)
       * The link or any of the interfaces has the 'tc' parameter
+
+      However, we should never set the link type for virtual links (currently,
+      tunnel links)
       """
+      if l.get('type','') in ['tunnel']:
+        continue
+
       must_be_lan = l.get('libvirt.provider',None) and 'vlan' not in l.type
       must_be_lan = must_be_lan or (p2p_bridge and l.get('type','p2p') == 'p2p')
       must_be_lan = must_be_lan or 'tc' in l or [ intf for intf in l.interfaces if 'tc' in intf ]

--- a/tests/coverage/expected/gre-source.yml
+++ b/tests/coverage/expected/gre-source.yml
@@ -1,8 +1,12 @@
 input:
 - coverage/input/gre-source.yml
 - package:topology-defaults.yml
+libvirt:
+  providers:
+    clab: true
 links:
 - _linkname: links[1]
+  bridge: input_1
   interfaces:
   - ifindex: 1
     ifname: eth1
@@ -12,13 +16,17 @@ links:
     ifname: eth1
     ipv4: 10.1.0.2/30
     node: r2
+  libvirt:
+    provider:
+      clab: true
   linkindex: 1
   name: uplink
   node_count: 2
   prefix:
     ipv4: 10.1.0.0/30
-  type: p2p
+  type: lan
 - _linkname: links[2]
+  bridge: input_2
   interfaces:
   - ifindex: 2
     ifname: eth2
@@ -29,12 +37,15 @@ links:
     ipv4: 10.1.0.6/30
     node: r2
     role: mobile
+  libvirt:
+    provider:
+      clab: true
   linkindex: 2
   node_count: 2
   prefix:
     ipv4: 10.1.0.4/30
   role: backup
-  type: p2p
+  type: lan
 - _linkname: links[3]
   bridge: input_3
   interfaces:
@@ -46,6 +57,9 @@ links:
     ifname: Tunnel0
     ipv4: 10.1.0.10/30
     node: r2
+  libvirt:
+    provider:
+      clab: true
   linkindex: 3
   node_count: 2
   prefix:
@@ -75,6 +89,9 @@ links:
       source:
         link:
           role: mobile
+  libvirt:
+    provider:
+      clab: true
   linkindex: 4
   node_count: 2
   prefix:
@@ -94,9 +111,11 @@ nodes:
     config:
     - tunnel.gre
     device: none
+    hostname: clab-input-r1
     id: 1
     interfaces:
-    - ifindex: 1
+    - bridge: input_1
+      ifindex: 1
       ifname: eth1
       ipv4: 10.1.0.1/30
       linkindex: 1
@@ -105,8 +124,9 @@ nodes:
       - ifname: eth1
         ipv4: 10.1.0.2/30
         node: r2
-      type: p2p
-    - ifindex: 2
+      type: lan
+    - bridge: input_2
+      ifindex: 2
       ifname: eth2
       ipv4: 10.1.0.5/30
       linkindex: 2
@@ -116,7 +136,7 @@ nodes:
         ipv4: 10.1.0.6/30
         node: r2
       role: backup
-      type: p2p
+      type: lan
     - ifindex: 20000
       ifname: Tunnel0
       ipv4: 10.1.0.9/30
@@ -179,6 +199,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: ca:fe:00:01:00:00
     name: r1
+    provider: clab
   r2:
     af:
       ipv4: true
@@ -188,7 +209,8 @@ nodes:
     device: none
     id: 2
     interfaces:
-    - ifindex: 1
+    - bridge: input_1
+      ifindex: 1
       ifname: eth1
       ipv4: 10.1.0.2/30
       linkindex: 1
@@ -197,8 +219,9 @@ nodes:
       - ifname: eth1
         ipv4: 10.1.0.1/30
         node: r1
-      type: p2p
-    - ifindex: 2
+      type: lan
+    - bridge: input_2
+      ifindex: 2
       ifname: eth2
       ipv4: 10.1.0.6/30
       linkindex: 2
@@ -208,7 +231,7 @@ nodes:
         ipv4: 10.1.0.5/30
         node: r1
       role: mobile
-      type: p2p
+      type: lan
     - ifindex: 20000
       ifname: Tunnel0
       ipv4: 10.1.0.10/30

--- a/tests/coverage/input/gre-source.yml
+++ b/tests/coverage/input/gre-source.yml
@@ -7,7 +7,9 @@ defaults.device: none
 
 nodes:
   r1:
+    provider: clab
   r2:
+    provider: libvirt
 
 links:
 - r1:


### PR DESCRIPTION
With a tunnel established between a VM (libvirt) and a container, the libvirt provider would stomp on the link.type field and change it to 'lan'. This fix:

* Adds a "should we leave this link alone" check to multi-provider link augmentation code (currently: tunnel links)
* Move the "set link type to tunnel" part of tunnel plugins to the pre_transform (previously: pre_link_transform) processing to ensure the link type is set before the cross-provider checks