### PR TITLE
Disable RA listener on Linux container mgmt interface

### DIFF
--- a/docs/labs/linux.md
+++ b/docs/labs/linux.md
@@ -61,13 +61,17 @@ The netlab-generated entries are *appended* to the existing `/etc/hosts` file on
 (linux-forwarding)=
 ## Static Routes and Packet Forwarding on Linux
 
-Linux devices are usually hosts that use [static routes](node-router-host) with the [default gateway](links-gateway) as the next hop. The default route is created by *containerlab* and points to the management network, allowing Linux containers to access external destinations through the management network.
+Linux devices are usually hosts that use [static routes](node-router-host) with the [default gateway](links-gateway) as the next hop. The IPv4 default route is created by *containerlab* and points to the management network, allowing Linux containers to access external destinations through the management network.
 
 IPv4 and IPv6 packet forwarding on Linux devices is controlled with the **role** node parameter:
 
 * **host** (default): a Linux device does not perform packet forwarding and cannot be the default gateway for other hosts.
 * **gateway**: a Linux device does not perform packet forwarding but acts as the default gateway for other hosts. You will have to install a proxy (or a similar solution) for inter-subnet packet forwarding.
 * **router**: A Linux device performs packet forwarding but does not run routing protocols. Use the **frr** device if you want to run routing protocols on a Linux server.
+
+```{warning}
+Linux-based *host* devices use the RA-derived IPv6 default route for intra-lab connectivity. The Linux container management interface is thus configured not to accept RA messages.
+```
 
 You can also enable the IPv4/IPv6 packet forwarding on a Linux device with the **netlab_ip_forwarding** node attribute/group variable set to *True*.
 

--- a/docs/release/26.08.md
+++ b/docs/release/26.08.md
@@ -36,7 +36,8 @@ Arista EOS:
 ## Breaking changes
 
 * We enabled the [Transparent Management _containerlab_ feature](https://containerlab.dev/manual/vrnetlab/#management-interface) on vrnetlab-based devices supporting it in July 2026. This change should not impact older containers, but will change the management IPv4 address on virtual machines running in some newly-built containers from 10.0.0.15 (the default management IPv4 address) to the outside (container) management IPv4 address.
-* The use of the Transparent Management feature broke some vrnetlab containers that assumed the *containerlab* management network always had an IPv6 subnet. While that's been [fixed in *vrnetlab*](https://github.com/srl-labs/vrnetlab/pull/511), _netlab_ nonetheless configures a default IPv6 management subnet (`fd00:df:1ab::/64`) on the *containerlab* management network to ensure the older containers keep working.
+* The use of the Transparent Management feature broke some vrnetlab containers that assumed the *containerlab* management network always had an IPv6 subnet. While that's been [fixed in *vrnetlab*](https://github.com/srl-labs/vrnetlab/pull/511), _netlab_ nonetheless configures a default IPv6 management subnet (`fd00:df:1ab::/64`, adjusted on _[multilab](plugin-multilab)_ instances) on the *containerlab* management network to ensure the older containers keep working.
+* The default IPv6 management subnet broke the default route on lab hosts without a management VRF (for example, the Linux containers). The Linux container initial configuration script thus disables the RA listener on the management interface (the IPv6 management address is configured by _containerlab_).
 * We switched to [sudo-less *containerlab* operation](https://containerlab.dev/install/#sudo-less-operation). If your containerlab-based labs fail to start, check whether your username is in the `clab_admins` group with the `groups` command. To add your username to that group, use:
 
 ```

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -20,7 +20,13 @@ sysctl -w net.ipv6.conf.all.forwarding={{ pkt_fwd }}
 {% if loopback is defined %}
 {{ ifconfig(loopback) }}
 {% endif %}
-
+#
+# Disable RA-derived IPv6 default route on management interface. We need it for intra-lab connectivity
+#
+if ip -6 addr show dev {{ mgmt.ifname }} | grep inet6; then
+  sysctl -qw net/ipv6/conf/{{ mgmt.ifname }}/accept_ra=0
+  sudo ip -6 route del default dev {{ mgmt.ifname }} || echo "No default route on {{ mgmt.ifname }}"
+fi
 #
 # Interface addressing, create any bond devices
 #

--- a/tests/platform-integration/clab/02-mac-ip.yml
+++ b/tests/platform-integration/clab/02-mac-ip.yml
@@ -54,11 +54,11 @@ validate:
   v6mgmt:
     description: Check for default IPv6 management subnet
     nodes: [ h2 ]
-    exec.linux: ip -6 addr show dev {{ mgmt.ifname }}
+    exec.linux: ip -6 addr show dev {{ mgmt.ifname }} scope global
     valid: |
       'inet6' in stdout
   ping:
     description: Check end-to-end connectivity
     wait: ping_long
     nodes: [ h1, h2, r3 ]
-    plugin: ping('r1')
+    plugin: ping('r1',af='ipv6')

--- a/tests/platform-integration/clab/02-mac-ip.yml
+++ b/tests/platform-integration/clab/02-mac-ip.yml
@@ -3,6 +3,8 @@ message: |
   can successfully configure them. It also checks the configuration of containers
   disconnected from the management network.
 
+defaults.sources.extra: [ ../../integration/wait_times.yml ]
+
 provider: clab
 defaults.device: eos
 module: [ ospf ]
@@ -11,7 +13,11 @@ ospf.timers:
   dead: 4
 
 defaults.multilab.change.addressing.mgmt.ipv4: '192.42.42.0/24'
-addressing.mgmt.ipv4: '192.42.42.0/24'
+addressing:
+  mgmt.ipv4: '192.42.42.0/24'
+  loopback.ipv6: 2001:db8:1::/48
+  lan.ipv6: 2001:db8:cafe::/48
+  p2p.ipv6: 2001:db8:42::/48
 
 nodes:
   r1:
@@ -25,11 +31,34 @@ nodes:
   r3:
     device: frr
     clab.network-mode: none
+  h1:
+    device: linux
+    clab.network-mode: none
+  h2:
+    device: linux
 
-links: [ r1-r2, r2-r3 ]
+links: [ r1-r2, r2-r3, r3-h1, r3-h2 ]
 
 validate:
   adj:
     plugin: ospf_neighbor(nodes.r2.ospf.router_id)
-    wait: 15
+    wait: ospfv2_adj_p2p
     nodes: [ r1, r3 ]
+  ra:
+    description: Check RA-generated default route
+    wait: ra_send
+    wait_msg: Waiting for RA message to generate the default route
+    nodes: [ h1, h2 ]
+    plugin: default6()
+    stop_on_error: True
+  v6mgmt:
+    description: Check for default IPv6 management subnet
+    nodes: [ h2 ]
+    exec.linux: ip -6 addr show dev {{ mgmt.ifname }}
+    valid: |
+      'inet6' in stdout
+  ping:
+    description: Check end-to-end connectivity
+    wait: ping_long
+    nodes: [ h1, h2, r3 ]
+    plugin: ping('r1')


### PR DESCRIPTION
The Linux containers are configured with a default IPv6 address on the management interface after #3746 and thus get a default route pointing to the management interface, breaking intra-lab IPv6 connectivity.

This fix disables RA on management interface (if it exists) in vanilla Linux initial configuration (used for Linux containers, BIRD...)