### PR TITLE
Sphinx "features" directive generates "supported features" tables

### DIFF
--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -2,7 +2,7 @@
 Sphinx extension implementing the *features* directive.
 
 The directive takes a YAML-formatted list of features as its content.
-See developer documentation (docs/dev/feature-tables.md) for details.
+See developer documentation (docs/dev/features-tables.md) for details.
 
 Usage (from within MyST parser)::
 
@@ -281,7 +281,7 @@ class Features(SphinxDirective):
 
     raise self.error(f"Cannot parse feature table definition as YAML: {error}")
 
-  def _build_table(self, table_def: Box) -> nodes.table:
+  def _build_table(self, table_def: Box) -> typing.Tuple:
     """
     Build docutils table: create it, add header, collect device data and footnotes,
     and convert device data into a full-blown table

--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -31,24 +31,38 @@ def table_cell(
       text: str,
       align: str = '',
       fn: typing.Optional[Box] = None) -> nodes.entry:
-  entry = nodes.entry()
-  if align:
+  """
+  Add a cell to the features table. The cell can be aligned (with a CSS class),
+  the cell text is split into multiple lines based on "<br>" tag, and parsed
+  as Markdown to support markup like links/bold/italic. Finally, a footnote
+  (specified as label/refid dict) can be added to the text.
+  """
+  entry = nodes.entry()                                     # Create a new cell
+  if align:                                                 # If needed, assign a CSS class to it
     entry['classes'].append('text-'+align)
   para_list = []
-  for line in text.split('<br>'):
-    paragraph = nodes.paragraph()
+  for line in text.split('<br>'):                           # Iterate over lines of text
+    paragraph = nodes.paragraph()                           # Each line becomes a paragraph, its contents parsed as Markdown
     paragraph += nested_parse_to_nodes(DIRECTIVE.state,line,offset=DIRECTIVE.content_offset)
     para_list += paragraph
-  if fn:
+  if fn:                                                    # If needed, add footnote reference to the last paragraph
     para_list[-1] += nodes.footnote_reference(text=fn.label,refid=fn.refid)
-  entry += para_list
-  return entry
+  entry += para_list                                        # ... add paragraphs to the cell
+  return entry                                              # ... and return cell data structure
 
 def features_columns(tgroup: nodes.tgroup, features: dict) -> None:
+  """
+  Create N+1 (device + feature list) columns for the features table. The
+  columns have equal width; the table relies on browser rendering it as needed.
+  """
   for _ in range(len(features)+1):
     tgroup += nodes.colspec(colwidth=1)
 
 def create_features_table(features: dict) -> typing.Tuple[nodes.table,nodes.tgroup]:
+  """
+  Create the scaffolding for the features table -- a table object with
+  a table group with column definitions
+  """
   table = nodes.table()
   tgroup = nodes.tgroup(cols=len(features) + 1)
   table += tgroup
@@ -56,6 +70,10 @@ def create_features_table(features: dict) -> typing.Tuple[nodes.table,nodes.tgro
   return (table,tgroup)
 
 def features_header(tgroup: nodes.tgroup, features: BoxList) -> None:
+  """
+  Create the header for the features table: a new THEAD object with a
+  single row containing feature titles
+  """
   thead = nodes.thead()
   tgroup += thead
   header_row = nodes.row()
@@ -65,117 +83,145 @@ def features_header(tgroup: nodes.tgroup, features: BoxList) -> None:
     header_row += table_cell(header.get('title','???'),align="center")
 
 def features_body(tgroup: nodes.tgroup, device_data: typing.List[typing.List]) -> None:
-  tbody = nodes.tbody()
-  tgroup += tbody
+  """
+  Create the body of the features table passed as a row-list-of-column-data-lists.
+  The column data are dicts that could have 'text' key (for verbatim text) or
+  'status' key (for device has/does-not-have a feature). The elements with 'status'
+  key could include 'caveat' key -- a refid to the device caveats.
+  """
+  tbody = nodes.tbody()                           # Create TBODY structure
+  tgroup += tbody                                 # ... and append it to table group
 
-  for d_row in device_data:
-    trow = nodes.row()
+  for d_row in device_data:                       # Next, iterate over devices
+    trow = nodes.row()                            # ... creating a row for each device
     tbody += trow
-    for d_data in d_row:
-      if 'text' in d_data:
+    for d_data in d_row:                          # Finally, iterate over device data
+      if 'text' in d_data:                        # ... verbatim text?
         trow += table_cell(d_data['text'],fn=d_data.get('fn',''))
-      elif 'status' in d_data:
+      elif 'status' in d_data:                    # ... or status (OK/MISSING)
         txt = '✅' if d_data['status'] else '❌'
-        if 'caveat' in d_data:
-          txt += f'[❗]({d_data["caveat"]})'
+        if 'caveat' in d_data:                    # Do we have to add a caveat?
+          txt += f'[❗]({d_data["caveat"]})'      # Use Markdown link to point to the caveat (MyST will resolve ref IDs)
         trow += table_cell(txt,align='center')
       else:
-        trow += table_cell('🤦‍♂️')    
+        trow += table_cell('🤦‍♂️')                  # None of the above, we failed miserably :()
 
 def get_feature_list(settings: Box, table_def: Box) -> Box:
+  """
+  Build the per-device lists of features displayed in the table from the device
+  definitions.
+  """
   df_data = get_empty_box()
 
-  for dname,ddata in settings.devices.items():
-    df_row = []
-    f_valid = False
-    local_data = ddata + ddata.features
-    for f_def in table_def.features:
-      try:
+  for dname,ddata in settings.devices.items():    # Iterate over all devices
+    df_row = []                                   # ... starting with an empty row for each device
+    f_valid = False                               # ... assuming the device is not relevant and should not be included
+    local_data = ddata + ddata.features           # Prepare local data that will be used to evaluate features
+    for f_def in table_def.features:              # Ready? Now iterate over feature definitions
+      try:                                        # Try to evaluate whether the device supports the feature
         f_OK = bool(eval(f_def.enabled,locals=local_data))
-      except Exception:
-        f_OK = False
-      dt_value = {'status': f_OK}
-      if f_OK and 'caveats' in f_def:
-        try:
+      except Exception:                           # Failed miserably? It could be any number of reasons
+        f_OK = False                              # ... but we'll just assume the device DOES NOT support the feature
+      dt_value = {'status': f_OK}                 # Save the results
+      if f_OK and 'caveats' in f_def:             # ... but wait, there's more. Do we need to check for caveats?
+        try:                                      # Let's do it. Try to evaluate caveat data
           f_caveat = eval(f_def.caveats,locals=local_data)
           dt_value['caveat'] = 'caveats-'+dname if f_caveat is True else f_caveat
-        except Exception:
+        except Exception:                         # Failed? Looks like there's nothing to mentio ;)
           pass
-      df_row.append(dt_value)
-      f_valid = f_valid or f_OK
+      df_row.append(dt_value)                     # OK, the "feature status" is ready, append it to the device features row
+      f_valid = f_valid or f_OK                   # ... and remember if the device is relevant (at least one feature is implemented)
 
-    if f_valid:
-      df_data[dname].features = df_row
+    if f_valid:                                   # Do we have a relevant device?
+      df_data[dname].features = df_row            # We do? Store its data, it needs to get into the features table
 
   return df_data
 
 def remove_duplicate_features(settings: Box, df_data: Box) -> None:
-  for dname in list(df_data.keys()):
+  """
+  The craziest of them all: remove child devices that have identical features as the parent
+  device (so they were probably inherited)
+  """
+  for dname in list(df_data.keys()):              # Iterate over all relevant devices
     ddata = settings.devices[dname]
-    p_list = ddata.get('_parents',[])
-    if not p_list:
+    p_list = ddata.get('_parents',[])             # ... and get a list of device's parent
+    if not p_list:                                # ... No parent? Cool.
       continue
-    parent = p_list[0]
-    if parent not in df_data:
+    parent = p_list[0]                            # Here's the cool trick: the most-generic parent is always the first in the list ;)
+    if parent not in df_data:                     # But it wasn't relevant? No worries, move on
       continue
     if not settings.devices[parent].get('docparent',True):
-      continue
+      continue                                    # Some devices (like FRR) don't want to appear as parents (for SONiC)
     if df_data[dname].features == df_data[parent].features:
-      df_data.pop(dname)
+      df_data.pop(dname)                          # Child and (grand?)parent have identical features? Remove the child
       append_to_list(df_data[parent],'ch_match',dname)
-    else:
+    else:                                         # Otherwise mark that a (grand)child has diverted from the parent
       append_to_list(df_data[parent],'ch_mismatch',dname)
 
 def remove_meta_devices(settings: Box,df_data: Box) -> None:
+  """
+  Remove meta-devices (generic parents, "none" and "unknown") that have no relevant children.
+  This automatically removes the "none" and "unknown" devices.
+  """
   for dname in list(df_data.keys()):
     ddata = settings.devices[dname]
-    if not ddata.get('_meta_device',False):
+    if not ddata.get('_meta_device',False):       # Not a meta device? Move on...
       continue
-    if 'ch_match' in df_data[dname]:
-      continue
-    df_data.pop(dname)
+    if 'ch_match' in df_data[dname]:              # Does the meta device has relevant children that inherited its features?
+      continue                                    # The children were removed, so we have to keep the meta-device
+    df_data.pop(dname)                            # ... otherwise remove it
 
 def build_device_feature_matrix(
       settings: Box,
       df_data: Box) -> typing.Tuple[typing.List[typing.List],typing.List]:
-
-  global TABLE_COUNT
+  """
+  Given the device/feature data, build the features table
+  """
+  global TABLE_COUNT                              # Need to count documentation-wide tables for link anchors
   TABLE_COUNT += 1
 
   device_data: list = []
-  footnotes:   list = []
+  footnotes:   list = []                          # We might need "this parent device includes these children" footnotes
 
   dev_data = settings.devices
   devices = { dname: dev_data[dname].get('docname',dev_data[dname].get('description',dname)) 
-                for dname in dev_data }
+                for dname in dev_data }           # Get device short names (or descriptions or just device codes)
 
   label_count = 0
-  for dname in sorted(devices,key=devices.get):         # type: ignore # (and feel free to fix it)
+  for dname in sorted(devices,key=devices.get):   # type: ignore # This is how you get dict keys sorted by dict value, but MyPy hates it
     if dname not in df_data:
       continue
 
-    df_results = df_data[dname].features
-    dc_name = get_box({'text': devices[dname] })
-    ch_match = df_data[dname].get('ch_match',[])
-    if ch_match:
+    df_results = df_data[dname].features          # Get the device feature data
+    dc_name = get_box({'text': devices[dname] })  # First cell is the device short name
+    ch_match = df_data[dname].get('ch_match',[])  # Is this a parent device?
+    if ch_match:                                  # ... then we need a footnote saying "this includes these other devices"
       label_count += 1
-      fn_name = f'ft{TABLE_COUNT}-{dname}'
+      fn_name = f'ft{TABLE_COUNT}-{dname}'        # Get the footnote name (based on table# and device name)
       dc_name.fn.refid = fn_name
-      dc_name.fn.label = f"*{label_count}"
-      fn = nodes.footnote(ids=[fn_name])
-      fn += nodes.label(text=dc_name.fn.label)
+      dc_name.fn.label = f"*{label_count}"        # ... the footnote labels are numbered per-table
+      fn = nodes.footnote(ids=[fn_name])          # Create a new footnote
+      fn += nodes.label(text=dc_name.fn.label)    # ... add its label and "includes... " text
       fn_text = 'Includes '+', '.join([ devices[x] for x in ch_match ])
-      if 'ch_mismatch' in df_data[dname]:
+      if 'ch_mismatch' in df_data[dname]:         # ... add "does not include" text if needed
         fn_text += ', but not '+', '.join([ devices[x] for x in df_data[dname].ch_mismatch ])
-      fn += nodes.paragraph(text=fn_text)
-      footnotes += [ fn ]
+      fn += nodes.paragraph(text=fn_text)         # Convert the text into a paragraph
+      footnotes += [ fn ]                         # ... and save the footnote
 
-    device_row = [ dc_name ] + df_results
-    device_data.append(device_row)
+    device_row = [ dc_name ] + df_results         # Convert device features into a device row
+    device_data.append(device_row)                # ... and append it to the table list-of-lists
 
   return (device_data,footnotes)
 
 def device_features(settings: Box, table_def: Box) -> typing.Tuple[typing.List[typing.List],typing.List]:
+  """
+  Create the device features table contents
+
+  * Get the device data (which device supports which feature)
+  * Remove child devices that inherited features from their parents
+  * Remove meta devices that have no children
+  * Return the list-of-lists table data structure and footnotes
+  """
   df_data = get_feature_list(settings,table_def)
   remove_duplicate_features(settings,df_data)
   remove_meta_devices(settings,df_data)
@@ -190,6 +236,10 @@ class Features(SphinxDirective):
   has_content = True
 
   def run(self) -> list[nodes.Node]:
+    """
+    Directive entry point: parse the features from directive contents and return
+    the table/footnotes
+    """
     global DIRECTIVE
     DIRECTIVE = self
 
@@ -200,6 +250,10 @@ class Features(SphinxDirective):
     return [ table ] + footnotes
 
   def _parse_features(self) -> Box:
+    """
+    Convert directive contents into YAML and try to parse it, first as a dictionary,
+    then as a list (which gets into "features" dictionary)
+    """
     yaml = "\n".join(self.content)
     try:
       return Box.from_yaml(yaml_string=yaml)
@@ -214,6 +268,10 @@ class Features(SphinxDirective):
     raise self.error(f"Cannot parse feature table definition as YAML: {error}")
 
   def _build_table(self, table_def: Box) -> nodes.table:
+    """
+    Build docutils table: create it, add header, collect device data and footnotes,
+    and convert device data into a full-blown table
+    """
     global SETTINGS
     (table,tgroup) = create_features_table(table_def.features)
     features_header(tgroup,table_def.features)
@@ -222,6 +280,10 @@ class Features(SphinxDirective):
     return (table,footnotes)
 
 def setup(app: typing.Any) -> dict[str, object]:
+  """
+  Directive setup: read system defaults, move daemons into "devices" dictionary,
+  process child device inheritances, and register the directive.
+  """
   global SETTINGS
   topology = _read.load("package:cli/empty.yml",user_defaults=[])
   devices.merge_daemons(topology)

--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -1,0 +1,72 @@
+"""
+Sphinx extension implementing the *features* directive.
+
+The directive takes a comma-separated list of ``feature=header`` parameters.
+Each parameter defines one column of a table: *feature* is the machine-readable
+feature name used by the code populating the table body, *header* is the
+human-readable column header.
+
+Usage::
+
+    .. features:: vlan=VLAN support, vrf=VRF support, mpls=MPLS support
+"""
+
+from typing import Any
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+class Features(Directive):
+  """Create a table with one column per feature parameter."""
+
+  required_arguments = 1
+  optional_arguments = 0
+  final_argument_whitespace = True
+  has_content = False
+
+  def run(self) -> list[nodes.Node]:
+    features = self._parse_features()
+    return [self._build_table(features)]
+
+  def _parse_features(self) -> dict[str, str]:
+    features = {}
+    for parameter in self.arguments[0].split(","):
+      name, separator, header = parameter.partition("=")
+      name = name.strip()
+      header = header.strip()
+      if not separator or not name or not header:
+        raise self.error(f"Invalid feature parameter '{parameter.strip()}', expected 'feature=header'")
+      features[name] = header
+    return features
+
+  def _build_table(self, features: dict[str, str]) -> nodes.table:
+    table = nodes.table()
+    tgroup = nodes.tgroup(cols=len(features))
+    table += tgroup
+    for _ in features:
+      tgroup += nodes.colspec(colwidth=1)
+    thead = nodes.thead()
+    tgroup += thead
+    header_row = nodes.row()
+    thead += header_row
+    for header in features.values():
+      header_row += self._build_cell(header)
+    tgroup += nodes.tbody()
+    return table
+
+  def _build_cell(self, text: str) -> nodes.entry:
+    entry = nodes.entry()
+    paragraph = nodes.paragraph()
+    paragraph += nodes.Text(text)
+    entry += paragraph
+    return entry
+
+
+def setup(app: Any) -> dict[str, object]:
+  app.add_directive("features", Features)
+  return {
+    "version": "0.1",
+    "parallel_read_safe": True,
+    "parallel_write_safe": True,
+  }

--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -11,59 +11,209 @@ Usage::
     .. features:: vlan=VLAN support, vrf=VRF support, mpls=MPLS support
 """
 
-from typing import Any
+import typing
 
+from box import Box, BoxList
+from box.exceptions import BoxError
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from sphinx.util.docutils import SphinxDirective
 
+from netsim.augment import devices
+from netsim.data import append_to_list, get_box, get_empty_box
+from netsim.utils import read as _read
 
-class Features(Directive):
+SETTINGS: Box
+DIRECTIVE: SphinxDirective
+TABLE_COUNT: int = 0
+
+def table_cell(text: str, align: str = '', fn: typing.Optional[Box] = None) -> nodes.entry:
+  entry = nodes.entry()
+  if align:
+    entry['classes'].append('text-'+align)
+  para_list = []
+  for line in text.split('<br>'):
+    paragraph = nodes.paragraph()
+    paragraph += DIRECTIVE.parse_text_to_nodes(line)
+    para_list += paragraph
+  if fn:
+    para_list[-1] += nodes.footnote_reference(text=fn.label,refid=fn.refid)
+  entry += para_list
+  return entry
+
+def features_columns(tgroup: nodes.tgroup, features: dict) -> None:
+  for _ in range(len(features)+1):
+    tgroup += nodes.colspec(colwidth=1)
+
+def create_features_table(features: dict) -> typing.Tuple[nodes.table,nodes.tgroup]:
+  table = nodes.table()
+  tgroup = nodes.tgroup(cols=len(features) + 1)
+  table += tgroup
+  features_columns(tgroup,features)
+  return (table,tgroup)
+
+def features_header(tgroup: nodes.tgroup, features: BoxList) -> None:
+  thead = nodes.thead()
+  tgroup += thead
+  header_row = nodes.row()
+  thead += header_row
+  header_row += table_cell('Device')
+  for header in features:
+    header_row += table_cell(header.get('title','???'),align="center")
+
+def features_body(tgroup: nodes.tgroup, device_data: typing.List[typing.List]) -> None:
+  tbody = nodes.tbody()
+  tgroup += tbody
+
+  for d_row in device_data:
+    trow = nodes.row()
+    tbody += trow
+    for d_data in d_row:
+      if 'text' in d_data:
+        trow += table_cell(d_data['text'],fn=d_data.get('fn',''))
+      elif 'status' in d_data:
+        trow += table_cell('✅' if d_data['status'] else '❌',align='center')
+      else:
+        trow += table_cell('🤦‍♂️')    
+
+def get_feature_list(settings: Box, table_def: Box) -> Box:
+  df_data = get_empty_box()
+
+  for dname,ddata in settings.devices.items():
+    df_row = []
+    f_valid = False
+    for f_def in table_def.features:
+      try:
+        f_OK = bool(eval(f_def.enabled,locals=ddata + ddata.features))
+      except Exception:
+        f_OK = False
+      df_row.append({'status': f_OK})
+      f_valid = f_valid or f_OK
+
+    if f_valid:
+      df_data[dname].features = df_row
+
+  return df_data
+
+def remove_duplicate_features(settings: Box, df_data: Box) -> None:
+  for dname in list(df_data.keys()):
+    ddata = settings.devices[dname]
+    p_list = ddata.get('_parents',[])
+    if not p_list:
+      continue
+    parent = p_list[0]
+    if parent not in df_data:
+      continue
+    if not ddata.get('docparent',True):
+      continue
+    if df_data[dname].features == df_data[parent].features:
+      df_data.pop(dname)
+      append_to_list(df_data[parent],'ch_match',dname)
+    else:
+      append_to_list(df_data[parent],'ch_mismatch',dname)
+
+def remove_meta_devices(settings: Box,df_data: Box) -> None:
+  for dname in list(df_data.keys()):
+    ddata = settings.devices[dname]
+    if not ddata.get('_meta_device',False):
+      continue
+    if 'ch_match' in df_data[dname]:
+      continue
+    df_data.pop(dname)
+
+def build_device_feature_matrix(
+      settings: Box,
+      df_data: Box) -> typing.Tuple[typing.List[typing.List],typing.List]:
+
+  global TABLE_COUNT
+  TABLE_COUNT += 1
+
+  device_data: list = []
+  footnotes:   list = []
+
+  dev_data = settings.devices
+  devices = { dname: dev_data[dname].get('docname',dev_data[dname].get('description',dname)) 
+                for dname in dev_data }
+
+  label_count = 0
+  for dname in sorted(devices,key=devices.get):         # type: ignore # (and feel free to fix it)
+    if dname not in df_data:
+      continue
+
+    df_results = df_data[dname].features
+    dc_name = get_box({'text': devices[dname] })
+    ch_match = df_data[dname].get('ch_match',[])
+    if ch_match:
+      label_count += 1
+      fn_name = f'ft{TABLE_COUNT}-{dname}'
+      dc_name.fn.refid = fn_name
+      dc_name.fn.label = f"*{label_count}"
+      fn = nodes.footnote(ids=[fn_name])
+      fn += nodes.label(text=dc_name.fn.label)
+      fn_text = 'Includes '+', '.join([ devices[x] for x in ch_match ])
+      if 'ch_mismatch' in df_data[dname]:
+        fn_text += ', but not '+', '.join([ devices[x] for x in df_data[dname].ch_mismatch ])
+      fn += nodes.paragraph(text=fn_text)
+      footnotes += [ fn ]
+
+    device_row = [ dc_name ] + df_results
+    device_data.append(device_row)
+
+  return (device_data,footnotes)
+
+def device_features(settings: Box, table_def: Box) -> typing.Tuple[typing.List[typing.List],typing.List]:
+  df_data = get_feature_list(settings,table_def)
+  remove_duplicate_features(settings,df_data)
+  remove_meta_devices(settings,df_data)
+  return build_device_feature_matrix(settings,df_data)
+
+class Features(SphinxDirective):
   """Create a table with one column per feature parameter."""
 
-  required_arguments = 1
+  required_arguments = 0
   optional_arguments = 0
   final_argument_whitespace = True
-  has_content = False
+  has_content = True
 
   def run(self) -> list[nodes.Node]:
-    features = self._parse_features()
-    return [self._build_table(features)]
+    global DIRECTIVE
+    DIRECTIVE = self
 
-  def _parse_features(self) -> dict[str, str]:
-    features = {}
-    for parameter in self.arguments[0].split(","):
-      name, separator, header = parameter.partition("=")
-      name = name.strip()
-      header = header.strip()
-      if not separator or not name or not header:
-        raise self.error(f"Invalid feature parameter '{parameter.strip()}', expected 'feature=header'")
-      features[name] = header
-    return features
+    table_def = self._parse_features()
+    (table,footnotes) = self._build_table(table_def)
+#    for fn in footnotes:
+#      print(fn)
+    return [ table ] + footnotes
 
-  def _build_table(self, features: dict[str, str]) -> nodes.table:
-    table = nodes.table()
-    tgroup = nodes.tgroup(cols=len(features))
-    table += tgroup
-    for _ in features:
-      tgroup += nodes.colspec(colwidth=1)
-    thead = nodes.thead()
-    tgroup += thead
-    header_row = nodes.row()
-    thead += header_row
-    for header in features.values():
-      header_row += self._build_cell(header)
-    tgroup += nodes.tbody()
-    return table
+  def _parse_features(self) -> Box:
+    yaml = "\n".join(self.content)
+    try:
+      return Box.from_yaml(yaml_string=yaml)
+    except BoxError:
+      try:
+        return get_box({'features': BoxList.from_yaml(yaml_string=yaml)})
+      except Exception as ex:
+        error = ex
+    except Exception as ex:
+      error = ex
 
-  def _build_cell(self, text: str) -> nodes.entry:
-    entry = nodes.entry()
-    paragraph = nodes.paragraph()
-    paragraph += nodes.Text(text)
-    entry += paragraph
-    return entry
+    raise self.error(f"Cannot parse feature table definition as YAML: {error}")
 
+  def _build_table(self, table_def: Box) -> nodes.table:
+    global SETTINGS
+    (table,tgroup) = create_features_table(table_def.features)
+    features_header(tgroup,table_def.features)
+    (device_data,footnotes) = device_features(SETTINGS,table_def)
+    features_body(tgroup,device_data)
+    return (table,footnotes)
 
-def setup(app: Any) -> dict[str, object]:
+def setup(app: typing.Any) -> dict[str, object]:
+  global SETTINGS
+  topology = _read.load("package:cli/empty.yml",user_defaults=[])
+  devices.merge_daemons(topology)
+  devices.process_device_inheritance(topology)
+
+  SETTINGS = topology.defaults
+
   app.add_directive("features", Features)
   return {
     "version": "0.1",

--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -17,6 +17,7 @@ from box import Box, BoxList
 from box.exceptions import BoxError
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
+from sphinx.util.parsing import nested_parse_to_nodes
 
 from netsim.augment import devices
 from netsim.data import append_to_list, get_box, get_empty_box
@@ -26,14 +27,17 @@ SETTINGS: Box
 DIRECTIVE: SphinxDirective
 TABLE_COUNT: int = 0
 
-def table_cell(text: str, align: str = '', fn: typing.Optional[Box] = None) -> nodes.entry:
+def table_cell(
+      text: str,
+      align: str = '',
+      fn: typing.Optional[Box] = None) -> nodes.entry:
   entry = nodes.entry()
   if align:
     entry['classes'].append('text-'+align)
   para_list = []
   for line in text.split('<br>'):
     paragraph = nodes.paragraph()
-    paragraph += DIRECTIVE.parse_text_to_nodes(line)
+    paragraph += nested_parse_to_nodes(DIRECTIVE.state,line,offset=DIRECTIVE.content_offset)
     para_list += paragraph
   if fn:
     para_list[-1] += nodes.footnote_reference(text=fn.label,refid=fn.refid)
@@ -71,7 +75,10 @@ def features_body(tgroup: nodes.tgroup, device_data: typing.List[typing.List]) -
       if 'text' in d_data:
         trow += table_cell(d_data['text'],fn=d_data.get('fn',''))
       elif 'status' in d_data:
-        trow += table_cell('✅' if d_data['status'] else '❌',align='center')
+        txt = '✅' if d_data['status'] else '❌'
+        if 'caveat' in d_data:
+          txt += f'[❗]({d_data["caveat"]})'
+        trow += table_cell(txt,align='center')
       else:
         trow += table_cell('🤦‍♂️')    
 
@@ -81,12 +88,20 @@ def get_feature_list(settings: Box, table_def: Box) -> Box:
   for dname,ddata in settings.devices.items():
     df_row = []
     f_valid = False
+    local_data = ddata + ddata.features
     for f_def in table_def.features:
       try:
-        f_OK = bool(eval(f_def.enabled,locals=ddata + ddata.features))
+        f_OK = bool(eval(f_def.enabled,locals=local_data))
       except Exception:
         f_OK = False
-      df_row.append({'status': f_OK})
+      dt_value = {'status': f_OK}
+      if f_OK and 'caveats' in f_def:
+        try:
+          f_caveat = eval(f_def.caveats,locals=local_data)
+          dt_value['caveat'] = 'caveats-'+dname if f_caveat is True else f_caveat
+        except Exception:
+          pass
+      df_row.append(dt_value)
       f_valid = f_valid or f_OK
 
     if f_valid:
@@ -103,7 +118,7 @@ def remove_duplicate_features(settings: Box, df_data: Box) -> None:
     parent = p_list[0]
     if parent not in df_data:
       continue
-    if not ddata.get('docparent',True):
+    if not settings.devices[parent].get('docparent',True):
       continue
     if df_data[dname].features == df_data[parent].features:
       df_data.pop(dname)

--- a/docs/_ext/features.py
+++ b/docs/_ext/features.py
@@ -1,14 +1,15 @@
 """
 Sphinx extension implementing the *features* directive.
 
-The directive takes a comma-separated list of ``feature=header`` parameters.
-Each parameter defines one column of a table: *feature* is the machine-readable
-feature name used by the code populating the table body, *header* is the
-human-readable column header.
+The directive takes a YAML-formatted list of features as its content.
+See developer documentation (docs/dev/feature-tables.md) for details.
 
-Usage::
+Usage (from within MyST parser)::
 
-    .. features:: vlan=VLAN support, vrf=VRF support, mpls=MPLS support
+    ```{features}
+    - title: VLAN support
+      enabled: bfd
+    ```
 """
 
 import typing
@@ -27,6 +28,19 @@ SETTINGS: Box
 DIRECTIVE: SphinxDirective
 TABLE_COUNT: int = 0
 
+BUILTINS: dict = {                            # Allowed built-in functions. Extend as needed ;)
+  'len': len
+}
+
+def safer_eval(xpr: str, locals: Box) -> typing.Any:
+  """
+  We might need operators and functions in feature/caveat expressions, so we
+  need to use "eval". However, we could make it a bit safer ;)
+  """
+  global BUILTINS
+
+  return eval(xpr,locals=locals,globals={ '__builtins__': BUILTINS })
+
 def table_cell(
       text: str,
       align: str = '',
@@ -44,9 +58,9 @@ def table_cell(
   for line in text.split('<br>'):                           # Iterate over lines of text
     paragraph = nodes.paragraph()                           # Each line becomes a paragraph, its contents parsed as Markdown
     paragraph += nested_parse_to_nodes(DIRECTIVE.state,line,offset=DIRECTIVE.content_offset)
-    para_list += paragraph
+    para_list.append(paragraph)
   if fn:                                                    # If needed, add footnote reference to the last paragraph
-    para_list[-1] += nodes.footnote_reference(text=fn.label,refid=fn.refid)
+    paragraph[-1] += nodes.footnote_reference(text=fn.label,refid=fn.refid)
   entry += para_list                                        # ... add paragraphs to the cell
   return entry                                              # ... and return cell data structure
 
@@ -119,13 +133,13 @@ def get_feature_list(settings: Box, table_def: Box) -> Box:
     local_data = ddata + ddata.features           # Prepare local data that will be used to evaluate features
     for f_def in table_def.features:              # Ready? Now iterate over feature definitions
       try:                                        # Try to evaluate whether the device supports the feature
-        f_OK = bool(eval(f_def.enabled,locals=local_data))
+        f_OK = bool(safer_eval(f_def.enabled,locals=local_data))
       except Exception:                           # Failed miserably? It could be any number of reasons
         f_OK = False                              # ... but we'll just assume the device DOES NOT support the feature
       dt_value = {'status': f_OK}                 # Save the results
       if f_OK and 'caveats' in f_def:             # ... but wait, there's more. Do we need to check for caveats?
         try:                                      # Let's do it. Try to evaluate caveat data
-          f_caveat = eval(f_def.caveats,locals=local_data)
+          f_caveat = safer_eval(f_def.caveats,locals=local_data)
           dt_value['caveat'] = 'caveats-'+dname if f_caveat is True else f_caveat
         except Exception:                         # Failed? Looks like there's nothing to mentio ;)
           pass

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,10 @@ author = 'Ivan Pepelnjak'
 
 source_suffix = ['.rst', '.md']
 
+sys.path.insert(0, os.path.abspath('_ext'))
+
 extensions = [
+  'features',
   'myst_parser',
   'sphinxcontrib.jquery',
   'sphinx_rtd_dark_mode'

--- a/docs/dev/advanced.md
+++ b/docs/dev/advanced.md
@@ -27,4 +27,5 @@ Want to know how _netlab_ works behind the scenes? These documents might give yo
    integration-tests.md
    clab-netns.md
    debugging.md
+   features-tables.md
 ```

--- a/docs/dev/features-tables.md
+++ b/docs/dev/features-tables.md
@@ -1,0 +1,44 @@
+# Auto-Generated "Supported Features" Tables
+
+The `features` Sphinx directive generates the _supported features_ tables for the [](supported-platforms) document and the module descriptions.
+
+```{warning}
+The current implementation does not support provider-specific features.
+```
+
+The `features` directive is invoked with the [MyST directive syntax](https://myst-parser.readthedocs.io/en/latest/syntax/roles-and-directives.html#syntax-directives):
+
+````md
+```{features}
+```
+````
+
+The directive content is a YAML-formatted description of the features that should be included in the table, for example:
+
+````md
+```{features}
+- title: BFD<br>protocol
+  enabled: bfd
+  caveats: bfd.caveats
+- title: OSPF<br>with BFD
+  enabled: ospf and bfd
+- title: IS-IS<br>with BFD
+  enabled: isis and bfd
+- title: BGP<br>with BFD
+  enabled: bgp.bfd
+  caveats: bgp.bfd.caveats
+```
+````
+
+Each column definition (feature) can have these parameters:
+
+* **title** (required) -- the column header
+* **enabled** (required) -- the Python expression that results in a truthy value if the feature works on the device. The expression can use all device definition data (for example, `libvirt.image`), and the device features (for example, `ospf.areas`)
+* **caveats** (optional) -- the Python expression that checks whether the device/feature entry should include a link to caveats. The value of the specified device feature could be **true**, in which case the link pointing to the caveat is `caveats-_device_`, or a documentation anchor ID.
+
+When dealing with the parent/child devices (for example, Cisco IOS or Junos platforms), the `features` directive automatically detects whether a child device supports a different set of features than the parent device, removes child devices that inherit feature settings from their parents, and creates a "this parent device includes these other devices" footnote.
+
+Two other device parameters influence the auto-generated "supported features" tables:
+
+* **docname** is a shorter device name (between device code and full device description). For example, Arista EOS has `eos` device code, "Arista vEOS VM or cEOS container" **description**, and "Arista EOS" **docname**.
+* Sometimes, you don't want a device to be displayed like a parent device in the features table. For example, the `sonic` device uses `frr` as its parent, but we'd definitely not want to have "FRR includes SONiC" as a footnote. In these cases, set the **docparent** parameter of the parent device to `False`.

--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -18,24 +18,6 @@ BFD is supported on these platforms:
   caveats: bgp.bfd.caveats
 ```
 
-| Operating system      | Configurable<br>timers | OSPF | IS-IS | BGP |
-| --------------------- | :-: | :-: | :-: | :-: |
-| Arista EOS            | ✅  | ✅  | ✅  | ✅ |
-| Aruba AOS-CX          | ✅  | ✅  |  ❌  | ✅ |
-| BIRD                  | ✅  |  ❌  |  ❌  | ✅  |
-| Cisco IOS             | ✅  | ✅  | ✅  | ✅ |
-| Cisco IOS XE[^18v]    | ✅  | ✅  | ✅  | ✅ |
-| Cisco Nexus OS        | ✅  | ✅  | ✅  |  ❌  |
-| Cumulus Linux         | ✅[❗](caveats-frr) | ✅  |  ❌  | ✅ |
-| FRR                   | ✅[❗](caveats-frr) | ✅  |  ❌  | ✅ |
-| Dell OS10             | ✅  | ✅  |  ❌  |  ❌  |
-| Junos[^Junos]         | ✅[❗](caveats-junos) | ✅  | ✅  | ✅ |
-| Mikrotik RouterOS 6   |  ❌  | ✅  | ✅  |  ❌  |
-| Mikrotik RouterOS 7   | ✅  | ✅  |  ❌  |  ❌  |
-| Nokia SR Linux        | ✅  | ✅  | ✅  | ✅ |
-| Nokia SR OS[^SROS]    | ✅  | ✅  | ✅  |  ❌  |
-| VyOS                  | ✅[❗](caveats-vyos) | ✅  | ✅  |  ❌  |
-
 ```{tip}
 See the integration test results for more details:
 
@@ -43,12 +25,6 @@ See the integration test results for more details:
 * [OSPFv3 test results](https://release.netlab.tools/_html/coverage.ospfv3)
 * [BGP sessions test results](https://release.netlab.tools/_html/coverage.bgp.session)
 ```
-
-[^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
-
-[^Junos]: Includes cRPD, vMX, vSRX, vPTX, vJunos-switch, and vJunos-router
-
-[^SROS]: Includes the Nokia SR-SIM container and the Virtualized 7750 SR and 7950 XRS Simulator (vSIM) virtual machine
 
 ## Parameters
 

--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -5,6 +5,20 @@ This configuration module configures the basic BFD ([RFC5880](https://datatracke
 (bfd-platform)=
 BFD is supported on these platforms:
 
+```eval_rst
+.. features::
+   - title: BFD<br>protocol
+     enabled: bfd
+     caveats: bfd.caveats
+   - title: OSPF<br>with BFD
+     enabled: ospf and bfd
+   - title: IS-IS<br>with BFD
+     enabled: isis and bfd
+   - title: BGP<br>with BFD
+     enabled: bgp.bfd
+     caveats: bgp.bfd.caveats
+```
+
 | Operating system      | Configurable<br>timers | OSPF | IS-IS | BGP |
 | --------------------- | :-: | :-: | :-: | :-: |
 | Arista EOS            | ✅  | ✅  | ✅  | ✅ |

--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -5,8 +5,7 @@ This configuration module configures the basic BFD ([RFC5880](https://datatracke
 (bfd-platform)=
 BFD is supported on these platforms:
 
-```eval_rst
-.. features::
+```{features}
    - title: BFD<br>protocol
      enabled: bfd
      caveats: bfd.caveats

--- a/docs/module/bfd.md
+++ b/docs/module/bfd.md
@@ -6,16 +6,16 @@ This configuration module configures the basic BFD ([RFC5880](https://datatracke
 BFD is supported on these platforms:
 
 ```{features}
-   - title: BFD<br>protocol
-     enabled: bfd
-     caveats: bfd.caveats
-   - title: OSPF<br>with BFD
-     enabled: ospf and bfd
-   - title: IS-IS<br>with BFD
-     enabled: isis and bfd
-   - title: BGP<br>with BFD
-     enabled: bgp.bfd
-     caveats: bgp.bfd.caveats
+- title: BFD<br>protocol
+  enabled: bfd
+  caveats: bfd.caveats
+- title: OSPF<br>with BFD
+  enabled: ospf and bfd
+- title: IS-IS<br>with BFD
+  enabled: isis and bfd
+- title: BGP<br>with BFD
+  enabled: bgp.bfd
+  caveats: bgp.bfd.caveats
 ```
 
 | Operating system      | Configurable<br>timers | OSPF | IS-IS | BGP |

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,9 @@ ignore_missing_imports = True
 
 [mypy-netaddr]
 ignore_missing_imports = True
+
+[mypy-recommonmark.*]
+ignore_missing_imports = True
+
+[mypy-docutils.*]
+ignore_missing_imports = True

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -213,7 +213,10 @@ def process_child_device(dname: str, devices: Box) -> None:
 
   process_child_device(p_device,devices)                    # Process inheritance in parent device
   p_data = Box(devices[p_device].to_dict())                 # Build a copy of parent device data
-  for kw in ("template","_meta_device"):                    # ... remove the template/meta device flags
+
+  # Remove fields that should not be inherited
+  #
+  for kw in ("template","_meta_device","docname","docparent"):
     p_data.pop(kw,None)
   devices[dname] = p_data + devices[dname]                  # ... and merge parent settings with the child device
   data.append_to_list(devices[dname],'_parents',p_device)

--- a/netsim/daemons/bird.yml
+++ b/netsim/daemons/bird.yml
@@ -1,5 +1,6 @@
 ---
 description: BIRD Internet Routing Daemon
+docname: BIRD
 group_vars:
   netlab_import_map:
     bgp: RTS_BGP

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -1,5 +1,5 @@
 ---
-description: ArubaOS-CX
+description: Aruba AOS-CX
 interface_name: 1/1/{ifindex}
 mgmt_if: mgmt
 loopback_interface_name: "loopback {ifindex}"

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -1,5 +1,6 @@
 ---
 description: Cumulus VX 4.x or 5.x configured without NVUE
+docname: Cumulus Linux
 support:
   level: obsolete
   caveats:

--- a/netsim/devices/cumulus.yml
+++ b/netsim/devices/cumulus.yml
@@ -55,7 +55,7 @@ features:
       lla: True
     collect: true
     reload: true
-  bfd: True
+  bfd.caveats: caveats-frr
   bgp:
     activate_af: True
     advertise: True

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -1,5 +1,6 @@
 ---
 description: Arista vEOS VM or cEOS container
+docname: Arista EOS
 interface_name: Ethernet{ifindex}
 mgmt_if: Management1
 loopback_interface_name: Loopback{ifindex}

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -86,7 +86,7 @@ features:
     generate_mac: [ svi ]
     collect: true
     reload: true
-  bfd: True
+  bfd.caveats: caveats-frr
   bgp:
     activate_af: true
     advertise: true

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -1,5 +1,7 @@
 ---
 description: FRR container
+docname: FRRouting
+docparent: False                    # Do not use as a parent device in feature support tables
 interface_name: eth{ifindex}
 mgmt_if: eth0
 loopback_interface_name: lo{ifindex if ifindex else ""}

--- a/netsim/devices/ioll2.yml
+++ b/netsim/devices/ioll2.yml
@@ -1,5 +1,5 @@
 ---
-description: IOSv L2 image
+description: Cisco IOL layer-2 image
 parent: iol
 lag_interface_name: "Port-channel{lag.ifindex}"
 

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -1,5 +1,6 @@
 ---
 description: Generic Cisco IOS device (meta device, used only as parent)
+docname: Cisco IOS
 _meta_device: True
 template: True
 attributes:

--- a/netsim/devices/iosvl2.yml
+++ b/netsim/devices/iosvl2.yml
@@ -1,5 +1,5 @@
 ---
-description: IOSv L2 image
+description: Cisco IOSv layer-2 image
 interface_name: GigabitEthernet{ifindex // 4}/{ifindex % 4}
 lag_interface_name: "Port-channel{lag.ifindex}"
 

--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -1,5 +1,6 @@
 ---
 description: Generic Juniper device (meta device, used only as parent)
+docname: Junos
 _meta_device: True
 template: true
 loopback_interface_name: "lo0.{ifindex}"

--- a/netsim/devices/nxos.yml
+++ b/netsim/devices/nxos.yml
@@ -1,5 +1,6 @@
 ---
 description: Cisco Nexus 9300v
+docname: Cisco Nexus OS
 support:
   level: best-effort
 interface_name: Ethernet1/{ifindex}

--- a/netsim/devices/routeros.yml
+++ b/netsim/devices/routeros.yml
@@ -1,5 +1,6 @@
 ---
 description: Mikrotik RouterOS version 6
+docname: Mikrotik RouterOS 6
 support:
   level: obsolete
 interface_name: ether{ifindex}

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -1,5 +1,6 @@
 ---
 description: Mikrotik RouterOS version 7
+docname: Mikrotik RouterOS 7
 support:
   level: minimal
 interface_name: ether{ifindex}

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -1,5 +1,6 @@
 ---
 description: Nokia SR Linux container
+docname: Nokia SR Linux
 # containerlab nokia_srlinux type enum (schemas/clab.schema.json)
 clab_types:
   ixs-a1:

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -1,5 +1,6 @@
 ---
 description: Nokia SR OS VM in container
+docname: Nokia SR OS
 support:
   level: minimal
   caveats:

--- a/netsim/devices/srsim.yml
+++ b/netsim/devices/srsim.yml
@@ -1,5 +1,6 @@
 ---
 description: Nokia SR-SIM (SR-OS) container
+docname: Nokia SR-SIM
 support:
 mgmt_if: A/1
 parent: sros

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -22,7 +22,7 @@ features:
       lla: True
     collect: true
     reload: true
-  bfd: true
+  bfd.caveats: true
   bgp:
     activate_af: true
     advertise: true

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -1,5 +1,6 @@
 ---
 description: VyOS VM/container
+docname: VyOS
 interface_name: eth{ifindex}
 loopback_interface_name: "dum{ifindex}"
 lag_interface_name: "bond{lag.ifindex}"


### PR DESCRIPTION
The "features" Sphinx directive can be used to generate the "supported
features" tables in platform/module documentation. It accepts a YAML-
formatted definition of features (table columns) and creates a table
listing all devices that have at least one of those features enabled.

The directive can be used to replace "simple" tables (where the feature
support is not provider-dependent), and has been used to reimplement the
BFD platform support table.

The directive relies on a new "docname" device attribute that contains
a short description of the device (what's used in current tables). That
attribute has been added to most devices that support BFD.

Based on the discussions in #3734.