### PR TITLE
Make OpenBSD use extra_initial, add guard for VLAN usage

### DIFF
--- a/netsim/ansible/templates/initial/openbsd.j2
+++ b/netsim/ansible/templates/initial/openbsd.j2
@@ -25,15 +25,11 @@ echo -n > /etc/rad.conf
 {% if loopback is defined %}
 {{   ifconfig(loopback,alias='alias') }}
 {% endif %}
+{# Setup the required base for GRE/VLAN/VRF/Wireguard #}
+{% from '_extra_initial.j2' import extra_initial with context %}
+{{ extra_initial() }}
 {% for intf in interfaces %}
-{#
-   OpenBSD does not like configuring IPs on devices like
-   VLANs that need parent inteface first, skip and come back
-   to assigning those in the VLAN module
-#}
-{%   if not intf.vlan is defined %}
 {{     ifconfig(intf) }}
-{%   endif %}
 {% endfor %}
 
 {% if role == 'router' %}

--- a/netsim/ansible/templates/vlan/openbsd.initial.j2
+++ b/netsim/ansible/templates/vlan/openbsd.initial.j2
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e # Exit immediately when any command fails
+set -x # Track commands for troubleshooting
+
+{% for ifdata in interfaces if ifdata.vlan is defined %}
+{%   if ifdata.type == 'vlan_member' %}
+ifconfig {{ ifdata.ifname }} parent {{ ifdata.parent_ifname }} vnetid {{ ifdata.vlan.access_id }}
+{%   endif %}
+{% endfor %}
+

--- a/netsim/ansible/templates/vlan/openbsd.j2
+++ b/netsim/ansible/templates/vlan/openbsd.j2
@@ -1,36 +1,20 @@
-{% from "initial/openbsd-ifconfig.j2" import ifconfig with context %}
-{#
-  This script configures OpenBSD VLANs
-#}
 #!/bin/sh
 
 set -e # Exit immediately when any command fails
 set -x # Track commands for troubleshooting
 
 {% for ifdata in interfaces if ifdata.vlan is defined %}
-{% if ifdata.type == 'vlan_member' %}
-ifconfig {{ ifdata.ifname }} parent {{ ifdata.parent_ifname }} vnetid {{ ifdata.vlan.access_id }}
-{% endif %}
-{{ ifconfig(ifdata) }}
-{% if ifdata.vlan.access is defined %}
-ifconfig veb{{ vlans[ifdata.vlan.access].id }} add {{ ifdata.ifname }} up
-{% endif %}
-{% if ifdata.vlan.native is defined %}
-ifconfig veb{{ vlans[ifdata.vlan.native].id }} add {{ ifdata.ifname }} up
-{% endif %}
-{% if ifdata.type=='svi' %}
-{%   for vname,vdata in vlans.items() %}
-{%     if ifdata.vlan.name == vname %}
+{%   if ifdata.vlan.access is defined %}
+ifconfig veb{{ ifdata.vlan.access_id }} add {{ ifdata.ifname }} up
+{%   endif %}
+{%   if ifdata.vlan.native is defined %}
+ifconfig veb{{ ifdata.vlan.access_id }} add {{ ifdata.ifname }} up
+{%   endif %}
+{%   if ifdata.type=='svi' %}
+{%     for vname,vdata in (vlans|default({})).items() %}
+{%       if ifdata.vlan.name == vname %}
 ifconfig veb{{ vdata.id }} add {{ ifdata.ifname }} up
-{%     endif %}
-{%   endfor %}
-{% endif %}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {% endfor %}
-
-{% if role == 'router' %}
-#
-# (re-)start RA daemon
-#
-pkill -q rad || true
-rad
-{% endif %}


### PR DESCRIPTION
Change OpenBSD over to the `extra_initial` type

Also fixed issue with missing check for vlan is defined while here.

Passed all vlan tests

<details><summary>VLAN tests</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p libvirt -d openbsd vlan/
[sudo] password for netlab:
Pre-test cleanup:
08:14:28 vlan/01-vlan-bridge-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:15:12 vlan/02-vlan-bridge-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:16:01 vlan/21-vlan-irb-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:16:50 vlan/22-vlan-irb-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:17:40 vlan/23-vlan-mixed-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:18:31 vlan/31-vlan-bridge-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:20:21 vlan/32-vlan-bridge-trunk-router.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:21:08 vlan/33-vlan-irb-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:22:47 vlan/41-vlan-bridge-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:24:37 vlan/42-vlan-irb-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:26:15 vlan/51-vlan-routed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:27:55 vlan/52-vlan-vrf-lite.yml: create(FAIL)
08:27:55 vlan/61-vlan-routed-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:29:35 vlan/62-vlan-mixed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:30:41 vlan/63-vlan-mixed-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:31:47 vlan/70-vlan-1-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```
</details>