### PR TITLE
Add 'netmiko' device configuration method

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -262,13 +262,13 @@ _netlab_ uses Ansible playbooks and device-specific task lists to deploy device 
 
 [^cRBS]: The configuration deployment uses a custom **bash** script that calls **cli** command to execute **load merge** followed by **commit**. The custom script is used as the *shebang* interpreter for the configuration snippets.
 
-Several other devices can use alternate (faster) configuration methods that are not enabled by default; you have to set the **netlab_config_mode** group variable[^NCMGV] or node parameter to use them:
+Several other devices can use alternate (faster) configuration methods that are not enabled by default; you have to set the **netlab_config_mode** device group variable[^NCMGV] or node parameter to use them:
 
 | Device    | containerlab<br> deployment method |
 |-----------|------------------------------------|
 | Arista EOS | **sh**[^EOSSH] |
 | Aruba CX  | **startup** |
-| Cisco IOS/IOS XE[^18v] | **startup** |
+| Cisco IOS/IOS XE[^18v] | **startup**, **netmiko** |
 | Cisco IOS XRd | **sh**[^XRDSH] |
 | Dell OS10 | **startup** |
 | Junos[^Junos] | **startup** |
@@ -279,9 +279,10 @@ Several other devices can use alternate (faster) configuration methods that are 
 
 **Notes:**
 
-* The **startup** deployment method uses *containerlab* `startup-config` parameter with partial device configurations. This is an experimental method that won't report errors in device configurations ([more details](https://blog.ipspace.net/2026/02/netlab-startup-config-caveats/)).
+* The **startup** deployment method (available only for containers) uses *containerlab* `startup-config` parameter with partial device configurations. This experimental method won't report errors in device configurations ([more details](https://blog.ipspace.net/2026/02/netlab-startup-config-caveats/)).
+* The **netmiko** deployment method (available for containers and virtual machines) uses the *netmiko* library to configure network devices. **netlab install ansible** automatically installs it; you can also install it manually with **pip3 install netmiko**.
 
-[^NCMGV]: For example, set the **defaults.devices.iol.clab.group_vars.netlab_config_mode** [topology default](topo-defaults) to **startup** to use startup configuration with Cisco IOL nodes
+[^NCMGV]: For example, set the **defaults.devices.iol.clab.group_vars.netlab_config_mode** [topology default](topo-defaults) to **startup** to use startup configuration with Cisco IOL nodes, or **defaults.devices.ios.group_vars.netlab_config_mode** to **netmiko** to use *netmiko* to configure Cisco IOS-based devices.
 
 ## Initial Device Configurations
 

--- a/netsim/cli/initial/deploy.py
+++ b/netsim/cli/initial/deploy.py
@@ -15,7 +15,7 @@ from ...augment import devices as _a_devices
 from ...providers import execute_node
 from ...utils import log, strings
 from .. import ansible, error_and_exit, external_commands, get_message, is_dry_run, lab_status_change
-from . import configs, ready, utils
+from . import configs, netmiko, ready, utils
 
 """
 get_normalize_list -- get a list of all nodes that require normalization step
@@ -32,7 +32,11 @@ def get_normalize_list(topology: Box, nodeset: list) -> list:
 
   return normalize_list
 
-def deploy_provider_config(nodeset: list, topology: Box, args: argparse.Namespace) -> typing.Tuple[bool, bool]:
+INTERNAL_CONFIG_MECHANISMS: dict = {
+  'netmiko': netmiko.deploy
+}
+
+def deploy_internal_config(nodeset: list, topology: Box, args: argparse.Namespace) -> typing.Tuple[bool, bool]:
   OK = True
   Used = False
 
@@ -47,7 +51,13 @@ def deploy_provider_config(nodeset: list, topology: Box, args: argparse.Namespac
       return
     if log.VERBOSE:
       log.info(f'Starting deployment thread for {n_name} to deploy {deploy_parts}')
-    execute_node("deploy_node_config", n_data, topology, deploy_list=n_deploy)
+    try:
+      config_mode = _a_devices.get_node_group_var(n_data,'netlab_config_mode',topology.defaults)
+      if config_mode and config_mode in INTERNAL_CONFIG_MECHANISMS:
+        INTERNAL_CONFIG_MECHANISMS[config_mode](n_data,topology,n_deploy)
+      execute_node("deploy_node_config", n_data, topology, deploy_list=n_deploy)
+    except Exception as ex:
+      log.error(f"Failed to deploy configuration on {n_name}: {ex}",category=log.FatalError,module='initial')
 
   with concurrent.futures.ThreadPoolExecutor() as executor:
     executor.map(deploy_node, nodeset)
@@ -177,7 +187,7 @@ def run(
     log.section_header('Config',f'Normalizing device configurations')
     lab_status_change(topology,f'normalizing device configurations')
     args.normalize = True
-    (used_internal, status_internal) = deploy_provider_config(normalize_list, topology, args)
+    (used_internal, status_internal) = deploy_internal_config(normalize_list, topology, args)
     (used_ansible, status_ansible) = deploy_ansible_playbook(topology,args,normalize_list,rest,'normalize' if used_internal else '')
     args.normalize = False
 
@@ -194,7 +204,7 @@ def run(
 
   log.section_header('Config',f'Deploying device configurations')
   lab_status_change(topology, f"deploying configuration: {deploy_text}")
-  (used_internal, status_internal) = deploy_provider_config(nodeset, topology, args)
+  (used_internal, status_internal) = deploy_internal_config(nodeset, topology, args)
   (used_ansible, status_ansible) = deploy_ansible_playbook(topology,args,nodeset,rest,'deploy' if used_internal else '')
 
   print_internal_stats(topology,not used_ansible)

--- a/netsim/cli/initial/netmiko.py
+++ b/netsim/cli/initial/netmiko.py
@@ -1,0 +1,142 @@
+"""
+Use netmiko instead of Ansible to deploy device configurations
+"""
+import inspect
+import os
+import typing
+
+from box import Box
+
+from ...augment import devices as a_devices
+from ...data import append_to_list
+from ...utils import log
+
+NETMIKO_IS_MISSING: bool = False
+NETMIKO_LOAD_ERROR: str = ''
+
+try:
+  import netmiko as _netmiko
+except Exception as ex:
+  NETMIKO_LOAD_ERROR = str(ex)
+  NETMIKO_IS_MISSING = True
+
+def check_netmiko(n_data: Box) -> bool:
+  """
+  Check is we have working netmiko module, generate error on first reference
+  """
+  global NETMIKO_IS_MISSING, NETMIKO_LOAD_ERROR
+
+  if not NETMIKO_IS_MISSING:                      # Did we manage to load netmiko?
+    return True                                   # ... cool, life is good
+
+  if NETMIKO_LOAD_ERROR:                          # Did we already scream at the user?
+    log.error(f'Cannot load netmiko library to configure {n_data.name}: {NETMIKO_LOAD_ERROR}',category=log.FatalError,module='netmiko')
+    NETMIKO_LOAD_ERROR = ''
+
+  return False
+
+NETMIKO_GROUP_VARS: dict = {
+  'netmiko_device_type': 'device_type',
+  'ansible_user': 'username',
+  'ansible_ssh_pass': 'password',
+  'ansible_become_password': '*secret'
+}
+
+def prepare_params(n_data: Box, topology: Box) -> typing.Optional[dict]:
+  """
+  Prepare netmiko connection parameters
+  """
+  global NETMIKO_GROUP_VARS
+
+  config_err_list = []                            # Accumulated list of errors
+  netmiko_params:dict = {}                        # Netmiko connection parameters
+
+  for gv,np in NETMIKO_GROUP_VARS.items():        # Translate netsim parameters into netmiko parameters
+    gv_value = a_devices.get_node_group_var(n_data,gv,topology.defaults)
+    if gv_value is not None:                      # We got a value, but be careful: the target could be optional (marked with '*')
+      netmiko_params[np.replace('*','')] = gv_value
+    elif '*' not in np:                           # Are we missing a value for a non-optional target?
+      config_err_list.append(f'{gv} node/group variable is not set')
+
+  netmiko_host = n_data.mgmt.get('ipv4',None) or n_data.mgmt.get('ipv6',None)
+  if not netmiko_host:                            # Finally, try to add management IP address
+    config_err_list.append('Cannot use netmiko with devices that have no management IP addresses')
+  else:
+    netmiko_params['host'] = netmiko_host
+
+  if config_err_list:                             # Any errors so far?
+    log.error(
+      f'Cannot use netmiko to configure {n_data.name} (device {n_data.device})',
+      more_hints=config_err_list,
+      category=log.MissingValue,
+      module='netmiko')
+    return None
+
+  # Cool, we're good to go. Just the final detail: add session log file
+  #
+  netmiko_params['session_log'] = f'node_files/{n_data.name}/netmiko.log'
+  return netmiko_params
+
+def connect(n_data: Box, netmiko_params: dict) -> typing.Optional[_netmiko.BaseConnection]:
+  """
+  Use netmiko to open a SSH session to a lab device
+  """
+  try:
+    net_connect = _netmiko.ConnectHandler(**netmiko_params)
+    if log.VERBOSE:
+      log.info(f'Connected to {n_data.name}',module='netmiko')
+  except Exception as ex:
+    log.error(
+      f'netmiko cannot connect to {n_data.name}',
+      more_data=[ str(ex) ],
+      category=log.FatalError,
+      module='netmiko')
+    return None
+
+  return net_connect
+
+def deploy(n_data: Box,topology: Box,n_deploy: list) -> None:
+  node_config = n_data.get('_node_config',None)
+  if not node_config:
+    return
+
+  if not check_netmiko(n_data):
+    return
+
+  netmiko_params = prepare_params(n_data,topology)
+  if not netmiko_params:
+    return None
+
+  net_connect = connect(n_data,netmiko_params)
+  if not net_connect:
+    return
+
+  session_log = netmiko_params["session_log"]
+  netmiko_err_list = a_devices.get_node_group_var(n_data,'netmiko_error_regexp',topology.defaults)
+  netmiko_errors = rf"({'|'.join(netmiko_err_list)})" if isinstance(netmiko_err_list,list) else (netmiko_err_list or "")
+  for cfg_item in n_deploy:
+    if node_config.get(cfg_item.replace('.','@'),None) != ':netmiko':
+      return
+    cfg_file = f'node_files/{n_data.name}/{cfg_item}'
+    if not os.path.exists(cfg_file):
+      log.error(f'Skipping {cfg_item} config on {n_data.name}; cannot find {cfg_file}',category=log.FatalError,module='netmiko')
+      continue
+    try:
+      net_connect.send_config_from_file(cfg_file,error_pattern=netmiko_errors)
+      log.info(f'Sent {cfg_item} configuration to {n_data.name}',module='netmiko')
+      if inspect.getattr_static(net_connect,'commit') is not _netmiko.BaseConnection.commit:
+        net_connect.commit()
+      if cfg_item in ['normalize','initial']:
+        net_connect.set_base_prompt()
+      append_to_list(n_data._deploy,'success',cfg_item)
+    except Exception as ex:
+      append_to_list(n_data._deploy,'failed',cfg_item)
+      log.error(
+        f'{cfg_item} configuration failed on {n_data.name}',
+        more_data=str(ex),
+        more_hints=f'Inspect the session log file {session_log} for more details',
+        module='netmiko')
+      return
+
+  if log.VERBOSE:
+    log.info(f"Configuration session log for {n_data.name} is in {session_log}")

--- a/netsim/cli/initial/netmiko.py
+++ b/netsim/cli/initial/netmiko.py
@@ -30,7 +30,11 @@ def check_netmiko(n_data: Box) -> bool:
     return True                                   # ... cool, life is good
 
   if NETMIKO_LOAD_ERROR:                          # Did we already scream at the user?
-    log.error(f'Cannot load netmiko library to configure {n_data.name}: {NETMIKO_LOAD_ERROR}',category=log.FatalError,module='netmiko')
+    log.error(
+      f'Cannot load netmiko library to configure {n_data.name}: {NETMIKO_LOAD_ERROR}',
+      more_hints='use "pip3 install netmiko" or equivalent to install it',
+      category=log.FatalError,
+      module='netmiko')
     NETMIKO_LOAD_ERROR = ''
 
   return False
@@ -77,7 +81,7 @@ def prepare_params(n_data: Box, topology: Box) -> typing.Optional[dict]:
   netmiko_params['session_log'] = f'node_files/{n_data.name}/netmiko.log'
   return netmiko_params
 
-def connect(n_data: Box, netmiko_params: dict) -> typing.Optional[_netmiko.BaseConnection]:
+def connect(n_data: Box, netmiko_params: dict) -> 'typing.Optional[_netmiko.BaseConnection]':
   """
   Use netmiko to open a SSH session to a lab device
   """
@@ -101,14 +105,17 @@ def deploy(n_data: Box,topology: Box,n_deploy: list) -> None:
     return
 
   if not check_netmiko(n_data):
+    append_to_list(n_data._deploy,'failed',n_deploy[0])
     return
 
   netmiko_params = prepare_params(n_data,topology)
   if not netmiko_params:
+    append_to_list(n_data._deploy,'failed',n_deploy[0])
     return None
 
   net_connect = connect(n_data,netmiko_params)
   if not net_connect:
+    append_to_list(n_data._deploy,'failed',n_deploy[0])
     return
 
   session_log = netmiko_params["session_log"]
@@ -120,6 +127,7 @@ def deploy(n_data: Box,topology: Box,n_deploy: list) -> None:
     cfg_file = f'node_files/{n_data.name}/{cfg_item}'
     if not os.path.exists(cfg_file):
       log.error(f'Skipping {cfg_item} config on {n_data.name}; cannot find {cfg_file}',category=log.FatalError,module='netmiko')
+      append_to_list(n_data._deploy,'failed',cfg_item)
       continue
     try:
       net_connect.send_config_from_file(cfg_file,error_pattern=netmiko_errors)

--- a/netsim/cli/initial/netmiko.py
+++ b/netsim/cli/initial/netmiko.py
@@ -15,7 +15,7 @@ NETMIKO_IS_MISSING: bool = False
 NETMIKO_LOAD_ERROR: str = ''
 
 try:
-  import netmiko as _netmiko
+  import netmiko as _netmiko  # type: ignore # Do not try to type-check netmiko if it's missing
 except Exception as ex:
   NETMIKO_LOAD_ERROR = str(ex)
   NETMIKO_IS_MISSING = True

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -17,6 +17,8 @@ group_vars:
   ansible_become_method: enable
   ansible_network_os: ios
   ansible_connection: network_cli
+  netmiko_device_type: cisco_ios
+  netmiko_error_regexp: ^%
   # yamllint disable-line rule:line-length
   netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
 
@@ -29,7 +31,7 @@ clab:
     netlab_ready: [ ssh ]
   features:
     initial:
-      config_mode: [ startup ]
+      config_mode: [ startup, netmiko ]
 
 role: router
 routing:
@@ -84,6 +86,7 @@ features:
     ra: true
     collect: true
     reload: true
+    config_mode: [ netmiko ]
   isis:
     circuit_type: true
     import: [ bgp, ospf, ripv2, connected, static ]

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -18,7 +18,9 @@ group_vars:
   ansible_network_os: ios
   ansible_connection: network_cli
   netmiko_device_type: cisco_ios
-  netmiko_error_regexp: ^%
+  netmiko_error_regexp:
+  - (?i:invalid|incomplete|ambiguous|error|overlap|enabled|bad)
+
   # yamllint disable-line rule:line-length
   netlab_ssh_args: "-o KexAlgorithms=+diffie-hellman-group-exchange-sha1 -o PubkeyAcceptedKeyTypes=ssh-rsa -o HostKeyAlgorithms=+ssh-rsa"
 

--- a/netsim/devices/none.yml
+++ b/netsim/devices/none.yml
@@ -74,6 +74,7 @@ features:
     mgmt_vrf: True
     ra: True
     roles: [ router, bridge, host ]
+    config_mode: [ sh, startup, netmiko ]
     collect: True
     reload: True
   isis:

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -446,7 +446,7 @@ def add_default_config_mode(node: Box, topology: Box) -> bool:
   if cfg_mode not in d_features.get('initial.config_mode',[]):
     log.error(
       f'Configuration mode {cfg_mode} is not valid for device {node.device} (node {node.name})',
-      module='clab',
+      module='config',
       category=log.IncorrectValue)
     return False
 

--- a/netsim/providers/__init__.py
+++ b/netsim/providers/__init__.py
@@ -433,3 +433,45 @@ def tc_netem_set(intf: str, tc_data: Box, pfx: str = '') -> typing.Union[str,boo
     return netem_params if status else False
   else:
     return ''
+
+def add_default_config_mode(node: Box, topology: Box) -> bool:
+  '''
+  If the netlab_config_mode is set, add configured modules to _node_config dictionary
+  '''
+  cfg_mode = devices.get_node_group_var(node,'netlab_config_mode',topology.defaults)
+  if not cfg_mode:
+    return False
+
+  d_features = devices.get_device_features(node,topology.defaults)
+  if cfg_mode not in d_features.get('initial.config_mode',[]):
+    log.error(
+      f'Configuration mode {cfg_mode} is not valid for device {node.device} (node {node.name})',
+      module='clab',
+      category=log.IncorrectValue)
+    return False
+
+  # Get what's already been processed and the list of configuration snippets. That list
+  # has to include initial configuration, all modules, and custom config templates
+  #
+  features = devices.get_device_features(node,topology.defaults)
+  mod_list = ['normalize'] if features.initial.get('normalize',False) else []
+  mod_list += ['initial'] + node.get('module',[]) + node.get('config',[])
+  node_cfg = node.get('_node_config',{}) + node.get('_daemon_config',{})
+  node_cfg_path = devices.get_node_group_var(node,'netlab_config_path',topology.defaults)
+  for idx,m in enumerate(mod_list,start=1):
+    append_to_list(node,'netlab_ansible_skip_module',m)
+    m = m.replace('.','@')                        # Use the @-as-. hack for things like bgp.session
+    if m in node_cfg:                             # Module already processed, move on
+      continue
+    file_target = ''                              # By default, config file is not accessible in the container
+    if cfg_mode == 'sh':                          # File mapped into container using a containerlab bind
+      cfg_path = node_cfg_path or '/etc/config/'
+      file_target = f'{cfg_path}{idx:02d}-{m}.sh'
+    elif cfg_mode == 'cp_sh':                     # File copied into container, must use existing directory
+      cfg_path = node_cfg_path or '/etc/cfg-'
+      file_target = f'{cfg_path}-{idx:02d}-{m}.sh'
+
+    # Finally, store the mapping of this config item into _node_config
+    node._node_config[m] = f'{file_target}:{cfg_mode}'
+
+  return True

--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -15,6 +15,7 @@ from .. import (
   SHARED_PREFIX,
   SHARED_SUFFIX,
   _Provider,
+  add_default_config_mode,
   get_provider_forwarded_ports,
   node_add_forwarded_ports,
   tc_netem_set,
@@ -34,7 +35,8 @@ class Containerlab(_Provider):
   def node_post_transform(self, node: Box, topology: Box) -> None:
     utils.add_clab_exec(node,'netlab_start_exec',topology)
     configs.set_node_config_targets(node,topology)
-    configs.add_default_config_mode(node,topology)
+    if add_default_config_mode(node,topology):                        # Are we using internal config mechanisms?
+      utils.add_clab_exec(node,'netlab_config_exec',topology)         # ... in that case, maybe the device needs extra start commands
     binds.add_config_filemaps(node,topology)
     binds.normalize_clab_filemaps(node)
     validate_mgmt_ip(node,required=True,provider='clab',mgmt=topology.addressing.mgmt)

--- a/netsim/providers/clab/configs.py
+++ b/netsim/providers/clab/configs.py
@@ -12,51 +12,7 @@ from ...cli import external_commands
 from ...data import append_to_list
 from ...utils import log, strings
 from .. import PRINT_LOCK
-from . import utils
 
-
-def add_default_config_mode(node: Box, topology: Box) -> None:
-  '''
-  If the netlab_config_mode is set, add configured modules to _node_config dictionary
-  '''
-  cfg_mode = devices.get_node_group_var(node,'netlab_config_mode',topology.defaults)
-  if not cfg_mode:
-    return
-
-  d_features = devices.get_device_features(node,topology.defaults)
-  if cfg_mode not in d_features.get('initial.config_mode',[]):
-    log.error(
-      f'Configuration mode {cfg_mode} is not valid for device {node.device} (node {node.name})',
-      module='clab',
-      category=log.IncorrectValue)
-
-  # Get what's already been processed and the list of configuration snippets. That list
-  # has to include initial configuration, all modules, and custom config templates
-  #
-  features = devices.get_device_features(node,topology.defaults)
-  mod_list = ['normalize'] if features.initial.get('normalize',False) else []
-  mod_list += ['initial'] + node.get('module',[]) + node.get('config',[])
-  node_cfg = node.get('_node_config',{}) + node.get('_daemon_config',{})
-  node_cfg_path = devices.get_node_group_var(node,'netlab_config_path',topology.defaults)
-  for idx,m in enumerate(mod_list,start=1):
-    append_to_list(node,'netlab_ansible_skip_module',m)
-    m = m.replace('.','@')                        # Use the @-as-. hack for things like bgp.session
-    if m in node_cfg:                             # Module already processed, move on
-      continue
-    file_target = ''                              # By default, config file is not accessible in the container
-    if cfg_mode == 'sh':                          # File mapped into container using a containerlab bind
-      cfg_path = node_cfg_path or '/etc/config/'
-      file_target = f'{cfg_path}{idx:02d}-{m}.sh'
-    elif cfg_mode == 'cp_sh':                     # File copied into container, must use existing directory
-      cfg_path = node_cfg_path or '/etc/cfg-'
-      file_target = f'{cfg_path}-{idx:02d}-{m}.sh'
-
-    # Finally, store the mapping of this config item into _node_config
-    node._node_config[m] = f'{file_target}:{cfg_mode}'
-
-  # Finally, if the container needs extra precautions to work with config mode (hi there, FRR),
-  # add the exec commands to the container exec list
-  utils.add_clab_exec(node,'netlab_config_exec',topology)
 
 def set_node_config_targets(node: Box, topology: Box) -> None:
   '''

--- a/netsim/providers/libvirt.py
+++ b/netsim/providers/libvirt.py
@@ -18,7 +18,14 @@ from ..cli import external_commands, is_dry_run
 from ..data import get_box, get_empty_box, types
 from ..utils import files as _files
 from ..utils import linuxbridge, log, strings
-from . import _Provider, get_provider_forwarded_ports, node_add_forwarded_ports, tc_netem_set, validate_mgmt_ip
+from . import (
+  _Provider,
+  add_default_config_mode,
+  get_provider_forwarded_ports,
+  node_add_forwarded_ports,
+  tc_netem_set,
+  validate_mgmt_ip,
+)
 
 LIBVIRT_MANAGEMENT_NETWORK_NAME  = "vagrant-libvirt"
 LIBVIRT_MANAGEMENT_BRIDGE_NAME   = "libvirt-mgmt"
@@ -350,13 +357,20 @@ class Libvirt(_Provider):
       pad_node_interfaces(node,topology)
     validate_mgmt_ip(node,required=True,v4only=True,provider='libvirt',mgmt=topology.addressing.mgmt)
 
-    # libvirt does not support netlab_config_mode parameter yet, but we have
-    # to make it work with "none" device to pass CI/CD integration tests.
+    # libvirt does not support provider-specific netlab_config_mode parameter (it can work with 'netmiko),
+    # but we have to make it work with "none" device to pass CI/CD integration tests.
     #
-    if devices.get_node_group_var(node,'netlab_config_mode',topology.defaults) and node.device != 'none':
+    ncm = devices.get_node_group_var(node,'netlab_config_mode',topology.defaults)
+    if not ncm:
+      return
+
+    if ncm not in ['netmiko'] and node.device != 'none':
       log.error(
         'netlab_config_mode parameter is not usable with libvirt provider',
         category=log.IncorrectAttr)
+      return
+
+    add_default_config_mode(node,topology)
 
   def transform_node_images(self, topology: Box) -> None:
     self.node_image_version(topology)

--- a/tests/integration/initial/01c-netmiko.yml
+++ b/tests/integration/initial/01c-netmiko.yml
@@ -1,0 +1,50 @@
+---
+message: |
+  This lab tests the device configuration through netmiko. The topology
+  tries to configure OSPF on the device and checks OSPF adjacencies.
+
+defaults.sources.extra: [ ../wait_times.yml, ../warnings.yml ]
+module: [ ospf ]
+
+groups:
+  probes:
+    device: frr
+    provider: clab
+    members: [ x1, x2, x3 ]
+
+nodes:
+  dut:
+    ospf.area: 2
+    role: router
+    netlab_config_mode: netmiko
+    id: 1
+  x1:
+    ospf.area: 0
+  x2:
+    ospf.area: 2
+  x3:
+    ospf.area: 3
+
+links:
+- dut:
+  x1:
+  ospf.area: 0
+  mtu: 1500
+
+- dut:
+  x2:
+  ospf.area: 2
+  mtu: 1500
+
+- dut:
+  x3:
+  ospf.area: 3
+  mtu: 1500
+
+validate:
+  adj:
+    description: Check OSPF adjacencies
+    wait: ospfv2_adj_p2p
+    wait_msg: Waiting for OSPF adjacency process to complete
+    nodes: [ x1, x2, x3 ]
+    plugin: ospf_neighbor(nodes.dut.ospf.router_id)

--- a/tests/platform-integration/config/06-netmiko.yml
+++ b/tests/platform-integration/config/06-netmiko.yml
@@ -1,0 +1,56 @@
+message:
+  This lab tests the netmiko-based configuration deployment using Cisco IOL
+  layer-2 image (to include "normalize" setp) as the netmiko-configured node.
+  The test is a simplified copy of the BGP default route origination to test the
+  plugin templates.
+
+plugin: [ bgp.session, files ]
+module: [ bgp ]
+
+defaults:
+  sources.extra: [ ../../integration/wait_times.yml, ../../integrationwarnings.yml ]
+  devices.ioll2.group_vars:
+    netmiko_device_type: cisco_ios
+    netlab_config_mode: netmiko
+
+provider: clab
+
+nodes:
+  dut:
+    device: ioll2
+    module: [ bgp ]
+    bgp.as: 65000
+    config.inline: |
+      ip route 1.2.3.4 255.255.255.255 null0
+      router bgp {{ bgp.as }}
+        address-family ipv4
+          network 1.2.3.4 mask 255.255.255.255
+    _features.initial.config_mode: [ netmiko ]
+  x1:                         # Global default route
+    device: frr
+    bgp.as: 65100
+
+links:
+- dut:
+    bgp.default_originate: true
+  x1:
+
+validate:
+  ebgp:
+    description: Check IPv4 EBGP sessions with DUT
+    wait_msg: Waiting for EBGP session establishment
+    wait: ebgp_session
+    nodes: [ x1 ]
+    plugin: bgp_neighbor(node.bgp.neighbors,'dut')
+  def_ipv4:
+    description: Check whether DUT advertises IPv4 default route to X1
+    wait: bgp_scan_time
+    wait_msg: Waiting for BGP convergence
+    nodes: [ x1 ]
+    plugin: bgp_prefix('0.0.0.0/0')
+  orig_ipv4:
+    description: Check the origination of custom IPv4 prefix
+    wait: bgp_scan_time
+    wait_msg: Waiting for BGP convergence
+    nodes: [ x1 ]
+    plugin: bgp_prefix('1.2.3.4/32')

--- a/tests/platform-integration/config/06-netmiko.yml
+++ b/tests/platform-integration/config/06-netmiko.yml
@@ -8,7 +8,7 @@ plugin: [ bgp.session, files ]
 module: [ bgp ]
 
 defaults:
-  sources.extra: [ ../../integration/wait_times.yml, ../../integrationwarnings.yml ]
+  sources.extra: [ ../../integration/wait_times.yml, ../../integration/warnings.yml ]
   devices.ioll2.group_vars:
     netmiko_device_type: cisco_ios
     netlab_config_mode: netmiko


### PR DESCRIPTION
This code adds support for 'netmiko' netlab_config_mode which invokes netmiko library to connect to the lab device(s) and send configuration commands from node_files.

Initial test case: Cisco IOS devices -- netmiko configuration method is allowed but not enabled. You have to enable it in user defaults

Changes made to 'cli/initial/deploy':
* Rename 'deploy_provider_config' to 'deploy_internal_config' (because it's no longer provider-specific)
* Add a lookup table of internal config mechanisms (currently: netmiko)
* Execute internal config mechanism and provider-specific config mechanism

Changes made to provider code:
* 'add_default_config_mode' is now a shared provider function
* clab code calls the shared function and adds 'netlab_config_exec' command only if the shared function returns True (the default config method is used)
* libvirt allows 'netlab_config_method' for 'none' device and for 'netmiko' value

Also included:
* Documentation update
* Platform integration test
* Initial configuration integration test