### PR TITLE
Make clab default mgmt IPv6 subnet multilab-aware

### DIFF
--- a/docs/plugins/multilab.md
+++ b/docs/plugins/multilab.md
@@ -78,7 +78,7 @@ change:
   name: 'ml-{id}'
   defaults.name: 'ml-{id}'
   defaults.providers.libvirt.tunnel_id: '{id}'
-  defaults.providers.libvirt.vifprefix: 'vif_{id}'
+  defaults.providers.libvirt.vifprefix: 'vgif_{id}'
   defaults.providers.clab.mgmt_default_ipv6: 'fd00:df:1ab:{id}::/64'
   addressing.mgmt:
     ipv4: '192.168.{id}.0/24'

--- a/docs/plugins/multilab.md
+++ b/docs/plugins/multilab.md
@@ -79,6 +79,7 @@ change:
   defaults.name: 'ml-{id}'
   defaults.providers.libvirt.tunnel_id: '{id}'
   defaults.providers.libvirt.vifprefix: 'vif_{id}'
+  defaults.providers.clab.mgmt_default_ipv6: 'fd00:df:1ab:{id}::/64'
   addressing.mgmt:
     ipv4: '192.168.{id}.0/24'
     _network: 'nl_mgmt_{id}'

--- a/netsim/defaults/multilab.yml
+++ b/netsim/defaults/multilab.yml
@@ -8,6 +8,7 @@ change:
   defaults.name: 'ml-{id}'
   defaults.providers.libvirt.tunnel_id: '{id}'
   defaults.providers.libvirt.vifprefix: 'vgif_{id}'
+  defaults.providers.clab.mgmt_default_ipv6: 'fd00:df:1ab:{id}::/64'
   addressing.mgmt:
     ipv4: '192.168.{id}.0/24'
     _network: 'nl_mgmt_{id}'

--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -3,7 +3,8 @@
 #
 description: containerlab with Docker
 config: clab.yml
-lab_prefix: "clab" # Containerlab default, set to "" to remove prefix
+lab_prefix: "clab"                      # Containerlab default, set to "" to remove prefix
+mgmt_default_ipv6: fd00:df:1ab::/64     # Needed for old vrnetlab containers with Transparent Management
 node_config_special: [ binds, config_templates, image, kind, startup-config, srl-agents ]
 template: clab.j2
 version: "0.75.0"       # Triple-check the exact release tag containerlab is using when changing this :(

--- a/netsim/templates/provider/clab/clab.j2
+++ b/netsim/templates/provider/clab/clab.j2
@@ -5,7 +5,7 @@ prefix: "{{ defaults.providers.clab.lab_prefix|default( "" ) }}"
 mgmt:
   network: {{ addressing.mgmt._network|default('') or 'netlab_mgmt' }}
   ipv4-subnet: {{ addressing.mgmt.ipv4|default('172.20.20.0/24') }}
-  ipv6-subnet: {{ defaults.addressing.mgmt.ipv6|default('fd00:df:1ab::/64') }}
+  ipv6-subnet: {{ defaults.addressing.mgmt.ipv6|default(defaults.providers.clab.mgmt_default_ipv6) }}
 {% if addressing.mgmt._bridge|default('') %}
   bridge: {{ addressing.mgmt._bridge }}
 {% endif %}


### PR DESCRIPTION
The clab default management IPv6 subnet (introduced in #3746) was hard-coded in the clab.j2 template, and of course crashed the second lab instance ran with multilab plugin.

It's worth noting that none of us nor the AI review caught this FUBAR