### PR TITLE
Fix: Display 'found list' not 'BoxList' in validation errors

### DIFF
--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -53,7 +53,10 @@ def init_wrong_type() -> None:
   _attr_help_cache = None
 
 def wrong_type_text(x : typing.Any) -> str:
-  return "dictionary" if isinstance(x,dict) else str(type(x).__name__)
+  return \
+    "dictionary" if isinstance(x,dict) \
+    else "list" if isinstance(x,list) \
+    else str(type(x).__name__)
 
 def err_add_alt_types(ctx: dict) -> str:
   a_types = ctx.get('_alt_types',[])

--- a/tests/coverage/errors/attr-ip-prefix-host.log
+++ b/tests/coverage/errors/attr-ip-prefix-host.log
@@ -5,6 +5,6 @@ IncorrectValue in nodes: attribute 'nodes.x.hp4[7]' must be IPv4 address or pref
 IncorrectValue in nodes: attribute 'nodes.x.hp4[8]' must be IPv4 address or prefix
 IncorrectValue in nodes: attribute 'nodes.x.hp4[9]' must be IPv4 address or prefix
 ... An integer value is only valid as interface offset or a 32-bit ID
-IncorrectType in nodes: attribute 'nodes.x.hp4[10]' must be IPv4 address or prefix, found BoxList
+IncorrectType in nodes: attribute 'nodes.x.hp4[10]' must be IPv4 address or prefix, found list
 IncorrectType in nodes: attribute 'nodes.x.hp4[11]' must be IPv4 address or prefix, found dictionary
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/validate-bool.log
+++ b/tests/coverage/errors/validate-bool.log
@@ -4,6 +4,6 @@ IncorrectValue in isis: attribute nodes.r2.isis.type has invalid value(s): wrong
 IncorrectType in mpls: attribute 'nodes.r3.mpls.bgp.disable_unlabeled' must be a boolean, found NoneType
 ... use 'netlab show attributes --module mpls node' to display valid attributes
 IncorrectType in isis: attribute 'nodes.r3.isis.type' must be a string, found bool
-IncorrectType in mpls: attribute 'nodes.r4.mpls.bgp.disable_unlabeled' must be a boolean, found BoxList
-IncorrectType in isis: attribute 'nodes.r4.isis.type' must be a string, found BoxList
+IncorrectType in mpls: attribute 'nodes.r4.mpls.bgp.disable_unlabeled' must be a boolean, found list
+IncorrectType in isis: attribute 'nodes.r4.isis.type' must be a string, found list
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/validate-int.log
+++ b/tests/coverage/errors/validate-int.log
@@ -3,6 +3,6 @@ IncorrectType in bgp: attribute 'nodes.r2.bgp.as' must be a 4-octet AS number wi
 IncorrectType in bgp: attribute 'nodes.r3.bgp.as' must be a 4-octet AS number, found bool
 ... FYI: a 4-octet AS number is an integer between 1 and 4294967295,
 ... optionally written as asdot string N.N where N <= 65535
-IncorrectType in bgp: attribute 'nodes.r4.bgp.as' must be a 4-octet AS number, found BoxList
+IncorrectType in bgp: attribute 'nodes.r4.bgp.as' must be a 4-octet AS number, found list
 IncorrectType in bgp: attribute 'nodes.r5.bgp.as' must be a 4-octet AS number, found NoneType
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/validate-string.log
+++ b/tests/coverage/errors/validate-string.log
@@ -2,7 +2,7 @@ IncorrectValue in isis: attribute nodes.r2.isis.type has invalid value(s): wrong
 ... valid values are: level-1, level-2, level-1-2
 ... use 'netlab show attributes --module isis node' to display valid attributes
 IncorrectType in isis: attribute 'nodes.r3.isis.type' must be a string, found bool
-IncorrectType in isis: attribute 'nodes.r4.isis.type' must be a string, found BoxList
+IncorrectType in isis: attribute 'nodes.r4.isis.type' must be a string, found list
 IncorrectType in isis: attribute 'nodes.r5.isis.type' must be a string, found NoneType
 IncorrectType in isis: attribute 'nodes.r6.isis.type' must be a string, found int
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/ia-bfd.log
+++ b/tests/errors/ia-bfd.log
@@ -1,10 +1,10 @@
-IncorrectType in bfd: attribute 'bfd.min_tx' must be an integer, found BoxList
+IncorrectType in bfd: attribute 'bfd.min_tx' must be an integer, found list
 ... use 'netlab show attributes --module bfd' to display valid attributes
 IncorrectType in bfd: attribute 'bfd.min_rx' must be an integer, found str
 IncorrectValue in bfd: attribute 'nodes.r1.bfd.min_echo_rx' must be an integer larger or equal to 0
 ... use 'netlab show attributes --module bfd node' to display valid attributes
 IncorrectValue in bfd: attribute 'nodes.r1.bfd.multiplier' must be a true number (not a bool)
-IncorrectType in bfd: attribute 'nodes.r1.bfd.min_tx' must be an integer, found BoxList
+IncorrectType in bfd: attribute 'nodes.r1.bfd.min_tx' must be an integer, found list
 IncorrectType in bfd: attribute 'nodes.r1.bfd.min_rx' must be an integer, found str
 IncorrectType in bfd: attribute 'nodes.r2.bfd.min_tx' must be an integer, found NoneType
 IncorrectType in bfd: attribute 'nodes.r2.bfd.min_rx' must be an integer, found str

--- a/tests/errors/ia-node.log
+++ b/tests/errors/ia-node.log
@@ -4,7 +4,7 @@ IncorrectAttr in bgp: Invalid bgp node attribute 'wrong' found in nodes.r1.bgp
 IncorrectAttr in nodes: nodes.r1 uses an attribute from module ospf which is not enabled in nodes.r1
 IncorrectAttr in nodes: Invalid node attribute 'also_wrong' found in nodes.r1
 ... use 'netlab show attributes node' to display valid attributes
-IncorrectType in nodes: attribute 'nodes.r1.role' must be a string, found BoxList
+IncorrectType in nodes: attribute 'nodes.r1.role' must be a string, found list
 IncorrectValue in nodes: attribute 'nodes.r1.mtu' must be an integer between 64 and 9216
 IncorrectValue in nodes: attribute 'nodes.r1.id' must be an integer between 1 and 150
 IncorrectType in nodes: attribute 'nodes.r1.memory' must be an integer, found str

--- a/tests/errors/ia-ospf-nodes.log
+++ b/tests/errors/ia-ospf-nodes.log
@@ -8,7 +8,7 @@ IncorrectType in ospf: attribute 'nodes.r2.ospf.af.ipv6' must be a boolean, foun
 IncorrectType in ospf: attribute 'nodes.r2.ospf.process' must be an integer, found str
 IncorrectValue in ospf: attribute 'nodes.r2.ospf.router_id' must be IPv4 address (Unexpected '/' in '1.2.3.4/32')
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.area' must be an IPv4 address or an integer between 0 and 2**32
-IncorrectType in ospf: attribute 'nodes.r3.ospf.process' must be an integer, found BoxList
+IncorrectType in ospf: attribute 'nodes.r3.ospf.process' must be an integer, found list
 IncorrectValue in ospf: attribute 'nodes.r3.ospf.router_id' must be IPv4 address
 ... A boolean value is valid only on an interface or as a subnet prefix
 IncorrectType in ospf: attribute 'nodes.r3.ospf.af' must be a dictionary or NoneType, found str

--- a/tests/errors/ia-vlan.log
+++ b/tests/errors/ia-vlan.log
@@ -1,9 +1,9 @@
-IncorrectType in topology: attribute 'vlans.red.id' must be an integer, found BoxList
+IncorrectType in topology: attribute 'vlans.red.id' must be an integer, found list
 ... use 'netlab show attributes vlan' to display valid attributes
 IncorrectValue in topology: attribute vlans.red.mode has invalid value(s): wrong
 ... valid values are: bridge, irb, route
 IncorrectValue in topology: attribute 'vlans.blue.id' must be an integer between 1 and 4095
-IncorrectType in topology: attribute 'vlans.blue.pool' must be a 16-character identifier, found BoxList
+IncorrectType in topology: attribute 'vlans.blue.pool' must be a 16-character identifier, found list
 ... FYI: a 16-character identifier is a string starting with a letter or
 ... an underscore and containing up to 16 letters, numbers, or underscores
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/errors/ia-vrf.log
+++ b/tests/errors/ia-vrf.log
@@ -1,4 +1,4 @@
-IncorrectType in topology: attribute 'vrfs.green.rd' must be route distinguisher, found BoxList
+IncorrectType in topology: attribute 'vrfs.green.rd' must be route distinguisher, found list
 ... use 'netlab show attributes vrf' to display valid attributes
 IncorrectValue in topology: attribute 'vrfs.yellow.rd' must be route distinguisher in asn:id or ip:id format
 IncorrectValue in topology: attribute 'vrfs.orange.rd' must be an RD in asn:id or ip:id format where id is an integer value

--- a/tests/errors/rp-invalid-data-types-1.log
+++ b/tests/errors/rp-invalid-data-types-1.log
@@ -4,7 +4,7 @@ IncorrectType in routing: topology.routing.policy.p5%1 must be a 16-character id
 IncorrectType in routing: attribute 'topology.routing.policy.p1[1]' must be a dictionary, found str
 ... use 'netlab show attributes --module routing' to display valid attributes
 IncorrectType in routing: attribute 'topology.routing.policy.p2[1]' must be a dictionary, found str
-IncorrectType in routing: attribute 'routing.policy.p3[1].set.locpref' must be an integer, found BoxList
+IncorrectType in routing: attribute 'routing.policy.p3[1].set.locpref' must be an integer, found list
 IncorrectType in routing: attribute 'topology.routing.policy.p4[1]' must be a dictionary, found int
 IncorrectType in validate: Cannot validate attributes in nodes.r1.routing -- that should have been a dictionary, found bool
 IncorrectType in routing: attribute 'nodes.r2.routing.policy' must be a dictionary, found int

--- a/tests/errors/rp-invalid-data-types-2.log
+++ b/tests/errors/rp-invalid-data-types-2.log
@@ -1,4 +1,4 @@
-IncorrectType in routing: attribute 'nodes.r1.routing.policy' must be a dictionary, found BoxList
+IncorrectType in routing: attribute 'nodes.r1.routing.policy' must be a dictionary, found list
 ... use 'netlab show attributes --module routing node' to display valid attributes
 IncorrectType in routing: attribute 'nodes.r2.routing.policy' must be a dictionary, found str
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting


### PR DESCRIPTION
BoxList is the internal data type used by Box to represent lists. It is meaningless to the user; we should tell the user we found a list where something else was expected.

Note to self: we'll need something similar for Ruamel :(