### PR TITLE
Fix: Podman cli status & memory

### DIFF
--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -86,12 +86,18 @@ class Containerlab(_Provider):
       if not isinstance(status,str):
         return stat_box
       try:
-        for line in status.split('\n'):
+        status_str = status.strip()
+        if status_str.startswith('['):                        # Podman: normalize array to one-object-per-line
+          status_str = '\n'.join(
+            json.dumps({**item, 'Names': item['Names'][0] if isinstance(item.get('Names'), list) else item.get('Names','')})
+            for item in json.loads(status_str))
+
+        for line in status_str.split('\n'):
           if not line.startswith('{'):
             continue
           docker_stats = json.loads(line)
-          stat_box[docker_stats['Names']].status = docker_stats['Status']
-          stat_box[docker_stats['Names']].image = docker_stats['Image']
+          stat_box[docker_stats['Names']].status = docker_stats.get('Status','')
+          stat_box[docker_stats['Names']].image = docker_stats.get('Image','')
       except Exception as ex:
         log.error(f'Cannot get Docker status: {ex}',category=log.FatalError,module='clab')
         return stat_box
@@ -127,14 +133,22 @@ class Containerlab(_Provider):
       return
 
     try:
-      for line in stats.split('\n'):
+      stats_str = stats.strip()
+      if stats_str.startswith('['):                           # Podman: normalize array to one-object-per-line
+        stats_str = '\n'.join(
+          json.dumps({**item, 'Name': item.get('name', item.get('Name','')), 'MemUsage': item.get('mem_usage', item.get('MemUsage',''))})
+          for item in json.loads(stats_str))
+
+      for line in stats_str.split('\n'):
         if not line.startswith('{'):
           continue
         docker_stats = json.loads(line)
-        c_name = docker_stats.get('Name',None)
+        c_name = docker_stats.get('Name', None)
         if c_name not in stat_box:                          # Ignore containers not in this lab
           continue
-        stat_box[c_name].memory = docker_stats.get('MemUsage','').split('/')[0].strip()
+        mem_str = docker_stats.get('MemUsage', '').split('/')[0].strip()
+        mem_kb = strings.parse_memory_size(mem_str)
+        stat_box[c_name].memory = strings.format_memory_size(mem_kb) if mem_kb else mem_str
     except Exception as ex:
       log.print_verbose(f'Cannot get Docker memory usage: {ex}')
 

--- a/netsim/utils/strings.py
+++ b/netsim/utils/strings.py
@@ -110,6 +110,10 @@ Memory size units (as printed by 'docker stats') and their size in KB
 """
 MEMORY_UNITS: typing.Final[dict] = {
   'B':   1 / 1024,
+  'KB':  1000 / 1024,
+  'MB':  1000 * 1000 / 1024,
+  'GB':  1000 * 1000 * 1000 / 1024,
+  'TB':  1000 * 1000 * 1000 * 1000 / 1024,
   'KiB': 1,
   'MiB': 1024,
   'GiB': 1024 * 1024,
@@ -129,7 +133,7 @@ Parse a memory size printed by format_memory_size or 'docker stats' into KB.
 Anything we cannot parse (including an empty string) counts as zero.
 """
 def parse_memory_size(txt: str) -> float:
-  m = re.match(r'^([0-9.]+)([KMGT]iB|B)$',txt.strip())
+  m = re.match(r'^([0-9.]+)([KMGT]iB|[KMGT]B|B)$',txt.strip())
   if not m:
     return 0
 


### PR DESCRIPTION
## Fix `netlab status --memory` for Podman runtime

When using `defaults.providers.clab.runtime: podman`, the `netlab status` and
`netlab status --memory` commands showed no container status or memory usage.

### Root cause

Podman's Docker-compatible CLI returns JSON differently from Docker:

| | Docker | Podman |
|---|---|---|
| `docker ps --format json` | one JSON object per line | JSON array |
| `Names` field | string | list of strings |
| `docker stats --format json` | one JSON object per line | JSON array |
| field names | `Name`, `MemUsage` | `name`, `mem_usage` |
| memory units | binary (`KiB`, `MiB`, `GiB`) | decimal (`kB`, `MB`, `GB`) |

### Changes

**`providers/clab/__init__.py`**

- `get_lab_status`: if `docker ps` output is a JSON array (Podman), normalize it
  to Docker's per-line format and unwrap `Names` from list to string before
  running the existing parsing logic unchanged.
- `add_memory_usage`: same normalization for `docker stats` — map Podman's
  `name`/`mem_usage` fields to Docker's `Name`/`MemUsage`, then parse and
  re-format the value in binary units (MiB/GiB) so the memory column is
  consistent across Docker, Podman, and libvirt VMs.

**`utils/strings.py`**

- `MEMORY_UNITS`: added decimal SI units (`KB`, `MB`, `GB`, `TB`) alongside
  the existing binary ones, with correct byte-to-KiB conversion factors.
- `parse_memory_size`: extended the regex to also match decimal unit suffixes
  (`[KMGT]B`).