### PR TITLE
Fix: Ensure Vagrant uses libvirt as provider for destroy command

### DIFF
--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -416,6 +416,10 @@ class Libvirt(_Provider):
     create_vagrant_network(topology)
     create_vagrant_batches(topology)
 
+  def pre_stop_lab(self, topology: Box) -> None:
+    log.print_verbose('pre-stop hook for libvirt')
+    os.environ["VAGRANT_DEFAULT_PROVIDER"] = "libvirt"              # Force Vagrant to use libvirt as the provider
+
   def post_start_lab(self, topology: Box) -> None:
     log.print_verbose('libvirt lab has started, fixing Linux bridges')
     mgmt_bridge = get_linux_bridge_name(topology.addressing.mgmt._network or LIBVIRT_MANAGEMENT_NETWORK_NAME)


### PR DESCRIPTION
Fixes Vagrant preferring `virtualbox` for WSL Linux instances

We already tell Vagrant to use `libvirt` for bringing up virtual machines via the `-p libvirt` flag.

Unfortunately that flag does not exist for `vagrant destroy`.

Let us set environment variable `VAGRANT_DEFAULT_PROVIDER=libvirt` before running `vagrant destroy` so it uses correct provider.
