### PR TITLE
Default containerlab IPv6 management subnet

### DIFF
--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -141,7 +141,7 @@ In multi-provider topologies, set the **uplink** parameter only for the primary 
 *containerlab* creates a dedicated Docker network to connect the container management interfaces to the host TCP/IP stack. You can change the management network parameters in the **addressing.mgmt** pool:
 
 * **ipv4**: The IPv4 prefix used for the management network (default: `192.168.121.0/24`)
-* **ipv6**: Optional IPv6 management network prefix. It's not set by default.
+* **ipv6**: Optional IPv6 management network prefix (`fd00:df:1ab::/64` is configured on the management Docker network when this parameter is not set).
 * **start**: The offset of the first management IP address in the management network (default: `100`). For example, with **start** set to 50, the device with **node.id** set to 1 will get the 51st IP address in the management IP prefix.
 * **\_network**: The Docker network name (default: `netlab_mgmt`)
 * **\_bridge**: The name of the underlying Linux bridge (default: unspecified, created by Docker)

--- a/docs/release/26.08.md
+++ b/docs/release/26.08.md
@@ -36,7 +36,7 @@ Arista EOS:
 ## Breaking changes
 
 * We enabled the [Transparent Management _containerlab_ feature](https://containerlab.dev/manual/vrnetlab/#management-interface) on vrnetlab-based devices supporting it in July 2026. This change should not impact older containers, but will change the management IPv4 address on virtual machines running in some newly-built containers from 10.0.0.15 (the default management IPv4 address) to the outside (container) management IPv4 address.
-* The use of the Transparent Management feature broke some vrnetlab containers that assumed the *containerlab* management network always had an IPv6 subnet. While that's been [fixed in *vrnetlab*](https://github.com/srl-labs/vrnetlab/pull/511), _netlab_ nonetheless configures a default IPv6 management subnet (`fd00:df:1ab::/64 `) on the *containerlab* management network to ensure the older containers keep working.
+* The use of the Transparent Management feature broke some vrnetlab containers that assumed the *containerlab* management network always had an IPv6 subnet. While that's been [fixed in *vrnetlab*](https://github.com/srl-labs/vrnetlab/pull/511), _netlab_ nonetheless configures a default IPv6 management subnet (`fd00:df:1ab::/64`) on the *containerlab* management network to ensure the older containers keep working.
 * We switched to [sudo-less *containerlab* operation](https://containerlab.dev/install/#sudo-less-operation). If your containerlab-based labs fail to start, check whether your username is in the `clab_admins` group with the `groups` command. To add your username to that group, use:
 
 ```

--- a/docs/release/26.08.md
+++ b/docs/release/26.08.md
@@ -35,7 +35,8 @@ Arista EOS:
 (release-26.08-breaking)=
 ## Breaking changes
 
-* We enabled the [Transparent Management _containerlab_ feature](https://containerlab.dev/manual/vrnetlab/#management-interface) on vrnetlab-based devices supporting it in July 2026. This change should not impact older containers, but will change the management IPv4 address on virtual machines running within some newly-built containers from 10.0.0.15 (default management IPv4 address) to the outside (container) management IPv4 address.
+* We enabled the [Transparent Management _containerlab_ feature](https://containerlab.dev/manual/vrnetlab/#management-interface) on vrnetlab-based devices supporting it in July 2026. This change should not impact older containers, but will change the management IPv4 address on virtual machines running in some newly-built containers from 10.0.0.15 (the default management IPv4 address) to the outside (container) management IPv4 address.
+* The use of the Transparent Management feature broke some vrnetlab containers that assumed the *containerlab* management network always had an IPv6 subnet. While that's been [fixed in *vrnetlab*](https://github.com/srl-labs/vrnetlab/pull/511), _netlab_ nonetheless configures a default IPv6 management subnet (`fd00:df:1ab::/64 `) on the *containerlab* management network to ensure the older containers keep working.
 * We switched to [sudo-less *containerlab* operation](https://containerlab.dev/install/#sudo-less-operation). If your containerlab-based labs fail to start, check whether your username is in the `clab_admins` group with the `groups` command. To add your username to that group, use:
 
 ```

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -5,10 +5,7 @@ prefix: "{{ defaults.providers.clab.lab_prefix|default( "" ) }}"
 mgmt:
   network: {{ addressing.mgmt._network|default('') or 'netlab_mgmt' }}
   ipv4-subnet: {{ addressing.mgmt.ipv4|default('172.20.20.0/24') }}
-  # Note: 'start' not validated
-{% if defaults.addressing.mgmt.ipv6 is defined %}
-  ipv6-subnet: {{ defaults.addressing.mgmt.ipv6 }}
-{% endif %}
+  ipv6-subnet: {{ defaults.addressing.mgmt.ipv6|default('fd00:df:1ab::/64') }}
 {% if addressing.mgmt._bridge|default('') %}
   bridge: {{ addressing.mgmt._bridge }}
 {% endif %}


### PR DESCRIPTION
Closes #3685 (you'll find the details there)