### PR TITLE
Fix: Routing protocol config is no longer dependent on DHCP

### DIFF
--- a/netsim/modules/eigrp.yml
+++ b/netsim/modules/eigrp.yml
@@ -4,7 +4,7 @@
 #
 ---
 transform_after: [ vlan, vrf ]
-config_after: [ vlan, dhcp, routing ]
+config_after: [ vlan, routing ]
 as: 1
 attributes:
   global:

--- a/netsim/modules/isis.yml
+++ b/netsim/modules/isis.yml
@@ -5,7 +5,7 @@ area: "49.0001"
 type: level-2
 instance: Gandalf
 transform_after: [ vlan, vrf ]
-config_after: [ vlan, dhcp, routing ]
+config_after: [ vlan, routing ]
 attributes:
   global:
     af:

--- a/netsim/modules/ospf.yml
+++ b/netsim/modules/ospf.yml
@@ -3,7 +3,7 @@
 ---
 area: 0.0.0.0
 transform_after: [ vlan, vrf ]
-config_after: [ vlan, dhcp, routing ]
+config_after: [ vlan, routing ]
 attributes:
   global:
     af:

--- a/netsim/modules/ripv2.yml
+++ b/netsim/modules/ripv2.yml
@@ -3,7 +3,7 @@
 ---
 version: 2                            # A fake RIP attribute to create RIP data structure in RIP-enabled nodes
 transform_after: [ vlan, vrf ]
-config_after: [ vlan, dhcp, routing ]
+config_after: [ vlan, routing ]
 attributes:
   global:
     version: { type: int, min_value: 2, max_value: 2 }

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -594,8 +594,8 @@ nodes:
       ipv4: 192.168.121.106
       mac: ca:fe:00:06:00:00
     module:
-    - dhcp
     - ospf
+    - dhcp
     name: r1
     ospf:
       af:

--- a/tests/topology/expected/groups-hierarchy.yml
+++ b/tests/topology/expected/groups-hierarchy.yml
@@ -66,8 +66,8 @@ links:
     ipv4: 172.16.0.0/24
   type: lan
 module:
-- dhcp
 - ospf
+- dhcp
 - bgp
 name: input
 nodes:


### PR DESCRIPTION
The supported only device that supported dynamic routing over DHCP client interfaces (IOS XE) now configures the DHCP client in the initial configuration. There is thus no need to have routing protocol configs depend on DHCP config

Fixes #3651