### PR TITLE
Technology-specific tunnel interface names

### DIFF
--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -364,6 +364,21 @@ def create_regular_interface(node: Box, ifdata: Box, defaults: Box) -> None:
     provider = devices.get_provider(node,defaults)
     ifdata[provider] = pdata
 
+def get_device_ifname(node: Box, devtype: str, ifdata: Box, defaults: Box) -> typing.Optional[str]:
+  """
+  Get the device-specific interface name format for the specified interface type. Handle mode-specific
+  interfaces names (primarily used for tunnels).
+  """
+  iff = devices.get_device_attribute(node,f'{devtype}_interface_name',defaults)
+  if not iff or isinstance(iff,str):                        # Missing interface name format, or a simple string
+    return iff                                              # Just return it
+  if not isinstance(iff,Box):                               # Otherwise, it must be a box -- complain very loudly if needed
+    log.fatal(f'defaults.devices.{node.device}.{devtype}_interface_name has invalid value (expected string or dict), aborting')
+  if_mode = ifdata.get(f'{devtype}.mode',None)              # Try to get the iftype-specific mode (for example, tunnel.mode)
+  if not if_mode:                                           # Not set on this interface?
+    return iff.get('default',None)                          # ... return the "default" iftype-specific ifname
+  return iff.get(if_mode,iff.get('default',None))           # Otherwise try to get the correct interface name, with "default" as fallback
+
 def create_virtual_interface(node: Box, ifdata: Box, defaults: Box) -> None:
   devtype = ifdata.get('type','loopback')         # Get virtual interface type, default to loopback interface
   ifindex_offset = (
@@ -387,7 +402,7 @@ def create_virtual_interface(node: Box, ifdata: Box, defaults: Box) -> None:
   # ifindex. For example, loopback interfaces have ifindex starting with 10001, but
   # the interface names start with Loopback1
   #
-  ifname_format  = devices.get_device_attribute(node,f'{devtype}_interface_name',defaults)
+  ifname_format  = get_device_ifname(node,devtype,ifdata,defaults)
   if ifname_format:
     ifdata.ifname = strings.eval_format(ifname_format,ifdata + { 'ifindex': ifdata.ifindex - devtype_offset })
     return

--- a/netsim/augment/links.py
+++ b/netsim/augment/links.py
@@ -370,7 +370,7 @@ def get_device_ifname(node: Box, devtype: str, ifdata: Box, defaults: Box) -> ty
   interfaces names (primarily used for tunnels).
   """
   iff = devices.get_device_attribute(node,f'{devtype}_interface_name',defaults)
-  if not iff or isinstance(iff,str):                        # Missing interface name format, or a simple string
+  if iff is None or isinstance(iff,str):                    # Missing interface name format, or a simple string
     return iff                                              # Just return it
   if not isinstance(iff,Box):                               # Otherwise, it must be a box -- complain very loudly if needed
     log.fatal(f'defaults.devices.{node.device}.{devtype}_interface_name has invalid value (expected string or dict), aborting')

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -3,7 +3,10 @@ description: FRR container
 interface_name: eth{ifindex}
 mgmt_if: eth0
 loopback_interface_name: lo{ifindex if ifindex else ""}
-tunnel_interface_name: "tun{ifindex}"
+tunnel_interface_name:
+  gre: "gre{ifindex + 1}"
+  wireguard: "wg{ifindex}"
+  default: "tun{ifindex}"
 lag_interface_name: "bond{lag.ifindex}"
 role: router
 routing:

--- a/tests/coverage/expected/wg-listen-port.yml
+++ b/tests/coverage/expected/wg-listen-port.yml
@@ -21,14 +21,14 @@ links:
   bridge: input_2
   interfaces:
   - ifindex: 20000
-    ifname: tun0
+    ifname: wg0
     ipv4: 10.1.0.5/30
     node: dut
     tunnel:
       private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
       public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
   - ifindex: 20000
-    ifname: tun0
+    ifname: wg0
     ipv4: 10.1.0.6/30
     node: r2
     tunnel:
@@ -69,13 +69,13 @@ nodes:
         node: r2
       type: p2p
     - ifindex: 20000
-      ifname: tun0
+      ifname: wg0
       ipv4: 10.1.0.5/30
       linkindex: 2
       mtu: 1440
       name: dut -> r2 [WireGuard tunnel]
       neighbors:
-      - ifname: tun0
+      - ifname: wg0
         ipv4: 10.1.0.6/30
         node: r2
       tunnel:
@@ -137,13 +137,13 @@ nodes:
         node: dut
       type: p2p
     - ifindex: 20000
-      ifname: tun0
+      ifname: wg0
       ipv4: 10.1.0.6/30
       linkindex: 2
       mtu: 1440
       name: r2 -> dut [WireGuard tunnel]
       neighbors:
-      - ifname: tun0
+      - ifname: wg0
         ipv4: 10.1.0.5/30
         node: dut
       tunnel:

--- a/tests/coverage/expected/wg-unique-ports.yml
+++ b/tests/coverage/expected/wg-unique-ports.yml
@@ -26,14 +26,14 @@ links:
   bridge: input_2
   interfaces:
   - ifindex: 20000
-    ifname: tun0
+    ifname: wg0
     ipv4: 10.1.0.1/30
     node: dut
     tunnel:
       private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
       public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
   - ifindex: 20000
-    ifname: tun0
+    ifname: wg0
     ipv4: 10.1.0.2/30
     node: r2
     tunnel:
@@ -51,14 +51,14 @@ links:
   bridge: input_3
   interfaces:
   - ifindex: 20001
-    ifname: tun1
+    ifname: wg1
     ipv4: 10.1.0.5/30
     node: dut
     tunnel:
       private_key: dwdtCnMYpX08FsFyUbJmRd9ML4frwJkqsXf7pR25LCo=
       public_key: hSDwCYkwp1R0i33ctD73Wg2/Og0mOBr066SpjqqbTmo=
   - ifindex: 20000
-    ifname: tun0
+    ifname: wg0
     ipv4: 10.1.0.6/30
     node: r3
     tunnel:
@@ -102,13 +102,13 @@ nodes:
         node: r3
       type: lan
     - ifindex: 20000
-      ifname: tun0
+      ifname: wg0
       ipv4: 10.1.0.1/30
       linkindex: 2
       mtu: 1440
       name: dut -> r2 [WireGuard tunnel]
       neighbors:
-      - ifname: tun0
+      - ifname: wg0
         ipv4: 10.1.0.2/30
         node: r2
       tunnel:
@@ -134,13 +134,13 @@ nodes:
       type: tunnel
       virtual_interface: true
     - ifindex: 20001
-      ifname: tun1
+      ifname: wg1
       ipv4: 10.1.0.5/30
       linkindex: 3
       mtu: 1440
       name: dut -> r3 [WireGuard tunnel]
       neighbors:
-      - ifname: tun0
+      - ifname: wg0
         ipv4: 10.1.0.6/30
         node: r3
       tunnel:
@@ -206,13 +206,13 @@ nodes:
         node: r3
       type: lan
     - ifindex: 20000
-      ifname: tun0
+      ifname: wg0
       ipv4: 10.1.0.2/30
       linkindex: 2
       mtu: 1440
       name: r2 -> dut [WireGuard tunnel]
       neighbors:
-      - ifname: tun0
+      - ifname: wg0
         ipv4: 10.1.0.1/30
         node: dut
       tunnel:
@@ -278,13 +278,13 @@ nodes:
         node: r2
       type: lan
     - ifindex: 20000
-      ifname: tun0
+      ifname: wg0
       ipv4: 10.1.0.6/30
       linkindex: 3
       mtu: 1440
       name: r3 -> dut [WireGuard tunnel]
       neighbors:
-      - ifname: tun1
+      - ifname: wg1
         ipv4: 10.1.0.5/30
         node: dut
       tunnel:


### PR DESCRIPTION
Some devices (Junos, RouterOS7, OpenBSD) use different interface names for different tunnel types. This commit adds a generic "select interface name based on interface technology" function, and uses FRR as an implementation example.