### PR TITLE
Cleanup DNS client implementation

### DIFF
--- a/netsim/ansible/templates/initial/eos.j2
+++ b/netsim/ansible/templates/initial/eos.j2
@@ -19,7 +19,7 @@ no ipv6 unicast-routing
 {% include 'eos.vrf.j2' %}
 {% endif %}
 !
-{% if services.dns.ipv4 is not defined and services.dns.ipv6 is not defined %}
+{% if services.dns._no_hosts is not defined %}
 {%     for hname,hdata in hosts.items() if 'ipv4' in hdata and hname != inventory_hostname %}
 ip host {{ hname|replace('_','') }} {{ hdata.ipv4|join (' ') }}
 {%     endfor %}

--- a/netsim/ansible/templates/initial/ios.j2
+++ b/netsim/ansible/templates/initial/ios.j2
@@ -8,7 +8,7 @@ logging buffered 256000
 !
 lldp run
 !
-{% if services.dns.ipv4 is not defined and services.dns.ipv6 is not defined %}
+{% if services.dns._no_hosts is not defined %}
 {%   for hname,hdata in hosts.items() if hname != inventory_hostname %}
 {%     set ipv6_addr = hdata.ipv6|default([]) if netlab_device_type not in ['iosvl2','ioll2'] else [] %}
 {%     set addr_list = hdata.ipv4|default([]) + ipv6_addr %}

--- a/netsim/ansible/templates/initial/linux/resolv.j2
+++ b/netsim/ansible/templates/initial/linux/resolv.j2
@@ -7,8 +7,7 @@
     client, it's only used on the VMs if the IPv4/IPv6 DNS server is defined, so a VM will never
     try to use the Docker nameserver.
 #}
-{% set dns_srv_list = (services.dns.ipv6|default([]) + services.dns.ipv4|default([]))[:3] or ['127.0.0.11'] %}
-{% for srv_ip in dns_srv_list %}
+{% for srv_ip in services.dns._server_list|default(['127.0.0.11']) %}
 nameserver {{ srv_ip }}
 {% endfor %}
 {% if services.dns.domain|default(False) %}

--- a/netsim/ansible/templates/initial/linux/resolv.j2
+++ b/netsim/ansible/templates/initial/linux/resolv.j2
@@ -7,7 +7,7 @@
     client, it's only used on the VMs if the IPv4/IPv6 DNS server is defined, so a VM will never
     try to use the Docker nameserver.
 #}
-{% for srv_ip in services.dns._server_list|default(['127.0.0.11']) %}
+{% for srv_ip in (services.dns._server_list|default(['127.0.0.11']))[:3] %}
 nameserver {{ srv_ip }}
 {% endfor %}
 {% if services.dns.domain|default(False) %}

--- a/netsim/ansible/templates/services/eos.j2
+++ b/netsim/ansible/templates/services/eos.j2
@@ -1,11 +1,10 @@
-{% if services.dns.ipv4 is defined or services.dns.ipv6 is defined %}
+{% if services.dns._server_list is defined %}
 {#
-    Collect IPv6 and IPv4 DNS server addresses, use at most six of them
+    Define at most six DNS server addresses
 #}
-{%   set dns_srv_list = (services.dns.ipv6|default([]) + services.dns.ipv4|default([]))[:6] %}
 ip name-server {% if services.dns.transport_vrf is defined
   %}vrf {{ services.dns.transport_vrf }} {% endif
-  %}{{ dns_srv_list|join(' ') }}
+  %}{{ services.dns._server_list[:6]|join(' ') }}
 {% endif %}
 {% if services.dns.domain|default(False) %}
 ip domain-list {{ services.dns.domain }}

--- a/netsim/ansible/templates/services/frr.j2
+++ b/netsim/ansible/templates/services/frr.j2
@@ -3,7 +3,7 @@
     If the node uses a DNS client, we have to create the /etc/resolv.conf file on FRR VMs
 #}
 {% if clab is not defined %}
-{%   if services.dns.ipv4 is defined or services.dns.ipv6 is defined %}
+{%   if services.dns._server_list is defined %}
 cat <<'CONFIG' >/etc/resolv.conf
 {%     include 'initial/linux/resolv.j2' +%}
 CONFIG

--- a/netsim/ansible/templates/services/ios.j2
+++ b/netsim/ansible/templates/services/ios.j2
@@ -1,12 +1,11 @@
-{% if services.dns.ipv4 is defined or services.dns.ipv6 is defined %}
+{% if services.dns._server_list is defined %}
 {#
-    Collect IPv6 and IPv4 DNS server addresses, use at most six of them
+    Use at most six DNS server addresses
 #}
-{%   set dns_srv_list = (services.dns.ipv6|default([]) + services.dns.ipv4|default([]))[:6] %}
 ip domain lookup
 ip name-server {% if services.dns.transport_vrf is defined
   %}vrf {{ services.dns.transport_vrf }} {% endif
-  %}{{ dns_srv_list|join(' ') }}
+  %}{{ services.dns._server_list[:6]|join(' ') }}
 {% endif %}
 {% if services.dns.domain|default(False) %}
 ip domain name {{ services.dns.domain }}

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -101,7 +101,7 @@ def set_dns_fields(ndata: Box) -> None:
   dns_data = ndata.get('services.dns',{})
   if not dns_data:                                # No DNS services, nothing to do
     return
-  srv_list = dns_data.get('ipv4',[]) + dns_data.get('ipv6',[])
+  srv_list = dns_data.get('ipv6',[]) + dns_data.get('ipv4',[])
   if not srv_list:                                # No DNS servers defined
     return
   dns_data._server_list = srv_list                # Set combined IPv4/IPv6 server list field

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -94,6 +94,20 @@ def check_vrf(ndata: Box,mod_attr: Box) -> None:
         category=log.MissingDependency,
         module='services')
 
+def set_dns_fields(ndata: Box) -> None:
+  """
+  Set extra fields to simplify DNS templates
+  """
+  dns_data = ndata.get('services.dns',{})
+  if not dns_data:                                # No DNS services, nothing to do
+    return
+  srv_list = dns_data.get('ipv4',[]) + dns_data.get('ipv6',[])
+  if not srv_list:                                # No DNS servers defined
+    return
+  dns_data._server_list = srv_list                # Set combined IPv4/IPv6 server list field
+  if 'services.server.dns' not in ndata:          # Are we also a DNS server?
+    dns_data._no_hosts = True                     # Nope, we can skip the "ip host" definitions
+
 def disable_shared_hosts(ndata: Box) -> None:
   """
   Containers running a DNS client should not use shared /etc/hosts file
@@ -126,8 +140,10 @@ class Services(_Module):
       svc_data = ndata.get('services',None)
       if not svc_data:
         continue
+
       svc_nodes.append(ndata)
       resolve_servers(ndata,svc_data,topology,mod_attr,svc_cache)
+      set_dns_fields(ndata)
       disable_shared_hosts(ndata)
       check_feature_support(ndata,svc_data,topology,mod_attr)
       check_vrf(ndata,mod_attr)

--- a/netsim/templates/provider/clab/linux/hosts.j2
+++ b/netsim/templates/provider/clab/linux/hosts.j2
@@ -8,7 +8,7 @@ ff00::0	ip6-mcastprefix
 ff02::1	ip6-allnodes
 ff02::2	ip6-allrouters
 #
-{% if (services.dns.ipv4 is not defined and services.dns.ipv6 is not defined) or services.server.dns is defined %}
+{% if services.dns._no_hosts is not defined %}
 {%   if _hosts_entries is defined %}
 {{ _hosts_entries }}
 {%   else %}

--- a/tests/coverage/expected/svc-server.yml
+++ b/tests/coverage/expected/svc-server.yml
@@ -81,6 +81,10 @@ nodes:
     name: dns_c1
     services:
       dns:
+        _no_hosts: true
+        _server_list:
+        - 10.0.0.3
+        - 172.16.0.4
         domain: netlab.local
         ipv4:
         - 10.0.0.3
@@ -133,6 +137,11 @@ nodes:
     name: dns_c2
     services:
       dns:
+        _no_hosts: true
+        _server_list:
+        - 10.0.0.3
+        - 172.16.0.4
+        - 2001:db8::4
         domain: netlab.local
         ipv4:
         - 10.0.0.3
@@ -187,6 +196,10 @@ nodes:
     name: dns_s1
     services:
       dns:
+        _server_list:
+        - 10.0.0.3
+        - 172.16.0.4
+        - 2001:db8::4
         domain: netlab.local
         ipv4:
         - 10.0.0.3
@@ -236,6 +249,10 @@ nodes:
     name: dns_s2
     services:
       dns:
+        _server_list:
+        - 10.0.0.3
+        - 172.16.0.4
+        - 2001:db8::4
         domain: netlab.local
         ipv4:
         - 10.0.0.3

--- a/tests/integration/services/01-dns-client.yml
+++ b/tests/integration/services/01-dns-client.yml
@@ -8,11 +8,13 @@ message: |
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 
 nodes:
-  dut:
+  dut_dns:
     module: [ services ]
     services:
       dns.server: dnssrv
       server.dns: False
+  dut_hosts:
+    module: []
   dnssrv:
     device: dnsmasq
     provider: clab
@@ -21,11 +23,11 @@ nodes:
     device: linux
     provider: clab
 
-links: [ dut-dnssrv-t1 ]
+links: [ dut_dns-dut_hosts-dnssrv-t1 ]
 
 validate:
   ping:
-    nodes: [ dut ]
+    nodes: [ dut_dns, dut_hosts ]
     wait: ping
     wait_msg: Waiting for interfaces/DNS to wake up
     exec:
@@ -39,7 +41,7 @@ validate:
       linux: ping -c 3 t1
       frr: ping -c 3 t1
     valid: >-
-      "172.16.0.3" in stdout
+      "172.16.0.4" in stdout
   query:
     nodes: [ dnssrv ]
     devices: [ dnsmasq ]


### PR DESCRIPTION
* Define commonly-used conditions (DNS server list, no ip hosts conifg) in Python code instead of in separate jinja2 templates
* Simplify the Jinja2 initial/services/resolv configurations
* Add a second DUT node to the DNS client test to check that we haven't broken the traditional "ip hosts" implementation