### PR TITLE
GRE: Transport address family check

### DIFF
--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -189,7 +189,7 @@ features:
     supported_protocols: [ stp ]  # Implementation uses a separate bridge per VLAN
     enable_per_port: False
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
     wireguard: [ vrf ]
   vlan:
     mixed_trunk: true

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -20,6 +20,8 @@ features:
   lag:
     mlag: False
     passive: True
+  tunnel:
+    gre: [ vrf, ipv4 ]
 clab:
   group_vars:
     netlab_device_type: ioll2

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -138,7 +138,7 @@ features:
       inter_vrf: True
       discard: True
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
   vlan:
     model: router
     svi_interface_name: BVI{bvi}

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -159,5 +159,5 @@ features:
   vxlan:
     vtep6: true
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
     wireguard: [ vrf ]

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -15,7 +15,7 @@ features:
     bundle: [ vlan_aware ]
     transport: [ vxlan ]
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
   vlan:
     model: router
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -15,7 +15,7 @@ features:
   lag:
     passive: True
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
   vlan:
     model: router
     subif_name: "{ifname}.{vlan.access_id}"

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -83,7 +83,7 @@ features:
       inter_vrf: True
       discard: True
   tunnel:
-    gre: [ vrf ]
+    gre: [ vrf, ipv4, ipv6 ]
   vlan:
     model: l3-switch
     svi_interface_name: "br0.{vlan}"

--- a/netsim/extra/tunnel/__init__.py
+++ b/netsim/extra/tunnel/__init__.py
@@ -165,7 +165,7 @@ def check_feature(
   Checks whether the node supports the required tunnel feature
   """
   features = a_devices.get_device_features(ndata,topology.defaults)
-  df_value = features.tunnel.get(f_name,None)
+  df_value = features.get(f'tunnel.{f_name}',None)
   if df_value:
     if f_value is None:
       return True

--- a/netsim/extra/tunnel/_p2p.py
+++ b/netsim/extra/tunnel/_p2p.py
@@ -44,15 +44,15 @@ def feature_check(
     if t_af:                                                # Do we have to check the transport AF support?
       for u_af in ['ipv4','ipv6']:                          # Check IPv4 and IPv6
         for intf in t_iflist:
-          t_af = intf.get('tunnel.af',t_default_af)         # Try to get the tunnel transport AF
-          if t_af != u_af:                                  # Not the one we're interested in? Move on
+          tpt_af = intf.get('tunnel.af',t_default_af)       # Try to get the tunnel transport AF
+          if tpt_af != u_af:                                # Not the one we're interested in? Move on
             continue
           if not _tunnel.check_feature(                     # Check the AF feature
                     ndata,
                     topology,
                     f_name=t_mode,
                     f_desc=f'{t_desc} over {u_af}',
-                    f_value=t_af):
+                    f_value=u_af):
             check_OK = False                                # Mark the failure if needed
           break                                             # And get out of the interface loop
 

--- a/netsim/extra/tunnel/_p2p.py
+++ b/netsim/extra/tunnel/_p2p.py
@@ -19,7 +19,13 @@ def init(topology: Box) -> None:
   '''
   log.fatal("You cannot use the 'tunnel._p2p' plugin. Use a plugin for the tunnel mode you're interested in")
 
-def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
+def feature_check(
+      topology: Box,
+      t_mode: str,                      # Tunnel mode, used primarily for error messages
+      t_desc: str,                      # Tunnel mode description, used primarily for error messages
+      t_af: bool = False,               # Do we need to check transport AF?
+      t_default_af: str = '',           # Default transport AF
+      ) -> dict:
   '''
   Check whether the devices using tunnels support them. Returns a dictionary
   of nodes using the specified tunnel technology
@@ -34,14 +40,34 @@ def feature_check(topology: Box, t_mode: str, t_desc: str) -> dict:
     if not _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=t_desc):
       continue                                              # Device does not support tunnel features, move on
 
-    VRF_OK = True
+    check_OK = True
+    if t_af:                                                # Do we have to check the transport AF support?
+      for u_af in ['ipv4','ipv6']:                          # Check IPv4 and IPv6
+        for intf in t_iflist:
+          t_af = intf.get('tunnel.af',t_default_af)         # Try to get the tunnel transport AF
+          if t_af != u_af:                                  # Not the one we're interested in? Move on
+            continue
+          if not _tunnel.check_feature(                     # Check the AF feature
+                    ndata,
+                    topology,
+                    f_name=t_mode,
+                    f_desc=f'{t_desc} over {u_af}',
+                    f_value=t_af):
+            check_OK = False                                # Mark the failure if needed
+          break                                             # And get out of the interface loop
+
     for intf in t_iflist:                                   # Next check: VRF features
       if not 'tunnel.vrf' in intf:                          # Tunnel does not use transport VRF? Cool, move on
         continue
-      VRF_OK = _tunnel.check_feature(ndata,topology,f_name=t_mode,f_desc=f'VRF {t_desc}',f_value='vrf')
-      break
+      if not _tunnel.check_feature(                         # Check the VRF feature
+                ndata,
+                topology,
+                f_name=t_mode,
+                f_desc=f'VRF {t_desc}',f_value='vrf'):
+        check_OK = False                                    # Missing? Mark the failure
+      break                                                 # And get out of the interface loop
 
-    if not VRF_OK:                                          # If VRF check failed, move to next node
+    if not check_OK:                                        # If any advanced check failed, move to next node
       continue
 
     node_iflist[node] = t_iflist

--- a/netsim/extra/tunnel/gre/__init__.py
+++ b/netsim/extra/tunnel/gre/__init__.py
@@ -27,7 +27,7 @@ def post_transform(topology: Box) -> None:
 
   # Use shared P2P tunnel function to check feature support
   #
-  node_iflist = _p2p.feature_check(topology,t_mode='gre',t_desc='GRE tunnels')
+  node_iflist = _p2p.feature_check(topology,t_mode='gre',t_desc='GRE tunnels',t_af=True,t_default_af='ipv4')
   _p2p.tunnel_source(topology,node_iflist,default_af='ipv4',t_name='GRE')
 
   if log.get_error_count():                                 # Has someone reported an error?

--- a/tests/coverage/errors/gre-support.log
+++ b/tests/coverage/errors/gre-support.log
@@ -1,0 +1,6 @@
+IncorrectValue in tunnel: Device none (node r1) does not support GRE tunnels
+IncorrectValue in tunnel: Device none (node r2) does not support GRE tunnels over ipv6
+IncorrectValue in tunnel: Device none (node r2) does not support VRF GRE tunnels
+MissingDependency in tunnel: Cannot get ipv6 tunnel source for link links[4] on node r3
+... Tunnel source data: none
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/gre-support.yml
+++ b/tests/coverage/errors/gre-support.yml
@@ -1,0 +1,26 @@
+---
+message: |
+  Test the GRE tunnel.source options
+
+plugin: [ tunnel.gre ]
+defaults.device: none
+
+nodes:
+  r1:
+    _features.tunnel:
+  r2:
+    _features.tunnel.gre: [ ipv4 ]
+  r3:
+    _features.tunnel.gre: [ ipv4, ipv6 ]
+
+links:
+- r1-r2
+- r2-r3
+- r1:
+  r2:
+  tunnel.mode: gre
+- r2:
+    tunnel.vrf: tenant
+  r3:
+  tunnel.mode: gre
+  tunnel.af: ipv6


### PR DESCRIPTION
Cisco IOL L2 image does not support GRE tunnels over IPv6, so the GRE tunnel plugin checks the transport AF support.

The "supported transport AF" check was added to the _p2p.feature_check shared function and is thus available to any tunnel plugin.