### PR TITLE
'device' validation type accepts template devices

### DIFF
--- a/docs/dev/validation-types.txt
+++ b/docs/dev/validation-types.txt
@@ -59,7 +59,7 @@ See [](validation-definition-examples) and [](inter-attribute-examples) for more
 
 When an attribute has a data type defined with the **type** attribute, you can use the following attributes to perform value-based validations:
 
-{.wrap-cells}
+{.table-wrap}
 | Data type | Value validation option |
 |-----------|-------------------------|
 | **str**   | **valid_values** -- list of valid values |
@@ -74,13 +74,14 @@ When an attribute has a data type defined with the **type** attribute, you can u
 | **dict**  | **create_empty** (bool) -- replace None value with an empty dictionary |
 |           | **_keys** -- validation rules for individual dictionary keys. |
 |           | **_subtype** -- validate values as belonging to the specified subtype |
-|           | **_keytype** -- validate keys as belonging to the specified scalar type |
+|           | **_keytype** -- validate keys as belonging to the specified type |
 |           | **_list_to_dict** -- [value can be specified as a list](validation-list-to-dict) |
 | **float** | **min_value** -- minimum parameter value |
 |           | **max_value** -- maximum parameter value |
-| **id**    | **max_length** -- maximum identifier length |
 | **int**   | **min_value** -- minimum parameter value |
 |           | **max_value** -- maximum parameter value |
+| **device**| **include_templates** (bool) -- accept template devices (for example, `ios` or `junos`) that are otherwise not valid device types |
+| **id**    | **max_length** -- maximum identifier length |
 | **ipv4**  | **use** -- [the use of IPv4 address/prefix](validation-ip-address) |
 | **ipv6**  | **use** -- [the use of IPv6 address/prefix](validation-ip-address) |
 

--- a/netsim/augment/devices.py
+++ b/netsim/augment/devices.py
@@ -340,6 +340,7 @@ def augment_device_settings(topology: Box) -> None:
 
   for dname in list(devices.keys()):              # After completing device transformation, do a few sanity checks
     if 'template' in devices[dname]:              # Remove template devices
+      data.append_to_list(topology.defaults.const,'template_devices',dname)
       devices.pop(dname,None)
       continue
 

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -1002,7 +1002,7 @@ def must_be_device(value: typing.Any, include_templates: bool = False) -> dict:
   if not value in list_of_devices:
     error = True
     if include_templates:
-      template_devices = global_vars.get_const('template_devices')
+      template_devices = global_vars.get_const('template_devices',[])
       error = value not in template_devices
     if error:
       status['_value'] = f'known device type identifier (got {value})'

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -987,7 +987,7 @@ def must_be_rd(value: typing.Any) -> dict:
 
 
 @type_test()
-def must_be_device(value: typing.Any) -> dict:
+def must_be_device(value: typing.Any, include_templates: bool = False) -> dict:
   from .validate import list_of_devices
 
   status = {
@@ -1000,8 +1000,13 @@ def must_be_device(value: typing.Any) -> dict:
     return status
 
   if not value in list_of_devices:
-    status['_value'] = f'known device type identifier (got {value})'
-    return status
+    error = True
+    if include_templates:
+      template_devices = global_vars.get_const('template_devices')
+      error = value not in template_devices
+    if error:
+      status['_value'] = f'known device type identifier (got {value})'
+      return status
 
   return { '_valid': True }
 


### PR DESCRIPTION
Sometimes (= in validation tests) we have to accept template devices (ios, junos...) that are otherwise not valid devices.

The 'must_be_device' validation function thus got the 'include_templates' parameter (default: false) that extends the checks with template devices removed from the 'defaults.devices' dict.

However, we (somehow) need those devices, so the 'augment.devices' code stores them into defaults.const.template_devices' before removing them.

Unrelated:
* Rearranged data types in validation documentation to have standard data types before the netlab-specific ones
* Fixed the omission from #3757 -- _keytype can be any type, not just a scalar one