### PR TITLE
SR Linux: DNS client and static host mappings

### DIFF
--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -110,8 +110,10 @@ updates:
 - path: /system/dns-instance[name=default]
   value:
     network-instance: default
-    host-entry:
 {%   for hname,hdata in hosts.items() if hname != inventory_hostname %}
+{%     if loop.first %}
+    host-entry:
+{%     endif %}
     - name: "{{ hname }}"
 {%     if 'ipv4' in hdata %}
       ipv4-address: {{ hdata.ipv4 }}

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -109,6 +109,7 @@ updates:
 {% if services.dns._no_hosts is not defined %}
 - path: /system/dns-instance[name=default]
   value:
+    network-instance: default
     host-entry:
 {%   for hname,hdata in hosts.items() if hname != inventory_hostname %}
     - name: "{{ hname }}"

--- a/netsim/ansible/templates/initial/srlinux.j2
+++ b/netsim/ansible/templates/initial/srlinux.j2
@@ -82,18 +82,18 @@ updates:
 {% set if_index = if_name_index[1] if if_name_index|length > 1 else '0' %}
 - path: /network-instance[name={{ vrf }}]
   value:
-   type: {{ 'default' if vrf=='default' else 'ip-vrf' }}
-   interface:
-   - name: {{ if_name }}.{{ if_index }}
+    type: {{ 'default' if vrf=='default' else 'ip-vrf' }}
+    interface:
+    - name: {{ if_name }}.{{ if_index }}
 {% endfor %}
 {% endmacro %}
 
 {# Make sure the default VRF is called 'default', and has system0.0 interface #}
 - path: /network-instance[name=default]
   value:
-   type: default
-   interface:
-   - name: system0.0
+    type: default
+    interface:
+    - name: system0.0
 
 {{ list_interfaces('default') }}
 
@@ -104,4 +104,19 @@ updates:
 {{ list_interfaces(vname) }}
 
 {% endfor %}
+{% endif %}
+
+{% if services.dns._no_hosts is not defined %}
+- path: /system/dns-instance[name=default]
+  value:
+    host-entry:
+{%   for hname,hdata in hosts.items() if hname != inventory_hostname %}
+    - name: "{{ hname }}"
+{%     if 'ipv4' in hdata %}
+      ipv4-address: {{ hdata.ipv4 }}
+{%     endif %}
+{%     if 'ipv6' in hdata %}
+      ipv6-address: {{ hdata.ipv6 }}
+{%     endif %}
+{%   endfor %}
 {% endif %}

--- a/netsim/ansible/templates/services/srlinux.j2
+++ b/netsim/ansible/templates/services/srlinux.j2
@@ -1,5 +1,5 @@
 updates:
-{% if services.dns is defined %}
+{% if services.dns._server_list is defined %}
 - path: /system/dns-instance[name=default]
   value:
     network-instance: default

--- a/netsim/ansible/templates/services/srlinux.j2
+++ b/netsim/ansible/templates/services/srlinux.j2
@@ -1,0 +1,10 @@
+updates:
+{% if services.dns is defined %}
+- path: /system/dns-instance[name=default]
+  value:
+    network-instance: default
+{%   if services.dns.domain|default(False) %}
+    search-list: [ {{ services.dns.domain }} ]
+{%   endif %}
+    server-list: {{ services.dns._server_list[:6] }}
+{% endif %}

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -58,8 +58,6 @@ clab:
   node:
     kind: srl
     type: ixr-d2
-    config_templates:
-      hosts: /etc/hosts
   interface:
     name: e1-{ifindex}
   group_vars:
@@ -131,6 +129,11 @@ features:
     static:
       vrf: True
       discard: True
+  services:
+    dns:
+      ipv4: True
+      ipv6: True
+      transport_vrf: False
   sr:
     af: [ ipv4, ipv6 ]
     protocol: [ isis ]

--- a/tests/integration/services/01-dns-client.yml
+++ b/tests/integration/services/01-dns-client.yml
@@ -38,6 +38,7 @@ validate:
       junos: ping count 3 t1
       nxos: ping t1 count 3
       xr: ping t1 count 3
+      srlinux: ping t1 network-instance default -c 3
     valid: >-
       "172.16.0.4" in stdout
   query:

--- a/tests/topology/expected/multiserver-explicit.yml
+++ b/tests/topology/expected/multiserver-explicit.yml
@@ -513,12 +513,6 @@ nodes:
       ipv4: true
     box: ghcr.io/nokia/srlinux:26.7.1
     clab:
-      binds:
-      - source: node_files/srl1/hosts
-        target: /etc/hosts
-      config_templates:
-      - source: hosts
-        target: /etc/hosts
       kind: srl
       type: ixr-d2
     device: srlinux


### PR DESCRIPTION
Note: We used /etc/hosts for static host mappings on SR Linux. That no longer works, so this commit includes host-entry records for the default network instance.