### PR TITLE
Bump vJunos router image to 26.2R1.7

### DIFF
--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -25,7 +25,7 @@ features:
   vxlan: true
 
 clab:
-  image: vrnetlab/juniper_vjunos-router:23.4R2-S2.1
+  image: vrnetlab/juniper_vjunos-router:26.2R1.7
   build: https://containerlab.dev/manual/kinds/vr-vjunosrouter/
   mtu: 1500
   node:


### PR DESCRIPTION
This PR updates the vJunos router image version from 23.4R2-S2.1 to 26.2R1.7 to provide the latest Junos OS features and fixes.

This change was separated from PR #3686 (Enable vrnetlab CLAB_MGMT_PASSTHROUGH on devices supporting it) to keep image version bumps as separate changes, following the "one change per PR" principle.

## Changes
- Update `netsim/devices/vjunos-router.yml`: vJunos router image: 23.4R2-S2.1 → 26.2R1.7

## Related
- See PR #3686 for the Transparent Management feature enablement across devices