### PR TITLE
Consider files created by configlets in check.config

### DIFF
--- a/netsim/extra/check/config/__init__.py
+++ b/netsim/extra/check/config/__init__.py
@@ -1,13 +1,21 @@
+import typing
 
 from box import Box
 
 from netsim import data
+from netsim.augment import devices as a_devices
 from netsim.utils import files as _files
 from netsim.utils import log, strings
 
+_execute_after    = [ 'files' ]
 
-def cleanup(topology: Box) -> None:
+def post_quirks(topology: Box) -> None:
   missing = data.get_empty_box()
+  if 'files' in topology:
+    extra_files = [ x.path for x in topology.files if isinstance(x,Box) and 'path' in x ]
+  else:
+    extra_files = []
+
   for ndata in topology.nodes.values():
     if not 'config' in ndata:
       continue
@@ -18,9 +26,14 @@ def cleanup(topology: Box) -> None:
       f'{ndata.device}.j2' ]
 
     for cfg in list(ndata.config):
+      cfg_file: typing.Optional[str] = None
       for cfg_candidate in candidate_files:
-        cfg_file = _files.find_file(f'{cfg}/{cfg_candidate}',topology.defaults.paths.custom.dirs)
+        cfg_path = f'{cfg}/{cfg_candidate}'
+        if cfg_path in extra_files:
+          cfg_file = cfg_path
+          break
 
+        cfg_file = _files.find_file(cfg_path,topology.defaults.paths.custom.dirs)
         if cfg_file:
           break
 

--- a/netsim/extra/check/config/__init__.py
+++ b/netsim/extra/check/config/__init__.py
@@ -3,7 +3,6 @@ import typing
 from box import Box
 
 from netsim import data
-from netsim.augment import devices as a_devices
 from netsim.utils import files as _files
 from netsim.utils import log, strings
 
@@ -11,10 +10,9 @@ _execute_after    = [ 'files' ]
 
 def post_quirks(topology: Box) -> None:
   missing = data.get_empty_box()
+  extra_files: set = set()
   if 'files' in topology:
-    extra_files = [ x.path for x in topology.files if isinstance(x,Box) and 'path' in x ]
-  else:
-    extra_files = []
+    extra_files = { x.path for x in topology.files if isinstance(x,Box) and 'path' in x }
 
   for ndata in topology.nodes.values():
     if not 'config' in ndata:

--- a/tests/coverage/expected/check-config-files.yml
+++ b/tests/coverage/expected/check-config-files.yml
@@ -1,0 +1,161 @@
+files:
+- content: '! hello world configlet'
+  path: hello/frr.j2
+input:
+- coverage/input/check-config-files.yml
+- package:topology-defaults.yml
+links:
+- _linkname: links[1]
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.2/30
+    node: r2
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  type: p2p
+name: input
+nodes:
+  r1:
+    _node_config:
+      hello: /etc/config/02-hello.sh:sh
+      initial: /etc/config/01-initial.sh:sh
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.6.1
+    clab:
+      binds:
+      - source: node_files/r1/initial
+        target: /etc/config/01-initial.sh
+      - source: node_files/r1/hello
+        target: /etc/config/02-hello.sh
+      - source: node_files/r1/daemons
+        target: /etc/frr/daemons
+      - mode: ro
+        source: node_files/-shared-hosts
+        target: /etc/hosts
+      - source: node_files/r1/resolv
+        target: /etc/resolv.conf
+      config_templates:
+      - mode: sh
+        source: initial
+        target: /etc/config/01-initial.sh
+      - mode: sh
+        source: hello
+        target: /etc/config/02-hello.sh
+      - source: daemons
+        target: /etc/frr/daemons
+      - mode: shared
+        source: hosts
+        target: /etc/hosts
+      - source: resolv
+        target: /etc/resolv.conf
+      exec:
+      - sleep 1
+      kind: linux
+    config:
+    - hello
+    device: frr
+    hostname: clab-input-r1
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.1/30
+      linkindex: 1
+      mtu: 1500
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.2/30
+        node: r2
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    mtu: 1500
+    name: r1
+    netlab_ansible_skip_module:
+    - initial
+    - hello
+    role: router
+  r2:
+    _node_config:
+      initial: /etc/config/01-initial.sh:sh
+    af:
+      ipv4: true
+    box: quay.io/frrouting/frr:10.6.1
+    clab:
+      binds:
+      - source: node_files/r2/initial
+        target: /etc/config/01-initial.sh
+      - source: node_files/r2/daemons
+        target: /etc/frr/daemons
+      - mode: ro
+        source: node_files/-shared-hosts
+        target: /etc/hosts
+      - source: node_files/r2/resolv
+        target: /etc/resolv.conf
+      config_templates:
+      - mode: sh
+        source: initial
+        target: /etc/config/01-initial.sh
+      - source: daemons
+        target: /etc/frr/daemons
+      - mode: shared
+        source: hosts
+        target: /etc/hosts
+      - source: resolv
+        target: /etc/resolv.conf
+      exec:
+      - sleep 1
+      kind: linux
+    device: frr
+    hostname: clab-input-r2
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.2/30
+      linkindex: 1
+      mtu: 1500
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.1/30
+        node: r1
+      type: p2p
+    loopback:
+      ifindex: 0
+      ifname: lo
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    mtu: 1500
+    name: r2
+    netlab_ansible_skip_module:
+    - initial
+    role: router
+plugin:
+- files
+- check.config
+provider: clab

--- a/tests/coverage/input/check-config-files.yml
+++ b/tests/coverage/input/check-config-files.yml
@@ -1,0 +1,10 @@
+provider: clab
+plugin: [ files, check.config ]
+defaults.device: frr
+configlets:
+  hello:
+    frr: "! hello world configlet"
+nodes:
+  r1: { config: [ hello ] }
+  r2: {}
+links: [ r1-r2 ]


### PR DESCRIPTION
* The 'check.config' main loop checks files that will be created by the 'files' plugin (the 'files' list) when trying to figure out if it's safe to use a custom configuration template.
* The 'check.config' logic was moved to the 'post_quirks' plugin hook to be executed before provider post_transform hook which creates all sorts of hard-to-deal-with data (in clab case). This should be late enough in the process to have the final 'config' list, and it's also the very last plugin hook before clab provider does its stuff.