### PR TITLE
Tweak services module for syslog services

### DIFF
--- a/docs/module/services.md
+++ b/docs/module/services.md
@@ -47,7 +47,7 @@ _Syslog_ is supported on these platforms:
 
 You can configure the services (DNS, Syslog) clients with the global/node **services._service_** dictionary, which can contain these parameters:
 
-* **server** (node name or list of node names): Specifies the DNS server(s) node name. The node name(s) are resolved to IPv4/IPv6 addresses, which are then used to configure the lab devices.
+* **server** (node name or list of node names): Specifies the DNS/Syslog server(s) node name. The node name(s) are resolved to IPv4/IPv6 addresses, which are then used to configure the lab devices.
 * **ipv4** and **ipv6** (address or list of addresses): Hard-coded IPv4/IPv6 server addresses.
 * **transport_vrf**: the VRF used to reach the DNS/Syslog server.
 

--- a/docs/module/services.md
+++ b/docs/module/services.md
@@ -1,7 +1,7 @@
 (module-services)=
 # Network Services Configuration Module
 
-The initial version of the Network Services configuration module implements [DNS clients and servers](services-dns-platform), with syslog, NTP, and SNMP planned for future releases.
+The Network Services configuration module implements DNS and Syslog clients and servers; NTP and SNMP are planned for future releases.
 
 ```eval_rst
 .. contents:: Table of Contents
@@ -10,8 +10,8 @@ The initial version of the Network Services configuration module implements [DNS
    :backlinks: none
 ```
 
-(services-dns-platform)=
-## DNS Support
+(services-platform)=
+## Platform Support
 
 _netlab_ can configure DNS clients or servers on these platforms:
 
@@ -29,20 +29,44 @@ _netlab_ can configure DNS clients or servers on these platforms:
   enabled: services.server.dns
 ```
 
-(services-dns-parameters)=
-## DNS Parameters
+_Syslog_ is supported on these platforms:
 
-You can configure the DNS client with the global/node **services.dns** dictionary:
-
-* **services.dns.domain** (string): The lab domain (default: `netlab.local`)
-* **services.dns.server** (node name or list of node names): Specifies the DNS server(s) node name. The node name(s) are resolved to IPv4/IPv6 addresses, which are then used to configure the lab devices.
-* **services.dns.ipv4** and **services.dns.ipv6** (address or list of addresses): Hard-coded IPv4/IPv6 DNS server addresses.
-* **services.dns.transport_vrf**: the VRF used to reach the DNS server.
-
-```{warning}
-Configuring `module: [ services ]` and `services.dns.server` at the lab topology level is not enough to run DNS clients on all [host nodes](node-role-host). The hosts do not inherit topology-level modules; you have to configure the *services* module on hosts (preferably within a [group](topo-groups)).
+```{features}
+- title: Syslog<br>client
+  enabled: |
+    services.syslog
+- title: Transport<br>VRF
+  enabled: |
+    services.syslog and services.get('syslog.transport_vrf',True) != False
+- title: Syslog server
+  enabled: services.server.syslog
 ```
 
-The DNS server is configured with the **services.server.dns** parameter, which can be a boolean value or a dictionary with these parameters:
+(services-common-parameters)=
+## Common Network Services Parameters
+
+You can configure the services (DNS, Syslog) clients with the global/node **services._service_** dictionary, which can contain these parameters:
+
+* **server** (node name or list of node names): Specifies the DNS server(s) node name. The node name(s) are resolved to IPv4/IPv6 addresses, which are then used to configure the lab devices.
+* **ipv4** and **ipv6** (address or list of addresses): Hard-coded IPv4/IPv6 server addresses.
+* **transport_vrf**: the VRF used to reach the DNS/Syslog server.
+
+```{warning}
+Configuring `module: [ services ]` and `services.dns.server` at the lab topology level is not enough to run DNS clients on all [host nodes](node-role-host). Hosts do not inherit topology-level modules; you must configure the *services* module on hosts (preferably within a [group](topo-groups)).
+```
+
+(services-dns-parameters)=
+## DNS-Specific Parameters
+
+* Specify the DNS server(s) on the DNS clients with the **services.dns** [common network services parameters](services-common-parameters).
+* The **services.dns.domain** (string) global/node parameter sets the lab DNS domain (default: `netlab.local`)
+
+The DNS server is enabled on supported nodes with the **services.server.dns** parameter, which can be a boolean value or a dictionary with these parameters:
 
 * **forwarder.ipv4** and **forwarder.ipv6** (address or list of addresses): upstream DNS servers used for name resolution of domains other than **services.dns.domain**.
+
+(services-syslog-parameters)=
+## syslog Parameters
+
+* Specify the Syslog server(s) on client nodes with the [common network services parameters](services-common-parameters)
+* The syslog server is enabled on supported nodes with the **services.server.syslog: True** parameter.

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ The highlights of release 26.08 include:
 
 * Support for ArcOS by [@roc-ops](https://github.com/roc-ops), VPP (FD.io) by [@jbemmel](https://github.com/jbemmel), and SONiC containers (also by [@roc-ops](https://github.com/roc-ops))
 * The [**routing** module](generic-routing) supports [IPv4/IPv6 access control lists](generic-routing-acl) (by [@DanPartelly](https://github.com/danpartelly))
-* The new [**services** module](module-services) configures [DNS clients and servers](services-dns-platform)
+* The new [**services** module](module-services) configures [DNS clients and servers](services-platform)
 * GRE tunnels on Arista EOS and GRE/WireGuard tunnels on Mikrotik RouterOS7 and OpenBSD (by [@snuffy22](https://github.com/snuffy22))
 * *clab* provider supports the **podman** container runtime ([details](lab-clab))
 

--- a/docs/release/26.08.md
+++ b/docs/release/26.08.md
@@ -16,7 +16,7 @@
 ## New Functionality
 
 * The [**routing** module](generic-routing) supports [IPv4/IPv6 access control lists](generic-routing-acl) on Arista EOS and Cisco IOS/IOS XE.
-* The new [**services** module](module-services) configures [DNS clients and servers](services-dns-platform): Arista EOS, Cisco IOS/IOS XE, FRR, and Linux nodes can be configured as DNS clients, and a dnsmasq node can act as a DNS server.
+* The new [**services** module](module-services) configures [DNS clients and servers](services-platform): Arista EOS, Cisco IOS/IOS XE, FRR, and Linux nodes can be configured as DNS clients, and a dnsmasq node can act as a DNS server.
 * *clab* provider supports the **podman** container runtime ([details](lab-clab)). Use **netlab install podman** to install podman and containerlab, and **netlab test podman** to verify the installation.
 * The **linkid** link/interface attribute [uniquely identifies a link or an interface](link-linkid) and can be used to select an endpoint of a tunnel link.
 

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -103,7 +103,9 @@ def check_vrf(ndata: Box,mod_attr: Box) -> None:
 
 def set_dns_fields(ndata: Box) -> None:
   """
-  Set extra fields to simplify DNS templates
+  Set DNS-related extra fields to simplify configuration templates:
+
+  * Disable static host definition
   """
   dns_servers = ndata.get('services.dns._server_list',[])
   if not dns_servers:                             # No DNS servers configured, nothing to do

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -13,18 +13,21 @@ def resolve_servers(node: Box, svc_data: Box, topology: Box, mod_attr: Box, svc_
   for kw in svc_data.keys():
     if kw not in mod_attr.clients:
       continue
-    if 'server' not in svc_data[kw]:
-      if kw not in svc_data.get('server',{}) and 'ipv4' not in svc_data[kw] and 'ipv6' not in svc_data[kw]:
+    has_attr  = [ atk for atk in svc_data[kw] if atk not in mod_attr.clients[kw].ignore ]
+    is_client = [ atk for atk in svc_data[kw] if atk in mod_attr.clients[kw].must_have and svc_data[kw][atk] ]
+    if not is_client:
+      if has_attr:
         log.error(
           f'Node {node.name} has services.{kw} parameters, but is neither a client nor a server',
           more_hints=[
-            f'Every node using {kw} services must have either services.{kw}.server or services.server.{kw} attribute',
-            f'You can also specify {kw} server as services.{kw}.ipv4 or services.{kw}.ipv6 address'],
+            f'Every node using {kw} services must have either non-empty services.{kw}.server',
+            f'or services.server.{kw} attribute. You can also specify {kw} server as',
+            f'non-empty services.{kw}.ipv4 or services.{kw}.ipv6 address lists'],
           category=log.MissingValue,
           module='services')
       continue
 
-    for srv_name in svc_data[kw].server:
+    for srv_name in svc_data[kw].get('server',[]):
       if 'err_clients' in svc_cache[srv_name][kw]:
         data.append_to_list(svc_cache[srv_name][kw],'err_clients',node.name)
         continue
@@ -48,6 +51,10 @@ def resolve_servers(node: Box, svc_data: Box, topology: Box, mod_attr: Box, svc_
 
       if not af_found:
         data.append_to_list(svc_cache[srv_name][kw],'err_af',node.name)
+
+    srv_list = svc_data[kw].get('ipv6',[]) + svc_data[kw].get('ipv4',[])
+    if srv_list:                                    # We're a client and have some server(s) configured
+      svc_data[kw]._server_list = srv_list          # ... so remember them
 
 def check_feature_support(ndata: Box, svc_data: Box, topology: Box, mod_attr: Box) -> None:
   is_server = 'services.server' in ndata
@@ -98,15 +105,11 @@ def set_dns_fields(ndata: Box) -> None:
   """
   Set extra fields to simplify DNS templates
   """
-  dns_data = ndata.get('services.dns',{})
-  if not dns_data:                                # No DNS services, nothing to do
+  dns_servers = ndata.get('services.dns._server_list',{})
+  if not dns_servers:                             # No DNS services, nothing to do
     return
-  srv_list = dns_data.get('ipv6',[]) + dns_data.get('ipv4',[])
-  if not srv_list:                                # No DNS servers defined
-    return
-  dns_data._server_list = srv_list                # Set combined IPv4/IPv6 server list field
   if 'services.server.dns' not in ndata:          # Are we also a DNS server?
-    dns_data._no_hosts = True                     # Nope, we can skip the "ip host" definitions
+    ndata.services.dns._no_hosts = True           # Nope, we can skip the "ip host" definitions
 
 def disable_shared_hosts(ndata: Box) -> None:
   """

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -105,8 +105,8 @@ def set_dns_fields(ndata: Box) -> None:
   """
   Set extra fields to simplify DNS templates
   """
-  dns_servers = ndata.get('services.dns._server_list',{})
-  if not dns_servers:                             # No DNS services, nothing to do
+  dns_servers = ndata.get('services.dns._server_list',[])
+  if not dns_servers:                             # No DNS servers configured, nothing to do
     return
   if 'services.server.dns' not in ndata:          # Are we also a DNS server?
     ndata.services.dns._no_hosts = True           # Nope, we can skip the "ip host" definitions

--- a/netsim/modules/services.yml
+++ b/netsim/modules/services.yml
@@ -42,9 +42,17 @@ attributes:
               _subtype: { type: ipv6, use: address }
         true_value: {}
         _remove_when_false: True
-      syslog: bool
-  clients: [ dns, syslog ]              # List of supported services clients
+      syslog:
+        type: bool
+        _remove_when_false: True
 
+  clients:                                        # List of supported services clients
+    dns:
+      ignore: [ domain ]                          # These parameters can be present even on non-clients
+      must_have: [ server, ipv4, ipv6 ]           # ... otherwise, one of these must be present
+    syslog:
+      ignore: []
+      must_have: [ server, ipv4, ipv6 ]
 features:
   dns: DNS client
   syslog: syslog client

--- a/tests/coverage/errors/svc-errors.log
+++ b/tests/coverage/errors/svc-errors.log
@@ -1,8 +1,13 @@
 MissingDependency in services: VRF missing used to reach dns server from node dns_c1 is not present on that node
 IncorrectAttr in services: Device none does not support services.dns used in topology.nodes.dns_c2.services
+MissingValue in services: Node dns_c3 has services.dns parameters, but is neither a client nor a server
+... Every node using dns services must have either non-empty services.dns.server
+... or services.server.dns attribute. You can also specify dns server as
+... non-empty services.dns.ipv4 or services.dns.ipv6 address lists
+MissingValue in services: Node dns_c4 has services.dns parameters, but is neither a client nor a server
 IncorrectAttr in services: Device none does not support services.server.dns used in topology.nodes.dns_s1.services.server
 MissingDependency in services: dns server dns_s1 has no address family in common with some of its clients
 ... Conflict with dns client(s) on node(s) dns_c1
 IncorrectValue in services: Node dns_s2 is not a dns server
-... Used by dns client(s) on node(s) dns_c1,dns_c2,dns_s1,dns_s2
+... Used by dns client(s) on node(s) dns_c1,dns_c2
 Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/svc-errors.yml
+++ b/tests/coverage/errors/svc-errors.yml
@@ -9,8 +9,6 @@ provider: clab
 
 module: [ services ]
 
-services.dns.server: [ dns_s1, dns_s2 ]
-
 vrfs:
   tenant:
 
@@ -18,10 +16,17 @@ nodes:
   dns_c1:
     module: [ services, vrf ]
     services.dns.transport_vrf: missing
+    services.dns.server: [ dns_s1, dns_s2 ]
   dns_c2:
     module: [ services, vrf ]
     _features.services: False
     services.dns.transport_vrf: tenant
+    services.dns.server: [ dns_s1, dns_s2 ]
+  dns_c3:
+    module: [ services, vrf ]
+    services.dns.transport_vrf: tenant
+  dns_c4:
+    services.dns.server: False
   dns_s1:
     services.server.dns: True
     _features.services.server.dns: False
@@ -33,6 +38,8 @@ links:
 - dns_c1:
     ipv6: False
   dns_c2:
+    vrf: tenant
+  dns_c3:
     vrf: tenant
   dns_s1:
     ipv4: False


### PR DESCRIPTION
* Use '_server_list' for all network services
* Adjust the 'check for server specs' code to ignore harmless client parameters (for example, dns.domain)
* Further fixes to enable single-service (syslog only) operation