### PR TITLE
dnsmasq: Syslog server

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -368,7 +368,7 @@ Netlab enables VRRPv3 by default on Dell OS10, overriding any platform defaults.
 (caveats-dnsmasq)=
 ## dnsmasq DHCP server
 
-* You have to build the *dnsmasq* container image with the **netlab clab build dnsmasq** command.
+You have to build the *dnsmasq* container image with the **netlab clab build dnsmasq** command ([more details](build-dnsmasq))
 
 (caveats-vpp)=
 ## VPP (Vector Packet Processor)

--- a/docs/labs/clab.md
+++ b/docs/labs/clab.md
@@ -64,7 +64,7 @@ Lab topology file created by **[netlab up](../netlab/up.md)** or **[netlab creat
 | VyOS                   | ghcr.io/sysoleg/vyos-container |
 
 * FRR, Linux, Nokia SR Linux, and VyOS images are automatically downloaded from public container registries.
-* Build the [BIRD](build-bird), dnsmasq, [VPP](build-vpp), and [Netscaler](build-netscaler) images with the **netlab clab build** command. BIRD and VPP FD.io build process supports configurable software releases.
+* Build the [BIRD](build-bird), [dnsmasq](build-dnsmasq), [VPP](build-vpp), and [Netscaler](build-netscaler) images with the **netlab clab build** command. BIRD and VPP FD.io build process supports configurable software releases.
 * The Arista cEOS image has to be [downloaded and installed manually](ceos.md).
 * Nokia SR OS and SR-SIM container images require a license; see also [vrnetlab instructions](https://containerlab.dev/manual/vrnetlab/).
 * Follow Cisco's documentation to install the IOS XRd container, making sure the container image name matches the one _netlab_ uses (alternatively, [change the default image name](default-device-image) for the IOS XRd container).
@@ -442,6 +442,7 @@ server.
    arcos.md
    ceos.md
    bird.md
+   dnsmasq.md
    linux.md
    netscaler.md
    vpp.md

--- a/docs/labs/dnsmasq.md
+++ b/docs/labs/dnsmasq.md
@@ -1,0 +1,8 @@
+(build-dnsmasq)=
+# Building dnsmasq Containers
+
+The _netlab_ dnsmasq container includes the dnsmasq DNS/DHCP server and the rsyslog Syslog server. You must build a local container image with the **[netlab clab build dnsmasq](netlab-clab-build)** command before you can use `device: dnsmasq` (which only works with `provider: clab`).
+
+The *dnsmasq* server starts when the container provides DNS or DHCP services, and the *rsyslog* server starts when the container provides Syslog services.
+
+The default *dnsmasq* device settings enable DHCP, DNS, and syslog servers.

--- a/netsim/daemons/dnsmasq.yml
+++ b/netsim/daemons/dnsmasq.yml
@@ -14,6 +14,10 @@ clab:
     docker_shell: bash -il
   image: netlab/dnsmasq:latest
   build: True
+  node:
+    config_templates:
+      start: /etc/netlab-start.sh
+      rsyslogd: /etc/rsyslog.d/50-default.conf
   features:
     initial:
       roles: [ host ]
@@ -29,8 +33,12 @@ features:
     roles: [ host ]
   services:
     dns: true
-    server.dns: true
+    server:
+      dns: true
+      syslog: true
 dhcp:
   server: true
 services:
-  server.dns: true
+  server:
+    dns: true
+    syslog: true

--- a/netsim/daemons/dnsmasq/Dockerfile
+++ b/netsim/daemons/dnsmasq/Dockerfile
@@ -2,10 +2,18 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL maintainer="Netlab project <netlab.tools>"
-LABEL description="dnsmasq DHCP server"
+LABEL description="dnsmasq DHCP/DNS server"
 
-RUN apt-get update && apt-get install -y iputils-ping net-tools dnsmasq
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y iputils-ping net-tools dnsmasq rsyslog; \
+    cat <<'SCRIPT' >/etc/netlab-start.sh
+#!/bin/bash
+/usr/sbin/dnsmasq -R -C /etc/dnsmasq.conf --no-daemon &
+wait
+echo "Exiting"
+SCRIPT
 
 WORKDIR /root
 
-CMD [ "/usr/sbin/dnsmasq", "-R", "-C", "/etc/dnsmasq.conf", "--no-daemon" ]
+CMD [ "/bin/sh","/etc/netlab-start.sh" ]

--- a/netsim/daemons/dnsmasq/rsyslogd.j2
+++ b/netsim/daemons/dnsmasq/rsyslogd.j2
@@ -1,0 +1,47 @@
+#Enable UDP and TCP syslog reception
+module(load="imudp")
+input(type="imudp" port="514")
+module(load="imtcp")
+input(type="imtcp" port="514")
+
+auth,authpriv.*			/var/log/auth.log
+#cron.*				/var/log/cron.log
+#daemon.*			-/var/log/daemon.log
+kern.*				-/var/log/kern.log
+*.debug;kern.none	-/var/log/syslog
+#lpr.*				-/var/log/lpr.log
+mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+mail.err			/var/log/mail.err
+
+#
+# Some "catch-all" log files.
+#
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg				:omusrmsg:*
+
+#
+# I like to have messages displayed on the console, but only on a virtual
+# console I usually leave idle.
+#
+#daemon,mail.*;\
+#	news.=crit;news.=err;news.=notice;\
+#	*.=debug;*.=info;\
+#	*.=notice;*.=warn	/dev/tty8

--- a/netsim/daemons/dnsmasq/start.j2
+++ b/netsim/daemons/dnsmasq/start.j2
@@ -1,0 +1,14 @@
+#!/bin/sh
+{% if dhcp.server|default(False) or services.server.dns|default(False) %}
+echo "Starting dnsmasq DNS/DHCP server"
+/usr/sbin/dnsmasq -R -C /etc/dnsmasq.conf --no-daemon &
+{% endif %}
+{% if services.server.syslog|default(False) %}
+echo "Starting rsyslog syslog server"
+/usr/sbin/rsyslogd -n &
+{% endif %}
+echo
+echo "======================================================="
+echo "Startup script completed, sleeping until the Big Freeze"
+echo "======================================================="
+sleep infinity

--- a/netsim/daemons/dnsmasq/start.j2
+++ b/netsim/daemons/dnsmasq/start.j2
@@ -1,5 +1,5 @@
 #!/bin/sh
-{% if dhcp.server|default(False) or services.server.dns|default(False) %}
+{% if dhcp.server|default(False) or services.server.dns is defined %}
 echo "Starting dnsmasq DNS/DHCP server"
 /usr/sbin/dnsmasq -R -C /etc/dnsmasq.conf --no-daemon &
 {% endif %}

--- a/tests/integration/services/11-syslog-client.yml
+++ b/tests/integration/services/11-syslog-client.yml
@@ -1,0 +1,42 @@
+message: |
+  The test checks the syslog client configuration on DUT. An OSPFv2
+  session is established between X1 and DUT, and we expect DUT to log it
+  to the syslog server.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+
+groups:
+  probes:
+    members: [ x1 ]
+    device: frr
+    provider: clab
+
+nodes:
+  dut:
+    module: [ services, ospf ]
+    services:
+      syslog.server: nms
+      server.syslog: False
+  nms:
+    device: dnsmasq
+    provider: clab
+    services.server.syslog: True
+  x1:
+    module: [ services, ospf ]
+
+links:
+- interfaces: [ dut, nms, x1 ]
+  ospf.network_type: point-to-point
+
+validate:
+  ospf_adj:
+    nodes: [ x1 ]
+    wait: ospfv2_adj_p2p
+    wait_msg: Waiting for OSPF adjacency
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)
+  logging:
+    nodes: [ nms ]
+    devices: [ dnsmasq ]
+    exec: cat /var/log/syslog
+    valid: >-
+      " dut " in stdout

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -85,6 +85,10 @@ nodes:
         target: /etc/hosts
       - source: node_files/dhs/resolv
         target: /etc/resolv.conf
+      - source: node_files/dhs/start
+        target: /etc/netlab-start.sh
+      - source: node_files/dhs/rsyslogd
+        target: /etc/rsyslog.d/50-default.conf
       config_templates:
       - mode: ns
         source: initial
@@ -102,6 +106,10 @@ nodes:
         target: /etc/hosts
       - source: resolv
         target: /etc/resolv.conf
+      - source: start
+        target: /etc/netlab-start.sh
+      - source: rsyslogd
+        target: /etc/rsyslog.d/50-default.conf
       kind: linux
     device: dnsmasq
     dhcp:
@@ -157,6 +165,7 @@ nodes:
         domain: netlab.local
       server:
         dns: {}
+        syslog: true
   h1:
     af:
       ipv4: true

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -281,6 +281,10 @@ nodes:
         target: /etc/hosts
       - source: node_files/dhs/resolv
         target: /etc/resolv.conf
+      - source: node_files/dhs/start
+        target: /etc/netlab-start.sh
+      - source: node_files/dhs/rsyslogd
+        target: /etc/rsyslog.d/50-default.conf
       config_templates:
       - mode: ns
         source: initial
@@ -298,6 +302,10 @@ nodes:
         target: /etc/hosts
       - source: resolv
         target: /etc/resolv.conf
+      - source: start
+        target: /etc/netlab-start.sh
+      - source: rsyslogd
+        target: /etc/rsyslog.d/50-default.conf
       kind: linux
     device: dnsmasq
     dhcp:
@@ -388,6 +396,7 @@ nodes:
         domain: netlab.local
       server:
         dns: {}
+        syslog: true
   h1:
     af:
       ipv4: true


### PR DESCRIPTION
* Add 'rsyslog' package to Dockerfile
* Start daemons with the '/etc/netlab-start.sh' script
* Create the start script with a Jinja2 template to start the servers only when needed
* Add rsyslogd default configuration: enable UDP and TCP transport, log everything but kernel messages into /var/log/syslog
* Add syslog client integration test
* Update the transformation test results (dnsmasq has more mapped files)