### PR TITLE
Fix: Map /etc/resolv.conf file in device quirks

### DIFF
--- a/netsim/devices/bird.py
+++ b/netsim/devices/bird.py
@@ -5,6 +5,7 @@ from box import Box
 
 from . import _Quirks
 from ._common import check_daemon_dataplane_config
+from .linux import etc_resolv_mapping
 
 
 def bird_transform_rt(rt: str) -> str:
@@ -46,6 +47,7 @@ class Bird(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
+    etc_resolv_mapping(node,topology)
     check_daemon_dataplane_config(node,topology)
     bird_vrf_rt(node)
     bird_vlan_evpn_rt(node)

--- a/netsim/devices/dnsmasq.py
+++ b/netsim/devices/dnsmasq.py
@@ -1,0 +1,14 @@
+#
+# dnsmasq quirks
+#
+from box import Box
+
+from . import _Quirks
+from .linux import etc_resolv_mapping
+
+
+class Dnsmasq(_Quirks):
+
+  @classmethod
+  def device_quirks(self, node: Box, topology: Box) -> None:
+    etc_resolv_mapping(node,topology)

--- a/netsim/devices/frr.py
+++ b/netsim/devices/frr.py
@@ -5,6 +5,7 @@ from box import Box
 
 from ..utils import log
 from . import _Quirks, report_quirk
+from .linux import etc_resolv_mapping
 
 """
 Because FRR uses a 'bridge per VLAN' model, STP BPDUs are sent as tagged packets, not untagged.
@@ -28,6 +29,7 @@ class FRR(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
+    etc_resolv_mapping(node,topology)
     mods = node.get('module',[])
     if 'stp' in mods and node.get('stp.enable',True):
       if log.debug_active('quirks'):

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -56,7 +56,6 @@ clab:
     config_templates:
       daemons: /etc/frr/daemons
       hosts: /etc/hosts:shared
-      resolv: /etc/resolv.conf
 
 libvirt:
   image: debian/bookworm64

--- a/netsim/devices/linux.py
+++ b/netsim/devices/linux.py
@@ -38,7 +38,7 @@ def etc_resolv_mapping(node: Box, topology: Box) -> None:
     return
   if 'services.dns._server_list' not in node:
     return
-  if 'clab.node.config_templates.resolv' not in node:
+  if 'clab.config_templates.resolv' not in node:
     node.clab.config_templates.resolv = '/etc/resolv.conf'
 
 class Linux(_Quirks):

--- a/netsim/devices/linux.py
+++ b/netsim/devices/linux.py
@@ -30,11 +30,23 @@ def check_extra_loopbacks(node: Box, topology: Box) -> None:
     category=log.IncorrectType,
     quirk='ubuntu_dummy')
 
+def etc_resolv_mapping(node: Box, topology: Box) -> None:
+  """
+  Add /etc/resolv.conf mapping for Linux-based containers using DNS services
+  """
+  if devices.get_provider(node,topology) != 'clab':
+    return
+  if 'services.dns._server_list' not in node:
+    return
+  if 'clab.node.config_templates.resolv' not in node:
+    node.clab.config_templates.resolv = '/etc/resolv.conf'
+
 class Linux(_Quirks):
 
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
     check_indirect_static_routes(node)
+    etc_resolv_mapping(node,topology)
 
     if devices.get_provider(node,topology) != 'clab':
       check_vm_modules(node,topology)

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -73,7 +73,6 @@ clab:
     kind: linux
     config_templates:
       hosts: /etc/hosts:shared
-      resolv: /etc/resolv.conf
   group_vars:
     ansible_connection: docker
     ansible_user: root

--- a/tests/coverage/expected/check-config-files.yml
+++ b/tests/coverage/expected/check-config-files.yml
@@ -40,8 +40,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -54,8 +52,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux
@@ -108,8 +104,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -119,8 +113,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux

--- a/tests/coverage/expected/device-module-defaults.yml
+++ b/tests/coverage/expected/device-module-defaults.yml
@@ -83,8 +83,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/l1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -97,8 +95,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux

--- a/tests/coverage/expected/device-node-defaults.yml
+++ b/tests/coverage/expected/device-node-defaults.yml
@@ -62,8 +62,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -74,8 +72,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -142,8 +138,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -154,8 +148,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2
@@ -228,8 +220,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/rtr/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -242,8 +232,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       image: none

--- a/tests/topology/expected/bridge-module-attr.yml
+++ b/tests/topology/expected/bridge-module-attr.yml
@@ -73,8 +73,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/br/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -85,8 +83,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-br
@@ -187,8 +183,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -201,8 +195,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux
@@ -283,8 +275,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -297,8 +287,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux

--- a/tests/topology/expected/clab-attributes.yml
+++ b/tests/topology/expected/clab-attributes.yml
@@ -14,8 +14,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/n/resolv
-        target: /etc/resolv.conf
       cmd: /bin/bash
       config_templates:
       - source: daemons
@@ -23,8 +21,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       dns:
         search:
         - example.com

--- a/tests/topology/expected/components.yml
+++ b/tests/topology/expected/components.yml
@@ -697,8 +697,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/pod_1_l1_srv/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -709,8 +707,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-pod_1_l1_srv
@@ -930,8 +926,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/pod_1_l2_srv/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -942,8 +936,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-pod_1_l2_srv
@@ -1467,8 +1459,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/pod_2_l1_srv/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -1479,8 +1469,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-pod_2_l1_srv
@@ -1700,8 +1688,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/pod_2_l2_srv/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -1712,8 +1698,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-pod_2_l2_srv

--- a/tests/topology/expected/dhcp-server-on-segment.yml
+++ b/tests/topology/expected/dhcp-server-on-segment.yml
@@ -83,8 +83,6 @@ nodes:
         target: /etc/dhcp.ignore
       - source: node_files/dhs/hosts
         target: /etc/hosts
-      - source: node_files/dhs/resolv
-        target: /etc/resolv.conf
       - source: node_files/dhs/start
         target: /etc/netlab-start.sh
       - source: node_files/dhs/rsyslogd
@@ -104,8 +102,6 @@ nodes:
         target: /etc/dhcp.ignore
       - source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       - source: start
         target: /etc/netlab-start.sh
       - source: rsyslogd

--- a/tests/topology/expected/dhcp-vlan.yml
+++ b/tests/topology/expected/dhcp-vlan.yml
@@ -279,8 +279,6 @@ nodes:
         target: /etc/dhcp.ignore
       - source: node_files/dhs/hosts
         target: /etc/hosts
-      - source: node_files/dhs/resolv
-        target: /etc/resolv.conf
       - source: node_files/dhs/start
         target: /etc/netlab-start.sh
       - source: node_files/dhs/rsyslogd
@@ -300,8 +298,6 @@ nodes:
         target: /etc/dhcp.ignore
       - source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       - source: start
         target: /etc/netlab-start.sh
       - source: rsyslogd

--- a/tests/topology/expected/group-ansible-variables.yml
+++ b/tests/topology/expected/group-ansible-variables.yml
@@ -51,8 +51,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -60,8 +58,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2
@@ -89,8 +85,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h3/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -98,8 +92,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h3

--- a/tests/topology/expected/libvirt-clab-complex.yml
+++ b/tests/topology/expected/libvirt-clab-complex.yml
@@ -147,8 +147,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -159,8 +157,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
       ports:
       - '2004:22'
@@ -248,8 +244,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -260,8 +254,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
       ports:
       - '2005:22'

--- a/tests/topology/expected/multiserver-explicit.yml
+++ b/tests/topology/expected/multiserver-explicit.yml
@@ -212,8 +212,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/frr1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -223,8 +221,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux

--- a/tests/topology/expected/stp-port-type.yml
+++ b/tests/topology/expected/stp-port-type.yml
@@ -244,8 +244,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -256,8 +254,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -312,8 +308,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -324,8 +318,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2
@@ -380,8 +372,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h3/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -392,8 +382,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h3
@@ -445,8 +433,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h4/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -457,8 +443,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h4

--- a/tests/topology/expected/stp.yml
+++ b/tests/topology/expected/stp.yml
@@ -251,8 +251,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -263,8 +261,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -324,8 +320,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -336,8 +330,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2
@@ -397,8 +389,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h3/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -409,8 +399,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h3
@@ -470,8 +458,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h4/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -482,8 +468,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h4

--- a/tests/topology/expected/vlan-access-links.yml
+++ b/tests/topology/expected/vlan-access-links.yml
@@ -108,8 +108,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -120,8 +118,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -204,8 +200,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -216,8 +210,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/vlan-access-single.yml
+++ b/tests/topology/expected/vlan-access-single.yml
@@ -135,8 +135,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -147,8 +145,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h1
@@ -239,8 +235,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/h2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: ns
         source: initial
@@ -251,8 +245,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       kind: linux
     device: linux
     hostname: clab-input-h2

--- a/tests/topology/expected/vlan-routed-multiprovider.yml
+++ b/tests/topology/expected/vlan-routed-multiprovider.yml
@@ -146,8 +146,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/s/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -160,8 +158,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux

--- a/tests/topology/expected/vlan-routed-vrf.yml
+++ b/tests/topology/expected/vlan-routed-vrf.yml
@@ -365,8 +365,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r1/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -382,8 +380,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux
@@ -633,8 +629,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/r2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -650,8 +644,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux
@@ -1155,8 +1147,6 @@ nodes:
       - mode: ro
         source: node_files/-shared-hosts
         target: /etc/hosts
-      - source: node_files/s2/resolv
-        target: /etc/resolv.conf
       config_templates:
       - mode: sh
         source: initial
@@ -1172,8 +1162,6 @@ nodes:
       - mode: shared
         source: hosts
         target: /etc/hosts
-      - source: resolv
-        target: /etc/resolv.conf
       exec:
       - sleep 1
       kind: linux


### PR DESCRIPTION
The initial approach to DNS client on Linux containers blindly mapped /etc/resolv.conf file and used the Docker DNS forwarder as the DNS resolver. That broke on Podman (see #3803).

This fix maps the /etc/resolv.conf file into the container only when we need to set our own DNS servers, otherwise it leaves the container management system to do its job. The mapping is done in device quirks and has to be applied to Linux, FRR, and all daemons.