### PR TITLE
Fix: Junos does not support DNS client in a VRF

### DIFF
--- a/netsim/devices/junos.yml
+++ b/netsim/devices/junos.yml
@@ -91,7 +91,10 @@ features:
       standard: True
       large: True
   services:
-    dns: True
+    dns:
+      ipv4: True
+      ipv6: True
+      transport_vrf: False
   sr:
     af: [ ipv4, ipv6 ]
     protocol: [ isis ]


### PR DESCRIPTION
Junos can specify that a name server is reachable through a routing instance, but the instance type cannot be set to VRF (what netlab is using at the moment).