### PR TITLE
Doc: DNS features table

### DIFF
--- a/docs/module/services.md
+++ b/docs/module/services.md
@@ -15,15 +15,19 @@ The initial version of the Network Services configuration module implements [DNS
 
 _netlab_ can configure DNS clients or servers on these platforms:
 
-| Operating system      | IPv4 DNS<br>client | IPv6 DNS<br>client | Transport<br>VRF | DNS server |
-| --------------------- | :-: | :-: | :-: | :-: |
-| Arista EOS            | ✅  | ✅  | ✅  |  ❌  |
-| Cisco IOS/IOS XE[^18v]| ✅  | ✅  | ✅  |  ❌  |
-| FRR (containers)      | ✅  | ✅  | ❌  |  ❌  |
-| Linux (containers)    | ✅  | ✅  | ❌  |  ❌  |
-| dnsmasq               | ✅  | ✅  | ❌  |  ✅  |
-
-[^18v]: Includes Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOSv, Cisco IOSv L2 image, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image.
+```{features}
+- title: IPv4 DNS<br>client
+  enabled: |
+    services.dns is True or 'ipv4' in services.dns
+- title: IPv6 DNS<br>client
+  enabled: |
+    services.dns is True or 'ipv6' in services.dns
+- title: Transport<br>VRF
+  enabled: |
+    services.dns and services.get('dns.transport_vrf',True) != False
+- title: DNS server
+  enabled: services.server.dns
+```
 
 (services-dns-parameters)=
 ## DNS Parameters

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -1,5 +1,6 @@
 ---
-description: DNSmasq - DNS and DHCP server
+description: dnsmasq - DNS and DHCP server
+docname: dnsmasq
 packages:
   dnsmasq: dnsmasq
 daemon_config:

--- a/netsim/daemons/kind.yml
+++ b/netsim/daemons/kind.yml
@@ -1,5 +1,6 @@
 ---
 description: Kubernetes in Docker (KinD) cluster
+docname: KinD cluster
 parent: linux
 role: router
 plugin: [ kind ]

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -45,6 +45,8 @@ clab:
       config_mode: [ sh ]
     services:
       dns:
+        ipv4: True
+        ipv6: True
         transport_vrf: False
   image: quay.io/frrouting/frr:10.6.1
   kmods:

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -1,4 +1,5 @@
 description: Generic Linux host
+docname: Linux
 interface_name: eth{ifindex}
 lag_interface_name: "bond{lag.ifindex}"
 loopback_interface_name: lo{ifindex if ifindex else ""}
@@ -61,6 +62,8 @@ clab:
       svi_interface_name: vlan{vlan}
     services:
       dns:
+        ipv4: True
+        ipv6: True
         transport_vrf: False
   image: python:3.13-alpine
   mtu: 1500


### PR DESCRIPTION
Includes docnames on first-time devices and "extra" dns.ipv4/dns.ipv6 services.dns features on devices that do not support transport VRF