### PR TITLE
Check VLAN structures exist before use in RouterOS7

### DIFF
--- a/netsim/ansible/templates/vlan/routeros7.initial.j2
+++ b/netsim/ansible/templates/vlan/routeros7.initial.j2
@@ -4,15 +4,18 @@
 {#
 # Created Switched VLANs interfaces
 #}
-{% for vname,vdata in vlans.items() if vdata.mode is defined and vdata.mode != 'route' %}
+{% if vlans is defined %}
+{%   for vname,vdata in vlans.items() if vdata.mode is defined and vdata.mode != 'route' %}
 /interface/vlan add name=vlan{{ vdata.id }} vlan-id={{ vdata.id }} interface=switch
-{% endfor +%}
+{%   endfor +%}
+{% endif %}
 
 {#
 # Created Routed VLANs interfaces
 #}
-{% for interface in interfaces 
-     if interface.vlan.access_id is defined
-        and interface.vlan.mode|default('') == 'route' %}
-/interface/vlan add name={{ interface.ifname }} vlan-id={{ interface.vlan.access_id }} interface={{ interface.parent_ifname }}
+{% for intf in interfaces
+       if intf.vlan is defined
+          and intf.vlan.access_id is defined
+          and intf.vlan.mode|default('') == 'route' %}
+/interface/vlan add name={{ intf.ifname }} vlan-id={{ intf.vlan.access_id }} interface={{ intf.parent_ifname }}
 {% endfor %}

--- a/netsim/ansible/templates/vlan/routeros7.j2
+++ b/netsim/ansible/templates/vlan/routeros7.j2
@@ -3,9 +3,11 @@
 # First of all define all switching VLANs (mode!=route)
 #}
 
-{% for vlan,vdata in vlans.items() if vdata.mode != 'route' %}
+{% if vlans is defined %}
+{%   for vlan,vdata in vlans.items() if vdata.mode != 'route' %}
 /interface/bridge/vlan add bridge=switch vlan-ids={{vdata.id}} tagged=switch
-{% endfor %}
+{%   endfor %}
+{% endif %}
 
 {% for ifdata in interfaces|default([]) 
      if ifdata.vlan is defined 


### PR DESCRIPTION
Add guard to check `vlans` exist, found when attempting some EVPN tests.