### PR TITLE
Cleanup: Use utils.read.system_defaults

### DIFF
--- a/netsim/cli/show/__init__.py
+++ b/netsim/cli/show/__init__.py
@@ -95,12 +95,11 @@ def run(cli_args: typing.List[str]) -> None:
 
   args = parse_show_args(cli_args)
 
-  empty_file = "package:cli/empty.yml"
-  user_defaults: typing.Optional[list] = [] if 'system' in args and args.system else None
-  topology = _read.load(empty_file,user_defaults=user_defaults)
-  if topology is None:
-    log.fatal("Cannot read system settings")
-    return
+  user_defaults = not ('system' in args and args.system)
+  try:
+    topology = _read.system_defaults(include_user=user_defaults)
+  except Exception as ex:
+    log.fatal(f"Cannot read system settings: {str(ex)}")
 
   # Skip meta devices when displaying device/module support
   DEVICES_TO_SKIP.extend(

--- a/netsim/cli/usage_actions/show.py
+++ b/netsim/cli/usage_actions/show.py
@@ -110,7 +110,7 @@ def show_plugins(args: argparse.Namespace) -> None:
 
 def show_devices(args: argparse.Namespace) -> None:
   d_stat = stats.read_stats()
-  topology = _read.load("package:cli/empty.yml")
+  topology = _read.system_defaults(include_user=True)
   t_header = { 'key': 'device', 'total': 'Total' }
   p_list = sorted(topology.defaults.providers.keys())
   for p_name in p_list:

--- a/netsim/cli/version.py
+++ b/netsim/cli/version.py
@@ -32,9 +32,8 @@ def print_default_locations() -> None:
     topology = _read.system_defaults(include_user=True)
     user_defaults = [ src for src in topology.input if 'package:' not in src ]
     if user_defaults:
-      print(f"  user defaults: {user_defaults}")
     else:
-      print(f"  no user defaults")
+      print("  no user defaults")
   except Exception as ex:
     print(f"  cannot load default settings: {str(ex)}")
 

--- a/netsim/cli/version.py
+++ b/netsim/cli/version.py
@@ -29,10 +29,14 @@ MISSING_OK = ['ruamel.yaml']
 
 def print_default_locations() -> None:
   try:
-    topology = _read.load('package:cli/empty.yml')
-    print(f"  user defaults: {[ src for src in topology.input if 'package:' not in src ]}")
+    topology = _read.system_defaults(include_user=True)
+    user_defaults = [ src for src in topology.input if 'package:' not in src ]
+    if user_defaults:
+      print(f"  user defaults: {user_defaults}")
+    else:
+      print(f"  no user defaults")
   except Exception as ex:
-    print(f"  cannot load default topology: {str(ex)}")
+    print(f"  cannot load default settings: {str(ex)}")
 
 def package_version(package: str) -> None:
   try:


### PR DESCRIPTION
Parts of the code were still using the manual "load empty.yml topo" approach to reading system defaults instead of shared function in utils.read. Fixed that and added a few more just-in-case error messages.