### PR TITLE
docs: invalid links for Containerlab

### DIFF
--- a/docs/dev/device-box.md
+++ b/docs/dev/device-box.md
@@ -6,7 +6,7 @@ Here's what you have to do:
 
 * Choose a short name for the new device type (examples: *ios*, *eos*, *cumulus*...)
 * Select one or more virtualization providers you want to work with.
-* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
+* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.dev/).
 * Document the process in a blog post or GitHub gist.
 * Add device parameter file `<device>.yml` to `netsim/devices` directory (see the next section for details).
 * Update [Supported Platforms](supported-platforms) and [box](libvirt-build-boxes) or [container](clab-images) building documentation.

--- a/docs/dev/device-platform.md
+++ b/docs/dev/device-platform.md
@@ -4,7 +4,7 @@ If you want to run a network device on a virtualization provider that is not yet
 
 Here's what you have to do:
 
-* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.srlinux.dev/).
+* Build a Vagrant box from whatever image your vendor supplies. It's not as hard as it sounds, there are [tons of recipes on codingpackets.com](https://codingpackets.com/blog/tag/#vagrant). If you want to build a container to use with *containerlab*, please refer to [their documentation](https://containerlab.dev/).
 * Document the process in a blog post or GitHub gist.
 * Modify the device parameter file `netsim/devices/<device>.yml`
 * Update [Supported Platforms](supported-platforms) and [box](libvirt-build-boxes) or [container](clab-images) building documentation.

--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -1,9 +1,9 @@
 (lab-clab)=
 # Using Containerlab with *netlab*
 
-[Containerlab](https://containerlab.srlinux.dev/) is a Linux-based container orchestration system that creates virtual network topologies using containers as network devices. To use it:
+[Containerlab](https://containerlab.dev/) is a Linux-based container orchestration system that creates virtual network topologies using containers as network devices. To use it:
 
-* Use **[netlab install containerlab](../netlab/install.md)** on Ubuntu, or follow the [containerlab installation guide](https://containerlab.srlinux.dev/install/) on other Linux distributions.
+* Use **[netlab install containerlab](../netlab/install.md)** on Ubuntu, or follow the [containerlab installation guide](https://containerlab.dev/install/) on other Linux distributions.
 * Install network device container images
 * Create [lab topology file](../topology-overview.md). Use `provider: clab` in lab topology to select the *containerlab* virtualization provider.
 * Start the lab with **[netlab up](../netlab/up.md)**
@@ -66,7 +66,7 @@ Lab topology file created by **[netlab up](../netlab/up.md)** or **[netlab creat
 * FRR, Linux, Nokia SR Linux, and VyOS images are automatically downloaded from public container registries.
 * Build the [BIRD](build-bird), dnsmasq, [VPP](build-vpp), and [Netscaler](build-netscaler) images with the **netlab clab build** command. BIRD and VPP FD.io build process supports configurable software releases.
 * The Arista cEOS image has to be [downloaded and installed manually](ceos.md).
-* Nokia SR OS and SR-SIM container images require a license; see also [vrnetlab instructions](https://containerlab.srlinux.dev/manual/vrnetlab/).
+* Nokia SR OS and SR-SIM container images require a license; see also [vrnetlab instructions](https://containerlab.dev/manual/vrnetlab/).
 * Follow Cisco's documentation to install the IOS XRd container, making sure the container image name matches the one _netlab_ uses (alternatively, [change the default image name](default-device-image) for the IOS XRd container).
 * Cisco 8000v containerlab image (once you manage to get it) has to be  [installed](https://containerlab.dev/manual/kinds/c8000/#getting-cisco-8000-containerlab-docker-images) with the **docker image load** command.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -105,7 +105,7 @@ Most devices behave as routers (or layer-3 switches); the following devices can 
 **netlab create** can generate configuration files for these [virtualization providers](providers.md):
 
 * [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt), including support for *veryisolated* private networks and UDP point-to-point tunnels.
-* [Containerlab](https://containerlab.srlinux.dev/)
+* [Containerlab](https://containerlab.dev/)
 * External -- *meta* virtualization provider that allows you to configure external physical or virtual devices with *netlab*
 
 You cannot use all supported network devices with all virtualization providers. These are the supported combinations (use **[netlab show images](netlab/show.md)** command to display the current system settings); daemons always run in containers.


### PR DESCRIPTION
Fixing a few incorrect links to containerlab docs