### PR TITLE
Enable vrnetlab CLAB_MGMT_PASSTHROUGH on devices supporting it

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -239,7 +239,15 @@ $ netlab defaults devices.iosv.clab.group_vars.ansible_ssh_pass=Baggins
 (vrnetlab-internal-net)=
 ### Internal Container Networking
 
-The packaged container's architecture requires an internal network. The [*vrnetlab* fork](https://github.com/srl-labs/vrnetlab) supported by *containerlab* uses the IPv4 prefix 10.0.0.0/24 on that network, which clashes with the *netlab* loopback address pool. Fortunately, that fork also adds management VRF (and default route within the management VRF) to most device configurations, making the overlap between the *vrnetlab* internal subnet and the *netlab* loopback pool irrelevant. However, all VMs in *vrnetlab* containers will have the same IP and MAC address on the management interface, potentially confusing any network management system you might use with your lab.
+The packaged container's architecture requires an internal network. Traditionally, the [*vrnetlab* fork](https://github.com/srl-labs/vrnetlab) supported by *containerlab* used the IPv4 prefix 10.0.0.0/24 on that network and assigned IPv4 address 10.0.0.15 to the management interface, clashing with the *netlab* loopback address pool.
+
+Fortunately, that fork also adds management VRF (and default route within the management VRF) to most device configurations, making the overlap between the *vrnetlab* internal subnet and the *netlab* loopback pool irrelevant. However, all VMs running within *vrnetlab* containers will have the same IP and MAC address on the management interface, potentially confusing any network management system you might use with your lab.
+
+Recently, *vrnetlab* implemented **[Transparent Management](https://containerlab.dev/manual/vrnetlab/#management-interface)**, which configures the IPv4 address configured on the container management interface on the network device VM. This feature is controlled by the `CLAB_MGMT_PASSTHROUGH` container environment variable and is enabled for all _netlab_ devices for which _vrnetlab_ already implemented it by July 2026. If you want to enable this feature on other devices, set the **devices._device_.clab.node.env.CLAB_MGMT_PASSTHROUGH** [topology default parameter](topo-defaults) or **clab.env.CLAB_MGMT_PASSTHROUGH** node variable to **True**.
+
+```{warning}
+Setting this environment variable to True for a *‌vrnetlab* container that does not implement the Transparent Management might result in an unreachable management interface.
+```
 
 Finally, if you're still experiencing connectivity problems or initial configuration failures with _vrnetlab_-based containers after rebuilding them with the [latest vrnetlab version](https://github.com/srl-labs/vrnetlab), add the following parameters to the lab configuration file to change the _netlab_ loopback addressing pool:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -169,6 +169,7 @@ For older releases, check the [release notes archive](release-archive.md).
    :caption: Individual release notes
    :maxdepth: 1
 
+   release/26.08.md
    release/26.07.md
    release/26.06.md
    release/26.05.md

--- a/docs/release/26.08.md
+++ b/docs/release/26.08.md
@@ -1,0 +1,45 @@
+# Changes in Release 26.08
+
+```eval_rst
+.. contents:: Table of Contents
+   :depth: 2
+   :local:
+```
+
+(release-26.08)=
+## New Functionality
+
+* Something new
+
+**Minor improvements**
+
+* Something new
+
+(release-26.08-device-features)=
+## New Device Features
+
+Arista EOS:
+* Something new
+
+(release-26.08-device-fixes)=
+## Fixes in Device Settings and Configuration Templates
+
+* [Transparent Management _containerlab_ feature] has been enabled for Cisco ASAv, Cisco Catalyst 8000v, Cisco CSR 1000v,  Cisco Nexus OS, Nokia SR-OS (the vrnetlab VM version, not SR-SIM), vJunos router, vJunos switch, vJunos Evolved (vPTX), and Juniper vSRX.
+
+Arista EOS:
+* Something new
+
+(release-26.08-breaking)=
+## Breaking changes
+
+* We enabled the [Transparent Management _containerlab_ feature](https://containerlab.dev/manual/vrnetlab/#management-interface) on vrnetlab-based devices supporting it in July 2026. This change should not impact older containers, but will change the management IPv4 address on virtual machines running within some newly-built containers from 10.0.0.15 (default management IPv4 address) to the outside (container) management IPv4 address.
+
+(bug-fixes-26.08)=
+## Bug Fixes
+
+* Bugs were fixed
+
+(doc-fixes-26.08)=
+## Documentation Fixes
+
+* Docs were fixed

--- a/netsim/devices/asav.yml
+++ b/netsim/devices/asav.yml
@@ -46,6 +46,8 @@ clab:
   image: vrnetlab/cisco_asav:9-16-4-57
   node:
     kind: cisco_asav
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
 #  interface.name: eth{ifindex}
   build: https://containerlab.dev/manual/kinds/cisco_asav/
   group_vars:

--- a/netsim/devices/cat8000v.yml
+++ b/netsim/devices/cat8000v.yml
@@ -9,6 +9,8 @@ clab:
   image: vrnetlab/cisco_c8000v:17.16.01a
   node:
     kind: cisco_c8000v
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface.name: eth{ifindex-1}
   build: https://containerlab.dev/manual/kinds/vr-c8000v/
 libvirt:

--- a/netsim/devices/csr.yml
+++ b/netsim/devices/csr.yml
@@ -7,6 +7,8 @@ clab:
   image: vrnetlab/vr-csr:17.03.04
   node:
     kind: cisco_csr1000v
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface.name: eth{ifindex-1}
   build: https://containerlab.dev/manual/kinds/vr-csr/
 group_vars:

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -13,6 +13,8 @@ clab:
   image: vrnetlab/vr-n9kv:9.3.8
   node:
     kind: cisco_n9kv
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface.name: eth{ifindex}
   build: https://containerlab.dev/manual/kinds/vr-n9kv/
 group_vars:

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -116,6 +116,8 @@ clab:
     kind: vr-sros
     type: sr-1                # By default emulate SR-1
     license: /Projects/SR_OS_VSR-SIM_license.txt
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface:
     name: eth{ifindex}
   group_vars:

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -25,7 +25,7 @@ features:
   vxlan: true
 
 clab:
-  image: vrnetlab/juniper_vjunos-router:26.2R1.7
+  image: vrnetlab/juniper_vjunos-router:23.4R2-S2.1
   build: https://containerlab.dev/manual/kinds/vr-vjunosrouter/
   mtu: 1500
   node:

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -25,11 +25,13 @@ features:
   vxlan: true
 
 clab:
-  image: vrnetlab/juniper_vjunos-router:23.4R2-S2.1
+  image: vrnetlab/juniper_vjunos-router:26.2R1.7
   build: https://containerlab.dev/manual/kinds/vr-vjunosrouter/
   mtu: 1500
   node:
     kind: juniper_vjunosrouter
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface:
     name: eth{ifindex+1}
   group_vars:

--- a/netsim/devices/vjunos-switch.yml
+++ b/netsim/devices/vjunos-switch.yml
@@ -27,6 +27,8 @@ clab:
   mtu: 1500
   node:
     kind: juniper_vjunosswitch
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface:
     name: eth{ifindex+1}
   group_vars:

--- a/netsim/devices/vptx.yml
+++ b/netsim/devices/vptx.yml
@@ -37,6 +37,8 @@ clab:
   mtu: 1500
   node:
     kind: juniper_vjunosevolved
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface:
     name: eth{ifindex+1}
   group_vars:

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -40,6 +40,8 @@ clab:
   build: https://containerlab.dev/manual/kinds/vr-vsrx/
   node:
     kind: vr-vsrx
+    env:
+      CLAB_MGMT_PASSTHROUGH: "true"
   interface:
     name: eth{ifindex+1}
   group_vars:


### PR DESCRIPTION
list obtained from the vrnetlab repo.

i was able to test only jnpr images.

See also https://github.com/ipspace/netlab/issues/3685 - need to have it solved either in vrnetlab or netlab or both