### PR TITLE
Add Tunnel support for EOS

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -56,6 +56,12 @@ nodes:
 * Arista EOS virtual machines and containers use [proprietary control-plane messages to indicate the loss of Ethernet line protocol](https://blog.ipspace.net/2025/03/arista-spooky-action-distance/). Set the **netlab_phy_control** node variable to *False* to disable this functionality.
 * Device configurations that contain `no lldp transmit` or `no lldp receive` configuration command trigger configuration reload failures due to an Arista EOS bug ([more details](https://github.com/ipspace/netlab/issues/2577)). These commands are thus automatically removed from collected device configurations.
 
+GRE tunnel caveats:
+
+* OSPFv2 routing process does not use routes reachable over tunnel interfaces unless the **tunnel routes** parameter is configured. _netlab_ enables OSPFv2 tunnel routes, as no other routing protocol has a similar limitation, and Arista EOS documentation claims it's enabled by default (which is not the case).
+* IS-IS does not work over GRE tunnels
+* Arista cEOS might forward multiple copies of the packets received over GRE tunnels
+
 (caveats-aruba)=
 ## Aruba AOS-CX
 

--- a/docs/plugins/tunnel.gre.md
+++ b/docs/plugins/tunnel.gre.md
@@ -9,6 +9,7 @@ The plugin includes Jinja2 templates for the following platforms:
 
 | Operating system    | GRE over<br>IPv4 | GRE over<br>IPv6 | Transport<br>VRF |
 |--------------|:-:|:-:|:-:|
+| Arista EOS          | ✅ | ❌ | ✅ |
 | Cisco IOS/XE[^18v] |✅|✅|✅|
 | FRR                 |✅|✅|✅|
 | Juniper vJunos-switch |✅|✅|✅|

--- a/netsim/ansible/templates/ospf/eos.ospfv2.j2
+++ b/netsim/ansible/templates/ospf/eos.ospfv2.j2
@@ -16,6 +16,7 @@ router ospf {{ ospf_pid }}
 {% if ospf_data.router_id is defined %}
  router-id {{ ospf_data.router_id }}
 {% endif %}
+ tunnel routes
  interface unnumbered hello mask tx 0.0.0.0
  timers spf delay initial 100 200 500
  timers lsa rx min interval 100

--- a/netsim/devices/eos.py
+++ b/netsim/devices/eos.py
@@ -107,6 +107,20 @@ def esi_identifier_format(node: Box, topology: Box) -> None:
       esi = intf.evpn._esi.id.replace(":", "")
       intf.evpn._esi._eos_id = ':'.join(esi[i:i+4] for i in range(0, len(esi), 4))
 
+def check_ipv6_gre(node: Box, topology: Box) -> None:
+  for intf in node.interfaces:
+    if intf.type != 'tunnel':                  # Skip non tunnel interfaces
+      continue
+
+    if intf.tunnel.af == 'ipv4':               # IPv4 GRE transit works fine
+      continue
+
+    report_quirk(
+      text=f'GRE6 / IPv6 transport GRE does not work on Arista cEOS ({node.name})',
+      node=node,
+      category=log.IncorrectType)
+    return
+
 class EOS(_Quirks):
 
   @classmethod
@@ -126,3 +140,5 @@ class EOS(_Quirks):
       configure_ceos_attributes(node,topology)
     if 'evpn.multihoming' in topology.get('plugin',[]):
       esi_identifier_format(node,topology)
+    if 'config' in node:
+      check_ipv6_gre(node,topology)

--- a/netsim/devices/eos.py
+++ b/netsim/devices/eos.py
@@ -107,20 +107,6 @@ def esi_identifier_format(node: Box, topology: Box) -> None:
       esi = intf.evpn._esi.id.replace(":", "")
       intf.evpn._esi._eos_id = ':'.join(esi[i:i+4] for i in range(0, len(esi), 4))
 
-def check_ipv6_gre(node: Box, topology: Box) -> None:
-  for intf in node.interfaces:
-    if intf.type != 'tunnel':                  # Skip non tunnel interfaces
-      continue
-
-    if intf.tunnel.af == 'ipv4':               # IPv4 GRE transit works fine
-      continue
-
-    report_quirk(
-      text=f'GRE6 / IPv6 transport GRE does not work on Arista cEOS ({node.name})',
-      node=node,
-      category=log.IncorrectType)
-    return
-
 class EOS(_Quirks):
 
   @classmethod
@@ -140,5 +126,3 @@ class EOS(_Quirks):
       configure_ceos_attributes(node,topology)
     if 'evpn.multihoming' in topology.get('plugin',[]):
       esi_identifier_format(node,topology)
-    if 'config' in node:
-      check_ipv6_gre(node,topology)

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -141,7 +141,7 @@ features:
     enable_per_port: True
     port_type: True
   tunnel:
-    gre: [ vrf ]
+    gre: [ ipv4, vrf ]
   vlan:
     model: l3-switch
     native_routed: true

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -140,6 +140,8 @@ features:
     supported_protocols: [ stp, rstp, mstp, pvrst ]
     enable_per_port: True
     port_type: True
+  tunnel:
+    gre: True
   vlan:
     model: l3-switch
     native_routed: true

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -141,7 +141,7 @@ features:
     enable_per_port: True
     port_type: True
   tunnel:
-    gre: True
+    gre: [ vrf ]
   vlan:
     model: l3-switch
     native_routed: true

--- a/netsim/extra/tunnel/gre/eos.j2
+++ b/netsim/extra/tunnel/gre/eos.j2
@@ -10,16 +10,3 @@ interface {{ intf.ifname }}
   tunnel path-mtu-discovery
   tunnel ttl 255
 {% endfor %}
-
-{% if ospf|default(False) %}
-{%   set ospf_pid = ospf.process|default(1) %}
-{%   if ospf.af.ipv4 is defined %}
-{%     if ospf_vrf %}
-router ospf {{ ospf_pid }} vrf {{ ospf_vrf }}
-  tunnel routes
-{%     else %}
-router ospf {{ ospf_pid }}
-  tunnel routes
-{%     endif %}
-{%   endif %}
-{% endif %}

--- a/netsim/extra/tunnel/gre/eos.j2
+++ b/netsim/extra/tunnel/gre/eos.j2
@@ -1,0 +1,34 @@
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
+!
+interface {{ intf.ifname }}
+  tunnel mode {{ intf.tunnel.mode }}
+{%   if intf.tunnel.vrf is defined %}
+  tunnel vrf {{ intf.tunnel.vrf }}
+{%   endif %}
+  tunnel source {{ intf.tunnel._source[intf.tunnel.af] }}
+  tunnel destination {{ intf.tunnel._destination[intf.tunnel.af] }}
+  tunnel path-mtu-discovery
+  tunnel ttl 255
+{% endfor %}
+
+{% if ospf|default(False) %}
+{%   set ospf_pid = ospf.process|default(1) %}
+{%   if ospf.af.ipv4 is defined %}
+{%     if ospf_vrf %}
+router ospf {{ ospf_pid }} vrf {{ ospf_vrf }}
+  tunnel routes
+{%     else %}
+router ospf {{ ospf_pid }}
+  tunnel routes
+{%     endif %}
+{%   endif %}
+{%   if ospf.af.ipv6 is defined %}
+{%     if ospf_vrf %}
+ipv6 router ospf {{ ospf_pid }} vrf {{ ospf_vrf }}
+  tunnel routes
+{%     else %}
+ipv6 router ospf {{ ospf_pid }}
+  tunnel routes
+{%     endif %}
+{%   endif %}
+{% endif %}

--- a/netsim/extra/tunnel/gre/eos.j2
+++ b/netsim/extra/tunnel/gre/eos.j2
@@ -22,13 +22,4 @@ router ospf {{ ospf_pid }}
   tunnel routes
 {%     endif %}
 {%   endif %}
-{%   if ospf.af.ipv6 is defined %}
-{%     if ospf_vrf %}
-ipv6 router ospf {{ ospf_pid }} vrf {{ ospf_vrf }}
-  tunnel routes
-{%     else %}
-ipv6 router ospf {{ ospf_pid }}
-  tunnel routes
-{%     endif %}
-{%   endif %}
 {% endif %}

--- a/netsim/extra/tunnel/gre/eos.j2
+++ b/netsim/extra/tunnel/gre/eos.j2
@@ -3,7 +3,7 @@
 interface {{ intf.ifname }}
   tunnel mode {{ intf.tunnel.mode }}
 {%   if intf.tunnel.vrf is defined %}
-  tunnel vrf {{ intf.tunnel.vrf }}
+  tunnel underlay vrf {{ intf.tunnel.vrf }}
 {%   endif %}
   tunnel source {{ intf.tunnel._source[intf.tunnel.af] }}
   tunnel destination {{ intf.tunnel._destination[intf.tunnel.af] }}


### PR DESCRIPTION
Add GRE support for EOS.

Passes tests as expected.

Do we want to update the `02-gre-vrf.yml` test ?


```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$ netlab up -p clab -d eos 01-gre.yml

(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$ netlab validate
[g4_adj_v4]  Check OSPF adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]       Test succeeded in 0.1 seconds

[g4_adj_v6]  Check OSPFv3 adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]       Test succeeded in 0.1 seconds

[g4_pfx_v4]  Check DUT IPv4 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]       Test succeeded in 0.1 seconds

[g4_pfx_v6]  Check DUT IPv6 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: The prefix 2001:db8::1/128 is in the OSPFv3 topology
[PASS]       Test succeeded in 0.1 seconds

[g4_ping_v4] Check end-to-end IPv4 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to 10.0.0.1 from 10.0.0.2/32 succeeded
[PASS]       Test succeeded in 0.1 seconds

[g4_ping_v6] Check end-to-end IPv6 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to ipv6 2001:db8::1 from 2001:db8::2/128 succeeded
[PASS]       Test succeeded in 0.1 seconds

[f_warning]  Starting test
[WARNING]    eos does not support GRE tunnels over IPv6

[INFO]       One test out of 7 tests generated a warning
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$
```