### PR TITLE
Bugfix: VPP/BIRD OSPFv3 loopback prefix advertisement (#3725)

### DIFF
--- a/netsim/ansible/templates/initial/bird-clab.j2
+++ b/netsim/ansible/templates/initial/bird-clab.j2
@@ -2,8 +2,5 @@
 set -x
 {% include 'linux-clab.j2' +%}
 #
-{% if loopback.ipv6 is defined %}
-set +e
-ip addr add fe80::1/64 dev lo scope link
-{% endif %}
+{% include 'bird.cp.j2' +%}
 exit 0

--- a/netsim/ansible/templates/initial/bird.cp.j2
+++ b/netsim/ansible/templates/initial/bird.cp.j2
@@ -1,0 +1,10 @@
+{#
+  Bird control-plane initial hooks that must run in the routing netns.
+
+  Used by bird-clab.j2 and by VPP (dataplane netns) so OSPFv3 can advertise
+  the loopback IPv6 prefix (needs a static LLA on the loopback interface).
+#}
+{% if loopback.ipv6 is defined %}
+set +e
+ip addr add fe80::1/64 dev {{ loopback.ifname }} scope link
+{% endif %}

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -119,7 +119,7 @@ protocol ospf {{ ver }} ospf_{{ proto_suffix }}_{{ ver }} {
     };
 {%     for l in ospf_interfaces if af in l and l.ospf.area|default('') == adata.area %}
 {%       if af == 'ipv6' and l.type == 'loopback' %}
-    stubnet {{ (vrf_data.loopback_address.ipv6 if vrf_name else loopback.ipv6) | ipaddr('address') }}/128;
+    stubnet {{ l.ipv6 | ipaddr('address') }}/128;
 {%       endif %}
     interface "{{ l.ifname }}" {
 {%       if l.ospf.passive|default(False) or l.type == 'loopback' %}

--- a/netsim/daemons/bird/ospf.macros.j2
+++ b/netsim/daemons/bird/ospf.macros.j2
@@ -118,7 +118,7 @@ protocol ospf {{ ver }} ospf_{{ proto_suffix }}_{{ ver }} {
 {%     endfor %}
     };
 {%     for l in ospf_interfaces if af in l and l.ospf.area|default('') == adata.area %}
-{%       if l.ifname == 'lo' and af == 'ipv6' %}
+{%       if af == 'ipv6' and l.type == 'loopback' %}
     stubnet {{ (vrf_data.loopback_address.ipv6 if vrf_name else loopback.ipv6) | ipaddr('address') }}/128;
 {%       endif %}
     interface "{{ l.ifname }}" {

--- a/netsim/templates/provider/clab/vpp/netlab-start.sh.j2
+++ b/netsim/templates/provider/clab/vpp/netlab-start.sh.j2
@@ -86,6 +86,10 @@ ip -n "$NETNS" addr add {{ l._parent_ipv4 }} peer {{ l._unnumbered_peer }} dev {
 case "$VPP_CONTROL_PLANE" in
   bird)
     mkdir -p /run/bird
+    # Control-plane initial hooks in the dataplane netns (e.g. IPv6 LLA on loopback)
+    ip netns exec "$NETNS" /bin/sh <<'CP_INITIAL'
+{% include 'initial/bird.cp.j2' %}
+CP_INITIAL
     # BIRD 2.x: omit -d so bird daemonizes; VPP stays foreground via wait
     ip netns exec "$NETNS" /usr/sbin/bird -c /etc/bird/bird.conf
     wait $VPP_PID


### PR DESCRIPTION
## Summary
- Run bird control-plane initial hooks (IPv6 LLA on the loopback) from VPP `netlab-start` in the dataplane netns, via shared `initial/bird.cp.j2`
- Advertise OSPFv3 `stubnet …/128` for all loopback-typed interfaces (not only `lo`), using each interface’s own address so multi-loopback nodes get correct prefixes

## Test plan
- [x] `netlab up ospf/ospfv3/01-network.yml -d vpp -p clab` passes
- [x] Bird lab with two loopbacks per node: both `/128` stubnets present and learned by the peer
- [x] `ospf/ospfv3/06-lb-prefix.yml` on VPP/clab (original failing case)

Fixes #3725

Note: We may want to extend ```06-lb-prefix.yml``` to test the case of multiple loopbacks