### PR TITLE
Add RouterOS7 GRE Tunnel Support

### DIFF
--- a/docs/module/routing-static.txt
+++ b/docs/module/routing-static.txt
@@ -21,6 +21,7 @@ _netlab_ supports static routes on these platforms:
 | FRR                 | ✅ | ✅ | ✅ | ✅ |
 | Junos               | ✅ | ✅ | ✅ | ❌ |
 | Linux               | ✅ |  ❌ |  ❌ |  ❌ |
+| Mikrotik RoutersOS 7 | ✅ | ✅ |  ❌ |  ❌ |
 | Nokia SR Linux      | ✅ | ✅ | ✅ |  ❌ |
 | Nokia SR OS[^SROS]  | ✅ | ✅ | ✅ |  ❌ |
 | OpenBSD             | ✅ | ✅ |  ❌ |  ❌ |

--- a/docs/module/routing-static.txt
+++ b/docs/module/routing-static.txt
@@ -21,7 +21,6 @@ _netlab_ supports static routes on these platforms:
 | FRR                 | ✅ | ✅ | ✅ | ✅ |
 | Junos               | ✅ | ✅ | ✅ | ❌ |
 | Linux               | ✅ |  ❌ |  ❌ |  ❌ |
-| Mikrotik RoutersOS 7 | ✅ | ✅ |  ❌ |  ❌ |
 | Nokia SR Linux      | ✅ | ✅ | ✅ |  ❌ |
 | Nokia SR OS[^SROS]  | ✅ | ✅ | ✅ |  ❌ |
 | OpenBSD             | ✅ | ✅ |  ❌ |  ❌ |

--- a/docs/plugins/tunnel.gre.md
+++ b/docs/plugins/tunnel.gre.md
@@ -13,6 +13,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | FRR                 |✅|✅|✅|
 | Juniper vJunos-switch |✅|✅|✅|
 | Juniper vSRX        |✅|✅|✅|
+| Mikrotik RouterOS 7 |✅|✅|✅|
 | VyOS               |✅|✅|✅|
 
 [^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.

--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -25,6 +25,12 @@
 /ipv6/address add interface=loopback address={{ loopback.ipv6 }}
 {% endif %}
 
+
+{% for l in interfaces if l.type == 'tunnel' %}
+{%   set t_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
+/interface/{{ t_type }} add name={{ l.ifname }} local-address={{ l.tunnel._source[l.tunnel.af] }} remote-address={{ l.tunnel._destination[l.tunnel.af] }}
+{% endfor %}
+
 {% if vlans is defined %}
 {% include 'routeros7.vlan.j2' %}
 {% endif %}
@@ -34,7 +40,13 @@
 {% endif %}
 
 {% for l in interfaces|default([]) %}
-{%   set intf_type = 'vlan' if l.type == 'svi' else 'ethernet' %}
+{%   if l.type == 'svi' %}
+{%     set intf_type = 'vlan' %}
+{%   elif l.type == 'tunnel' and l.tunnel.mode|default('') == 'gre' %}
+{%     set intf_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
+{%   else %}
+{%     set intf_type = 'ethernet' %}
+{%   endif %}
 
 {%   if l.name is defined %}
 /interface/{{ intf_type }} set comment="{{ l.name }}{{ " ["+l.role+"]" if l.role is defined else "" }}" {{ l.ifname }}

--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -26,7 +26,7 @@
 {% endif %}
 
 
-{% for l in interfaces if l.type == 'tunnel' %}
+{% for l in interfaces if l.type == 'tunnel' and l.tunnel.mode == 'gre' %}
 {%   set t_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
 /interface/{{ t_type }} add name={{ l.ifname }} local-address={{ l.tunnel._source[l.tunnel.af] }} remote-address={{ l.tunnel._destination[l.tunnel.af] }}
 {% endfor %}
@@ -42,7 +42,7 @@
 {% for l in interfaces|default([]) %}
 {%   if l.type == 'svi' %}
 {%     set intf_type = 'vlan' %}
-{%   elif l.type == 'tunnel' and l.tunnel.mode|default('') == 'gre' %}
+{%   elif l.type == 'tunnel' and l.tunnel.mode == 'gre' %}
 {%     set intf_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
 {%   else %}
 {%     set intf_type = 'ethernet' %}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -5,7 +5,7 @@ support:
 interface_name: ether{ifindex}
 mgmt_if: ether1
 loopback_interface_name: loopback{ifindex if ifindex else ""}
-tunnel_interface_name: Tunnel{ifindex}
+tunnel_interface_name: tunnel{ifindex}
 ifindex_offset: 2
 libvirt:
   image: mikrotik/chr7
@@ -47,7 +47,7 @@ features:
   vxlan:
     vtep6: True
   tunnel:
-    gre: True
+    gre: [ ipv4, ipv6, vrf ]
   routing:
     static:
       discard: true

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -5,6 +5,7 @@ support:
 interface_name: ether{ifindex}
 mgmt_if: ether1
 loopback_interface_name: loopback{ifindex if ifindex else ""}
+tunnel_interface_name: Tunnel{ifindex}
 ifindex_offset: 2
 libvirt:
   image: mikrotik/chr7
@@ -45,6 +46,11 @@ features:
     bgp: True
   vxlan:
     vtep6: True
+  tunnel:
+    gre: True
+  routing:
+    static:
+      discard: true
 clab:
   image: vrnetlab/mikrotik_routeros:7.21.4
   build: https://containerlab.dev/manual/kinds/vr-ros/

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -36,6 +36,8 @@ features:
     vpn: true
   ospf: true
   bfd: true
+  tunnel:
+    gre: [ ipv4, ipv6, vrf ]
   vlan:
     model: l3-switch
     svi_interface_name: "vlan{vlan}"
@@ -46,11 +48,6 @@ features:
     bgp: True
   vxlan:
     vtep6: True
-  tunnel:
-    gre: [ ipv4, ipv6, vrf ]
-  routing:
-    static:
-      discard: true
 clab:
   image: vrnetlab/mikrotik_routeros:7.21.4
   build: https://containerlab.dev/manual/kinds/vr-ros/

--- a/netsim/extra/tunnel/gre/routeros7.j2
+++ b/netsim/extra/tunnel/gre/routeros7.j2
@@ -1,1 +1,7 @@
-# Empty, all config done in initial
+
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
+{%   set t_type = 'gre6' if intf.tunnel.af == 'ipv6' else 'gre' %}
+{%   if intf.tunnel.vrf is defined %}
+/interface/{{ t_type }} set [find where interface={{ intf.ifname }}] remote-address={{ intf.tunnel._destination[intf.tunnel.af] }}@{{ intf.tunnel.vrf }}
+{%   endif %}
+{%  endfor %}

--- a/netsim/extra/tunnel/gre/routeros7.j2
+++ b/netsim/extra/tunnel/gre/routeros7.j2
@@ -1,0 +1,1 @@
+# Empty, all config done in initial


### PR DESCRIPTION
Add support for GRE to Router OS 7

Also works for the `02-gre-vrf.yml`

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$ netlab validate
[g4_adj_v4]  Check OSPF adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]       Test succeeded in 0.3 seconds

[g4_adj_v6]  Check OSPFv3 adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]       Test succeeded in 0.2 seconds

[g4_pfx_v4]  Check DUT IPv4 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]       Test succeeded in 0.2 seconds

[g4_pfx_v6]  Check DUT IPv6 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: The prefix 2001:db8::1/128 is in the OSPFv3 topology
[PASS]       Test succeeded in 0.2 seconds

[g4_ping_v4] Check end-to-end IPv4 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to 10.0.0.1 from 10.0.0.2/32 succeeded
[PASS]       Test succeeded in 0.2 seconds

[g4_ping_v6] Check end-to-end IPv6 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to ipv6 2001:db8::1 from 2001:db8::2/128 succeeded
[PASS]       Test succeeded in 0.2 seconds

[g6_adj_v4]  Check OSPF adjacencies (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]       Test succeeded in 0.2 seconds

[g6_adj_v6]  Check OSPFv3 adjacencies (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]       Test succeeded in 0.2 seconds

[g6_pfx_v4]  Check DUT IPv4 loopback prefix propagation (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]       Test succeeded in 0.2 seconds

[g6_pfx_v6]  Check DUT IPv6 loopback prefix propagation (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: The prefix 2001:db8::1/128 is in the OSPFv3 topology
[PASS]       Test succeeded in 0.2 seconds

[g6_ping_v4] Check end-to-end IPv4 connectivity (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: Ping to 10.0.0.1 from 10.0.0.3/32 succeeded
[PASS]       Test succeeded in 0.2 seconds

[g6_ping_v6] Check end-to-end IPv6 connectivity (GRE IPv6) [ node(s): r3 ]
[PASS]       r3: Ping to ipv6 2001:db8::1 from 2001:db8::3/128 succeeded
[PASS]       Test succeeded in 0.2 seconds

[SUCCESS]    Tests passed: 12
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$
```