### PR TITLE
docs(sonic): correct the docker-sonic-vs download instructions

### DIFF
--- a/docs/labs/sonic.md
+++ b/docs/labs/sonic.md
@@ -51,10 +51,6 @@ once you know the branch and the build ID from the *Build History* page:
 https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=202605&platform=vs&buildId=1166687&target=target%2Fdocker-sonic-vs.gz
 ```
 
-*containerlab* documents the same path for its
-[`sonic-vs` kind](https://containerlab.dev/manual/kinds/sonic-vs/), which uses this image. [sonic.software](https://SONiC.software/) is an unofficial index that is sometimes offered as an alternative, but it carries SONiC *installation* images (`sonic-vs.img`, used for the Vagrant box
-above) rather than the container artifact.
-
 After downloading the container, unpack and load it:
 
 ```

--- a/docs/labs/sonic.md
+++ b/docs/labs/sonic.md
@@ -36,9 +36,20 @@ a build artifact of the [sonic-buildimage](https://github.com/sonic-net/sonic-bu
 The SONiC container image is published as an artifact of the SONiC Azure build pipelines. From <https://sonic-build.azurewebsites.net/ui/sonic/pipelines>:
 
 * Scroll to the bottom of the pipeline list, where the **vs** platform is listed;
-* Pick a branch (for example `202405`) and open **Build History**;
-* Choose the latest build whose *Result* is successful and open **Artifacts**;
-* Open the artifact, scroll to **target/docker-sonic-vs.gz**, and download it.
+* Pick a branch -- the newest release branch (for example `202605`) or `master` -- and open **Build History**;
+* Choose the latest build whose *Result* is **succeeded** and open **Artifacts**. Builds that
+  were *canceled* are listed alongside the successful ones, and they have an **Artifacts** link
+  too;
+* Open the artifact (there is only one, `sonic-buildimage.vs`) and find **target/docker-sonic-vs.gz**
+  in the file list. Take care not to pick **target/docker-sonic-vs-asan.gz**, which sits next to
+  it -- that is an AddressSanitizer build.
+
+The file list is long; if you would rather not scroll it, the download URL can be built by hand
+once you know the branch and the build ID from the *Build History* page:
+
+```
+https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=202605&platform=vs&buildId=1166687&target=target%2Fdocker-sonic-vs.gz
+```
 
 *containerlab* documents the same path for its
 [`sonic-vs` kind](https://containerlab.dev/manual/kinds/sonic-vs/), which uses this image. [sonic.software](https://SONiC.software/) is an unofficial index that is sometimes offered as an alternative, but it carries SONiC *installation* images (`sonic-vs.img`, used for the Vagrant box
@@ -51,7 +62,22 @@ gunzip docker-sonic-vs.gz
 docker load -i docker-sonic-vs
 ```
 
-Check the tag `docker load` restored with **docker images**; retag it to `docker-sonic-vs:latest` if necessary.
+The archive carries the tag `docker-sonic-vs:latest`, which is what the device definition
+expects, so there is usually nothing to retag.
+
+```{warning}
+**docker load** replaces any existing `docker-sonic-vs:latest` image -- it prints
+`The image docker-sonic-vs:latest already exists, renaming the old one with ID ... to empty string`
+and leaves the previous image untagged. If you want to keep the image you already have, tag it
+first (for example `docker tag docker-sonic-vs:latest docker-sonic-vs:previous`) and select
+between them with `defaults.devices.sonic.clab.image`.
+```
+
+You can check which build you got with:
+
+```
+docker run --rm --entrypoint cat docker-sonic-vs:latest /etc/sonic/sonic_version.yml
+```
 
 ### Build a SONiC Container
 


### PR DESCRIPTION
Follow-up to #3680: the `docker-sonic-vs` download instructions I wrote in that PR were wrong in several places. I had never actually followed them — the image was already on my test box — so this corrects them after walking the path end to end and pulling SONiC `202605` build 1166687.

**The route in the original text was right; five details were not.**

* **The branch example was two years stale.** `202405` was given as the example; the current list is `master`, `202605`, `202511`, `202505`, `202411`, `202405`, `202311`, `202305`.
* **Cancelled builds sit beside successful ones** and have Artifacts links too, so "pick the latest build" needs to say *successful* explicitly.
* **`target/docker-sonic-vs-asan.gz` sits directly next to `target/docker-sonic-vs.gz`** in the artifact listing — an AddressSanitizer build, easy to take by mistake.
* **The download URL is constructible** from branch and build ID, which beats scrolling a long listing; added with a working example.
* **The `docker load` guidance had both halves backwards.** The archive already carries `docker-sonic-vs:latest`, so there is nothing to retag — and more importantly, **`docker load` silently replaces an existing image with that tag**, printing `renaming the old one with ID ... to empty string` and leaving the previous image untagged. Anyone following the old text to compare two builds would have lost the image they had. That is now a warning with a tag-first workaround.

Also adds a one-liner for identifying which build you ended up with (`cat /etc/sonic/sonic_version.yml`), which turned out to matter when comparing behaviour between builds.

Documentation only — no code, no template, no device changes.
