### PR TITLE
fix(sr): render SRGB (segment-routing global-block) under router isis on FRR

### DIFF
--- a/netsim/ansible/templates/sr/frr.j2
+++ b/netsim/ansible/templates/sr/frr.j2
@@ -15,6 +15,9 @@ cat >/tmp/config <<'CONFIG'
 {% if 'isis' in sr.protocol %}
 router isis {{ isis.instance }}
   segment-routing on
+{%   if sr.srgb.start is defined %}
+  segment-routing global-block {{ sr.srgb.start }} {{ sr.srgb.start + sr.srgb.size|default(8000) - 1 }}
+{%   endif %}
 {%   if isis.router_id is defined %}
   mpls-te router-address {{ isis.router_id }}
 {%   endif %}

--- a/tests/integration/sr/01-isis-ipv4-p.yml
+++ b/tests/integration/sr/01-isis-ipv4-p.yml
@@ -8,7 +8,6 @@ defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
 bgp.advertise_loopback: false
 isis.instance: Mordor
-sr.srgb.start: 16000    # exercise SRGB rendering under router isis (FRR)
 
 groups:
   _auto_create: True
@@ -27,6 +26,11 @@ groups:
     members: [ pe1, pe2, p2 ]
     device: frr
     provider: clab
+
+nodes:
+  dut:
+    id: 1
+    sr.srgb.start: 38400    # check IS-IS SRGB setup (see #3652)
 
 links:
 - h1:
@@ -54,6 +58,14 @@ validate:
     nodes: [ pe2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'pe1')
     stop_on_error: true
+  srgb:
+    description: Check DUT SRGB settings
+    nodes: [ pe2 ]
+    level: warning
+    fail: The DUT SRGB does not start at 38400
+    exec.frr: vtysh -c "show isis segment-routing node"
+    valid: >-
+      "38400" in stdout
   ping:
     description: Ping-based end-to-end reachability test
     wait_msg: We might have to wait a bit longer

--- a/tests/integration/sr/01-isis-ipv4-p.yml
+++ b/tests/integration/sr/01-isis-ipv4-p.yml
@@ -8,6 +8,7 @@ defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
 bgp.advertise_loopback: false
 isis.instance: Mordor
+sr.srgb.start: 16000    # exercise SRGB rendering under router isis (FRR)
 
 groups:
   _auto_create: True


### PR DESCRIPTION
## Problem

`netsim/ansible/templates/sr/frr.j2` renders the SRGB (`segment-routing global-block`, derived from `sr.srgb.start`) **only** inside the `{% if 'ospfv2' in sr.protocol %}` block. Under IS-IS SR the SRGB is silently dropped — `sr.srgb.start` is a no-op for `isisd`, so a lab that sets a custom SRGB gets FRR default global block instead of the requested one.

## Fix

Mirror the existing guarded block into the `router isis` section. FRR `isisd` accepts `segment-routing global-block <lower> <upper>` with the same syntax as `ospfd`.

```diff
 {% if 'isis' in sr.protocol %}
 router isis {{ isis.instance }}
   segment-routing on
+{%   if sr.srgb.start is defined %}
+  segment-routing global-block {{ sr.srgb.start }} {{ sr.srgb.start + sr.srgb.size|default(8000) - 1 }}
+{%   endif %}
 {%   if isis.router_id is defined %}
```

## Test

Added `sr.srgb.start: 16000` to `tests/integration/sr/01-isis-ipv4-p.yml` so the IS-IS SRGB rendering path is exercised.

## Verification

Offline Jinja render of the template:
- IS-IS case now emits `segment-routing global-block 16000 23999` under `router isis`.
- OSPF case unchanged (no regression).
