### PR TITLE
EXOS: add list of reserved name as Vlan quirk

### DIFF
--- a/netsim/devices/exos.py
+++ b/netsim/devices/exos.py
@@ -4,6 +4,18 @@ from ..utils import log
 from . import _common, _Quirks, need_ansible_collection, report_quirk
 
 EXOS_VLAN_1_NAME = 'Default'
+EXOS_RESERVED_NAMES = ["aaa", "access-list", "account", "accounts", "acl", "auto-peering", "auto-provision", "avb", "bandwidth", "banner", "bfd", "bgp", "bootprelay", "bootrom", "brm", "bvlan", "cdp", "cfgmgr", "cfm", "checkpoint- data", "clear", "clear-flow", "cli", "clipaging", "configuration", "configure", "cos-index", "counters", "cp", "cpu-monitoring", "create", "cvlan", "dcbx", "delete", "devmgr", "dhcp", "dhcp-client", "dhcp-server", "dhcpv6", "diagnostics", "diffserv", "disable", "dns", "dns-client", "dos-protect", "dot1ag", "dot1p", "dot1q", "ds", "dwdm", "eaps", "edp", "elrp", "elrp-client", "elsm", "ems", "enable", "epm", "erps", "esrp", "ethernet", "evpn", "exit", "exsh-var", "fabric", "failsafe- account", "fdb", "firmware", "flow-redirect", "force_synchronize", "forwarding", "get", "gptp", "hal", "hclag", "icmp", "identity- management", "idletimeout", "idmgr", "igmp", "image", "inline-power", "ip", "ip-fix", "ip-mtu", "ip-security", "iparp", "ipconfig", "ipforwarding", "ipmc", "ipmcforwarding", "ipmroute", "iproute", "ipstats", "ipv6", "ipagent", "irdp", "isid", "isis", "jumbo-frame", "jumbo-frame-size", "kernel", "l2pt", "l2stats", "l2vpn", "lacp", "ldap", "learning", "led", "license", "license-info", "licenses", "licMgr", "lldp", "load", "log", "logout", "mac", "mac-binding", "mac-lockdown- timeout", "mac-locking", "macsec", "management", "mcast", "mcm", "mcmgr", "memory", "memorycard", "meter", "mirror", "mlag", "mld", "modify", "mpls", "mrp", "msdp", "msgsrv", "msrp", "mstp", "mv", "mvr", "mvrp", "neighbor- discovery", "netlogin", "nettools", "network-clock", "node", "nodealias", "ntp", "orchestration", "ospf", "ospvdebug", "ospfv3", "otm", "packet", "performance", "pim", "poe", "policy", "ports", "power", "printk", "private-vlan", "process", "protocol", "put", "pwmib", "q", "qosprofile", "qosscheduler", "quit", "radius", "radius- accounting", "refresh", "rip", "ripng", "rmon", "router- discovery", "rtmgr", "run", "safe-default- script", "save", "screen", "script", "security", "session", "set", "sflow", "sharing", "show", "slot", "slot-poll- interval", "slpp", "snmp", "snmpMaster", "snmpv3", "sntp-client", "source", "ssh2", "sshd2", "ssl", "stacking", "stacking- support", "stm", "stp", "stpd", "svlan", "switch", "sys-health-check", "syslog", "sys-recovery- level", "system", "tacacs", "tech-support", "telnet", "telnetd", "tftpd", "throw", "thttpd", "time", "trusted-servers", "tunnel", "twamp", "udp-echo-server", "udp-profile", "unconfigure", "update", "upload", "upm", "usleep", "validate", "var", "version", "vid", "virtual-network", "virtual-router", "vlan", "vm", "vm-tracking", "vman", "vpex", "vr", "vrrp", "vsm", "watchdog", "web", "wred", "wredprofile", "xml-mode", "xml-notification", "xml-test", "xmlc", "xmld", "xx_force_synchronize", "xx_synchronize", "xx_synchronize2"]
+
+
+def check_reserved_vlans(node: Box, topology: Box) -> None:
+  for vname,_ in node.get('vlans',{}).items():
+    if vname in EXOS_RESERVED_NAMES:
+      report_quirk(
+        text=f'Cannot use VLAN NAME {vname} (VLAN {vname}) on Extreme EXOS',
+        node=node,
+        category=log.IncorrectValue,
+        quirk='vlan.reserved',
+        module='quirks')
 
 def check_vrrp_address_families(node: Box) -> None:
   for intf in node.interfaces:
@@ -63,6 +75,7 @@ class EXOS(_Quirks):
   def device_quirks(cls, node: Box, topology: Box) -> None:
     if 'vlan' in node.get('module',[]):
       default_vlan_1(node)
+      check_reserved_vlans(node,topology)
       _common.check_tagged_vlan_1(node)
     if 'gateway' in node.get('module',[]):
       check_vrrp_address_families(node)


### PR DESCRIPTION
I had an issue where I accidentally used a VLAN name reserved on an EXOS device on a topology: `fabric`
Who would want to call a Vlan `fabric` or `account` or whatever else is on that long list? Apparently me!

Not sure the correct formatting for such list, I've left it as a long line, do we want to [ruff](https://github.com/ipspace/netlab/discussions/3653) this? On this one, it then looks like a awfully long list with 200+ lines, with one entry per line, pretty ugly from my point of view.