### PR TITLE
OpenBSD Wireguard implementation

### DIFF
--- a/netsim/ansible/templates/initial/openbsd-ifconfig.j2
+++ b/netsim/ansible/templates/initial/openbsd-ifconfig.j2
@@ -28,4 +28,10 @@ ifconfig {{ intf.ifname }} down
 {% else %}
 ifconfig {{ intf.ifname }} up
 {% endif %}
+{%   if 'ipv6' in intf and intf.tunnel.mode|default('') in ['wireguard'] %}
+# OpenBSD Wireguard does not automatically create IPv6 LLA make it ourselves
+{% set _last = range(1, 65536) | random %}
+{% set _lla = 'fe80::%x/64' | format(_last) %}
+ifconfig {{ intf.ifname }} inet6 {{ _lla }}
+{%   endif %}
 {% endmacro %}

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -3,7 +3,9 @@ support:
   level: best-effort
 interface_name: vio{ifindex}
 loopback_interface_name: lo{ifindex}
-tunnel_interface_name: gre{ifindex}
+tunnel_interface_name:
+  gre: gre{ifindex}
+  wireguard: wg{ifindex}
 ifindex_offset: 1
 mgmt_if: vio0
 role: router
@@ -59,6 +61,7 @@ features:
     vtep6: True
   tunnel:
     gre: [ ipv4 ]
+    wireguard: [ ipv4, ipv6 ]
 libvirt:
   create_template: openbsd.xml.j2
   image: netlab/openbsd

--- a/netsim/extra/tunnel/wireguard/openbsd.initial.j2
+++ b/netsim/extra/tunnel/wireguard/openbsd.initial.j2
@@ -1,0 +1,3 @@
+{% for l in interfaces if l.type == 'tunnel' and l.tunnel.mode == 'wireguard' %}
+ifconfig {{ l.ifname }} create
+{% endfor %}

--- a/netsim/extra/tunnel/wireguard/openbsd.j2
+++ b/netsim/extra/tunnel/wireguard/openbsd.j2
@@ -1,0 +1,10 @@
+#!/bin/sh
+# wg endpoint
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['wireguard'] %}
+{%   set dst = intf.tunnel._destination %}
+{%   set peer_ip = ('[' ~ dst.ipv6 ~ ']') if intf.tunnel.af == 'ipv6' else dst.ipv4 %}
+{%   set peer_endpoint = peer_ip ~ ':' ~ dst.listen_port %}
+ifconfig {{ intf.ifname }} wgkey {{ intf.tunnel.private_key }} wgport {{ intf.tunnel.listen_port }} up
+ifconfig {{ intf.ifname }} wgpeer {{ dst.public_key }} wgendpoint {{ peer_ip }} {{ dst.listen_port }} wgpka {{ intf.tunnel.persistent_keepalive }}
+ifconfig {{ intf.ifname }} wgpeer {{ dst.public_key }} wgaip {{ intf.tunnel.allowed_ips.split(',') | join(' wgaip ') }}
+{% endfor %}

--- a/tests/integration/tunnel/11-wireguard.yml
+++ b/tests/integration/tunnel/11-wireguard.yml
@@ -12,6 +12,7 @@ plugin: [ tunnel.wireguard, adjust_test ]
 addressing:
   loopback:
     ipv6: 2001:db8:1::/48
+    prefix6: 128
   lan:
     ipv6: 2001:db8:2::/48
   p2p:


### PR DESCRIPTION
This is more open for comment than ready for commit.

Three issues:
1. OpenBSD does not create IPv6 LLA addresses on WG interfaces because they are technically multipoint
2. Wireguard IPv6 test does not set prefix length for loopback (so fails for OpenBSD which only does /128)
3. Wireguard module does not support selecting only IPv4 or IPv6

One other question, is there a reason why we might do tunnel setup after our routing protocols like OSPF?
If tunnels happened before OSPF, I could move my 'non ideal' hack out of initial and just into the Wireguard config for OpenBSD.

<details><summary>Wireguard Test output</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$ netlab validate
[adj]     Check OSPFv2 adjacencies with DUT [ node(s): r2,r3 ]
[PASS]    r2: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]    r3: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]    Test succeeded in 0.3 seconds

[adj6]    Check OSPFv3 adjacencies with DUT [ node(s): r2,r3 ]
[PASS]    r2: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]    r3: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]    Test succeeded in 0.3 seconds

[pfx]     Check for DUT IPv4 loopback prefix being propagated to R2 [ node(s): r2,r3 ]
[PASS]    r2: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    r3: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    Test succeeded in 0.3 seconds

[pfx6]    Check for DUT IPv6 loopback prefix being propagated to R2 [ node(s): r2,r3 ]
[WAITING] Waiting for SPF to do its magic (retrying for 30 seconds)
[WAITING] Waiting for SPF to do its magic (14 seconds left)
[FAIL]    Node r2: The prefix 2001:db8:1:1::/64 is not in the OSPFv3 topology
[FAIL]    Node r3: The prefix 2001:db8:1:1::/64 is not in the OSPFv3 topology

[ping]    Check IPv4 connectivity over tunnel [ node(s): r2,r3 ]
[PASS]    r2: Ping to 10.0.0.1 succeeded
[PASS]    r3: Ping to 10.0.0.1 succeeded
[PASS]    Test succeeded in 0.3 seconds

[ping6]   Check IPv6 connectivity over tunnel [ node(s): r2,r3 ]
[PASS]    r2: Ping to ipv6 2001:db8:1:1::1 succeeded
[PASS]    r3: Ping to ipv6 2001:db8:1:1::1 succeeded
[PASS]    Test succeeded in 0.3 seconds

[mtu]     Check a full 1500-byte packet traverses the tunnel (underlay MTU 1560) [ node(s): r2,r3 ]
[PASS]    r2: Ping to 10.0.0.1 size 1500 succeeded
[PASS]    r3: Ping to 10.0.0.1 size 1500 succeeded
[PASS]    Test succeeded in 0.3 seconds

[x_ping]  Check end-to-end IPv4 connectivity [ node(s): r2 ]
[PASS]    r2: Ping to 10.0.0.3 succeeded
[PASS]    Test succeeded in 0.1 seconds

[x_ping6] Check end-to-end IPv6 connectivity [ node(s): r2 ]
[PASS]    r2: Ping to ipv6 2001:db8:1:3::1 succeeded
[PASS]    Test succeeded in 0.2 seconds

[FAIL]    16 tests completed, 2 tests failed
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration/tunnel$
```
</details>