### PR TITLE
Fix: Minimize FRR setup in WG VRF integration test

### DIFF
--- a/tests/integration/tunnel/12-wireguard-vrf.yml
+++ b/tests/integration/tunnel/12-wireguard-vrf.yml
@@ -25,7 +25,7 @@ groups:
     members: [ r2 ]
     module: [ ospf ]
   ce:
-    members: [ dut, r2 ]
+    members: [ dut ]
     module: [ ospf, vrf ]
 
 vrfs:
@@ -36,19 +36,20 @@ nodes:
   r2:
 
 links:
-- group: core
-  ospf: False
-  vrf: transport
+- ospf: False
   mtu: 1580
-  members: [ dut-r2 ]
+  dut:
+    vrf: transport
+  r2:
 - dut:
     tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
     tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+    tunnel.vrf: transport
   r2:
     tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
     tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
   tunnel.mode: wireguard
-  tunnel.vrf: transport
+  mtu: 1500
 
 validate:
   adj:


### PR DESCRIPTION
Use FRR WG probe in non-VRF setup to ensure its configuration does not impact the results of the integration test. Also, set MTU on the tunnel manually due to (currently) FUBARed MTU calculation.