### PR TITLE
Add 'prefix_or_host' use case to IPv4/IPv6 validators

### DIFF
--- a/docs/dev/validation-ip.txt
+++ b/docs/dev/validation-ip.txt
@@ -4,10 +4,13 @@
 **ipv4** and **ipv6** validators have a mandatory **use** parameter that can take the following values:
 
 * **address** -- an IP address without a subnet mask
-* **prefix** -- an IP prefix without the host bits.
+* **prefix** -- an IP prefix without the host bits. The prefix is not checked against reserved prefixes. Used in prefix lists.
+* **prefix_or_host** -- an IP prefix without the host bits or a host IP address (without prefix). Used in ACLs
 * **host_prefix** -- a host IP address with a prefix length. It must include the host bits unless the prefix length is /31 or /32 for IPv4 or /127 or /128 for IPv6.
-* **interface** -- an IP address specified on an interface. It can take an integer (offset within subnet), True (unnumbered) or False (disabled) value and does not have to include a prefix length. The missing prefix length is taken from the link IP prefix.
-* **subnet_prefix** -- an IP prefix that must include prefix length/subnet mask. It can take a True (unnumbered) or False (disabled) value.
-* **id** (IPv4 only) -- an IPv4 address or a 32-bit unsigned integer. Use **id** for parameters like OSPF areas, BGP cluster IDs, or router IDs.
+* **interface** -- an IP address specified on an interface. It can take an integer (offset within subnet), True (unnumbered), or False (disabled) value, and does not require a prefix length. The missing prefix length is taken from the link IP prefix. The **interface** use is a superset of the **host_prefix** one.
+* **subnet_prefix** -- an IP prefix that must include prefix length/subnet mask. It can take a True (unnumbered) or False (disabled) value, and cannot be a reserved prefix (for example, a multicast prefix).
+* **id** (IPv4 only) -- an IPv4 address or a 32-bit unsigned integer. Use **id** for parameters like OSPF areas, BGP cluster IDs, or router IDs. The value is not checked against reserved prefixes[^idrp]
 
 The **ipv4** validator recognizes an additional **named** parameter. When set to **true**, the value of the attribute can be a [named prefix](named-prefixes).
+
+[^idrp]: You can have router ID 224.0.0.1 (if your device accepts it).

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -774,7 +774,10 @@ def common_addr_parse(
 
   if isinstance(value,bool):                      # bool values are valid only on interfaces and subnets
     if use not in ('interface','subnet_prefix'):
-      return { '_value' : f'{exp_type} (boolean value is valid only on an interface)' }
+      return {
+        '_value' : exp_type,
+        '_hint_id': 'ip_bool_value',
+        '_hint': 'A boolean value is valid only on an interface or as a subnet prefix' }
     else:
       return { '_valid': True }
 
@@ -782,7 +785,10 @@ def common_addr_parse(
     if use == 'id' and af == 'IPv4':
       return check_int_value(value,xform_int)
     if use != 'interface':
-      return { '_value': f'{exp_type} (integer value is only valid as interface offset or a 32-bit ID)' }
+      return {
+        '_value' : exp_type,
+        '_hint_id': 'ip_int_value',
+        '_hint': 'An integer value is only valid as interface offset or a 32-bit ID' }
     return check_int_value(value,None)
 
   if not isinstance(value,str):

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -704,6 +704,7 @@ Common IP address validation functionality. Both tests recognize these use cases
 * 'subnet_prefix' -- an IP prefix that can be used on a subnet, including bool (unnum/LLA).
   Host bits must be zero, and it cannot be in the multicast range.
 * 'prefix' -- any IP prefix, including multicast prefixes. Use case: prefix lists
+* 'prefix_or_host' -- any IP prefix or host (IP address without a prefix). Use case: ACLs
 
 Valid types per use case:
 
@@ -712,6 +713,7 @@ Use case      | str (w/) | str (no/) | bool | int |
 address       |          |    OK     |      |     |
 prefix        |    OK    |           |      |     |
 host_prefix   |    OK    |           |      |     |
+prefix_or_host|    OK    |    OK     |      |     |
 interface     |    OK    |    OK     |  OK  | OK  |
 subnet_prefix |    OK    |           |  OK  |     |
 id            |          |    OK     |      | OK  |
@@ -763,9 +765,16 @@ def common_addr_parse(
 
     return None
 
+  if use not in ['address','prefix','host_prefix','prefix_or_host','interface','subnet_prefix','id']:
+    return {'_value': f'INTERNAL ERROR: invalid use parameter: {use}'}
+
+  exp_type = f'{af} address or prefix' if use == 'prefix_or_host' \
+                else f'{af} prefix' if 'prefix' in use  \
+                else f'{af} address'
+
   if isinstance(value,bool):                      # bool values are valid only on interfaces and subnets
     if use not in ('interface','subnet_prefix'):
-      return { '_value' : f'an {af} address (boolean value is valid only on an interface)' }
+      return { '_value' : f'{exp_type} (boolean value is valid only on an interface)' }
     else:
       return { '_valid': True }
 
@@ -773,11 +782,11 @@ def common_addr_parse(
     if use == 'id' and af == 'IPv4':
       return check_int_value(value,xform_int)
     if use != 'interface':
-      return { '_value': f'an {af} address or prefix (integer value is only valid as interface offset or a 32-bit ID)' }
+      return { '_value': f'{exp_type} (integer value is only valid as interface offset or a 32-bit ID)' }
     return check_int_value(value,None)
 
   if not isinstance(value,str):
-    return { '_type': f'{af} prefix' if 'prefix' in use else f'{af} address' }
+    return { '_type': exp_type }
 
   if named and xform_pfx is not None:             # Check whether we can use a named prefix
     topology = global_vars.get_topology()
@@ -789,7 +798,7 @@ def common_addr_parse(
         if 'ipv4' in pfxs[value]:
           return { '_valid': True, '_transform': xform_pfx }
 
-  if use in ['id','address'] or (use in ['interface'] and '/' not in value):
+  if use in ['id','address'] or (use in ['interface','prefix_or_host'] and '/' not in value):
     try:
       p_addr = addr_parse(value)
     except Exception as Ex:
@@ -802,7 +811,7 @@ def common_addr_parse(
     except Exception as Ex:
       return { '_value': f'{af} prefix ({Ex})' }
 
-  if use not in ['prefix','id']:
+  if use not in ['prefix','prefix_or_host','id']:
     r_hit = check_reserved_range(RESERVED_PREFIXES[af],p_addr)
     if r_hit:
       return {'_value': f'{af} {"prefix" if "prefix" in use else "address"}'+

--- a/tests/coverage/errors/attr-ip-prefix-host.log
+++ b/tests/coverage/errors/attr-ip-prefix-host.log
@@ -1,0 +1,8 @@
+IncorrectValue in nodes: attribute 'nodes.x.hp4[6]' must be IPv4 prefix (192.168.0.1/24 has host bits set)
+... use 'netlab show attributes node' to display valid attributes
+IncorrectValue in nodes: attribute 'nodes.x.hp4[7]' must be IPv4 address or prefix (boolean value is valid only on an interface)
+IncorrectValue in nodes: attribute 'nodes.x.hp4[8]' must be IPv4 address or prefix (boolean value is valid only on an interface)
+IncorrectValue in nodes: attribute 'nodes.x.hp4[9]' must be IPv4 address or prefix (integer value is only valid as interface offset or a 32-bit ID)
+IncorrectType in nodes: attribute 'nodes.x.hp4[10]' must be IPv4 address or prefix, found BoxList
+IncorrectType in nodes: attribute 'nodes.x.hp4[11]' must be IPv4 address or prefix, found dictionary
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/attr-ip-prefix-host.log
+++ b/tests/coverage/errors/attr-ip-prefix-host.log
@@ -1,8 +1,10 @@
 IncorrectValue in nodes: attribute 'nodes.x.hp4[6]' must be IPv4 prefix (192.168.0.1/24 has host bits set)
 ... use 'netlab show attributes node' to display valid attributes
-IncorrectValue in nodes: attribute 'nodes.x.hp4[7]' must be IPv4 address or prefix (boolean value is valid only on an interface)
-IncorrectValue in nodes: attribute 'nodes.x.hp4[8]' must be IPv4 address or prefix (boolean value is valid only on an interface)
-IncorrectValue in nodes: attribute 'nodes.x.hp4[9]' must be IPv4 address or prefix (integer value is only valid as interface offset or a 32-bit ID)
+IncorrectValue in nodes: attribute 'nodes.x.hp4[7]' must be IPv4 address or prefix
+... A boolean value is valid only on an interface or as a subnet prefix
+IncorrectValue in nodes: attribute 'nodes.x.hp4[8]' must be IPv4 address or prefix
+IncorrectValue in nodes: attribute 'nodes.x.hp4[9]' must be IPv4 address or prefix
+... An integer value is only valid as interface offset or a 32-bit ID
 IncorrectType in nodes: attribute 'nodes.x.hp4[10]' must be IPv4 address or prefix, found BoxList
 IncorrectType in nodes: attribute 'nodes.x.hp4[11]' must be IPv4 address or prefix, found dictionary
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/attr-ip-prefix-host.yml
+++ b/tests/coverage/errors/attr-ip-prefix-host.yml
@@ -1,0 +1,27 @@
+---
+message: |
+  Check the "prefix_or_host" use case for the IPv4/IPv6 validators
+
+defaults.attributes.node:
+  hp4:
+    type: list
+    _subtype: { type: ipv4, use: prefix_or_host }
+  hp6:
+    type: list
+    _subtype: { type: ipv6, use: prefix_or_host }
+
+nodes:
+  x:
+    device: none
+    hp4:
+    - 127.0.0.1                   # Valid
+    - 224.0.0.0/4                 # Valid
+    - 192.168.0.1                 # Valid
+    - 192.168.0.0/24              # Valid
+    - 192.168.0.1/32              # Valid
+    - 192.168.0.1/24              # Invalid -- host bits
+    - True                        # Bools, ints, dicts, or lists are also invalid
+    - False
+    - 12
+    - []
+    - {}

--- a/tests/errors/ia-ospf-nodes.log
+++ b/tests/errors/ia-ospf-nodes.log
@@ -9,7 +9,8 @@ IncorrectType in ospf: attribute 'nodes.r2.ospf.process' must be an integer, fou
 IncorrectValue in ospf: attribute 'nodes.r2.ospf.router_id' must be IPv4 address (Unexpected '/' in '1.2.3.4/32')
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectType in ospf: attribute 'nodes.r3.ospf.process' must be an integer, found BoxList
-IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be IPv4 address (boolean value is valid only on an interface)
+IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be IPv4 address
+... A boolean value is valid only on an interface or as a subnet prefix
 IncorrectType in ospf: attribute 'nodes.r3.ospf.af' must be a dictionary or NoneType, found str
 IncorrectValue in ospf: attribute 'nodes.r4.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectValue in ospf: attribute 'nodes.r4.ospf.process' must be an integer larger or equal to 1

--- a/tests/errors/ia-ospf-nodes.log
+++ b/tests/errors/ia-ospf-nodes.log
@@ -9,7 +9,7 @@ IncorrectType in ospf: attribute 'nodes.r2.ospf.process' must be an integer, fou
 IncorrectValue in ospf: attribute 'nodes.r2.ospf.router_id' must be IPv4 address (Unexpected '/' in '1.2.3.4/32')
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectType in ospf: attribute 'nodes.r3.ospf.process' must be an integer, found BoxList
-IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be an IPv4 address (boolean value is valid only on an interface)
+IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be IPv4 address (boolean value is valid only on an interface)
 IncorrectType in ospf: attribute 'nodes.r3.ospf.af' must be a dictionary or NoneType, found str
 IncorrectValue in ospf: attribute 'nodes.r4.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
 IncorrectValue in ospf: attribute 'nodes.r4.ospf.process' must be an integer larger or equal to 1


### PR DESCRIPTION
The ACLs accept either a prefix or an IP address (= host), but not the additional interface values (true/false/int). No existing 'use' value matched the requirements.