### PR TITLE
Add Wireguard support for RouterOS 7

### DIFF
--- a/docs/plugins/tunnel.wireguard.md
+++ b/docs/plugins/tunnel.wireguard.md
@@ -17,6 +17,7 @@ The plugin includes Jinja2 templates for the following platforms:
 | Operating system | WireGuard tunnels | Transport VRF |
 |------------------|:-:|:-:|
 | FRR              |✅|✅|
+| RouterOS 7       |✅|✅|
 
 ## Using the Plugin
 

--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -24,7 +24,7 @@
 /ipv6/address add interface=loopback address={{ loopback.ipv6 }}
 {% endif %}
 
-{# Setup the required base for GRE/VLAN/VRFs #}
+{# Setup the required base for GRE/VLAN/VRF/Wireguard #}
 {% from '_extra_initial.j2' import extra_initial with context %}
 {{ extra_initial() }}
 {#
@@ -35,6 +35,8 @@
 {%     set intf_type = 'vlan' %}
 {%   elif l.type == 'tunnel' and l.tunnel.mode == 'gre' %}
 {%     set intf_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
+{%   elif l.type == 'tunnel' and l.tunnel.mode == 'wireguard' %}
+{%     set intf_type = 'wireguard' %}
 {%   else %}
 {%     set intf_type = 'ethernet' %}
 {%   endif %}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -38,6 +38,7 @@ features:
   bfd: true
   tunnel:
     gre: [ ipv4, ipv6, vrf ]
+    wireguard: [ ipv4, ipv6, vrf ]
   routing:
     static:
       discard: True

--- a/netsim/extra/tunnel/wireguard/routeros7.initial.j2
+++ b/netsim/extra/tunnel/wireguard/routeros7.initial.j2
@@ -1,0 +1,5 @@
+# wireguard tunnel setup
+{% for l in interfaces if l.type == 'tunnel' and l.tunnel.mode == 'wireguard' %}
+{%   set vrf_str = 'vrf=' + l.tunnel.vrf if l.tunnel.vrf|default('') else '' %}
+/interface/wireguard add name={{ l.ifname }} listen-port={{ l.tunnel.listen_port }} {{ vrf_str }} private-key="{{ l.tunnel.private_key }}"
+{% endfor %}

--- a/netsim/extra/tunnel/wireguard/routeros7.j2
+++ b/netsim/extra/tunnel/wireguard/routeros7.j2
@@ -1,0 +1,8 @@
+# wg peers
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['wireguard'] %}
+{%   set dst = intf.tunnel._destination %}
+{%   set peer_ip = ('[' ~ dst.ipv6 ~ ']') if intf.tunnel.af == 'ipv6' else dst.ipv4 %}
+{%   set peer_endpoint = peer_ip ~ ':' ~ dst.listen_port %}
+/interface/wireguard/peers add interface={{ intf.ifname }} public-key="{{ dst.public_key }}" allowed-address={{ intf.tunnel.allowed_ips }} endpoint-address={{ peer_ip }} endpoint-port={{ dst.listen_port }} persistent-keepalive={{ intf.tunnel.persistent_keepalive }}
+
+{% endfor %}


### PR DESCRIPTION
Provide Wireguard support for RouterOS 7.

Can also provide update to 03/04 tests to have FRR as one side of the test.


<details><summary>03-wireguard.yml</summary>

```
PLAY RECAP ***********************************************************************************************************************************************************************************
dut_r1                     : ok=30   changed=4    unreachable=0    failed=0    skipped=11   rescued=0    ignored=0
dut_r2                     : ok=30   changed=4    unreachable=0    failed=0    skipped=11   rescued=0    ignored=0

Results of configuration script deployments
==============================================================================================================================================================================================
core             Script:  initial
r3               Script:  initial,routing,ospf


[SUCCESS] Lab devices configured


Test dual-stack WireGuard tunnels. The two tested devices have a WireGuard
tunnel carrying both IPv4 and IPv6 and run OSPFv2 and OSPFv3 over it. The
probe should receive the routes advertised from the remote device (DUT_R1)
and be able to ping its loopback over both address families.

[adj]     Check OSPFv2 adjacencies [ node(s): r3 ]
[PASS]    r3: OSPFv2 neighbor 10.0.0.2 is in state Full/-
[PASS]    Test succeeded in 0.1 seconds

[adj6]    Check OSPFv3 adjacencies [ node(s): r3 ]
[PASS]    r3: OSPFv3 neighbor 10.0.0.2 is in state Full
[PASS]    Test succeeded in 0.1 seconds

[pfx]     Check for DUT_R1 IPv4 loopback prefix being propagated to R3 [ node(s): r3 ]
[WAITING] Waiting for SPF to do its magic (retrying for 30 seconds)
[PASS]    r3: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    Test succeeded in 12.7 seconds

[pfx6]    Check for DUT_R1 IPv6 loopback prefix being propagated to R3 [ node(s): r3 ]
[PASS]    r3: The prefix 2001:db8:1:1::/64 is in the OSPFv3 topology
[PASS]    Test succeeded in 0.1 seconds

[ping]    Check end-to-end IPv4 connectivity [ node(s): r3 ]
[PASS]    r3: Ping to 10.0.0.1 succeeded
[PASS]    Test succeeded in 0.2 seconds

[ping6]   Check end-to-end IPv6 connectivity [ node(s): r3 ]
[PASS]    r3: Ping to ipv6 2001:db8:1:1::1 succeeded
[PASS]    Test succeeded in 1.1 seconds

[mtu]     Check a full 1500-byte packet traverses the tunnel (underlay MTU 1560) [ node(s): r3 ]
[PASS]    r3: Ping to 10.0.0.1 size 1472 succeeded
[PASS]    Test succeeded in 0.1 seconds

[SUCCESS] Tests passed: 7
```

</details>


<details><summary>04-wireguard-vrf.yml</summary>

```
PLAY RECAP ***********************************************************************************************************************************************************************************
dut_r1                     : ok=30   changed=4    unreachable=0    failed=0    skipped=11   rescued=0    ignored=0
dut_r2                     : ok=30   changed=4    unreachable=0    failed=0    skipped=11   rescued=0    ignored=0

Results of configuration script deployments
==============================================================================================================================================================================================
r3               Script:  initial,ospf


[SUCCESS] Lab devices configured


Test dual-stack WireGuard tunnels in a transport VRF. The two tested devices
have a WireGuard tunnel in the transport VRF carrying both IPv4 and IPv6 and
run (global) OSPFv2 and OSPFv3 over it. The probe should receive the routes
advertised from the remote device (DUT_R1) and be able to ping its loopback
over both address families.

[adj]     Check OSPFv2 adjacencies [ node(s): r3 ]
[PASS]    r3: OSPFv2 neighbor 10.0.0.2 is in state Full/-
[PASS]    Test succeeded in 0.1 seconds

[adj6]    Check OSPFv3 adjacencies [ node(s): r3 ]
[PASS]    r3: OSPFv3 neighbor 10.0.0.2 is in state Full
[PASS]    Test succeeded in 0.1 seconds

[pfx]     Check for DUT_R1 IPv4 loopback prefix being propagated to R3 [ node(s): r3 ]
[WAITING] Waiting for SPF to do its magic (retrying for 30 seconds)
[PASS]    r3: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    Test succeeded in 11.6 seconds

[pfx6]    Check for DUT_R1 IPv6 loopback prefix being propagated to R3 [ node(s): r3 ]
[PASS]    r3: The prefix 2001:db8:1:1::/64 is in the OSPFv3 topology
[PASS]    Test succeeded in 0.1 seconds

[ping]    Check end-to-end IPv4 connectivity [ node(s): r3 ]
[PASS]    r3: Ping to 10.0.0.1 succeeded
[PASS]    Test succeeded in 0.1 seconds

[ping6]   Check end-to-end IPv6 connectivity [ node(s): r3 ]
[PASS]    r3: Ping to ipv6 2001:db8:1:1::1 succeeded
[PASS]    Test succeeded in 1.1 seconds

[mtu]     Check a full 1500-byte packet traverses the tunnel (underlay MTU 1580) [ node(s): r3 ]
[PASS]    r3: Ping to 10.0.0.1 size 1472 succeeded
[PASS]    Test succeeded in 0.1 seconds

[SUCCESS] Tests passed: 7
```
</details>
