### PR TITLE
Fix: Assign target filenames to bare sh/cp_sh node_config entries

### DIFF
--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -33,6 +33,7 @@ class Containerlab(_Provider):
 
   def node_post_transform(self, node: Box, topology: Box) -> None:
     utils.add_clab_exec(node,'netlab_start_exec',topology)
+    configs.set_node_config_targets(node,topology)
     configs.add_default_config_mode(node,topology)
     binds.add_config_filemaps(node,topology)
     binds.normalize_clab_filemaps(node)

--- a/netsim/providers/clab/configs.py
+++ b/netsim/providers/clab/configs.py
@@ -14,10 +14,11 @@ from ...utils import log, strings
 from .. import PRINT_LOCK
 from . import utils
 
-'''
-add_default_config_mode: if the netlab_config_mode is set, add configured modules to _node_config dictionary
-'''
+
 def add_default_config_mode(node: Box, topology: Box) -> None:
+  '''
+  If the netlab_config_mode is set, add configured modules to _node_config dictionary
+  '''
   cfg_mode = devices.get_node_group_var(node,'netlab_config_mode',topology.defaults)
   if not cfg_mode:
     return
@@ -57,10 +58,27 @@ def add_default_config_mode(node: Box, topology: Box) -> None:
   # add the exec commands to the container exec list
   utils.add_clab_exec(node,'netlab_config_exec',topology)
 
-'''
-Get all configuration snippets with the specified mode
-'''
+def set_node_config_targets(node: Box, topology: Box) -> None:
+  '''
+  Set target filenames for sh/cp_sh config scripts that have no assigned target
+  '''
+  if '_node_config' not in node:
+    return
+
+  nc_dict = node._node_config
+  node_cfg_path: typing.Optional[str] = None
+  for nc_idx,nc_module in enumerate(nc_dict,start=100):
+    # We have to assign targets to bare sh/cp_sh methods
+    if nc_dict[nc_module] not in [':sh',':cp_sh']:
+      continue
+    if not node_cfg_path:                         # Find a viable config path
+      node_cfg_path = devices.get_node_group_var(node,'netlab_config_path',topology.defaults) or '/etc/cfg-'
+    nc_dict[nc_module] = f'{node_cfg_path}{nc_idx}-{nc_module}.sh{nc_dict[nc_module]}'
+
 def get_templates_with_mode(n: Box, mode: typing.Optional[str]) -> list:
+  '''
+  Get all configuration snippets with the specified mode
+  '''
   return [ item for item in n.get('clab.config_templates',[])   # Collect config template items
               if 'mode' in item and                             # ... that have mode set
                  (item.mode == mode or mode is None) ]          # ... and match the requested mode (None == all modes)


### PR DESCRIPTION
The node_config entries with 'sh' or 'cp_sh' method should have target files. Obviously, even people writing that code tend to forget it, so let's fix it for good and assign generated target filenames to entries that have 'sh' or 'cp_sh' method but no target.

Fixes the root cause for #3697