### PR TITLE
JunOS: removing gre over ipv6, add caveats for ospfv3

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -444,6 +444,7 @@ ansible_httpapi_port: 80
 * Junos configuration template configures BFD timers within routing protocol configuration, not on individual interfaces
 * Junos does not disable the default BGP address family on a BGP neighbor until another AF is configured.
 * IS-IS NSAP is configured on the loopback interface for the global IS-IS instance and with the protocol **net** parameter in VRF IS-IS instances.
+* OSPFv3 over a GRE tunnel signals interface MTU value of `0` on *DBD* packets. If you need to interoperate with other devices/vendors, you need to ignore the MTU mismatch on the peer device.
 
 Implementation limitations in import/export route filters (reported as errors that can be disabled with topology settings):
 

--- a/docs/plugins/tunnel.gre.md
+++ b/docs/plugins/tunnel.gre.md
@@ -11,8 +11,8 @@ The plugin includes Jinja2 templates for the following platforms:
 |--------------|:-:|:-:|:-:|
 | Cisco IOS/XE[^18v] |✅|✅|✅|
 | FRR                 |✅|✅|✅|
-| Juniper vJunos-switch |✅|✅|✅|
-| Juniper vSRX        |✅|✅|✅|
+| Juniper vJunos-switch[❗](caveats-junos) |✅|❌|✅|
+| Juniper vSRX[❗](caveats-junos) |✅|❌|✅|
 | Mikrotik RouterOS 7 |✅|✅|✅|
 | VyOS               |✅|✅|✅|
 

--- a/netsim/devices/vjunos-router.yml
+++ b/netsim/devices/vjunos-router.yml
@@ -15,7 +15,7 @@ features:
     bundle: [ vlan_aware ]
     transport: [ vxlan ]
   tunnel:
-    gre: [ vrf, ipv4, ipv6 ]
+    gre: [ vrf, ipv4 ]
   vlan:
     model: router
     svi_interface_name: irb.{vlan}

--- a/netsim/devices/vsrx.yml
+++ b/netsim/devices/vsrx.yml
@@ -15,7 +15,7 @@ features:
   lag:
     passive: True
   tunnel:
-    gre: [ vrf, ipv4, ipv6 ]
+    gre: [ vrf, ipv4 ]
   vlan:
     model: router
     subif_name: "{ifname}.{vlan.access_id}"

--- a/tests/integration/tunnel/01-gre.yml
+++ b/tests/integration/tunnel/01-gre.yml
@@ -20,7 +20,7 @@ addressing:
     ipv4: 172.23.0.0/16
     ipv6: 2001:db8:1::/48
 
-plugin: [ tunnel.gre, adjust_test ]
+plugin: [ tunnel.gre, files, adjust_test ]
 
 groups:
   probes:
@@ -76,6 +76,12 @@ links:
   pool: tunnel
   members: [ dut-r3 ]
 
+files:
+  mtu-ignore.j2: |
+    {% for intf in interfaces if 'ospf' in intf and 'ipv6' in intf %}
+    interface {{ intf.ifname }}
+      ipv6 ospf6 mtu-ignore
+    {% endfor %}
 _adjust:
 - nodes: [ dut ]              # Check for fast OSPF timers support
   features: [ ospf.timers ]
@@ -95,6 +101,15 @@ _adjust:
   - validate.g6_pfx_v6
   - validate.g6_ping_v4
   - validate.g6_ping_v6
+- nodes: [ dut ]
+  devices: [ vjunos-router, vsrx ]
+  warning: >-
+    {device} specifies incorrect MTU in OSPFv3 DBD packets. Ignoring incoming MTU on FRR
+  replace:
+  - key: nodes.r2.config
+    value: [ mtu-ignore ]
+  - key: nodes.r3.config
+    value: [ mtu-ignore ]
 
 validate:
   g4_adj_v4:


### PR DESCRIPTION
Related to #3657 .

@ipspace if you already have an idea on how to implement the FRR's config tweak during the test I'll let you implement this