### PR TITLE
Stabilize MTU validation after PMTU cache updates

### DIFF
--- a/tests/integration/initial/04-mtu.yml
+++ b/tests/integration/initial/04-mtu.yml
@@ -89,6 +89,13 @@ validate:
       eos: ping t1400 df-bit size 1400
     valid: |
       'bytes from' in stdout
+  flush_v4_1400:
+    description: Flush IPv4 PMTU cache on p1
+    nodes: [ p1 ]
+    exec:
+      eos: bash sudo ip route flush cache
+    valid: |
+      True
   v4_1400_ptb:
     description: IPv4 ping p1 => target (expecting Frag Needed)
     nodes: [ p1 ]
@@ -106,11 +113,19 @@ validate:
       'bytes from' not in stdout
   v6_1400_low:
     description: IPv6 ping p1 => target (under MTU)
+    wait: ping_long
     nodes: [ p1 ]
     exec:
       eos: ping ipv6 t1400 df-bit size 1400
     valid: |
       'bytes from' in stdout
+  flush_v6_1400:
+    description: Flush IPv6 PMTU cache on p1
+    nodes: [ p1 ]
+    exec:
+      eos: bash sudo ip -6 route flush cache
+    valid: |
+      True
   v6_1400_ptb:
     description: IPv6 ping p1 => target (expecting PTB)
     nodes: [ p1 ]


### PR DESCRIPTION
## Summary
- Flushes the cEOS probe's IPv4/IPv6 route (PMTU) cache between the under-MTU success checks and the Frag Needed / Packet Too Big expectations in `tests/integration/initial/04-mtu.yml`.
- Adds `wait: ping_long` on the IPv6 under-MTU check for the same path.

## Why
After an oversized DF ping, Linux/cEOS learns and caches the path MTU. The next oversized ping then fails locally with "message too long" instead of eliciting a fresh ICMP unreachable from the DUT, so the PTB validation becomes flaky or fails even when the DUT is correct. Flushing the cache forces a new discovery attempt and keeps the test asserting DUT behavior.

## Test plan
- [ ] Run `tests/integration/initial/04-mtu.yml` against a DUT that previously showed intermittent PTB failures
- [ ] Confirm `v4_1400_ptb` / `v6_1400_ptb` still match Frag Needed / Packet Too Big (not local message-too-long)


Made with [Cursor](https://cursor.com)