### PR TITLE
Docs: Require commit subjects to be at most 72 characters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,7 @@ When you don't have to change the code for other reasons:
 - All YAML must pass `yamllint`
 - Tests must pass before merging
 - No unused imports or variables (ruff enforces)
+- Commit subject lines must be ≤72 characters
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Document the 72-character commit subject limit in `AGENTS.md` Quality Gates

## Test plan
- [ ] Confirm the new Quality Gates bullet is visible in `AGENTS.md`


Made with [Cursor](https://cursor.com)