### PR TITLE
Fix: Use 'dns view' on Cisco IOS with dns.transport_vrf

### DIFF
--- a/netsim/ansible/templates/services/ios.j2
+++ b/netsim/ansible/templates/services/ios.j2
@@ -3,10 +3,18 @@
     Use at most six DNS server addresses
 #}
 ip domain lookup
-ip name-server {% if services.dns.transport_vrf is defined
-  %}vrf {{ services.dns.transport_vrf }} {% endif
-  %}{{ services.dns._server_list[:6]|join(' ') }}
-{% endif %}
-{% if services.dns.domain|default(False) %}
+{%   if services.dns.transport_vrf is defined %}
+ip dns view default
+{%     for srv_ip in services.dns._server_list[:6] %}
+ domain name-server vrf {{ services.dns.transport_vrf }} {{ srv_ip }}
+{%     endfor %}
+{%     if services.dns.domain|default(False) %}
+ domain name netlab.local
+{%     endif %}
+{%   else %}{# DNS client in global routing table #}
+ip name-server {{ services.dns._server_list[:6]|join(' ') }}
+{%     if services.dns.domain|default(False) %}
 ip domain name {{ services.dns.domain }}
+{%     endif %}
+{%   endif %}
 {% endif %}

--- a/netsim/ansible/templates/services/ios.j2
+++ b/netsim/ansible/templates/services/ios.j2
@@ -9,7 +9,7 @@ ip dns view default
  domain name-server vrf {{ services.dns.transport_vrf }} {{ srv_ip }}
 {%     endfor %}
 {%     if services.dns.domain|default(False) %}
- domain name netlab.local
+ domain name {{ services.dns.domain }}
 {%     endif %}
 {%   else %}{# DNS client in global routing table #}
 ip name-server {{ services.dns._server_list[:6]|join(' ') }}


### PR DESCRIPTION
Traditional 'ip name-server' command cannot specify the transport VRF. You have to use the 'dns view' to have DNS client running in a transport VRF.

This fix uses the old-school commands for the global DNS client and a DNS view when the 'services.dns.transport_vrf' is set