### PR TITLE
Fix: Show 'dhcp.client.routing' feature flag in 'show modules'

### DIFF
--- a/netsim/modules/dhcp.yml
+++ b/netsim/modules/dhcp.yml
@@ -27,6 +27,7 @@ attributes:
 features:
   client.ipv4: IPv4 DHCP client
   client.ipv6: IPv6 DHCP client
+  client.routing: Dynamic routing over DHCP IPv4/IPv6 addresses
   relay: DHCP relay (IPv4 and IPv6)
   server: DHCP server
   vrf: Inter-VRF DHCP relay


### PR DESCRIPTION
The DHCP feature information displayed by the 'netlab show modules' command did not include "dynamic routing over DHCP addresses" column