### PR TITLE
Fix: Move FRR 'netlab_linux_packages' to libvirt-only setup

### DIFF
--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -16,10 +16,6 @@ group_vars:
   ansible_network_os: frr
   ansible_python_interpreter: auto_silent
   netlab_initial: always
-  netlab_linux_packages:
-    gnupg: gpg
-    curl: curl
-    iproute2: bridge
   netlab_frr_daemons:
     bfd: [ bfdd ]
     bgp: [ bgpd ]
@@ -62,6 +58,10 @@ libvirt:
     ansible_ssh_pass: vagrant
     ansible_ssh_private_key_file: .vagrant/machines/{{ inventory_hostname }}/libvirt/private_key
     netlab_show_command: [ sudo, vtysh, -c, 'show $@' ]
+    netlab_linux_packages:
+      gnupg: gpg
+      curl: curl
+      iproute2: bridge
 
 external:
   image: none


### PR DESCRIPTION
The wireguard support (#3569) added Linux package installation to the clab path in the initial configuration script. Unfortunately, nobody (not the AI, not the principal PR author, not the reviewer) thought about the impact of that change -- packages needed to install FRR on Debian VM were now installed every time the FRR container was started.

This fix moves the 'packages we need to make FRR VM work' group var to 'libvirt' part of FRR device definition, as they're not needed on FRR containers.