### PR TITLE
Deprecate IOSv, describe its ancient SSH woes

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -205,7 +205,7 @@ These caveats are common to all Cisco IOS XE platforms:
 
 The Cisco IOSv SSH implementation uses RSA keys and older encryption algorithms that may not be enabled by default on newer Linux distributions.
 
-That wasn't a problem for Ansible users until October 2025, when the new version of the `ansible-pylibssh` package (installed with Ansible) was released. `ansible-pylibssh` release 1.3.0 uses `libssh` release 0.11.0, which [no longer supports legacy SSH algorithms](https://github.com/ipspace/netlab/discussions/2759).
+That wasn't a problem for Ansible users until October 2025, when the new version of the `ansible-pylibssh` package (installed with Ansible) was released. `ansible-pylibssh` release 1.3.0 bundles `libssh` release 0.11.0 with [disabled legacy SSH algorithms](https://github.com/ipspace/netlab/discussions/2759).
 
 _netlab_ automatically tells Ansible to use the **paramiko** library when it detects a newer version of the `ansible-pylibssh` library. You could also downgrade `ansible-pylibssh` to release 1.2.2 with a command similar to `pip3 install --upgrade ansible-pylibssh==1.2.2` (you might have to prefix the command with `sudo` or add the `--break-system-packages` argument to the **pip3** command). Alternatively, you can tell Ansible to use the **paramiko** SSH library with:
 
@@ -214,7 +214,7 @@ $ export ANSIBLE_NETWORK_CLI_SSH_TYPE=paramiko
 $ export ANSIBLE_PARAMIKO_LOOK_FOR_KEYS=False
 ```
 
-However, even the **paramiko** release 5.0 removed support for the ancient algorithms used in Cisco IOSv. You might be able to get IOSv to work with a downgraded version of paramiko installed, for example, with `pip3 install --upgrade 'paramiko<5.0'`. However, it would be much better if you could use IOL and IOLL2 containers instead of IOSv and IOSvL2.
+However, even the **paramiko** release 5.0 [removed support for the ancient algorithms used in Cisco IOSv](https://github.com/ipspace/netlab/discussions/3714). You might be able to get IOSv to work with a downgraded version of paramiko installed, for example, with `pip3 install --upgrade 'paramiko<5.0'`. However, it would be much better if you could use IOL and IOLL2 containers instead of IOSv and IOSvL2.
 
 We added a similar mechanism to _netlab_ commands that use SSH to connect to network devices. These commands append the group variable `netlab_ssh_args` (when defined) to the **ssh** command; the value of that variable for Cisco IOS/IOS-XE devices is set to:
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -203,7 +203,7 @@ These caveats are common to all Cisco IOS XE platforms:
 (cisco-ios-ssh)=
 ### SSH Access to Cisco IOS/IOS-XE
 
-The Cisco IOS/IOS-XE SSH implementation uses RSA keys and older encryption algorithms that may not be enabled by default on newer Linux distributions.
+The Cisco IOSv SSH implementation uses RSA keys and older encryption algorithms that may not be enabled by default on newer Linux distributions.
 
 That wasn't a problem for Ansible users until October 2025, when the new version of the `ansible-pylibssh` package (installed with Ansible) was released. `ansible-pylibssh` release 1.3.0 uses `libssh` release 0.11.0, which [no longer supports legacy SSH algorithms](https://github.com/ipspace/netlab/discussions/2759).
 
@@ -214,7 +214,9 @@ $ export ANSIBLE_NETWORK_CLI_SSH_TYPE=paramiko
 $ export ANSIBLE_PARAMIKO_LOOK_FOR_KEYS=False
 ```
 
-We added a similar mechanism to _netlab_ commands that use SSH to connect to network devices. These commands append group variable `netlab_ssh_args` (when defined) to the **ssh** command; the value of that variable for Cisco IOS/IOS-XE devices is set to:
+However, even the **paramiko** release 5.0 removed support for the ancient algorithms used in Cisco IOSv. You might be able to get IOSv to work with a downgraded version of paramiko installed, for example, with `pip3 install --upgrade 'paramiko<5.0'`. However, it would be much better if you could use IOL and IOLL2 containers instead of IOSv and IOSvL2.
+
+We added a similar mechanism to _netlab_ commands that use SSH to connect to network devices. These commands append the group variable `netlab_ssh_args` (when defined) to the **ssh** command; the value of that variable for Cisco IOS/IOS-XE devices is set to:
 
 ```
 group_vars:

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -200,33 +200,6 @@ These caveats are common to all Cisco IOS XE platforms:
 
 * Cisco IOS/XE does not accept VXLAN VNI values below 4096
 
-(cisco-ios-ssh)=
-### SSH Access to Cisco IOS/IOS-XE
-
-The Cisco IOSv SSH implementation uses RSA keys and older encryption algorithms that may not be enabled by default on newer Linux distributions.
-
-That wasn't a problem for Ansible users until October 2025, when the new version of the `ansible-pylibssh` package (installed with Ansible) was released. `ansible-pylibssh` release 1.3.0 bundles `libssh` release 0.11.0 with [disabled legacy SSH algorithms](https://github.com/ipspace/netlab/discussions/2759).
-
-_netlab_ automatically tells Ansible to use the **paramiko** library when it detects a newer version of the `ansible-pylibssh` library. You could also downgrade `ansible-pylibssh` to release 1.2.2 with a command similar to `pip3 install --upgrade ansible-pylibssh==1.2.2` (you might have to prefix the command with `sudo` or add the `--break-system-packages` argument to the **pip3** command). Alternatively, you can tell Ansible to use the **paramiko** SSH library with:
-
-```
-$ export ANSIBLE_NETWORK_CLI_SSH_TYPE=paramiko
-$ export ANSIBLE_PARAMIKO_LOOK_FOR_KEYS=False
-```
-
-However, even the **paramiko** release 5.0 [removed support for the ancient algorithms used in Cisco IOSv](https://github.com/ipspace/netlab/discussions/3714). You might be able to get IOSv to work with a downgraded version of paramiko installed, for example, with `pip3 install --upgrade 'paramiko<5.0'`. However, it would be much better if you could use IOL and IOLL2 containers instead of IOSv and IOSvL2.
-
-We added a similar mechanism to _netlab_ commands that use SSH to connect to network devices. These commands append the group variable `netlab_ssh_args` (when defined) to the **ssh** command; the value of that variable for Cisco IOS/IOS-XE devices is set to:
-
-```
-group_vars:
-  netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
-```
-
-You can change the additional SSH arguments with the node **netlab_ssh_args** parameter or with the **defaults.devices._device_.group_vars.netlab_ssh_args** [system default](topo-defaults).
-
-Additionally, you might have to execute `sudo update-crypto-policies --set LEGACY` on AlmaLinux/RHEL.
-
 (caveats-iosv)=
 ## Cisco IOSv/IOSvL2 Caveats
 These caveats apply only to Cisco IOSv and IOSvL2
@@ -239,6 +212,33 @@ These caveats apply only to Cisco IOSv and IOSvL2
 * Cisco IOSvL2 cannot configure tagged VLAN 1 in a trunk. Internal VLAN 1002 is used as a fake native VLAN on interfaces that have tagged VLAN 1 in a trunk.
 
 See also [common Cisco IOS](caveats-ios) caveats.
+
+(cisco-ios-ssh)=
+### SSH Access to Cisco IOSv
+
+The Cisco IOSv SSH implementation uses RSA keys and older encryption algorithms that newer Linux distributions may not enable by default.
+
+That wasn't a problem for Ansible users until October 2025, when the new version of the `ansible-pylibssh` package (installed with Ansible) was released. `ansible-pylibssh` release 1.3.0 bundles `libssh` release 0.11.0 with [disabled legacy SSH algorithms](https://github.com/ipspace/netlab/discussions/2759).
+
+_netlab_ automatically tells Ansible to use the **paramiko** library when it detects a newer version of the `ansible-pylibssh` library. You could also downgrade `ansible-pylibssh` to release 1.2.2 with a command similar to `pip3 install --upgrade ansible-pylibssh==1.2.2` (you might have to prefix the command with `sudo` or add the `--break-system-packages` argument to the **pip3** command). Alternatively, you can tell Ansible to use the **paramiko** SSH library with:
+
+```
+$ export ANSIBLE_NETWORK_CLI_SSH_TYPE=paramiko
+$ export ANSIBLE_PARAMIKO_LOOK_FOR_KEYS=False
+```
+
+However, even the **paramiko** release 5.0 [removed support for the ancient algorithms used in Cisco IOSv](https://github.com/ipspace/netlab/discussions/3714). You might be able to get IOSv to work with a downgraded version of paramiko installed, for example, with `pip3 install --upgrade 'paramiko<5.0'`. However, it's much better to use IOL and IOLL2 containers instead of IOSv and IOSvL2.
+
+We added a similar mechanism to _netlab_ commands that use SSH to connect to network devices. These commands append the group variable `netlab_ssh_args` (when defined) to the **ssh** command; the value of that variable for Cisco IOS/IOS-XE devices is set to:
+
+```
+group_vars:
+  netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
+```
+
+You can change the additional SSH arguments with the node **netlab_ssh_args** parameter or with the **defaults.devices._device_.group_vars.netlab_ssh_args** [system default](topo-defaults).
+
+Additionally, you might have to execute `sudo update-crypto-policies --set LEGACY` on AlmaLinux/RHEL.
 
 (caveats-iol)=
 ## Cisco IOS on Linux (IOL) and IOL Layer-2 Image

--- a/netsim/devices/iosv.py
+++ b/netsim/devices/iosv.py
@@ -64,17 +64,32 @@ def use_paramiko(node: Box, topology: Box) -> None:
     except:
       ANSIBLE_USE_PARAMIKO = False
 
-  if ANSIBLE_USE_PARAMIKO:
-    device = node.device
-    dev_vars = topology.defaults.devices[device].group_vars
-    if 'ansible_network_cli_ssh_type' not in dev_vars:
-      dev_vars.ansible_network_cli_ssh_type = 'paramiko'    # Force Paramiko connection
+  if not ANSIBLE_USE_PARAMIKO:
+    return
+
+  device = node.device
+  dev_vars = topology.defaults.devices[device].group_vars
+  if 'ansible_network_cli_ssh_type' not in dev_vars:
+    dev_vars.ansible_network_cli_ssh_type = 'paramiko'    # Force Paramiko connection
+    report_quirk(
+      f"Changing Ansible network_cli connection SSH type to 'paramiko'",
+      node,
+      quirk='paramiko',
+      category=Warning,
+      more_hints=[ 'The installed version of ansible-pylibssh might not work with Cisco IOS devices' ])
+
+  try:
+    import paramiko  # type:ignore
+    if paramiko.__version__ >= '5.0.0':
       report_quirk(
-        f"Changing Ansible network_cli connection SSH type to 'paramiko'",
+        f"Paramiko version {paramiko.__version__} does not support ancient SSH algorithms used in Cisco IOSv",
         node,
-        quirk='paramiko',
-        category=Warning,
-        more_hints=[ 'The installed version of ansible-pylibssh might not work with Cisco IOS devices' ])
+        quirk='paramiko_50',
+        category=log.MissingDependency,
+        more_hints=['Use "pip install --upgrade \'paramiko<5.0\'" to downgrade paramiko to version 4.0.0'],
+        doc_url='caveats/#cisco-ios-ssh')
+  except:
+    pass
 
 def tunnel_mtu(node: Box) -> None:
   """

--- a/netsim/devices/iosv.py
+++ b/netsim/devices/iosv.py
@@ -80,7 +80,8 @@ def use_paramiko(node: Box, topology: Box) -> None:
 
   try:
     import paramiko  # type:ignore
-    if paramiko.__version__ >= '5.0.0':
+    major = str(paramiko.__version__).split(".",1)[0]
+    if major.isdigit() and int(major) >= 5:
       report_quirk(
         f"Paramiko version {paramiko.__version__} does not support ancient SSH algorithms used in Cisco IOSv",
         node,

--- a/netsim/devices/iosv.yml
+++ b/netsim/devices/iosv.yml
@@ -4,7 +4,7 @@ parent: ios
 support:
   level: minimal
   caveats:
-  - Most SSH libraries no longer support the ancient algorithms used by Cisco IOS classic
+  - Most SSH libraries no longer support the ancient algorithms used by Cisco IOSv
 interface_name: GigabitEthernet0/{ifindex}
 group_vars:
   netlab_device_type: ios

--- a/netsim/devices/iosv.yml
+++ b/netsim/devices/iosv.yml
@@ -1,6 +1,10 @@
 ---
 description: Cisco IOSv
 parent: ios
+support:
+  level: minimal
+  caveats:
+  - Most SSH libraries no longer support the ancient algorithms used by Cisco IOS classic
 interface_name: GigabitEthernet0/{ifindex}
 group_vars:
   netlab_device_type: ios


### PR DESCRIPTION
Based on #3714:

* Change IOSv support level to 'minimal'
* Add a device caveat explaining the obsolesence of its SSH algorithms
* Expand the 'Cisco IOS SSH access' caveats to document the paramiko 5.0 changes and the potential downgrade path