### PR TITLE
Add OpenBSD GRE support

### DIFF
--- a/docs/plugins/tunnel.gre.md
+++ b/docs/plugins/tunnel.gre.md
@@ -14,6 +14,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Juniper vJunos-switch[❗](caveats-junos) |✅|❌|✅|
 | Juniper vSRX[❗](caveats-junos) |✅|❌|✅|
 | Mikrotik RouterOS 7 |✅|✅|✅|
+| OpenBSD            |✅|❌|❌|
 | VyOS               |✅|✅|✅|
 
 [^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -3,6 +3,7 @@ support:
   level: best-effort
 interface_name: vio{ifindex}
 loopback_interface_name: lo{ifindex}
+tunnel_interface_name: gre{ifindex}
 ifindex_offset: 1
 mgmt_if: vio0
 role: router
@@ -56,6 +57,8 @@ features:
     native_routed: true
   vxlan:
     vtep6: True
+  tunnel:
+    gre: [ ipv4 ]
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd

--- a/netsim/extra/tunnel/gre/openbsd.j2
+++ b/netsim/extra/tunnel/gre/openbsd.j2
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+set -e
+#
+sysctl net.inet.gre.allow=1
+
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['gre'] %}
+{%   set af = intf.tunnel.af|default('ipv4') %}
+ifconfig {{ intf.ifname }} tunnel {{ intf.tunnel._source[af] }} {{ intf.tunnel._destination[af] }}
+{%   if intf.ipv6 is defined %}
+{# ipv6 seems not to like specifying both ends so we leave it with the inet6 address configure in initial #}
+{%   endif %}
+{%   if intf.ipv4 is defined %}
+{# IPv4 requires specifying both endpoints #}
+ifconfig {{ intf.ifname }} {{ intf.ipv4|ansible.utils.ipaddr('address') }} {{ intf.neighbors[0].ipv4|ansible.utils.ipaddr('address') }}
+{%   endif %}
+ifconfig {{ intf.ifname }} tunnelttl 255 up
+{% endfor %}


### PR DESCRIPTION
Here is the OpenBSD GRE IPv4 support,

Couldn't make FRR and OpenBSD agree on IPv6 GRE and spent bit too much time trying to get it working.

<details><summary> tunnel/01-gre.yaml</summary>

```

PLAY RECAP ***********************************************************************************************************************************************************************************
dut                        : ok=30   changed=8    unreachable=0    failed=0    skipped=11   rescued=0    ignored=0

Results of configuration script deployments
==============================================================================================================================================================================================
r2               Script:  initial,routing,ospf,tunnel.gre
r3               Script:  initial,routing
core             Script:  initial


[SUCCESS] Lab devices configured


Test the GRE tunnels. The tested devices has GRE tunnels over IPv4 and IPv6
and runs OSPFv2 and OSPFv3 over them. The probes should receive OSPF routes
advertised from the DUT and be able to ping its loopback.


[WARNING] The following warnings were generated during the 'netlab up' processing
[WARNING] adjust_test: openbsd does not support GRE tunnels over IPv6
[g4_adj_v4]  Check OSPF adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]       Test succeeded in 0.1 seconds

[g4_adj_v6]  Check OSPFv3 adjacencies (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]       Test succeeded in 0.1 seconds

[g4_pfx_v4]  Check DUT IPv4 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[WAITING]    Waiting for SPF to do its magic (retrying for 10 seconds)
[PASS]       r2: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]       Test succeeded in 10.4 seconds

[g4_pfx_v6]  Check DUT IPv6 loopback prefix propagation (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: The prefix 2001:db8::1/128 is in the OSPFv3 topology
[PASS]       Test succeeded in 0.2 seconds

[g4_ping_v4] Check end-to-end IPv4 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to 10.0.0.1 from 10.0.0.2/32 succeeded
[PASS]       Test succeeded in 0.1 seconds

[g4_ping_v6] Check end-to-end IPv6 connectivity (GRE IPv4) [ node(s): r2 ]
[PASS]       r2: Ping to ipv6 2001:db8::1 from 2001:db8::2/128 succeeded
[PASS]       Test succeeded in 0.1 seconds

[f_warning]  Starting test
[WARNING]    openbsd does not support GRE tunnels over IPv6

[INFO]       One test out of 7 tests generated a warning
[WARNING] netlab validate: Validation generated a warning
(py3-snuff) netlab@netlab:~/snuffy-netlab/aaa$
```
</details>