### PR TITLE
Fix: Partial extra-initial-configuration functionality

### DIFF
--- a/netsim/ansible/templates/initial/_extra_initial.j2
+++ b/netsim/ansible/templates/initial/_extra_initial.j2
@@ -30,8 +30,8 @@
     that at most one template will be included.
 #}
 {% 
-   macro extra_module_initial() %}
-{%   for m in module|default([]) %}
+   macro extra_module_initial(mod_list=[]) %}
+{%   for m in module|default([]) if m in mod_list or not mod_list %}
 {%     include [ 
          m + '/' + netlab_device_type + '.initial.j2',
          m + '/' + ansible_network_os + '.initial.j2' ]
@@ -46,8 +46,8 @@
     name with dot replaced by slash.
 #}
 {% 
-   macro extra_plugin_initial() %}
-{%   for c in config|default([]) %}
+   macro extra_plugin_initial(plug_list=[]) %}
+{%   for c in config|default([]) if c in plug_list or not plug_list %}
 {%     include [ 
          c + '/' + netlab_device_type + '.initial.j2',
          c.replace('.','/') + '/' + netlab_device_type + '.initial.j2',


### PR DESCRIPTION
The "extra module/plugin initial configuration" functionality was introduced to configure VyOS tunnels and later used for VyOS VLAN/VRF configs. That worked beautifully as we could configure all those features early in the initial device configuration process.

The same functionality cannot be used to configure Cisco IOS DHCP clients, VLANs, and VRFs. VLANs and VRFs have to be configured before interfaces, while the DHCP client on L2 images has to be configured after interfaces (the core interface config contains "no switchport" command which cannot be used before VLANs are configured).

The only way around this SNAFU was to do partial-extra-initial-config. This PR adds the "limit extra-initial-config to these modules/plugins" functionality, the IOS DHCP client PR uses it to configure "ip address dhcp" on L3 interfaces.