### PR TITLE
Fix: Configure IOS DHCP client during initial interface config

### DIFF
--- a/netsim/ansible/templates/dhcp/ios.initial.j2
+++ b/netsim/ansible/templates/dhcp/ios.initial.j2
@@ -1,0 +1,13 @@
+{% for intf in interfaces if intf.dhcp.client is defined %}
+interface {{ intf.ifname }}
+{%   if intf.dhcp.client.ipv4 is defined %}
+{%     if intf.dhcp.client.default|default(True) is sameas false %}
+ no ip dhcp client request router
+{%     endif %}
+ ip address dhcp
+{%   endif %}
+{%   if intf.dhcp.client.ipv6 is defined %}
+ ipv6 enable
+ ipv6 address dhcp
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/dhcp/ios.j2
+++ b/netsim/ansible/templates/dhcp/ios.j2
@@ -6,18 +6,8 @@
 ip dhcp relay information option vpn
 !
 {% endif %}
-{% for intf in interfaces if intf.dhcp is defined %}
+{% for intf in interfaces if intf.dhcp.relay is defined %}
 interface {{ intf.ifname }}
-{%   if intf.dhcp.client.ipv4 is defined %}
-{%     if intf.dhcp.client.default|default(True) is sameas false %}
-  no ip dhcp client request router
-{%     endif %}
-  ip address dhcp
-{%   endif %}
-{%   if intf.dhcp.client.ipv6 is defined %}
-  ipv6 enable
-  ipv6 address dhcp
-{%   endif %}
 {%   for target in intf.dhcp.relay.ipv4|default([]) %}
 {%     set vrf = intf.dhcp.vrf|default('') %}
 {%     set vrf_kw = vrf +' ' if vrf == 'global' else 'vrf ' + vrf + ' ' if vrf else '' %}

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -1,3 +1,4 @@
+{% from '_extra_initial.j2' import extra_module_initial with context %}
 hostname {{ inventory_hostname }}
 !
 no ip domain lookup
@@ -139,6 +140,10 @@ interface {{ l.ifname }}
 {%   endif %}
 !
 {% endfor %}
+!
+! Configure DHCP client - has to be done before routing protocol config, but after generic interface config
+!
+{{ extra_module_initial(['dhcp']) }}
 !
 line vty 0 4
  exec-timeout 0 0 


### PR DESCRIPTION
We have to break the circular config dependencies between DHCP, routing protocols, and VRFs (see #3651). The only supported platform that supports routing over DHCP client IP addresses is IOS/IOS XE, so we have to fix its DHCP configuration and then break the circular references.

The fix uses modified 'extra_initial' functionality that allows the initial config template to specify which modules have to be configured at what place in the initial config process.