### PR TITLE
Add VRF OSPFv3 support to RouterOS 7

### DIFF
--- a/docs/module/vrf.md
+++ b/docs/module/vrf.md
@@ -63,7 +63,7 @@ These platforms support routing protocols in VRFs:
 | FRR [❗](caveats-frr) | ✅  | ✅  | ✅  | ✅ | ✅ | ✅ |
 | Junos[^Junos]         | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  |
 | Mikrotik RouterOS 6   | ✅  [❗](caveats-routeros6) |  ❌  | ✅  | ❌  | ❌  | ❌  |
-| Mikrotik RouterOS 7   | ✅  |  ❌  | ✅  | ❌  | ❌  | ❌  |
+| Mikrotik RouterOS 7   | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  |
 | Nokia SR Linux        | ✅  | ✅  | ✅  | ❌  | ❌  | ✅ |
 | Nokia SR OS[^SROS]    | ✅  | ✅  | ✅  | ❌  | ❌  | ✅ |
 | VyOS                  | ✅  | ✅  | ✅  | ❌  | ❌  | ❌  |

--- a/netsim/ansible/templates/vrf/routeros7.j2
+++ b/netsim/ansible/templates/vrf/routeros7.j2
@@ -4,4 +4,5 @@
 
 {% for vname,vdata in vrfs.items() if 'ospf' in vdata %}
 {%   include 'routeros7.ospfv2-vrf.j2' %}
+{%   include 'routeros7.ospfv3-vrf.j2' %}
 {% endfor %}

--- a/netsim/ansible/templates/vrf/routeros7.j2
+++ b/netsim/ansible/templates/vrf/routeros7.j2
@@ -3,6 +3,10 @@
 {% endif %}
 
 {% for vname,vdata in vrfs.items() if 'ospf' in vdata %}
+{% if vdata.ospf.af.ipv4 is defined %}
 {%   include 'routeros7.ospfv2-vrf.j2' %}
+{% endif %}
+{% if vdata.ospf.af.ipv6 is defined %}
 {%   include 'routeros7.ospfv3-vrf.j2' %}
+{% endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vrf/routeros7.j2
+++ b/netsim/ansible/templates/vrf/routeros7.j2
@@ -3,10 +3,10 @@
 {% endif %}
 
 {% for vname,vdata in vrfs.items() if 'ospf' in vdata %}
-{% if vdata.ospf.af.ipv4 is defined %}
-{%   include 'routeros7.ospfv2-vrf.j2' %}
-{% endif %}
-{% if vdata.ospf.af.ipv6 is defined %}
-{%   include 'routeros7.ospfv3-vrf.j2' %}
-{% endif %}
+{%   if vdata.ospf.af.ipv4 is defined %}
+{%     include 'routeros7.ospfv2-vrf.j2' %}
+{%   endif %}
+{%   if vdata.ospf.af.ipv6 is defined %}
+{%     include 'routeros7.ospfv3-vrf.j2' %}
+{%   endif %}
 {% endfor %}

--- a/netsim/ansible/templates/vrf/routeros7.ospfv3-vrf.j2
+++ b/netsim/ansible/templates/vrf/routeros7.ospfv3-vrf.j2
@@ -1,0 +1,13 @@
+
+{% set instance = "default6_" + vname %}
+{% set ospf_vrf = vname %}
+{% set ospf_main_vrf = False %}
+{% set ospf_router_id = vdata.ospf.router_id|default(ospf.router_id) %}
+
+{% set ospf_afi_check = "ipv6" %}
+{% set ospf_version = "3" %}
+{% set ospf_interfaces = vdata.ospf.interfaces|default([]) %}
+{% set ospf = vdata.ospf %}
+{% include 'templates/ospf/routeros7.ospf-include.j2' %}
+
+/routing/ospf/instance set [/routing/ospf/instance find name={{instance}}] redistribute=bgp,bgp-mpls-vpn,vpn,connected,static routing-table={{vname}}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -42,6 +42,7 @@ features:
     native_routed: true
   vrf:
     ospfv2: True
+    ospfv3: True
     bgp: True
   vxlan:
     vtep6: True


### PR DESCRIPTION
Add the missing component for OSPFv3 within VRFs for RouterOS 7.

While we are here, ensure that we only run the creation if the AF family matches.

Passes the following tests:
* 11-multi-vrf-ospf.yml (only generates OSPFv2)
* 21-multi-vrf-ospfv3.yml (generates OSPFv2 + OSPFv3 as expected)

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p clab -d routeros7 -l [12]1-multi vrf/
[sudo] password for netlab:
Pre-test cleanup:
05:42:43 vrf/11-multi-vrf-ospf.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
05:44:19 vrf/21-multi-vrf-ospfv3.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
```