### PR TITLE
Integration test documentation updates

### DIFF
--- a/tests/integration/bgp.policy/10-bgp-bandwidth-auto.yml
+++ b/tests/integration/bgp.policy/10-bgp-bandwidth-auto.yml
@@ -52,5 +52,5 @@ validate:
   prefix:
     description: Check for X2 prefix on X1
     wait: bgp_scan_long
-    nodes: [ x1, x2 ]
+    nodes: [ x1 ]
     plugin: bgp_prefix(nodes.x2.loopback.ipv4)

--- a/tests/integration/bgp.policy/11-bgp-bandwidth-value.yml
+++ b/tests/integration/bgp.policy/11-bgp-bandwidth-value.yml
@@ -52,5 +52,5 @@ validate:
   prefix:
     description: Check for X2 prefix on X1
     wait: bgp_scan_time
-    nodes: [ x1, x2 ]
+    nodes: [ x1 ]
     plugin: bgp_prefix(nodes.x2.loopback.ipv4)

--- a/tests/integration/bgp.policy/12-bgp-bandwidth-value-out.yml
+++ b/tests/integration/bgp.policy/12-bgp-bandwidth-value-out.yml
@@ -52,5 +52,5 @@ validate:
   prefix:
     description: Check for X2 prefix on X1
     wait: bgp_scan_time
-    nodes: [ x1, x2 ]
+    nodes: [ x1 ]
     plugin: bgp_prefix(nodes.x2.loopback.ipv4)

--- a/tests/integration/bgp.policy/21-locpref.yml
+++ b/tests/integration/bgp.policy/21-locpref.yml
@@ -65,13 +65,13 @@ validate:
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 
   ibgp_v4:
-    description: Check IBGP IPv4 sessions with DUT
+    description: Check IPv4 IBGP sessions with DUT
     wait: ibgp_session
     nodes: [ probe ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
 
   ibgp_v6:
-    description: Check IBGP IPv6 sessions with DUT
+    description: Check IPv6 IBGP sessions with DUT
     wait: ibgp_session
     nodes: [ probe ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')

--- a/tests/integration/bgp.session/01-allowas-in.yml
+++ b/tests/integration/bgp.session/01-allowas-in.yml
@@ -52,21 +52,21 @@ defaults.devices.arubacx.netlab_validate:
 
 validate:
   session_v4:
-    description: Check IPv4 EBGP sessions with dut
+    description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x1, x2, x3 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv4')
 
   session_v6:
-    description: Check IPv6 EBGP sessions with dut
+    description: Check IPv6 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x1, x2, x3 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
 
   resend:
-    description: Resend BGP prefixes from x2
+    description: Resend BGP prefixes from X2
     nodes: [ x2 ]
     devices: [ frr ]
     exec: vtysh -c 'clear bgp * soft out'

--- a/tests/integration/bgp.session/02-as-override.yml
+++ b/tests/integration/bgp.session/02-as-override.yml
@@ -46,14 +46,14 @@ links:
 
 validate:
   session_v4:
-    description: Check IPv4 EBGP sessions with dut
+    description: Check IPv4 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x1, x2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv4')
 
   session_v6:
-    description: Check IPv6 EBGP sessions with dut
+    description: Check IPv6 EBGP sessions with DUT
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x1, x2 ]

--- a/tests/integration/bgp.session/04-default-originate.yml
+++ b/tests/integration/bgp.session/04-default-originate.yml
@@ -110,25 +110,25 @@ validate:
     plugin: bgp_prefix('::/0',af='ipv6',state='missing')
 
   vrf_ebgp_v4:
-    description: Check IPv4 EBGP sessions with DUT (vrf)
+    description: Check IPv4 EBGP sessions with DUT VRF
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x2, r2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut')
   vrf_ebgp_v6:
-    description: Check IPv6 EBGP sessions with DUT (vrf)
+    description: Check IPv6 EBGP sessions with DUT VRF
     wait_msg: Waiting for EBGP session establishment
     wait: ebgp_session
     nodes: [ x2, r2 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
   vrf_def_ipv4:
-    description: Check whether DUT (vrf) advertises IPv4 default route to X2
+    description: Check whether DUT advertises VRF IPv4 default route to X2
     wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x2 ]
     plugin: bgp_prefix('0.0.0.0/0')
   vrf_def_ipv6:
-    description: Check whether (vrf) DUT advertises IPv6 default route to X2
+    description: Check whether DUT advertises VRF IPv6 default route to X2
     wait: bgp_scan_time
     wait_msg: Waiting for BGP convergence
     nodes: [ x2 ]

--- a/tests/integration/bgp.session/07-password.yml
+++ b/tests/integration/bgp.session/07-password.yml
@@ -1,6 +1,6 @@
 message:
   This lab tests the BGP MD5 password functionality. The EBGP session
-  between the probe and the lab device should be established.
+  between the probe and the DUT should be established.
 
 defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
 

--- a/tests/integration/bgp.session/13-bfd.yml
+++ b/tests/integration/bgp.session/13-bfd.yml
@@ -1,6 +1,6 @@
 message: |
   This lab tests the BGP BFD functionality. The EBGP session between the probe
-  and the lab device should trigger a BFD session between them.
+  and the DUT should trigger a BFD session between them.
 
 plugin: [ bgp.session ]
 module: [ bgp, bfd ]

--- a/tests/integration/bgp.session/14-gr.yml
+++ b/tests/integration/bgp.session/14-gr.yml
@@ -85,7 +85,7 @@ validate:
         result["{{ bgp.neighbors[0].ipv4 }}"].gracefulRestartInfo.remoteGrMode == "Helper"
 
   gr_disable:
-    description: Check that GR is disabled on dut
+    description: Check that GR is disabled on DUT
     nodes: [ x3, v2 ]
     show:
       frr: "bgp neighbors json"

--- a/tests/integration/bgp/13-ipv6-ibgp-rr.yml
+++ b/tests/integration/bgp/13-ipv6-ibgp-rr.yml
@@ -56,13 +56,13 @@ links:
 
 validate:
   session:
-    description: Check BGP sessions with DUT1
+    description: Check BGP sessions with DUT
     wait_msg: Wait for BGP sessions to be established
     wait: ibgp_session
     nodes: [ r1, r2, rr2, x1 ]
     plugin: bgp_neighbor(node.bgp.neighbors,'dut',af='ipv6')
   prefix:
-    description: Check whether DUT1 propagates the external beacon prefix
+    description: Check whether DUT propagates the external beacon prefix
     wait_msg: Wait for BGP convergence
     wait: bgp_scan_time
     nodes: [ r1, r2, rr2 ]

--- a/tests/integration/isis/12-passive.yml
+++ b/tests/integration/isis/12-passive.yml
@@ -54,7 +54,7 @@ validate:
   adj_x1:
     description: Is DUT a neigbor of X1?
     wait: isis_adj_p2p
-    wait_msg: Waiting for OSPF adjacency process to complete
+    wait_msg: Waiting for ISIS adjacency process to complete
     pass: OK, X1 has DUT as a neighbor
     nodes: [ x1 ]
     plugin: isis_neighbor('dut')


### PR DESCRIPTION
Revisit the DUT renaming, fix minor inconsistencies.

One non description/message change:
Remove `x2` from node list for `bgp.policy` tests 10,11,12, as we want to check for `x2` loopback on `x1`.
