### PR TITLE
Bugfix: Allocate unique wireguard udp port per tunnel

### DIFF
--- a/docs/plugins/tunnel.wireguard.md
+++ b/docs/plugins/tunnel.wireguard.md
@@ -32,7 +32,7 @@ The link/interface parameters supported by this plugin include:
 
 * **tunnel.private_key** (base64 string) -- this node's WireGuard private key (auto-generated when missing)
 * **tunnel.public_key** (base64 string) -- this node's WireGuard public key (derived or auto-generated when missing)
-* **tunnel.listen_port** (integer, 1-65535) -- UDP listen port (default: `51820`)
+* **tunnel.listen_port** (integer, 1-65535) -- UDP listen port. When omitted, the plugin allocates a unique port per tunnel on each node, starting at `51820`
 * **tunnel.allowed_ips** (prefix string) -- the peer's WireGuard [allowed IPs](plugin-tunnel-wireguard-allowed-ips) (default: a default route per active address family, so `0.0.0.0/0`, `::/0`, or both `0.0.0.0/0,::/0` for a dual-stack tunnel)
 * **tunnel.persistent_keepalive** (integer) -- keepalive interval in seconds (default: `25`)
 * **mtu** (integer) -- the WireGuard tunnel interface MTU (the standard link/interface `mtu` attribute). When not specified, it is derived from the underlay source interface MTU minus the WireGuard encapsulation overhead (60 bytes for an IPv4 underlay, 80 bytes for an IPv6 underlay), so it scales with jumbo-frame underlays. With a 1500-byte underlay this yields `1440` for IPv4 transport and `1420` for IPv6 transport.
@@ -53,7 +53,7 @@ Key generation uses the **wireguard-tools** commands (`wg genkey` and `wg pubkey
 
 The remote peer's **tunnel.public_key** and UDP endpoint do not have to be specified; they are taken from the peer device attached to the same tunnel.
 
-Specify **tunnel.private_key**, **tunnel.public_key**, and **tunnel.listen_port** only when you need stable keys across lab recreations or non-default UDP ports.
+Specify **tunnel.private_key**, **tunnel.public_key**, and **tunnel.listen_port** only when you need stable keys across lab recreations or a specific UDP port. When **tunnel.listen_port** is omitted, each tunnel on a node gets a unique port starting at `51820`.
 
 (plugin-tunnel-wireguard-allowed-ips)=
 ## Allowed IPs

--- a/docs/plugins/tunnel.wireguard.md
+++ b/docs/plugins/tunnel.wireguard.md
@@ -32,13 +32,15 @@ The link/interface parameters supported by this plugin include:
 
 * **tunnel.private_key** (base64 string) -- this node's WireGuard private key (auto-generated when missing)
 * **tunnel.public_key** (base64 string) -- this node's WireGuard public key (derived or auto-generated when missing)
-* **tunnel.listen_port** (integer, 1-65535) -- UDP listen port. When omitted, the plugin allocates a unique port per tunnel on each node, starting at `51820`
+* **tunnel.listen_port** (integer, 1-65535) -- UDP listen port. When omitted, the plugin allocates a unique port per tunnel on each node, starting at `51820`[^CPD]
 * **tunnel.allowed_ips** (prefix string) -- the peer's WireGuard [allowed IPs](plugin-tunnel-wireguard-allowed-ips) (default: a default route per active address family, so `0.0.0.0/0`, `::/0`, or both `0.0.0.0/0,::/0` for a dual-stack tunnel)
 * **tunnel.persistent_keepalive** (integer) -- keepalive interval in seconds (default: `25`)
 * **mtu** (integer) -- the WireGuard tunnel interface MTU (the standard link/interface `mtu` attribute). When not specified, it is derived from the underlay source interface MTU minus the WireGuard encapsulation overhead (60 bytes for an IPv4 underlay, 80 bytes for an IPv6 underlay), so it scales with jumbo-frame underlays. With a 1500-byte underlay this yields `1440` for IPv4 transport and `1420` for IPv6 transport.
 * **tunnel.af** (`ipv4` or `ipv6`) -- the transport address family. When not specified, it is inferred from the underlay source interface: `ipv4` when an IPv4 address is available, `ipv6` for an IPv6-only underlay.
 * **tunnel.vrf** (VRF name) -- the transport VRF (default: global routing table)
 * **tunnel.source** -- the [source interface](plugin-tunnel-wireguard-source) for the tunnel underlay
+
+[^CPD]: The starting UDP port can be changed in plugin defaults.
 
 (plugin-tunnel-wireguard-keys)=
 ## WireGuard Keys
@@ -53,7 +55,7 @@ Key generation uses the **wireguard-tools** commands (`wg genkey` and `wg pubkey
 
 The remote peer's **tunnel.public_key** and UDP endpoint do not have to be specified; they are taken from the peer device attached to the same tunnel.
 
-Specify **tunnel.private_key**, **tunnel.public_key**, and **tunnel.listen_port** only when you need stable keys across lab recreations or a specific UDP port. When **tunnel.listen_port** is omitted, each tunnel on a node gets a unique port starting at `51820`.
+Specify **tunnel.private_key**, **tunnel.public_key**, and **tunnel.listen_port** only when you need stable keys across lab recreations or a specific UDP port. When **tunnel.listen_port** is omitted, each tunnel on a node gets a unique port starting at `51820`[^CPD].
 
 (plugin-tunnel-wireguard-allowed-ips)=
 ## Allowed IPs

--- a/netsim/extra/tunnel/wireguard/__init__.py
+++ b/netsim/extra/tunnel/wireguard/__init__.py
@@ -5,12 +5,13 @@ from box import Box
 from netsim.augment import devices
 from netsim.augment import links as _links
 from netsim.data import get_box
+from netsim.extra import tunnel as _tunnel
+from netsim.extra.tunnel import _p2p
+from netsim.modules import _dataplane
 from netsim.utils import log
 
-from ... import tunnel as _tunnel
-from .. import _p2p
-
 _config_name = 'tunnel.wireguard'
+_WG_LISTEN_PORT_BASE = 51820   # First UDP listen port allocated to WireGuard tunnels
 
 def public_key_from_private(private_key: str) -> str:
   '''
@@ -96,6 +97,37 @@ def add_linux_packages(node: Box, topology: Box) -> None:
   packages['wireguard-tools'] = 'wg'
   node.netlab_linux_packages = packages
 
+def allocate_listen_ports(ndata: Box, topology: Box) -> None:
+  '''
+  Assign a unique UDP listen port to every WireGuard tunnel on the node.
+
+  User-specified ports are kept. Unspecified ports get the next free value
+  starting at _WG_LISTEN_PORT_BASE. Duplicate user-specified ports on the same
+  node are reported as errors (Linux cannot bind multiple WireGuard sockets to
+  the same UDP port).
+  '''
+  id_set = f'wg_listen_port_{ndata.name}'
+  _dataplane.create_id_set(id_set)
+
+  pending: list[Box] = []
+  for intf in _tunnel.interfaces(ndata,'wireguard'):
+    port = intf.tunnel.get('listen_port',None)
+    if port is None:
+      pending.append(intf)
+      continue
+    if _dataplane.is_id_used(id_set,port):
+      log.error(
+        f'Duplicate tunnel.listen_port {port} on node {ndata.name} interface {intf.ifname}',
+        more_data='Each WireGuard tunnel on a node needs a unique UDP listen port',
+        category=log.IncorrectValue,
+        module='tunnel.wireguard')
+    _dataplane.extend_id_set(id_set,{port})
+
+  max_port = topology.defaults.attributes.link.tunnel.listen_port.max_value
+  _dataplane.set_id_counter(id_set,_WG_LISTEN_PORT_BASE,max_port)
+  for intf in pending:
+    intf.tunnel.listen_port = _dataplane.get_next_id(id_set)
+
 def wireguard_intf_defaults(ndata: Box, intf: Box, topology: Box) -> bool:
   '''
   Set WireGuard-specific interface defaults after tunnel._source is known
@@ -153,6 +185,7 @@ def post_transform(topology: Box) -> None:
 
   for node in node_iflist:
     ndata = topology.nodes[node]
+    allocate_listen_ports(ndata,topology)
     for intf in _tunnel.interfaces(ndata,'wireguard'):
       if 'wireguard-tools' not in ndata.netlab_linux_packages:
         add_linux_packages(ndata,topology)

--- a/netsim/extra/tunnel/wireguard/__init__.py
+++ b/netsim/extra/tunnel/wireguard/__init__.py
@@ -11,7 +11,6 @@ from netsim.modules import _dataplane
 from netsim.utils import log
 
 _config_name = 'tunnel.wireguard'
-_WG_LISTEN_PORT_BASE = 51820   # First UDP listen port allocated to WireGuard tunnels
 
 def public_key_from_private(private_key: str) -> str:
   '''
@@ -102,7 +101,7 @@ def allocate_listen_ports(ndata: Box, topology: Box) -> None:
   Assign a unique UDP listen port to every WireGuard tunnel on the node.
 
   User-specified ports are kept. Unspecified ports get the next free value
-  starting at _WG_LISTEN_PORT_BASE. Duplicate user-specified ports on the same
+  starting at listen_port._start. Duplicate user-specified ports on the same
   node are reported as errors (Linux cannot bind multiple WireGuard sockets to
   the same UDP port).
   '''
@@ -123,8 +122,8 @@ def allocate_listen_ports(ndata: Box, topology: Box) -> None:
         module='tunnel.wireguard')
     _dataplane.extend_id_set(id_set,{port})
 
-  max_port = topology.defaults.attributes.link.tunnel.listen_port.max_value
-  _dataplane.set_id_counter(id_set,_WG_LISTEN_PORT_BASE,max_port)
+  listen_port = topology.defaults.attributes.link.tunnel.listen_port
+  _dataplane.set_id_counter(id_set,listen_port._start,listen_port.max_value)
   for intf in pending:
     intf.tunnel.listen_port = _dataplane.get_next_id(id_set)
 

--- a/netsim/extra/tunnel/wireguard/defaults.yml
+++ b/netsim/extra/tunnel/wireguard/defaults.yml
@@ -20,6 +20,7 @@ attributes:
         type: int             # Default allocated in Python (unique per tunnel instance)
         min_value: 1
         max_value: 65535
+        _start: 51820         # First UDP listen port allocated to WireGuard tunnels
       allowed_ips:            # Allowed IPs for the remote peer
         type: str
       persistent_keepalive:   # Keepalive interval in seconds

--- a/netsim/extra/tunnel/wireguard/defaults.yml
+++ b/netsim/extra/tunnel/wireguard/defaults.yml
@@ -17,10 +17,9 @@ attributes:
       public_key:             # WireGuard public key (derived or auto-generated when missing)
         type: str
       listen_port:            # UDP port used to accept WireGuard connections
-        type: int
+        type: int             # Default allocated in Python (unique per tunnel instance)
         min_value: 1
         max_value: 65535
-        _default: 51820
       allowed_ips:            # Allowed IPs for the remote peer
         type: str
       persistent_keepalive:   # Keepalive interval in seconds

--- a/tests/coverage/expected/wg-listen-port.yml
+++ b/tests/coverage/expected/wg-listen-port.yml
@@ -43,7 +43,7 @@ links:
     mode: wireguard
     persistent_keepalive: 25
   type: tunnel
-message: 'Link-level WireGuard tunnel.listen_port overrides the schema default
+message: 'Link-level WireGuard tunnel.listen_port is preserved on both peers
 
   '
 name: input

--- a/tests/coverage/expected/wg-unique-ports.yml
+++ b/tests/coverage/expected/wg-unique-ports.yml
@@ -105,7 +105,7 @@ nodes:
       ifname: tun0
       ipv4: 10.1.0.1/30
       linkindex: 2
-      mtu: 1500
+      mtu: 1440
       name: dut -> r2 [WireGuard tunnel]
       neighbors:
       - ifname: tun0
@@ -137,7 +137,7 @@ nodes:
       ifname: tun1
       ipv4: 10.1.0.5/30
       linkindex: 3
-      mtu: 1500
+      mtu: 1440
       name: dut -> r3 [WireGuard tunnel]
       neighbors:
       - ifname: tun0
@@ -209,7 +209,7 @@ nodes:
       ifname: tun0
       ipv4: 10.1.0.2/30
       linkindex: 2
-      mtu: 1500
+      mtu: 1440
       name: r2 -> dut [WireGuard tunnel]
       neighbors:
       - ifname: tun0
@@ -281,7 +281,7 @@ nodes:
       ifname: tun0
       ipv4: 10.1.0.6/30
       linkindex: 3
-      mtu: 1500
+      mtu: 1440
       name: r3 -> dut [WireGuard tunnel]
       neighbors:
       - ifname: tun1

--- a/tests/coverage/expected/wg-unique-ports.yml
+++ b/tests/coverage/expected/wg-unique-ports.yml
@@ -1,0 +1,330 @@
+input:
+- coverage/input/wg-unique-ports.yml
+- package:topology-defaults.yml
+links:
+- _linkname: links[1]
+  bridge: input_1
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.1/24
+    node: dut
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.2/24
+    node: r2
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: r3
+  linkindex: 1
+  node_count: 3
+  prefix:
+    ipv4: 172.16.0.0/24
+  type: lan
+- _linkname: links[2]
+  bridge: input_2
+  interfaces:
+  - ifindex: 20000
+    ifname: tun0
+    ipv4: 10.1.0.1/30
+    node: dut
+    tunnel:
+      private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+      public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  - ifindex: 20000
+    ifname: tun0
+    ipv4: 10.1.0.2/30
+    node: r2
+    tunnel:
+      private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+      public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  linkindex: 2
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  tunnel:
+    mode: wireguard
+    persistent_keepalive: 25
+  type: tunnel
+- _linkname: links[3]
+  bridge: input_3
+  interfaces:
+  - ifindex: 20001
+    ifname: tun1
+    ipv4: 10.1.0.5/30
+    node: dut
+    tunnel:
+      private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+      public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  - ifindex: 20000
+    ifname: tun0
+    ipv4: 10.1.0.6/30
+    node: r3
+    tunnel:
+      private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+      public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  linkindex: 3
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.4/30
+  tunnel:
+    mode: wireguard
+    persistent_keepalive: 25
+  type: tunnel
+message: 'Multiple WireGuard tunnels on a node get unique UDP listen ports
+
+  '
+name: input
+nodes:
+  dut:
+    af:
+      ipv4: true
+    box: debian/bookworm64
+    config:
+    - tunnel.wireguard
+    device: frr
+    id: 1
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.1/24
+      linkindex: 1
+      mtu: 1500
+      name: dut -> [r2,r3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: r2
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: r3
+      type: lan
+    - ifindex: 20000
+      ifname: tun0
+      ipv4: 10.1.0.1/30
+      linkindex: 2
+      mtu: 1500
+      name: dut -> r2 [WireGuard tunnel]
+      neighbors:
+      - ifname: tun0
+        ipv4: 10.1.0.2/30
+        node: r2
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 172.16.0.2
+          listen_port: 51820
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        _source:
+          ifname: eth1
+          ipv4: 172.16.0.1
+          listen_port: 51820
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 51820
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+        public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+      type: tunnel
+      virtual_interface: true
+    - ifindex: 20001
+      ifname: tun1
+      ipv4: 10.1.0.5/30
+      linkindex: 3
+      mtu: 1500
+      name: dut -> r3 [WireGuard tunnel]
+      neighbors:
+      - ifname: tun0
+        ipv4: 10.1.0.6/30
+        node: r3
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 172.16.0.3
+          listen_port: 51820
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        _source:
+          ifname: eth1
+          ipv4: 172.16.0.1
+          listen_port: 51821
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 51821
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+        public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+      type: tunnel
+      virtual_interface: true
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    mtu: 1500
+    name: dut
+    netlab_linux_packages:
+      wireguard-tools: wg
+    role: router
+  r2:
+    af:
+      ipv4: true
+    box: debian/bookworm64
+    config:
+    - tunnel.wireguard
+    device: frr
+    id: 2
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.2/24
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> [dut,r3]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: dut
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: r3
+      type: lan
+    - ifindex: 20000
+      ifname: tun0
+      ipv4: 10.1.0.2/30
+      linkindex: 2
+      mtu: 1500
+      name: r2 -> dut [WireGuard tunnel]
+      neighbors:
+      - ifname: tun0
+        ipv4: 10.1.0.1/30
+        node: dut
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 172.16.0.1
+          listen_port: 51820
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        _source:
+          ifname: eth1
+          ipv4: 172.16.0.2
+          listen_port: 51820
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 51820
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+        public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+      type: tunnel
+      virtual_interface: true
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    mtu: 1500
+    name: r2
+    netlab_linux_packages:
+      wireguard-tools: wg
+    role: router
+  r3:
+    af:
+      ipv4: true
+    box: debian/bookworm64
+    config:
+    - tunnel.wireguard
+    device: frr
+    id: 3
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 1
+      mtu: 1500
+      name: r3 -> [dut,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.1/24
+        node: dut
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: r2
+      type: lan
+    - ifindex: 20000
+      ifname: tun0
+      ipv4: 10.1.0.6/30
+      linkindex: 3
+      mtu: 1500
+      name: r3 -> dut [WireGuard tunnel]
+      neighbors:
+      - ifname: tun1
+        ipv4: 10.1.0.5/30
+        node: dut
+      tunnel:
+        _destination:
+          ifname: eth1
+          ipv4: 172.16.0.1
+          listen_port: 51821
+          mtu: 1500
+          public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+        _source:
+          ifname: eth1
+          ipv4: 172.16.0.3
+          listen_port: 51820
+          mtu: 1500
+          public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+        af: ipv4
+        allowed_ips: 0.0.0.0/0
+        listen_port: 51820
+        mode: wireguard
+        persistent_keepalive: 25
+        private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+        public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+      type: tunnel
+      virtual_interface: true
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.3/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: ca:fe:00:03:00:00
+    mtu: 1500
+    name: r3
+    netlab_linux_packages:
+      wireguard-tools: wg
+    role: router
+plugin:
+- tunnel.wireguard
+provider: libvirt

--- a/tests/coverage/input/wg-listen-port.yml
+++ b/tests/coverage/input/wg-listen-port.yml
@@ -1,8 +1,8 @@
 ---
 # Regression test for #3703: link-level tunnel.listen_port must not be
-# shadowed by the schema _default applied during interface validation.
+# overwritten when applying interface defaults.
 message: |
-  Link-level WireGuard tunnel.listen_port overrides the schema default
+  Link-level WireGuard tunnel.listen_port is preserved on both peers
 
 plugin: [ tunnel.wireguard ]
 defaults.device: frr

--- a/tests/coverage/input/wg-unique-ports.yml
+++ b/tests/coverage/input/wg-unique-ports.yml
@@ -1,0 +1,32 @@
+---
+# Regression test for #3706: multiple WireGuard tunnels on one node must
+# get unique UDP listen ports (Linux cannot bind them all to 51820).
+message: |
+  Multiple WireGuard tunnels on a node get unique UDP listen ports
+
+plugin: [ tunnel.wireguard ]
+defaults.device: frr
+
+nodes:
+  dut:
+  r2:
+  r3:
+
+links:
+- dut:
+  r2:
+  r3:
+- dut:
+    tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+    tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  r2:
+    tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+    tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  tunnel.mode: wireguard
+- dut:
+    tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+    tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  r3:
+    tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+    tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  tunnel.mode: wireguard

--- a/tests/integration/tunnel/11-wireguard.yml
+++ b/tests/integration/tunnel/11-wireguard.yml
@@ -24,9 +24,9 @@ groups:
   probes:
     device: frr
     provider: clab
-    members: [ core, r2 ]
+    members: [ core, r2, r3 ]
   ce:
-    members: [ dut, r2 ]
+    members: [ dut, r2, r3 ]
     routing.static:
     - pool: core
       nexthop.node: core
@@ -39,6 +39,7 @@ ospf.timers.dead: 3
 nodes:
   dut:
   r2:
+  r3:
   core:
     module: []
 
@@ -48,12 +49,20 @@ links:
   role: core
   pool: core
   mtu: 1560
-  members: [ dut-core, core-r2 ]
+  members: [ dut-core, core-r2, core-r3 ]
 
 - dut:
     tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
     tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
   r2:
+    tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
+    tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
+  tunnel.mode: wireguard
+  tunnel.source.link.role: core
+- dut:
+    tunnel.private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
+    tunnel.public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
+  r3:
     tunnel.private_key: XasIfmJKikt54X+Lg4AO5m87sSkmGLb9HC+LJ/+I4Os=
     tunnel.public_key: 3p7bfXt9wbTTW2HC7OQ1Nz+DQ8hbeGdNrfx+FG+IK08=
   tunnel.mode: wireguard
@@ -70,38 +79,49 @@ validate:
     description: Check OSPFv2 adjacencies with DUT
     wait: ospfv2_adj_p2p
     wait_msg: Waiting for OSPF adjacency process to complete
-    nodes: [ r2 ]
+    nodes: [ r2, r3 ]
     plugin: ospf_neighbor(nodes.dut.ospf.router_id)
   adj6:
     description: Check OSPFv3 adjacencies with DUT
     wait: ospfv3_adj_p2p
     wait_msg: Waiting for OSPFv3 adjacency process to complete
-    nodes: [ r2 ]
+    nodes: [ r2, r3 ]
     plugin: ospf6_neighbor(nodes.dut.ospf.router_id)
   pfx:
     description: Check for DUT IPv4 loopback prefix being propagated to R2
     wait: ospfv2_spf_long
     wait_msg: Waiting for SPF to do its magic
-    nodes: [ r2 ]
+    nodes: [ r2, r3 ]
     plugin: ospf_prefix(nodes.dut.loopback.ipv4)
   pfx6:
     description: Check for DUT IPv6 loopback prefix being propagated to R2
     wait: ospfv3_spf_long
     wait_msg: Waiting for SPF to do its magic
-    nodes: [ r2 ]
+    nodes: [ r2, r3 ]
     plugin: ospf6_prefix(nodes.dut.loopback.ipv6)
   ping:
+    description: Check IPv4 connectivity over tunnel
+    wait: ping
+    wait_msg: Still waiting for SPF...
+    nodes: [ r2, r3 ]
+    plugin: ping(nodes.dut.loopback.ipv4)
+  ping6:
+    description: Check IPv6 connectivity over tunnel
+    wait: ping
+    nodes: [ r2, r3 ]
+    plugin: ping(nodes.dut.loopback.ipv6,af='ipv6')
+  mtu:
+    description: Check a full 1500-byte packet traverses the tunnel (underlay MTU 1560)
+    nodes: [ r2, r3 ]
+    plugin: ping(nodes.dut.loopback.ipv4,pkt_len=1500)
+  x_ping:
     description: Check end-to-end IPv4 connectivity
     wait: ping
     wait_msg: Still waiting for SPF...
     nodes: [ r2 ]
-    plugin: ping(nodes.dut.loopback.ipv4)
-  ping6:
+    plugin: ping(nodes.r3.loopback.ipv4)
+  x_ping6:
     description: Check end-to-end IPv6 connectivity
     wait: ping
     nodes: [ r2 ]
-    plugin: ping(nodes.dut.loopback.ipv6,af='ipv6')
-  mtu:
-    description: Check a full 1500-byte packet traverses the tunnel (underlay MTU 1560)
-    nodes: [ r2 ]
-    plugin: ping(nodes.dut.loopback.ipv4,pkt_len=1500)
+    plugin: ping(nodes.r3.loopback.ipv6,af='ipv6')


### PR DESCRIPTION
Fixes #3706

Defines ```_start``` in ```defaults.yml``` such that users can override if desired