### PR TITLE
Containerlab podman support

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -277,17 +277,25 @@ The **netlab_check_retries** parameter is set higher in system defaults for virt
 
 ## Advanced Topics
 
-### Container Runtime Support
+### Podman Support
 
-Containerlab supports [multiple container runtimes](https://containerlab.dev/cmd/deploy/#runtime) besides the default **docker**. The runtime to use can be configured globally or per node, for example:
+Containerlab supports [**docker** and **podman** containers](https://containerlab.dev/cmd/deploy/#runtime). You can specify the **podman** runtime with the **providers.clab.runtime** [topology default](topo-defaults), for example:
 
 ```
 provider: clab
 defaults.providers.clab.runtime: podman
-nodes:
-  s1:
-    clab.runtime: ignite
 ```
+
+```{warning}
+* The _containerlab_ podman support is experimental. Don't expect miracles.
+* Because *containerlab* runs as **root**, the *podman* containers it creates are not visible to regular users. To use the **podman** runtime, you MUST run **netlab** as **root**.
+```
+
+To use `podman` runtime with `clab` provider, use the **netlab install podman** command on Ubuntu/Debian to install _podman_ and _containerlab_. On other Linux distributions, ensure that:
+
+* You've enabled the _podman_ API
+* The _podman_ management socket is available
+* The _podman_ Docker compatibility package (usually `podman-docker`) is installed (the **docker** command must be available).
 
 (lab-clab-binds)=
 ### Using File Binds

--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -289,6 +289,7 @@ defaults.providers.clab.runtime: podman
 ```{warning}
 * The _containerlab_ podman support is experimental. Don't expect miracles.
 * Because *containerlab* runs as **root**, the *podman* containers it creates are not visible to regular users. To use the **podman** runtime, you MUST run **netlab** as **root**.
+* We tested the basic *podman-with-containerlab* functionality on Ubuntu 26.04. We did not test advanced features like multi-provider labs.
 ```
 
 To use `podman` runtime with `clab` provider, use the **netlab install podman** command on Ubuntu/Debian to install _podman_ and _containerlab_. On other Linux distributions, ensure that:

--- a/docs/netlab/install.md
+++ b/docs/netlab/install.md
@@ -45,6 +45,7 @@ Ubuntu 26.04 introduced Hardware Enablement (`-hwe`) version of `qemu-system-x86
 * The *ansible* script uses **pip3** to install the latest version of Ansible, networking libraries (*netaddr, paramiko, netmiko*), text parsing libraries (*testfsm, ttp, ntc-templates*), and a few other utility libraries (*jmespath, yamllint, yq*)
 * The *graph* script installs GraphViz and D2 software needed to generate graphs from _netlab_ topologies
 * The *grpc* script installs gRPC Python libraries needed to configure Nokia SR Linux and Nokia SR OS.
+* The *podman* script installs *podman*, its Docker-compatible CLI, and *containerlab*.
 
 [^UT]: Tested on Ubuntu 22.04, 24.04, and 26.04
 
@@ -63,6 +64,7 @@ $ netlab install
 │ ansible      │ Ansible and prerequisite Python libraries         │
 │ grpc         │ GRPC libraries and Nokia GRPC Ansible collection  │
 │ graph        │ GraphViz and D2 software                          │
+│ podman       │ Podman and containerlab                           │
 └──────────────┴───────────────────────────────────────────────────┘
 ```
 

--- a/docs/netlab/test.md
+++ b/docs/netlab/test.md
@@ -11,7 +11,7 @@ usage: netlab test [-h] [-w WORKDIR] [-v] {clab,grpc,libvirt}
 Test virtual lab installation
 
 positional arguments:
-  {clab,grpc,libvirt}
+  {clab,grpc,libvirt,podman}
                         Run tests for the specified provider/environment
 
 options:
@@ -21,17 +21,21 @@ options:
   -v, --verbose         Verbose logging
 ```
 
+You can execute these tests:
+
+| Name | Tests |
+|------|---------------|
+| clab | Docker and containerlab using FRR Docker containers |
+| grpc | Docker, containerlab, and gRPC libraries using SR Linux Docker containers |
+| libvirt | Vagrant and libvirt using Linux virtual machines |
+| podman | Podman and containerlab using FRR podman containers |
+
 ## Testing Procedure
 
 **netlab test** command:
 
-* Checks whether the selected virtualization provider and Vagrant are installed;
-* Creates a working directory and copies sample lab topology containing three routers and a few links into that directory;
+* Checks whether the selected virtualization provider is installed;
+* Creates a working directory and copies the sample lab topology containing three routers and a few links into that directory;
 * Executes **netlab up** to create configuration files, start the lab, and configure network devices.
 * Destroys the lab with **netlab down**
 * Cleans up the working directory
-
-## Notes on Containerlab Tests
-
-* *containerlab* tests start Cumulus VX containers in *Docker* mode (container, not a micro-VM) and thus test the *containerlab* but not *firecracker* or *KVM* functionality.
-* See [Platform Support](../platforms.md) for more details on Cumulus VX running under *containerlab*.

--- a/docs/netlab/test.md
+++ b/docs/netlab/test.md
@@ -6,7 +6,7 @@
 ## Usage
 
 ```text
-usage: netlab test [-h] [-w WORKDIR] [-v] {clab,grpc,libvirt}
+usage: netlab test [-h] [-w WORKDIR] [-v] {clab,grpc,libvirt,podman}
 
 Test virtual lab installation
 

--- a/netsim/cli/test.py
+++ b/netsim/cli/test.py
@@ -24,7 +24,7 @@ from . import external_commands
 def test_parse(args: typing.List[str], settings: Box) -> argparse.Namespace:
   c_path  = _files.get_traversable_path('package:templates/tests')   # Directory containing test scenarios
   c_list  = _files.get_globbed_files(c_path,'*.yml')                  # Find all test scenarios
-  choices = [ Path(fn).stem for fn in c_list ]
+  choices = sorted([ Path(fn).stem for fn in c_list ])
 
   parser = argparse.ArgumentParser(
     prog='netlab test',

--- a/netsim/install/install.yml
+++ b/netsim/install/install.yml
@@ -72,6 +72,17 @@ scripts:
       probably OK for a test server or a throwaway VM, but you might not want to
       do that on a server that is supposed to be secure.
 
+  podman:
+    description: Podman and containerlab
+    distro: [ ubuntu, debian ]
+    uses: [ apt ]
+    intro: |
+      This script installs podman and containerlab on a Debian or Ubuntu system.
+      The script was tested on Ubuntu 26.04.
+    epilog: |
+      * Log out and back in to start using netlab with containerlab
+      * Use 'netlab test clab' command to test your installation
+
 shared:
   intro: |
     The script is set to abort on first error. If the installation completes

--- a/netsim/install/podman.sh
+++ b/netsim/install/podman.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Install a specific version of Containerlab -- it's now set in 'netlab install' before calling this script
+#
+set -e
+REPLACE="--upgrade"
+IGNORE="--ignore-installed"
+#
+echo "Update the package list"
+. apt-get-update.sh
+echo "Install podman"
+$SUDO apt-get install -y podman podman-docker
+$SUDO systemctl enable --now podman.socket
+$SUDO systemctl start podman.socket
+#
+echo "Install containerlab version $CONTAINERLAB_VERSION"
+$SUDO bash "-c" "$(curl -sL https://get.containerlab.dev)" -- -v $CONTAINERLAB_VERSION

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -4,7 +4,7 @@
 description: containerlab with Docker
 config: clab.yml
 lab_prefix: "clab" # Containerlab default, set to "" to remove prefix
-node_config_special: [ binds, config_templates, image, kind, startup-config, srl-agents, runtime ]
+node_config_special: [ binds, config_templates, image, kind, startup-config, srl-agents ]
 template: clab.j2
 version: "0.75.0"       # Triple-check the exact release tag containerlab is using when changing this :(
 start: containerlab deploy --reconfigure -t clab.yml
@@ -14,7 +14,9 @@ act_title: "Running containers"
 probe:
 - cmd: "containerlab version"
   err: "Containerlab is not installed"
-- cmd: [ bash, '-c', "groups | grep -w clab_admins"]
+- cmd: "docker version"
+  err: "The docker command is not available. Did you install Docker or podman-docker?"
+- cmd: [ bash, '-c', "(groups | grep -w clab_admins) || (whoami | grep -w root)"]
   err: >-
     You are not a member of the clab_admins group.
     See https://netlab.tools/labs/clab/ for details

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -15,7 +15,9 @@ probe:
 - cmd: "containerlab version"
   err: "Containerlab is not installed"
 - cmd: "docker version"
-  err: "The docker command is not available. Did you install Docker or podman-docker?"
+  err: >-
+    Cannot run 'docker version'. Install Docker or podman-docker and
+    ensure you can access the Docker/Podman socket.
 - cmd: [ bash, '-c', "(groups | grep -w clab_admins) || (whoami | grep -w root)"]
   err: >-
     You are not a member of the clab_admins group.

--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -52,12 +52,17 @@ class Containerlab(_Provider):
 
   def pre_start_lab(self, topology: Box) -> None:
     log.print_verbose('pre-start hook for Containerlab - create any bridges and load kernel modules')
+    labops.set_clab_runtime(topology)
+
     for brname in utils.list_bridges(topology):
       if labops.use_ovs_bridge(topology):
         labops.create_ovs_bridge(brname)
       else:
         labops.create_linux_bridge(brname)
     labops.load_kmods(topology)
+
+  def pre_stop_lab(self, topology: Box) -> None:
+    labops.set_clab_runtime(topology)
 
   def post_stop_lab(self, topology: Box) -> None:
     log.print_verbose('post-stop hook for Containerlab, cleaning up any bridges')

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -154,6 +154,6 @@ def set_clab_runtime(topology: Box) -> None:
     return
 
   log.info(f'Setting containerlab runtime to {runtime}')
-  os.environ['CLAB_RUNTIME'] = runtime
-  if runtime == 'podman' and os.environ['USER'] != 'root':
+  os.environ['CLAB_RUNTIME'] = str(runtime)
+  if runtime == 'podman' and os.geteuid() != 0:
     log.fatal('You must run netlab as the root user when using podman')

--- a/netsim/providers/clab/labops.py
+++ b/netsim/providers/clab/labops.py
@@ -1,6 +1,7 @@
 #
 # Containerlab provider module
 #
+import os
 import pathlib
 
 from box import Box
@@ -146,3 +147,13 @@ def load_kmods(topology: Box) -> None:
           log.info(f'Cannot load optional Linux kernel module {load_mod}')
 
   log.exit_on_error()
+
+def set_clab_runtime(topology: Box) -> None:
+  runtime = topology.get('defaults.providers.clab.runtime',None)
+  if not runtime:
+    return
+
+  log.info(f'Setting containerlab runtime to {runtime}')
+  os.environ['CLAB_RUNTIME'] = runtime
+  if runtime == 'podman' and os.environ['USER'] != 'root':
+    log.fatal('You must run netlab as the root user when using podman')

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -39,7 +39,6 @@ topology:
 {%     endif %}
 {%   endfor %}
       image: {{ clab.image|default(n.box) }}
-      runtime: {{ clab.runtime|default(defaults.providers.clab.runtime) }}
 {%   if groups is defined %}
       group: {% for g in groups if n.name in groups[g].members %}{{'' if loop.first else ','}}{{g}}{% endfor +%}
 {%   endif %}

--- a/netsim/templates/tests/podman.yml
+++ b/netsim/templates/tests/podman.yml
@@ -1,0 +1,18 @@
+#
+# Simple clab lab using three FRR containers
+#
+---
+defaults:
+  device: frr
+  providers.clab.runtime: podman
+
+provider: clab
+
+module: [ ospf ]
+
+nodes:
+  s1:
+  s2:
+  s3:
+
+links: [ s1-s2, s2-s3, s1-s2-s3 ]


### PR DESCRIPTION
Core functionality:
* Remove 'runtime' from the list of special clab attributes
* Do not generate node 'runtime' attribute in clab.yml from the provider defaults
* Check whether the 'docker' command is available and whether the user runs clab as root (mandatory for podman)
* Set CLAB_RUNTIME environment variable to tell containerlab to use podman (otherwise it crashes even if all nodes use podman)

Support functionality:
* Add podman installation script and post-install test
* Documentation (defaults, installation, caveats)
* Updated 'netlab test' and 'netlab install' docs

Also:
* Sort tests displayed in 'netlab test' to put 'podman' at the very end (sometimes we get lucky ;)
* Removed references to Cumulus VX test environment