### PR TITLE
Fix: Make routing.acl.in/out a link attribute

### DIFF
--- a/docs/module/routing-acl.txt
+++ b/docs/module/routing-acl.txt
@@ -78,7 +78,12 @@ Port matching parameters (TCP/UDP only) are specified within the **src.port**/**
 
 Once defined, an ACL is applied to an interface using the interface-level **routing.acl.in** and **routing.acl.out** attributes.
 
-**Note:** You cannot apply ACLs to loopback interfaces.
+```{note}
+* You cannot apply ACLs to loopback interfaces.
+* ACLs can be applied to a link, in which case all nodes attached to that link *‌with **routing** module enabled* will use that ACL on the attached interfaces.
+* ACLs can also be applied to a global VLAN definition, in which case they will be applied to the VLAN interfaces of all nodes that use the **‌routing** module and are connected to that VLAN.
+* You can also apply ACLs to a node VLAN definition to attach them to the node VLAN interface
+```
 
 Each attribute can specify an ACL name that is applied to all address families configured on the interface. Alternatively, the attributes could be dictionaries with **ipv4** and **ipv6** keys, limiting the ACLs to the specified address family.
 

--- a/docs/module/routing-acl.txt
+++ b/docs/module/routing-acl.txt
@@ -74,15 +74,15 @@ Port matching parameters (TCP/UDP only) are specified within the **src.port**/**
 * Most platforms do not support the *‌not in range* operation. The **‌not_in** parameter is thus rewritten as a combination of **‌lt** and **‌gt** parameters.
 ```
 
-## Applying ACLs to Interfaces
+### Applying ACLs to Interfaces
 
-Once defined, an ACL is applied to an interface using the interface-level **routing.acl.in** and **routing.acl.out** attributes.
+Once defined, apply an ACL to an interface, a link, or a VLAN using the **routing.acl.in** and **routing.acl.out** attributes.
 
 ```{note}
 * You cannot apply ACLs to loopback interfaces.
-* ACLs can be applied to a link, in which case all nodes attached to that link *‌with **routing** module enabled* will use that ACL on the attached interfaces.
-* ACLs can also be applied to a global VLAN definition, in which case they will be applied to the VLAN interfaces of all nodes that use the **‌routing** module and are connected to that VLAN.
-* You can also apply ACLs to a node VLAN definition to attach them to the node VLAN interface
+* ACLs can be applied to a link, in which case all nodes *with **routing** module enabled* attached to that link will get the specified ACL on the attached interface.
+* ACLs applied to a global VLAN definition will be applied to the VLAN interfaces of all nodes that use the **routing** module and are connected to that VLAN.
+* An ACL applied to a node VLAN definition is attached to the node VLAN interface.
 ```
 
 Each attribute can specify an ACL name that is applied to all address families configured on the interface. Alternatively, the attributes could be dictionaries with **ipv4** and **ipv6** keys, limiting the ACLs to the specified address family.
@@ -112,7 +112,7 @@ links:
 ```
 
 (routing-acl-global-node)=
-## Using Global- and Node-Level ACLs
+### Using Global- and Node-Level ACLs
 
 Like other routing objects (routing policies, prefix filters, AS-path filters, and BGP community filters), an ACL defined in the global **routing.acl** dictionary is not configured on a device unless it's referenced from that node — either by an interface **routing.acl.in**/**routing.acl.out** attribute or by mentioning the ACL name in the node-level **routing.acl** dictionary without a value:
 

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -90,7 +90,7 @@ attributes:
       _subtype:
         _alt_types: [NoneType]
 
-  interface:
+  link:
     acl:
       in:
         type: dict

--- a/tests/coverage/expected/acl-vlan.yml
+++ b/tests/coverage/expected/acl-vlan.yml
@@ -1,0 +1,514 @@
+groups:
+  hosts:
+    members:
+    - h1
+    - h2
+    node_data:
+      role: host
+input:
+- coverage/input/acl-vlan.yml
+- package:topology-defaults.yml
+links:
+- _linkname: vlans.tenant.links[1]
+  bridge: input_1
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  - _vlan_mode: irb
+    ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.1/24
+    node: r1
+    routing:
+      acl:
+        in: icmp
+    vlan:
+      access: tenant
+  linkindex: 1
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: tcp
+  type: lan
+  vlan:
+    access: tenant
+- _linkname: vlans.tenant.links[2]
+  bridge: input_2
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.0.1/24
+    node: r1
+    routing:
+      acl:
+        in: icmp
+    vlan:
+      access: tenant
+  - _vlan_mode: irb
+    ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.2/24
+    node: r2
+    vlan:
+      access: tenant
+  linkindex: 2
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: tcp
+  type: lan
+  vlan:
+    access: tenant
+- _linkname: vlans.tenant.links[3]
+  bridge: input_3
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.0.2/24
+    node: r2
+    vlan:
+      access: tenant
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  linkindex: 3
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: tcp
+  type: lan
+  vlan:
+    access: tenant
+module:
+- vlan
+- routing
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 3
+    interfaces:
+    - bridge: input_1
+      gateway:
+        ipv4: 172.16.0.1/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 1
+      name: h1 -> [r1,h2,r2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: icmp
+        vlan:
+          mode: irb
+          name: tenant
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: tcp
+        vlan:
+          mode: irb
+          name: tenant
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: ca:fe:00:03:00:00
+    module:
+    - routing
+    name: h1
+    role: host
+    routing:
+      static:
+      - ipv4: 0.0.0.0/0
+        nexthop:
+          idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+  h2:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 4
+    interfaces:
+    - bridge: input_3
+      gateway:
+        ipv4: 172.16.0.1/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      linkindex: 3
+      name: h2 -> [h1,r1,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: icmp
+        vlan:
+          mode: irb
+          name: tenant
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: tcp
+        vlan:
+          mode: irb
+          name: tenant
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: ca:fe:00:04:00:00
+    module:
+    - routing
+    name: h2
+    role: host
+    routing:
+      static:
+      - ipv4: 0.0.0.0/0
+        nexthop:
+          idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+  r1:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 1
+    interfaces:
+    - bridge: input_1
+      ifindex: 1
+      ifname: eth1
+      linkindex: 1
+      name: '[Access VLAN tenant] r1 -> h1'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      type: lan
+      vlan:
+        access: tenant
+        access_id: 1000
+    - bridge: input_2
+      ifindex: 2
+      ifname: eth2
+      linkindex: 2
+      name: '[Access VLAN tenant] r1 -> r2'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.2/24
+        node: r2
+      type: lan
+      vlan:
+        access: tenant
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 40000
+      ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN tenant (1000) -> [h1,h2,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: tcp
+        vlan:
+          mode: irb
+          name: tenant
+      routing:
+        acl:
+          in:
+            ipv4: icmp
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: tenant
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    module:
+    - vlan
+    - routing
+    name: r1
+    routing:
+      _acl:
+        ipv4:
+          icmp:
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: icmp
+            sequence: 100
+            src:
+              any: true
+              ipv4: 0.0.0.0/0
+      acl:
+        icmp:
+        - action: permit
+          dst:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+          protocol: icmp
+          sequence: 10
+          src:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      tenant:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        routing:
+          acl:
+            in: icmp
+  r2:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 2
+    interfaces:
+    - bridge: input_2
+      ifindex: 1
+      ifname: eth1
+      linkindex: 2
+      name: '[Access VLAN tenant] r2 -> r1'
+      neighbors:
+      - ifname: eth2
+        ipv4: 172.16.0.1/24
+        node: r1
+      type: lan
+      vlan:
+        access: tenant
+        access_id: 1000
+    - bridge: input_3
+      ifindex: 2
+      ifname: eth2
+      linkindex: 3
+      name: '[Access VLAN tenant] r2 -> h2'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: lan
+      vlan:
+        access: tenant
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 40000
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN tenant (1000) -> [h1,r1,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: icmp
+        vlan:
+          mode: irb
+          name: tenant
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      routing:
+        acl:
+          in:
+            ipv4: tcp
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: tenant
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    module:
+    - vlan
+    - routing
+    name: r2
+    routing:
+      _acl:
+        ipv4:
+          tcp:
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: tcp
+            sequence: 100
+            src:
+              any: true
+              ipv4: 0.0.0.0/0
+      acl:
+        tcp:
+        - action: permit
+          dst:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+          protocol: tcp
+          sequence: 10
+          src:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      tenant:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        routing:
+          acl:
+            in: tcp
+prefix:
+  any:
+    ipv4: 0.0.0.0/0
+    ipv6: ::/0
+provider: libvirt
+routing:
+  acl:
+    icmp:
+    - action: permit
+      dst:
+        ipv4:
+        - 0.0.0.0/0
+        ipv6:
+        - ::/0
+      protocol: icmp
+      sequence: 10
+      src:
+        ipv4:
+        - 0.0.0.0/0
+        ipv6:
+        - ::/0
+    tcp:
+    - action: permit
+      dst:
+        ipv4:
+        - 0.0.0.0/0
+        ipv6:
+        - ::/0
+      protocol: tcp
+      sequence: 10
+      src:
+        ipv4:
+        - 0.0.0.0/0
+        ipv6:
+        - ::/0
+vlans:
+  tenant:
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      node: r1
+      routing:
+        acl:
+          in: icmp
+      vlan:
+        mode: irb
+        name: tenant
+    - ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: r2
+      routing:
+        acl:
+          in: tcp
+      vlan:
+        mode: irb
+        name: tenant
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24
+    routing:
+      acl:
+        in: tcp

--- a/tests/coverage/input/acl-vlan.yml
+++ b/tests/coverage/input/acl-vlan.yml
@@ -1,0 +1,31 @@
+---
+defaults.sources.extra: [ ../warnings.yml ]
+defaults.device: none
+module: [ routing, vlan ]
+
+groups:
+  hosts:
+    members: [ h1, h2 ]
+    role: host
+
+routing.acl:
+  icmp:
+  - action: permit
+    protocol: icmp
+  tcp:
+  - action: permit
+    protocol: tcp
+
+vlans:
+  tenant:
+    routing.acl.in: tcp
+    links: [ h1-r1, r1-r2, r2-h2 ]
+
+nodes:
+  r1:
+    vlans:
+      tenant:
+        routing.acl.in: icmp
+  r2:
+  h1:
+  h2:

--- a/tests/topology/expected/acl-simple.yml
+++ b/tests/topology/expected/acl-simple.yml
@@ -58,9 +58,6 @@ nodes:
       - ifname: eth1
         ipv4: 192.168.0.2/24
         node: n1
-        routing:
-          acl:
-            in: h1_filter
       type: p2p
     - ifindex: 0
       ifname: Loopback0


### PR DESCRIPTION
You could apply routing.acl to an interface, which prevented its use on VLANs (see #3766). The attribute was changed to a link attribute, so it can be used on a link (or an interface), a global VLAN definition or a node VLAN definition. The attached coverage test validates the global/node VLAN use case.

The documentation was updated to explain where the routing.acl attribute could be attached.

Closes #3766