### PR TITLE
Bugfix: Wireguard tunnel mtu calculation for devices with a default node MTU

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -412,7 +412,7 @@ links:
   mtu: 1500
 ```
 
-[^TMTU]: Tunnel interfaces are excluded. Tunnel interface MTU is the responsibility of tunnel plugins (for example, WireGuard derives it from the underlay MTU minus encapsulation overhead).
+[^TMTU]: Excluding tunnel interfaces
 
 When the node **mtu** parameter is not specified, its default value is fetched from **defaults.interfaces.mtu** or **defaults.devices** setting.
 

--- a/docs/links.md
+++ b/docs/links.md
@@ -398,7 +398,7 @@ links:
 
 ### Node MTU
 
-**mtu** parameter specified on a node is applied to all node interfaces without MTU set through a link or interface parameter. In the following example, r1 has **mtu** set to 1500 bytes on the inter-router link and to **8192** bytes on the stub link:
+**mtu** parameter specified on a node is applied to all[^TMTU] node interfaces without MTU set through a link or interface parameter. In the following example, r1 has **mtu** set to 1500 bytes on the inter-router link and to **8192** bytes on the stub link:
 
 ```
 nodes:
@@ -411,6 +411,8 @@ links:
   r2:
   mtu: 1500
 ```
+
+[^TMTU]: Tunnel interfaces are excluded. Tunnel interface MTU is the responsibility of tunnel plugins (for example, WireGuard derives it from the underlay MTU minus encapsulation overhead).
 
 When the node **mtu** parameter is not specified, its default value is fetched from **defaults.interfaces.mtu** or **defaults.devices** setting.
 

--- a/docs/links.md
+++ b/docs/links.md
@@ -412,7 +412,7 @@ links:
   mtu: 1500
 ```
 
-[^TMTU]: Excluding tunnel interfaces
+[^TMTU]: Excluding tunnel and loopback interfaces
 
 When the node **mtu** parameter is not specified, its default value is fetched from **defaults.interfaces.mtu** or **defaults.devices** setting.
 

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -418,13 +418,7 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
 
   # Handle interface/node/system MTU.
   #
-  # Design assumption: tunnel interface MTU is the responsibility of tunnel
-  # plugins (they typically derive it from underlay MTU minus encapsulation
-  # overhead). Do not copy node/device default MTU onto tunnel interfaces, or
-  # plugins that only set MTU when it is absent will skip their derivation
-  # (see #3702). Explicit link/interface mtu on a tunnel is kept as-is.
-  #
-  if node.get('mtu',None):                      # Is node-level MTU defined (node setting, lab default or device default)
+  if node.get('mtu',None):                      # Is node-level MTU defined (node setting,lab default or device default)
     sys_mtu = devices.get_device_features(node,defaults).initial.get('system_mtu',False)
     if 'mtu' in ifdata:                         # Is MTU defined on the interface?
       if sys_mtu and node.mtu == ifdata.mtu:    # .. is it equal to node MTU?

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -416,6 +416,14 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
     if af in ifdata and not ifdata[af]:
       del ifdata[af]
 
+  # Handle interface/node/system MTU.
+  #
+  # Design assumption: tunnel interface MTU is the responsibility of tunnel
+  # plugins (they typically derive it from underlay MTU minus encapsulation
+  # overhead). Do not copy node/device default MTU onto tunnel interfaces, or
+  # plugins that only set MTU when it is absent will skip their derivation
+  # (see #3702). Explicit link/interface mtu on a tunnel is kept as-is.
+  #
   if node.get('mtu',None):                      # Is node-level MTU defined (node setting, lab default or device default)
     sys_mtu = devices.get_device_features(node,defaults).initial.get('system_mtu',False)
     if 'mtu' in ifdata:                         # Is MTU defined on the interface?
@@ -423,7 +431,8 @@ def add_node_interface(node: Box, ifdata: Box, defaults: Box) -> Box:
         ifdata.pop('mtu',None)                  # .... remove interface MTU on devices that support system MTU
     else:                                       # Node MTU is defined, interface MTU is not
       if not sys_mtu:                           # .. does the device support system MTU?
-        ifdata.mtu = node.mtu                   # .... no, copy node MTU to interface MTU
+        if ifdata.get('type',None) != 'tunnel': # .... tunnels: plugin sets MTU
+          ifdata.mtu = node.mtu                 # .... no, copy node MTU to interface MTU
 
   if ifdata.get('type',None) == 'loopback':
     ifdata.pop('mtu',None)                      # Remove MTU from loopback interfaces

--- a/tests/coverage/expected/wg-listen-port.yml
+++ b/tests/coverage/expected/wg-listen-port.yml
@@ -72,7 +72,7 @@ nodes:
       ifname: tun0
       ipv4: 10.1.0.5/30
       linkindex: 2
-      mtu: 1500
+      mtu: 1440
       name: dut -> r2 [WireGuard tunnel]
       neighbors:
       - ifname: tun0
@@ -140,7 +140,7 @@ nodes:
       ifname: tun0
       ipv4: 10.1.0.6/30
       linkindex: 2
-      mtu: 1500
+      mtu: 1440
       name: r2 -> dut [WireGuard tunnel]
       neighbors:
       - ifname: tun0


### PR DESCRIPTION
WireGuard derives tunnel MTU from the underlay (source MTU minus encapsulation overhead) only when the tunnel interface has no mtu yet. Core augmentation was copying node/device defaults (e.g. FRR’s mtu: 1500) onto every interface without an explicit MTU, including tunnels. That made an inherited default look like a user-set value, so derivation was skipped on FRR while RouterOS7 (no device MTU default) correctly computed underlay − overhead — peers disagreed by 20–60 bytes (#3702).

Skipping that copy for type: tunnel keeps tunnel MTU ownership with the tunnel plugins, matches how loopbacks already avoid inherited MTU, and still honors an explicit link/interface mtu on the tunnel provided by the user.