### PR TITLE
Add a general `ansible` validation action

### DIFF
--- a/docs/topology/validate.md
+++ b/docs/topology/validate.md
@@ -23,6 +23,7 @@ Each test has a name (dictionary key) and description (dictionary value) -- anot
 * **exec** (string or dictionary) -- any other valid network device command. The command will be executed with the `netlab connect` command.
 * **config** (string or dictionary) -- the configuration template that has to be deployed (using **[netlab config](netlab-config)**) on the specified nodes. Use this feature to trigger changes (for example, interface shutdown or BGP session shutdown) during the testing procedure.
 * **suzieq** (string or dictionary) -- the SuzieQ command to execute and the optional validation parameters ([more details](validate-suzieq)).
+* **ansible** (string or dictionary) -- a device show command fetched through the device Ansible module (`defaults.devices.<device>.netlab_validate.ansible_module`) instead of the standard SSH/`docker exec` validation transport. Use it for devices whose CLI cannot be driven with non-interactive SSH commands (for example, IP Infusion OcNOS). The result is parsed as JSON when the command emits JSON; otherwise the CLI text is available in the `stdout` variable.
 * **valid** (string or dictionary, optional) -- Python code that will be executed once the **show** or **exec** command has completed. The test succeeds if the Python code returns any value that evaluates to `True` when converted to a boolean[^TEX]. The Python code can use the results of the **show** command as variables; the **exec** command printout is available in the `stdout` variable.
 * **plugin** (valid Python function call as string, optional) -- a method of a custom [validation plugin](validate-plugin) that provides either a command to execute or validation results.
 * **wait** (integer, optional) -- Time to wait (when specified as the only action in the test) or retry (when used together with other actions). The first wait/retry timeout is measured from when the lab was started; subsequent times are measured from the previous test containing the **wait** parameter. The wait time could also be specified as an identifier; its value has to be defined in **defaults.const.validate** dictionary ([example](validate-retry)).
@@ -48,10 +49,10 @@ The **config** parameter can be a string (the template to deploy) or a dictionar
 
 **Notes:**
 
-* Every test entry should have **show**, **exec**, **config**, **suzieq** or **wait** parameter.
+* Every test entry should have **show**, **exec**, **config**, **suzieq**, **ansible** or **wait** parameter.
 * A test entry with just the **wait** parameter is valid and can be used to delay the test procedure.
 * Test entries with **show** parameter must have **valid** expression.
-* Test entries with **valid** expression must have **show**,  **exec**, or **suzieq** parameter.
+* Test entries with **valid** expression must have **show**,  **exec**, **suzieq**, or **ansible** parameter.
 
 ```{tip}
 A test entry with only **‌wait** and **‌stop_on_error** parameters is a *‌failure barrier*. It succeeds (without waiting) if all the prior test entries have passed and exits the validation process if at least one of the prior tests has failed.

--- a/netsim/augment/validate.py
+++ b/netsim/augment/validate.py
@@ -52,10 +52,10 @@ validate_test_entry: Check if the test makes sense
 
 def validate_test_entry(v_entry: Box, topology: Box) -> bool:
   kw_set = set(v_entry.keys())
-  action_set = set(['show','exec','config','wait','plugin','suzieq'])
+  action_set = set(['show','exec','config','wait','plugin','suzieq','ansible'])
   if not kw_set & action_set:                           # Test should have at least one of show/exec/wait
     log.error(
-          f'Test {v_entry.name} should have wait, show, exec, config, plugin, or suzieq option',
+          f'Test {v_entry.name} should have wait, show, exec, config, plugin, suzieq, or ansible option',
           category=log.MissingValue,
           module='validation')
     return False
@@ -70,7 +70,7 @@ def validate_test_entry(v_entry: Box, topology: Box) -> bool:
   # Each validation test should have exactly one action, the only exception is 'exec' and 'show
   # which can be used together to deal with devices that cannot produce JSON printout
   #
-  x_kw = [ kw for kw in ('show','exec','config','plugin','suzieq') if kw in v_entry ]
+  x_kw = [ kw for kw in ('show','exec','config','plugin','suzieq','ansible') if kw in v_entry ]
   if len(x_kw) > 1:                                     # We have more than one action. Now take away show/exec
     r_kw = [ kw for kw in x_kw if kw not in ('show','exec') ]
     if r_kw:                                            # If there's something left, we have a problem
@@ -99,7 +99,7 @@ def validate_test_entry(v_entry: Box, topology: Box) -> bool:
   if 'valid' not in v_entry:                            # A test does not have 'valid' option, no further validation needed
     return True
 
-  if not kw_set & set(['show','exec','suzieq']):        # If we know how to get results to validate, we're OK
+  if not kw_set & set(['show','exec','suzieq','ansible']): # If we know how to get results to validate, we're OK
     log.error(
           f'Test {v_entry.name} has a "valid" option but no action that would generate data to check',
           hint='valid',

--- a/netsim/cli/validate/ansible.py
+++ b/netsim/cli/validate/ansible.py
@@ -1,0 +1,106 @@
+#
+# Ansible functions for the netlab validate command
+#
+# The 'ansible' validation action fetches device state by running a show command
+# through an Ansible module (network_cli), for devices whose CLI cannot be driven
+# by netlab's SSH/docker validation transports -- e.g. IP Infusion OcNOS, whose
+# restricted `cmlsh` rejects every non-interactive SSH command. It is a validation
+# data *source*, a peer of suzieq.py (netsim/cli/validate/suzieq.py), not a device
+# connection method.
+#
+# A test selects it with an `ansible` action (or a plugin `ansible_<test>` function)
+# that supplies the show command; the device supplies the module in
+#   defaults.devices.<device>.netlab_validate.ansible_module
+# The result is parsed as JSON when the command emits JSON (e.g. `... | json`), so a
+# `valid:` expression can use structured data; otherwise the raw CLI text is returned
+# as `_result.stdout` for a plugin valid_<test>() to screen-scrape.
+#
+import json
+import shlex
+import subprocess
+import typing
+
+from box import Box
+
+from ... import data
+from ...utils import log
+from . import report, utils
+
+
+def get_result(v_entry: Box, n_name: typing.Optional[str], topology: Box, verbosity: int) -> Box:
+  err_value = data.get_box({'_error': True})
+  if not n_name:
+    return err_value
+  node = topology.nodes[n_name]
+
+  v_cmd = utils.get_exec_list(v_entry, 'ansible', node, topology)   # command tokens
+  if not v_cmd:
+    log.error(
+      f'Test {v_entry.name}: no ansible show command for {n_name}/{node.device}',
+      category=log.MissingValue, module='validation')
+    return err_value
+  command = ' '.join(v_cmd)
+
+  a_module = topology.defaults.devices[node.device].netlab_validate.ansible_module
+  if not a_module:
+    log.error(
+      f'Device {node.device} has no netlab_validate.ansible_module; cannot use the ansible validation action',
+      category=log.MissingValue, module='validation')
+    return err_value
+
+  # Build the module arguments. Networking "<os>_command" modules take the show
+  # command in a `commands` argument, passed as a single quoted string (ansible
+  # ad-hoc rejects a bare list literal: "does not support raw params"). The plain
+  # command/shell modules take the bare command line instead; other argument shapes
+  # can be added here later if a device needs them.
+  if str(a_module).split('.')[-1] in ('command', 'shell'):
+    module_args = command
+  else:
+    module_args = 'commands=%r' % command
+
+  # Reuse the netlab-generated inventory (hosts.yml + ansible.cfg in the lab dir).
+  cmd = ['ansible', n_name, '-m', str(a_module), '-a', module_args, '--one-line']
+  cmd_str = shlex.join(cmd)
+
+  # On any failure, surface the exact command so the user can run it by hand to see
+  # what went wrong (mirrors execute_netlab_config in netsim/cli/validate/devices.py).
+  def _fail(msg: str, detail: typing.Optional[str] = None) -> Box:
+    hint = f'Run the command manually to inspect the device output:\n  {cmd_str}'
+    if detail:
+      hint = f'{str(detail).rstrip()}\n\n{hint}'
+    report.log_failure(msg, topology, more_data=hint)
+    return err_value
+
+  if verbosity >= 3:
+    print(f'Preparing to execute {command!r} on {n_name} via Ansible ({a_module})')
+
+  try:
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+  except Exception as ex:                                   # noqa: BLE001
+    return _fail(f'Ansible action failed for "{command}" on {n_name}', str(ex))
+
+  raw = out.stdout or ''
+  # ansible --one-line: "<host> | SUCCESS => { ...json... }" (or FAILED!/UNREACHABLE!)
+  if ' => ' not in raw:
+    return _fail(f'Ansible action returned no parseable result for "{command}" on {n_name}',
+                 raw or out.stderr)
+  status, _, payload = raw.partition(' => ')
+  try:
+    a_result = json.loads(payload)
+  except Exception as ex:                                   # noqa: BLE001
+    return _fail(f'Cannot parse the Ansible result for "{command}" on {n_name}', str(ex))
+  if 'SUCCESS' not in status:
+    return _fail(f'Ansible command "{command}" failed on {n_name}', a_result.get('msg') or raw)
+
+  if verbosity >= 3:
+    print(f'Executed {command!r}, got {a_result}')
+
+  stdout = a_result.get('stdout', '')
+  text = '\n'.join(stdout) if isinstance(stdout, list) else str(stdout)
+
+  # If the device emitted JSON (e.g. `show ... | json`), hand structured data to the
+  # valid: expression; otherwise return the raw text for a valid_<test>() to parse.
+  parsed = utils.parse_JSON(text)
+  if isinstance(parsed, Exception):
+    return data.get_box({'stdout': text})
+  return parsed

--- a/netsim/cli/validate/plugin.py
+++ b/netsim/cli/validate/plugin.py
@@ -82,7 +82,7 @@ def find_plugin_action(v_entry: Box, node: Box) -> typing.Optional[str]:
     return None
 
   func_name = v_entry.plugin.split('(')[0]
-  for kw in ('show','exec'):
+  for kw in ('show','exec','ansible'):
     if getattr(plugin,f'{kw}_{func_name}',None):
       return kw
 

--- a/netsim/cli/validate/tests.py
+++ b/netsim/cli/validate/tests.py
@@ -12,7 +12,7 @@ from box import Box
 from ... import data
 from ...augment import devices as _devices
 from ...utils import log
-from . import devices, plugin, report, suzieq, utils
+from . import ansible, devices, plugin, report, suzieq, utils
 
 '''
 extend_first_wait_time: some devices need extra time to start working, even when
@@ -152,6 +152,11 @@ def execute_node_validation(
       if report_error:
         report.increase_fail_count(v_entry)
         return (True, False)                    # Return (processed, failed)
+  elif action == 'ansible':                     # Fetch DUT state via an Ansible module (e.g. OcNOS cmlsh)
+    result = ansible.get_result(v_entry,n_name,topology,args.verbose)
+    if '_error' in result:
+      report.increase_fail_count(v_entry)
+      return (True, False)
   elif action == 'suzieq':
     result = suzieq.get_result(v_entry,n_name,topology,args.verbose)
     OK = bool(result) != (v_entry.suzieq.get('expect','data') == 'empty')

--- a/netsim/cli/validate/utils.py
+++ b/netsim/cli/validate/utils.py
@@ -83,7 +83,7 @@ find_test_action -- find something that can be executed on current node
 '''
 def find_test_action(v_entry: Box, node: Box) -> typing.Optional[str]:
   action_kw_found = False
-  for kw in ('show','exec','config','suzieq'):
+  for kw in ('show','exec','config','suzieq','ansible'):
     if kw not in v_entry:
       continue
 

--- a/netsim/defaults/attributes.yml
+++ b/netsim/defaults/attributes.yml
@@ -206,6 +206,7 @@ _v_entry:                   # Validation entry
     _subtype: device
   exec: _v_option
   show: _v_option
+  ansible: _v_option
   config:
     template: str
     variable: dict

--- a/netsim/defaults/hints.yml
+++ b/netsim/defaults/hints.yml
@@ -63,11 +63,11 @@ routing:
 
 validation:
   nodes:
-    A test that uses 'show', 'exec' or 'plugin' action must specify the nodes on
+    A test that uses 'show', 'exec', 'ansible' or 'plugin' action must specify the nodes on
     which that action will be executed.
   valid:
     A test that includes the 'valid' check must generate some output to check. That
-    output can be generated with 'show','exec', or 'suzieq' action.
+    output can be generated with 'show','exec','suzieq', or 'ansible' action.
   show:
     The 'show' action should return structured data that is then validated with the
     'valid' check. If you want to execute a command on the device without checking

--- a/tests/coverage/errors/validation-checks.log
+++ b/tests/coverage/errors/validation-checks.log
@@ -1,7 +1,7 @@
-MissingValue in validation: Test f1 should have wait, show, exec, config, plugin, or suzieq option
+MissingValue in validation: Test f1 should have wait, show, exec, config, plugin, suzieq, or ansible option
 IncorrectValue in validation: Test f2 must specify the nodes to execute the test on
-... A test that uses 'show', 'exec' or 'plugin' action must specify the nodes on which
-    that action will be executed.
+... A test that uses 'show', 'exec', 'ansible' or 'plugin' action must specify the nodes
+    on which that action will be executed.
 IncorrectValue in validation: Test f3 must specify the nodes to execute the test on
 MissingValue in validation: Test f4 has a "show" option but no "valid" option
 ... The 'show' action should return structured data that is then validated with the
@@ -9,5 +9,5 @@ MissingValue in validation: Test f4 has a "show" option but no "valid" option
     results, use the 'exec' action.
 MissingValue in validation: Test f5 has a "valid" option but no action that would generate data to check
 ... A test that includes the 'valid' check must generate some output to check. That output
-    can be generated with 'show','exec', or 'suzieq' action.
+    can be generated with 'show','exec','suzieq', or 'ansible' action.
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting


### PR DESCRIPTION
# Add a general `ansible` validation action

Closes #3676.

`netlab validate` reads device state either by running a `show`/`exec` command over the node connection, or from an external source (`suzieq`). Both assume the platform can return command output to a non-interactive caller. Some network OSes only expose their operational data through a vendor Ansible module — their interactive CLI rejects non-interactive command execution — so neither existing path can reach them, and today such a device cannot be validated at all.

This PR adds an **`ansible` validation action** to close that gap. It is a validation **data source**, a peer of `netsim/cli/validate/suzieq.py` — **not** a connection method. `netsim/cli/connect.py` is unchanged; interactive `netlab connect` is untouched. As discussed on #3676, it is implemented as a first-class, reusable action rather than a device-specific plugin, so any platform in the same situation can adopt it.

## How it works

- A device declares the module it validates through, e.g.:
  ```yaml
  netlab_validate:
    ansible_module: ipinfusion.ocnos.ocnos_command
  ```
- A test can invoke it directly in a `validate` entry:
  ```yaml
  validate:
    adj:
      device: <device>
      ansible: show ip ospf neighbor
      valid: "'Full' in stdout"
  ```
  or a device validation plugin can supply the command from an `ansible_<test>()` function and assert on the result in `valid_<test>()`.
- `netsim/cli/validate/ansible.py` runs the module ad-hoc against the node using the netlab-generated inventory, and returns parsed **JSON** when the command emits it (`... | json`), otherwise the raw CLI text in `stdout` for a text assertion to match.

The action is registered everywhere a validation action is expected — the topology schema (`attributes.yml`), the augment/validation checks and their hint strings (`augment/validate.py`, `hints.yml`), and the test/plugin dispatchers — so `ansible:` is accepted and executed like any built-in action, and it's documented in `docs/topology/validate.md`.

## Files

- **new** `netsim/cli/validate/ansible.py` — the validation source (peer of `suzieq.py`)
- `netsim/cli/validate/tests.py`, `utils.py`, `plugin.py` — dispatch + action registration
- `netsim/augment/validate.py`, `netsim/defaults/attributes.yml`, `netsim/defaults/hints.yml` — accept `ansible:` as a first-class validation action (schema, checks, and user-facing hints)
- `docs/topology/validate.md` — documentation
- `tests/coverage/errors/validation-checks.log` — updated golden for the new action's error text

## Notes

The first consumer is the IP Infusion OcNOS device (submitted separately), whose restricted CLI (`cmlsh`) returns a non-zero exit on every non-interactive SSH command and so can't be reached by the standard `show`/`exec` transports. The action itself is device-agnostic. Verified live against a real OcNOS lab (OSPFv2/OSPFv3, BGP and IS-IS validators passing through the action).
