### PR TITLE
Configurable SR-MPLS SRGB on EOS, IOS/XE, IOS/XR

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -55,6 +55,7 @@ nodes:
 * IPv6 BFD for IS-IS cannot be enabled on individual interfaces.  If you set **isis.bfd.ipv6** to *True*, BFD is enabled on all IS-IS interfaces.
 * Arista EOS virtual machines and containers use [proprietary control-plane messages to indicate the loss of Ethernet line protocol](https://blog.ipspace.net/2025/03/arista-spooky-action-distance/). Set the **netlab_phy_control** node variable to *False* to disable this functionality.
 * Device configurations that contain `no lldp transmit` or `no lldp receive` configuration command trigger configuration reload failures due to an Arista EOS bug ([more details](https://github.com/ipspace/netlab/issues/2577)). These commands are thus automatically removed from collected device configurations.
+* Arista EOS uses per-protocol Segment Routing Global Blocks. If you run SR-MPLS with OSPFv2 and IS-IS on the same device, the SRGB specified in the lab topology is applied to IS-IS and not to OSPFv2.
 
 GRE tunnel caveats:
 

--- a/netsim/ansible/templates/sr/eos.j2
+++ b/netsim/ansible/templates/sr/eos.j2
@@ -3,6 +3,9 @@ mpls icmp ttl-exceeded tunneling
 !
 {% if 'isis' in sr.protocol %}
 !
+{%   if sr.srgb.start is defined %}
+mpls label range isis-sr {{ sr.srgb.start }} {{ sr.srgb.size }}
+{%   endif %}
 router isis {{ isis.instance }}
 {%   if isis.router_id is defined %}
   router-id ipv4 {{ isis.router_id }}
@@ -12,6 +15,9 @@ router isis {{ isis.instance }}
 {% endif %}
 {% if 'ospfv2' in sr.protocol %}
 !
+{%   if sr.srgb.start is defined and 'isis' not in sr.protocol %}
+mpls label range ospf-sr {{ sr.srgb.start }} {{ sr.srgb.size }}
+{%   endif %}
 router ospf {{ ospf.process|default(1) }}
   segment-routing mpls
     no shutdown

--- a/netsim/ansible/templates/sr/ios.j2
+++ b/netsim/ansible/templates/sr/ios.j2
@@ -2,6 +2,9 @@ mpls ip
 !
 segment-routing mpls
  !
+{%   if sr.srgb.start is defined %}
+ global-block {{ sr.srgb.start }} {{ sr.srgb._end }}
+{%   endif %}
  set-attributes
   address-family ipv4
    explicit-null

--- a/netsim/ansible/templates/sr/iosxr.j2
+++ b/netsim/ansible/templates/sr/iosxr.j2
@@ -1,3 +1,7 @@
+{%   if sr.srgb.start is defined %}
+segment-routing global-block {{ sr.srgb.start }} {{ sr.srgb._end }}
+!
+{%   endif %}
 {% if 'isis' in sr.protocol %}
 !
 router isis {{ isis.instance }}

--- a/netsim/modules/sr.py
+++ b/netsim/modules/sr.py
@@ -43,8 +43,9 @@ class SR(_Module):
       srgb = sr_data.srgb
       for (kw_start,kw_size,kw_end) in (('start','size','_end'),('dyn_start','dyn_size','_dyn_end')):
         if kw_start in srgb:                                # Do we have configured label block?
-          sr_size = srgb.get(kw_size,8000)                  # Default label block size = 8000 labels. Can be changed with device defaults
-          srgb[kw_end] = srgb[kw_start] + sr_size - 1       # Calcuate the end label
+          if kw_size not in srgb:                           # ... if we do, we also need its size
+            srgb[kw_size] = 8000                            # Default label block size = 8000 labels. Can be changed with device defaults
+          srgb[kw_end] = srgb[kw_start] + srgb[kw_size] - 1 # Calcuate the end label
 
     proto_af: set = set()                                   # Collect AFs supported by SR-MPLS protocols
     OK = True

--- a/tests/coverage/expected/migrated-attr.yml
+++ b/tests/coverage/expected/migrated-attr.yml
@@ -144,6 +144,7 @@ nodes:
       - isis
       srgb:
         _end: 107999
+        size: 8000
         start: 100000
   c2:
     af:
@@ -218,6 +219,7 @@ nodes:
       - isis
       srgb:
         _end: 107999
+        size: 8000
         start: 100000
   e1:
     af:
@@ -292,6 +294,7 @@ nodes:
       - isis
       srgb:
         _end: 107999
+        size: 8000
         start: 100000
   e2:
     af:
@@ -366,6 +369,7 @@ nodes:
       - isis
       srgb:
         _end: 107999
+        size: 8000
         start: 100000
 provider: libvirt
 sr:

--- a/tests/integration/sr/01-isis-ipv4-p.yml
+++ b/tests/integration/sr/01-isis-ipv4-p.yml
@@ -23,14 +23,18 @@ groups:
     members: [ dut, p2 ]
     module: [ isis, sr ]
   x_switches:
-    members: [ pe1, pe2, p2 ]
+    members: [ pe1, p2 ]
     device: frr
+    provider: clab
+  x_probes:
+    members: [ pe2 ]
+    device: eos
     provider: clab
 
 nodes:
   dut:
     id: 1
-    sr.srgb.start: 38400    # check IS-IS SRGB setup (see #3652)
+    sr.srgb.start: 407230    # check IS-IS SRGB setup (see #3652)
 
 links:
 - h1:
@@ -62,10 +66,10 @@ validate:
     description: Check DUT SRGB settings
     nodes: [ pe2 ]
     level: warning
-    fail: The DUT SRGB does not start at 38400
-    exec.frr: vtysh -c "show isis segment-routing node"
+    fail: The DUT SRGB does not start at 407230
+    exec.eos: show isis segment-routing global-blocks
     valid: >-
-      "38400" in stdout
+      "407230" in stdout
   ping:
     description: Ping-based end-to-end reachability test
     wait_msg: We might have to wait a bit longer

--- a/tests/integration/sr/21-ospf-ipv4-p.yml
+++ b/tests/integration/sr/21-ospf-ipv4-p.yml
@@ -45,7 +45,7 @@ groups:
 nodes:
   dut:
     id: 1
-    sr.srgb.start: 38400    # check OSPF SRGB setup (see #3652)
+    sr.srgb.start: 407230    # check OSPF SRGB setup (see #3652)
 
 links:
 - h1:
@@ -77,10 +77,10 @@ validate:
     description: Check DUT SRGB settings
     nodes: [ pe2 ]
     level: warning
-    fail: The DUT SRGB does not start at 38400
+    fail: The DUT SRGB does not start at 407230
     exec.eos: show ip ospf segment-routing global-blocks
     valid: >-
-      "38400" in stdout
+      "407230" in stdout
   ping:
     description: Ping-based end-to-end reachability test
     wait_msg: We might have to wait a bit longer


### PR DESCRIPTION
Also:
* Set the sr.srgb.size to default value (8000) if the .start parameter is specified but the size is missing.
* Change the SRGB values in integration tests to work with Arista EOS
* Use Arista EOS to check SRGB values in integration tests (FRR does not show what's configured on EOS).