### PR TITLE
netlab status: show memory usage per node and per lab

### DIFF
--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -145,7 +145,7 @@ def show_lab_instance(iid: Lab_Instance_ID, lab_state: Box) -> None:
   if lab_state.providers:
     print(f'  provider(s): {",".join(lab_state.providers)}')
   if lab_state.memory:
-    print(f'  memory used:      {lab_state.memory}')
+    print(f'  memory used: {lab_state.memory}')
   print()
 
 def load_provider_status(p_status: dict, provider: str, topology: Box) -> None:

--- a/netsim/cli/status.py
+++ b/netsim/cli/status.py
@@ -144,6 +144,8 @@ def show_lab_instance(iid: Lab_Instance_ID, lab_state: Box) -> None:
     print(f'  topology:    {lab_state.topology}')
   if lab_state.providers:
     print(f'  provider(s): {",".join(lab_state.providers)}')
+  if lab_state.memory:
+    print(f'  memory used:      {lab_state.memory}')
   print()
 
 def load_provider_status(p_status: dict, provider: str, topology: Box) -> None:
@@ -185,6 +187,7 @@ def fetch_node_status(ls: Box, topology: Box) -> None:
       node_stat.provider_name = wk_name
       wk_state = p_status[n_provider].get(wk_name,None) or p_status[n_provider].get(n_name,None) or get_empty_box()
       node_stat.status = wk_state.get('status','Unknown')
+      node_stat.memory = wk_state.get('memory','Unknown')
 
     ls.nodes[n_name] = node_stat
 
@@ -200,19 +203,25 @@ def fetch_node_status(ls: Box, topology: Box) -> None:
       'connection': 'docker',
       'provider': n_provider,
       'provider_name': wk_name,
-      'status': wk_state.get('status','Not running')
+      'status': wk_state.get('status','Not running'),
+      'memory': wk_state.get('memory','Unknown')
     }
+
+  total_memory = sum(strings.parse_memory_size(n.get('memory','')) for n in ls.nodes.values())
+  if total_memory:
+    ls.memory = strings.format_memory_size(total_memory)
 
 def show_lab_nodes(ls: Box, topology: Box) -> None:
   rows = []
-  heading = [ 'node', 'device', 'image', 'mgmt IP', 'connection', 'provider', 'VM/container', 'status']
+  heading = [ 'node', 'device', 'image', 'mgmt IP', 'connection', 'provider', 'VM/container', 'status', 'memory']
 
   for n_name,n_data in ls.nodes.items():
     mgmt = "\n".join([ addr for addr in (n_data.get('mgmt'),n_data.get('mgmt6')) if addr ])
 
     row = [ n_name, n_data.device, n_data.image, mgmt,
             n_data.connection, n_data.get('provider',''),
-            n_data.get('provider_name',''), n_data.status ]
+            n_data.get('provider_name',''), n_data.status,
+            n_data.get('memory','') ]
     rows.append(row)
 
   strings.print_table(heading,rows)

--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -96,10 +96,45 @@ class Containerlab(_Provider):
         log.error(f'Cannot get Docker status: {ex}',category=log.FatalError,module='clab')
         return stat_box
 
+      self.add_memory_usage(stat_box)
       return stat_box
     except Exception as ex:
       log.error(f'Cannot execute "docker ps": {ex}',category=log.FatalError,module='clab')
       return get_empty_box()
+
+  """
+  Add the current memory usage of running containers to the lab status data. 'docker stats'
+  reports the memory usage as 'used / limit'; we're interested only in the 'used' part.
+
+  Failures are non-fatal -- memory usage is extra information, not a prerequisite for
+  displaying the lab status.
+  """
+  def add_memory_usage(self, stat_box: Box) -> None:
+    try:
+      stats = external_commands.run_command(
+                  'docker stats --no-stream --format json',
+                  check_result=True,
+                  ignore_errors=True,
+                  return_stdout=True,
+                  run_always=True)
+    except Exception as ex:
+      log.print_verbose(f'Cannot execute "docker stats": {ex}')
+      return
+
+    if not isinstance(stats,str):
+      return
+
+    try:
+      for line in stats.split('\n'):
+        if not line.startswith('{'):
+          continue
+        docker_stats = json.loads(line)
+        c_name = docker_stats.get('Name',None)
+        if c_name not in stat_box:                          # Ignore containers not in this lab
+          continue
+        stat_box[c_name].memory = docker_stats.get('MemUsage','').split('/')[0].strip()
+    except Exception as ex:
+      log.print_verbose(f'Cannot get Docker memory usage: {ex}')
 
   """
   Defines the container host naming convention (globally), this becomes "ansible_host" in Ansible

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -259,6 +259,31 @@ def create_vagrant_batches(topology: Box) -> None:
     if libvirt_defaults.batch_interval:
       libvirt_defaults.start.append(f'sleep {libvirt_defaults.batch_interval}')
 
+"""
+Copy the memory usage from the 'virsh domstats' data of a single VM into the lab status data.
+
+The libvirt domain name is '<lab_prefix>_<node>' while the lab status data is keyed by the
+Vagrant machine name (<node>), so we have to find the matching lab status entry. Domains
+belonging to some other lab (or to a VM not managed by netlab) are silently ignored.
+
+Without a balloon driver in the guest OS we cannot get the memory the VM uses on the host
+and have to report the assigned memory instead (flagged with 'max' to avoid confusion).
+"""
+def set_vm_memory(stat_box: Box, vm_name: str, vm_stats: Box) -> None:
+  for wk_name in stat_box:
+    if vm_name != wk_name and not vm_name.endswith(f'_{wk_name}'):
+      continue
+
+    try:
+      if 'balloon.rss' in vm_stats:
+        stat_box[wk_name].memory = strings.format_memory_size(int(vm_stats['balloon.rss']))
+      elif 'balloon.current' in vm_stats:
+        stat_box[wk_name].memory = strings.format_memory_size(int(vm_stats['balloon.current'])) + ' (max)'
+    except ValueError as ex:
+      log.print_verbose(f'Cannot get the memory usage of libvirt domain {vm_name}: {ex}')
+
+    return
+
 class Libvirt(_Provider):
 
   """
@@ -472,10 +497,53 @@ class Libvirt(_Provider):
         log.error(f'Cannot get Vagrant status: {ex}',category=log.FatalError,module='libvirt')
         return stat_box
 
+      self.add_memory_usage(stat_box)
       return stat_box
     except Exception as ex:
       log.error(f'Cannot execute "vagrant status --machine-readable": {ex}',category=log.FatalError,module='libvirt')
       return get_empty_box()
+
+  """
+  Add the memory usage of the lab VMs to the lab status data.
+
+  'virsh domstats --balloon' reports (in KB) the resident set size of the QEMU process
+  (balloon.rss -- the memory the VM actually uses on the host) and the memory assigned to
+  the VM (balloon.current). The RSS value is available only when the VM runs a balloon
+  driver or a guest agent; without it, we can report only the assigned memory.
+
+  Vagrant knows the VMs as 'r1' while libvirt calls them '<lab_prefix>_r1', so we have to
+  match the libvirt domain names with the Vagrant machine names we already know about.
+
+  Failures are non-fatal -- memory usage is extra information, not a prerequisite for
+  displaying the lab status.
+  """
+  def add_memory_usage(self, stat_box: Box) -> None:
+    try:
+      stats = external_commands.run_command(
+                  'virsh domstats --balloon --list-running',
+                  check_result=True,
+                  ignore_errors=True,
+                  return_stdout=True,
+                  run_always=True)
+    except Exception as ex:
+      log.print_verbose(f'Cannot execute "virsh domstats": {ex}')
+      return
+
+    if not isinstance(stats,str):
+      return
+
+    vm_name = None
+    vm_stats = get_empty_box()
+    for line in stats.split('\n') + [ 'Domain: end-of-data' ]:
+      line = line.strip()
+      if line.startswith('Domain:'):                        # Start of a new domain, save the previous one
+        if vm_name is not None:
+          set_vm_memory(stat_box,vm_name,vm_stats)
+        vm_name = line.split("'")[1] if "'" in line else None
+        vm_stats = get_empty_box()
+      elif '=' in line:
+        (k,v) = line.split('=',1)
+        vm_stats[k] = v
 
   def get_node_name(self, node: str, topology: Box) -> str:
     return f'{ topology.name.split(".")[0] }_{ node }'

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -105,6 +105,39 @@ Generate error label of specified width (default: 10)
 def pad_err_code(t: str, w: int = 10) -> str:
   return pad_text(f"[{t}]",w)
 
+"""
+Memory size units (as printed by 'docker stats') and their size in KB
+"""
+MEMORY_UNITS: typing.Final[dict] = {
+  'B':   1 / 1024,
+  'KiB': 1,
+  'MiB': 1024,
+  'GiB': 1024 * 1024,
+  'TiB': 1024 * 1024 * 1024 }
+
+"""
+Print the memory size (specified in KB) the way 'docker stats' does it
+"""
+def format_memory_size(kb: float) -> str:
+  if kb >= MEMORY_UNITS['GiB']:
+    return f'{kb / MEMORY_UNITS["GiB"]:.3f}GiB'
+
+  return f'{kb / MEMORY_UNITS["MiB"]:.1f}MiB'
+
+"""
+Parse a memory size printed by format_memory_size or 'docker stats' into KB.
+Anything we cannot parse (including an empty string) counts as zero.
+"""
+def parse_memory_size(txt: str) -> float:
+  m = re.match(r'^([0-9.]+)([KMGT]iB|B)$',txt.strip())
+  if not m:
+    return 0
+
+  try:
+    return float(m.group(1)) * MEMORY_UNITS[m.group(2)]
+  except ValueError:
+    return 0
+
 def format_structured_dict(d: Box, prefix: str = '') -> str:
   lines = []
   for k,v in d.items():


### PR DESCRIPTION
As it has been discussed on the Network Automagic podcast, I wanted to give (AI a) go at showing the memory usage of a lab, per node.

This is the output for a lab with libvirt+clab:

```
Lab 2 in /home/sa/code/quick-netlab-lab/dns-lab
  status:      started
  topology:    topology.yml
  provider(s): libvirt,clab
  memory used: 1.838GiB

┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ node   ┃ device  ┃ mgmt IP       ┃ provider ┃ status        ┃ memory   ┃
┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ r1     │ arubacx │ 10.194.57.101 │ libvirt  │ running       │ 1.768GiB │
│ r2     │ frr     │ 10.194.57.102 │ clab     │ Up 11 minutes │ 30.56MiB │
│ r3     │ frr     │ 10.194.57.103 │ clab     │ Up 11 minutes │ 33.27MiB │
│ dnssrv │ dnsmasq │ 10.194.57.104 │ clab     │ Up 11 minutes │ 7.867MiB │
└────────┴─────────┴───────────────┴──────────┴───────────────┴──────────┘
```

**Disclosure:** high risk of AI slop from this point.

**Implementation** — each provider's `get_lab_status` enriches its status box with a `memory` key; `fetch_node_status` copies it into the node status and sums the total into `lab_state.memory` (so it also lands in `--format json`/`yaml`).

- **clab**: `docker stats --no-stream --format json` → `MemUsage`, "used" half only. The value after the slash is the host total when no limit is set (always, for netlab-generated labs), so it's dropped.
- **libvirt**: `virsh domstats --balloon --list-running` → `balloon.rss` (host RSS of the QEMU process). Falls back to `balloon.current` suffixed `(max)` when the guest has no balloon driver. Domain names are matched back to Vagrant machine names via the `_<node>` suffix; no new keys are added to the status box.
- **strings.py**: `format_memory_size` / `parse_memory_size` helpers, docker's `1.521GiB` / `184.5MiB` style.

Both collectors are non-fatal — failures are `print_verbose` only, memory is extra info.

**Caveats / things you may want changed:**

- Adds ~1.5–2s to `netlab status` for a clab lab (`docker stats --no-stream` samples every container on the host, not just the lab's).
- The two numbers aren't the same measure: cgroup footprint vs QEMU RSS, so the total sums slightly different things. It's the right ballpark for "what is this lab eating", not exact host-RAM accounting. With KSM enabled, summing RSS overstates real usage. _whatever that means 🫥_
- No `used / allocated` display, which could be useful for libvirt.