### PR TITLE
Fix: Do not apply schema _default on interfaces before link merge (#3703)

### DIFF
--- a/docs/dev/validation-types.txt
+++ b/docs/dev/validation-types.txt
@@ -40,7 +40,7 @@ All attributes defined with a dictionary (**mode** in the above example, but not
 * **true_value** -- value to use when the parameter is set to *True*
 * **_requires** -- a list of modules that must be enabled in global- or node context to allow the use of this attribute. See `vrfs` in `modules/vrf.yml` and `vlans` in `modules/vlan.yml` for more details.
 * **_required** (bool) -- the attribute must be present in the parent dictionary[^CRQ]
-* **_default** -- the default value of the attribute. Added to the data structure when the attribute is not specified in the lab topology
+* **_default** -- the default value of the attribute. Added to the data structure when the attribute is not specified in the lab topology[^DEF]
 * **_valid_with** -- a list or dictionary of attributes that can be used with this attribute ([example](inter-attribute-examples)).
 * **_invalid_with** -- specifies attributes that cannot be used together with this attribute. Can be:
 
@@ -51,6 +51,7 @@ All attributes defined with a dictionary (**mode** in the above example, but not
 * **_remove_when_false** (bool) -- remove the attribute when its value is *False* (otherwise, the attribute value could be turned into an empty list or dictionary).
 
 [^CRQ]: This does not make the parent dictionary mandatory, but if it's present, it must have the required attribute. Use a chain of `_required` attributes if you want to enforce the presence of an attribute deep in the data structure.
+[^DEF]: `_default` values are applied during attribute validation when `apply_defaults` is True (the default). Node-on-link interface validation passes `apply_defaults=False` so defaults stay on the link and are copied during link-to-interface propagation; otherwise an interface default would shadow an explicit link-level value.
 
 See [](validation-definition-examples) and [](inter-attribute-examples) for more details.
 

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -254,6 +254,8 @@ def validate(topology: Box) -> None:
 
     for intf in l_data.interfaces:
       n_data = topology.nodes[intf.node]
+      # Skip _default on interfaces: defaults are applied on the link and copied
+      # during link-to-interface merge. Applying them here would shadow link values (#3703).
       validate_attributes(
         data=intf,                                      # Validate interface data
         topology=topology,
@@ -263,7 +265,8 @@ def validate(topology: Box) -> None:
         modules=n_data.get('module',[]),                # ... against node modules
         extra_attributes=providers,                     # Allow provider-specific attributes in interfaces
         module_source=f'nodes.{intf.node}',
-        module='links')                                 # Function is called from 'links' module
+        module='links',                                 # Function is called from 'links' module
+        apply_defaults=False)
 
 """
 Get the link attributes that have to be propagated to interfaces: full set

--- a/netsim/data/validate.py
+++ b/netsim/data/validate.py
@@ -134,18 +134,23 @@ def validate_module_can_be_false(
 
 """
 check_required_keys -- checks that the required keys are present in the data structure and sets the default
-values for missing keys with _default attribute
+values for missing keys with _default attribute (when apply_defaults is True)
 """
 
-def check_required_keys(data: Box, attributes: Box, path: str,module: str) -> bool:
+def check_required_keys(
+      data: Box,
+      attributes: Box,
+      path: str,
+      module: str,
+      apply_defaults: bool = True) -> bool:
   result = True
   for k,v in attributes.items():
     if not isinstance(v,Box):
       continue
-    if '_default' in v and k not in data:
+    if apply_defaults and '_default' in v and k not in data:
       data[k] = v._default
     if '_required' in v and v._required:
-      if k in data:
+      if k in data or '_default' in v:                # Present, or _default will be applied later
         continue
       log.error(
         f"Mandatory attribute '{path}.{k}' is missing",
@@ -171,7 +176,8 @@ def validate_dictionary(
       topology: Box,
       attr_list: list,
       attributes: Box,
-      enabled_modules: list) -> bool:
+      enabled_modules: list,
+      apply_defaults: bool = True) -> bool:
 
   # Assume everything is OK
   return_value = True
@@ -209,7 +215,8 @@ def validate_dictionary(
           modules=enabled_modules,
           module=module,
           module_source=module_source,
-          attributes=attributes)
+          attributes=attributes,
+          apply_defaults=apply_defaults)
       else:                                       # Simple type that is validated with a must_be_something function
         OK = validate_item(                       # ... call the simpler item validation routine
           parent=data,
@@ -222,7 +229,8 @@ def validate_dictionary(
           topology=topology,
           attr_list=attr_list,
           attributes=attributes,
-          enabled_modules=enabled_modules)
+          enabled_modules=enabled_modules,
+          apply_defaults=apply_defaults)
 
       if OK is False:                             # Aggregate return results into a single boolean value
         return_value = False
@@ -264,9 +272,10 @@ def validate_dictionary(
         topology=topology,
         attr_list=attr_list,
         attributes=attributes,
-        enabled_modules=enabled_modules)
+        enabled_modules=enabled_modules,
+        apply_defaults=apply_defaults)
 
-  return_value = return_value and check_required_keys(data,data_type._keys,parent_path,module)
+  return_value = return_value and check_required_keys(data,data_type._keys,parent_path,module,apply_defaults)
   return return_value                             # Return final status
 
 """
@@ -285,7 +294,8 @@ def validate_list(
       topology: Box,
       attr_list: list,
       attributes: Box,
-      enabled_modules: list) -> bool:
+      enabled_modules: list,
+      apply_defaults: bool = True) -> bool:
 
   # Assume everything is OK
   return_value = True
@@ -307,7 +317,8 @@ def validate_list(
         modules=enabled_modules,
         module=module,
         module_source=module_source,
-        attributes=attributes)
+        attributes=attributes,
+        apply_defaults=apply_defaults)
     else:                                       # Simple type that is validated with a must_be_something function
       OK = validate_item(                       # ... call the simpler item validation routine
         parent=None,
@@ -320,7 +331,8 @@ def validate_list(
         topology=topology,
         attr_list=attr_list,
         attributes=attributes,
-        enabled_modules=enabled_modules)
+        enabled_modules=enabled_modules,
+        apply_defaults=apply_defaults)
 
       if OK is False:                             # Aggregate return results into a single boolean value
         return_value = False
@@ -545,7 +557,8 @@ def validate_item(
       topology: Box,
       attr_list: list,
       attributes: Box,
-      enabled_modules: list) -> typing.Any:
+      enabled_modules: list,
+      apply_defaults: bool = True) -> typing.Any:
   """
   validate_item -- validate a single item from an object:
 
@@ -687,7 +700,8 @@ def validate_item(
               topology=topology,
               attr_list=attr_list,
               attributes=attributes,
-              enabled_modules=enabled_modules)
+              enabled_modules=enabled_modules,
+              apply_defaults=apply_defaults)
 
   return OK
 
@@ -711,7 +725,8 @@ def validate_attributes(
       module_source: str = '',                          # Where did we get the list of modules?
       attributes: typing.Optional[Box] = None,          # Where to get valid attributes from
       extra_attributes: typing.Optional[Box] = None,    # Dynamic attributes (needed to validate provider and tool settings)
-      ignored: typing.Optional[list] = ['_']            # Ignored prefixes
+      ignored: typing.Optional[list] = ['_'],           # Ignored prefixes
+      apply_defaults: bool = True                       # Materialize schema _default values
         ) -> typing.Any: 
 
   #
@@ -773,7 +788,7 @@ def validate_attributes(
       'validate')
     return
 
-  check_required_keys(data,valid,data_path,module)
+  check_required_keys(data,valid,data_path,module,apply_defaults)
   check_valid_with(data,valid,data_path,data_name,module)
   for k in list(data.keys()):
     if any(k.startswith(i) for i in ignored):           # Skip internal attributes
@@ -792,7 +807,8 @@ def validate_attributes(
         enabled_modules=modules,
         topology=topology,
         attr_list=attr_list,
-        attributes=attributes)
+        attributes=attributes,
+        apply_defaults=apply_defaults)
       continue
 
     # The attribute is not valid for the base data type, but maybe...
@@ -812,7 +828,8 @@ def validate_attributes(
         modules=modules,                                # Keep the list of modules for _requires checks
         module_source=f'{module_source}(R)',            # ... but don't consider other modules during module attribute check
         module=k,                                       # Error message generated by the module
-        attributes=topology.defaults[k].attributes)     # Use module attributes
+        attributes=topology.defaults[k].attributes,     # Use module attributes
+        apply_defaults=apply_defaults)
 
       if data[k] is None:                               # If we're trying to validate module value None...
         data[k] = fixed_data                            # ... replace it with whatever recursive call returned (might be a dict)

--- a/netsim/extra/ebgp/multihop/__init__.py
+++ b/netsim/extra/ebgp/multihop/__init__.py
@@ -62,7 +62,8 @@ def pre_link_transform(topology: Box) -> None:
         attr_list=['interface','link'],               # We're checking interface or link attributes
         modules=v_mods,                               # ... against BGP/VRF attributes
         module_source='topology',
-        module='ebgp.multihop')                       # Function is called from 'ebgp.multihop' plugin
+        module='ebgp.multihop',                       # Function is called from 'ebgp.multihop' plugin
+        apply_defaults=False)
 
       if not 'loopback' in node:
         log.error(

--- a/tests/coverage/expected/wg-listen-port.yml
+++ b/tests/coverage/expected/wg-listen-port.yml
@@ -1,0 +1,189 @@
+input:
+- coverage/input/wg-listen-port.yml
+- package:topology-defaults.yml
+links:
+- _linkname: links[1]
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.1/30
+    node: dut
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.2/30
+    node: r2
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+- _linkname: links[2]
+  bridge: input_2
+  interfaces:
+  - ifindex: 20000
+    ifname: tun0
+    ipv4: 10.1.0.5/30
+    node: dut
+    tunnel:
+      private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+      public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  - ifindex: 20000
+    ifname: tun0
+    ipv4: 10.1.0.6/30
+    node: r2
+    tunnel:
+      private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+      public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  linkindex: 2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.4/30
+  tunnel:
+    listen_port: 59000
+    mode: wireguard
+    persistent_keepalive: 25
+  type: tunnel
+message: 'Link-level WireGuard tunnel.listen_port overrides the schema default
+
+  '
+name: input
+nodes:
+  dut:
+    af:
+      ipv4: true
+    box: debian/bookworm64
+    config:
+    - tunnel.wireguard
+    device: frr
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      mtu: 1500
+      name: dut -> r2
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.2/30
+        node: r2
+      type: p2p
+    - ifindex: 20000
+      ifname: tun0
+      ipv4: 10.1.0.5/30
+      linkindex: 2
+      mtu: 1500
+      name: dut -> r2 [WireGuard tunnel]
+      neighbors:
+      - ifname: tun0
+        ipv4: 10.1.0.6/30
+        node: r2
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 10.1.0.2
+          listen_port: 59000
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        _source:
+          ifname: eth1
+          ipv4: 10.1.0.1
+          listen_port: 59000
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 59000
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+        public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+      type: tunnel
+      virtual_interface: true
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    mtu: 1500
+    name: dut
+    netlab_linux_packages:
+      wireguard-tools: wg
+    role: router
+  r2:
+    af:
+      ipv4: true
+    box: debian/bookworm64
+    config:
+    - tunnel.wireguard
+    device: frr
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> dut
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.1/30
+        node: dut
+      type: p2p
+    - ifindex: 20000
+      ifname: tun0
+      ipv4: 10.1.0.6/30
+      linkindex: 2
+      mtu: 1500
+      name: r2 -> dut [WireGuard tunnel]
+      neighbors:
+      - ifname: tun0
+        ipv4: 10.1.0.5/30
+        node: dut
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 10.1.0.1
+          listen_port: 59000
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        _source:
+          ifname: eth1
+          ipv4: 10.1.0.2
+          listen_port: 59000
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 59000
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+        public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+      type: tunnel
+      virtual_interface: true
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    mtu: 1500
+    name: r2
+    netlab_linux_packages:
+      wireguard-tools: wg
+    role: router
+plugin:
+- tunnel.wireguard
+provider: libvirt

--- a/tests/coverage/input/wg-listen-port.yml
+++ b/tests/coverage/input/wg-listen-port.yml
@@ -1,0 +1,24 @@
+---
+# Regression test for #3703: link-level tunnel.listen_port must not be
+# shadowed by the schema _default applied during interface validation.
+message: |
+  Link-level WireGuard tunnel.listen_port overrides the schema default
+
+plugin: [ tunnel.wireguard ]
+defaults.device: frr
+
+nodes:
+  dut:
+  r2:
+
+links:
+- dut:
+  r2:
+- dut:
+    tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+    tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  r2:
+    tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+    tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  tunnel.mode: wireguard
+  tunnel.listen_port: 59000


### PR DESCRIPTION
Link-level attributes with _default were materialized onto node-on-link interfaces during validation, so the later merge kept the default and ignored an explicit link value (e.g. tunnel.listen_port). Skip default application when validating interfaces; treat _default as satisfying _required when defaults are deferred.

Fixes #3703 