### PR TITLE
Fix: Use isis.metric in configuration templates

### DIFF
--- a/netsim/ansible/templates/isis/arcos.j2
+++ b/netsim/ansible/templates/isis/arcos.j2
@@ -80,11 +80,9 @@ network-instance default protocol ISIS i1
     ("interface <if> level <N> metric <cost>"), not off the interface itself, so it is
     emitted once per level the interface participates in. Wide metrics need no knob: this
     build originates Extended Reachability / Extended IP Reachability (TLV 22/135)
-    natively -- a metric of 80000 shows up verbatim in a peer's LSDB. Sourced from
-    l.isis.metric with l.isis.cost as the fallback, the same pair templates/isis/eos.j2
-    and templates/isis/frr.j2 read. -#}
-{%       if l.isis.cost is defined or l.isis.metric is defined %}
-{%         set _metric = l.isis.metric|default(l.isis.cost) %}
+    natively -- a metric of 80000 shows up verbatim in a peer's LSDB. -#}
+{%       if l.isis.metric is defined %}
+{%         set _metric = l.isis.metric %}
 {%         if ityp in ["level-1","level-1-2"] %}
  interface {{ l.ifname }} level 1 metric {{ _metric }}
 {%         endif %}

--- a/netsim/ansible/templates/isis/asa.j2
+++ b/netsim/ansible/templates/isis/asa.j2
@@ -27,8 +27,8 @@ interface {{ l.ifname }}
 {%   if l.isis.type|default(False) %}
   isis circuit-type {{ l.isis.type }}
 {%   endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
-  isis metric {{ l.isis.metric|default(l.isis.cost) }}
+{%   if l.isis.metric is defined %}
+  isis metric {{ l.isis.metric }}
 {%     if 'ipv6' in l and 'ipv6' in isis.af %}
   ipv6 router isis
 {%     endif %}

--- a/netsim/ansible/templates/isis/eos.macro.j2
+++ b/netsim/ansible/templates/isis/eos.macro.j2
@@ -34,10 +34,10 @@ interface {{ l.ifname }}
 {% if l.isis.type is defined %}
  isis circuit-type {{ l.isis.type }}
 {% endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
-  isis metric {{ l.isis.metric|default(l.isis.cost) }}
+{%   if l.isis.metric is defined %}
+  isis metric {{ l.isis.metric }}
 {%     if 'ipv6' in isis.af and 'ipv6' in l %}
-  isis ipv6 metric {{ l.isis.metric|default(l.isis.cost) }}
+  isis ipv6 metric {{ l.isis.metric }}
 {%     endif %}
 {%   endif %}
 {%   if l.isis.bfd.ipv4|default(False) %}

--- a/netsim/ansible/templates/isis/frr.macro.j2
+++ b/netsim/ansible/templates/isis/frr.macro.j2
@@ -36,8 +36,8 @@ interface {{ l.ifname }}
 {% if l.isis.type is defined %}
  isis circuit-type {{ l.isis.type }}
 {% endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
- isis metric {{ l.isis.metric|default(l.isis.cost) }}
+{%   if l.isis.metric is defined %}
+ isis metric {{ l.isis.metric }}
 {%   endif %}
 {%   if l.isis.passive %}
  isis passive

--- a/netsim/ansible/templates/isis/ios.j2
+++ b/netsim/ansible/templates/isis/ios.j2
@@ -22,10 +22,10 @@ interface {{ l.ifname }}
 {% if l.isis.type is defined %}
   isis circuit-type {{ l.isis.type }}
 {% endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
-  isis metric {{ l.isis.metric|default(l.isis.cost) }}
+{%   if l.isis.metric is defined %}
+  isis metric {{ l.isis.metric }}
 {%     if ('ipv6' in l or 'ipv6' in l.dhcp.client|default({})) and 'ipv6' in isis.af  %}
-  isis ipv6 metric {{ l.isis.metric|default(l.isis.cost) }}
+  isis ipv6 metric {{ l.isis.metric }}
 {%     endif %}
 {%   endif %}
 {%   if l.isis.bfd.ipv4|default(False) %}

--- a/netsim/ansible/templates/isis/iosxr.j2
+++ b/netsim/ansible/templates/isis/iosxr.j2
@@ -39,8 +39,8 @@ router isis {{ 'isis_'+vrf if vrf else isis.instance }}
 {%   endif %}
 {%   for naf in ['ipv4','ipv6'] if naf in l and naf in isis.af %}
   address-family {{ naf }}
-{%     if l.isis.cost is defined or l.isis.metric is defined %}
-   metric {{ l.isis.metric|default(l.isis.cost) }}
+{%     if l.isis.metric is defined %}
+    metric {{ l.isis.metric }}
 {%     endif %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/ansible/templates/isis/junos.isis.j2
+++ b/netsim/ansible/templates/isis/junos.isis.j2
@@ -39,12 +39,12 @@
           }
         }
 {%   endif %}
-{%   if l.isis.metric is defined or l.isis.cost is defined %}
-      level 1 metric {{ l.isis.metric|default(l.isis.cost) }};
-      level 2 metric {{ l.isis.metric|default(l.isis.cost) }};
+{%   if l.isis.metric is defined %}
+      level 1 metric {{ l.isis.metric }};
+      level 2 metric {{ l.isis.metric }};
 {%     if 'ipv6' in isis.af and 'ipv6' in l %}
-      level 1 ipv6-unicast-metric {{ l.isis.metric|default(l.isis.cost) }};
-      level 2 ipv6-unicast-metric {{ l.isis.metric|default(l.isis.cost) }};
+      level 1 ipv6-unicast-metric {{ l.isis.metric }};
+      level 2 ipv6-unicast-metric {{ l.isis.metric }};
 {%     endif %}
 {%   endif %}
     }

--- a/netsim/ansible/templates/isis/nxos.j2
+++ b/netsim/ansible/templates/isis/nxos.j2
@@ -39,12 +39,12 @@ interface {{ l.ifname }}
 {% if l.isis.type is defined %}
   isis circuit-type {{ l.isis.type }}
 {% endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
-  isis metric {{ l.isis.metric|default(l.isis.cost) }} level-1
-  isis metric {{ l.isis.metric|default(l.isis.cost) }} level-2
+{%   if l.isis.metric is defined %}
+  isis metric {{ l.isis.metric }} level-1
+  isis metric {{ l.isis.metric }} level-2
 {%     if 'ipv6' in l and 'ipv6' in isis.af  %}
-  isis ipv6 metric {{ l.isis.metric|default(l.isis.cost) }} level-1
-  isis ipv6 metric {{ l.isis.metric|default(l.isis.cost) }} level-2
+  isis ipv6 metric {{ l.isis.metric }} level-1
+  isis ipv6 metric {{ l.isis.metric }} level-2
 {%     endif %}
 {%   endif %}
 {%   if l.isis.bfd.ipv4|default(False) %}

--- a/netsim/ansible/templates/isis/srlinux.macro.j2
+++ b/netsim/ansible/templates/isis/srlinux.macro.j2
@@ -46,15 +46,15 @@
          admin-state: enable
          enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
 {%     endif %}
-{%     if l.isis.metric is defined or l.isis.cost is defined or l.isis.type is defined %}
-       level:
+{%     if l.isis.metric is defined or l.isis.type is defined %}
+        level:
 {%       for level in ['1','2'] %}
 {%         if level not in l.isis.type|default('level-1-2') %}
-       - level-number: {{ level }}
-         disable: True
-{%         elif l.isis.metric is defined or l.isis.cost is defined %}
-       - level-number: {{ level }}
-         metric: {{ l.isis.metric|default(l.isis.cost) }}
+        - level-number: {{ level }}
+          disable: True
+{%         elif l.isis.metric is defined %}
+        - level-number: {{ level }}
+          metric: {{ l.isis.metric }}
 {%         endif %}
 {%       endfor %}
 {%     endif %}

--- a/netsim/ansible/templates/isis/srlinux.macro.j2
+++ b/netsim/ansible/templates/isis/srlinux.macro.j2
@@ -3,48 +3,48 @@
 {{ redistribute.config(vrf=vrf,proto='isis',p_data=isis,evpn_active=False,af=isis.af.keys()) }}
 - path: /network-instance[name={{ vrf }}]/protocols/isis
   value:
-   instance:
-   - name: {{ isis.instance }}
-     admin-state: enable
-     net: [ "{{ isis.net }}" ]
-     level-capability: "{{ 'L2' if isis.type=='level-2' else 'L1' if isis.type=='level-1' else 'L1L2' }}"
+    instance:
+    - name: {{ isis.instance }}
+      admin-state: enable
+      net: [ "{{ isis.net }}" ]
+      level-capability: "{{ 'L2' if isis.type=='level-2' else 'L1' if isis.type=='level-1' else 'L1L2' }}"
 {% if isis.default|default(False) or isis.import|default(False) %}
-     export-policy: "{{ vrf }}_export_isis"
+      export-policy: "{{ vrf }}_export_isis"
 {% endif %}
 {% if isis.af.ipv6 is defined %}
-     ipv6-unicast:
-       admin-state: enable
-       multi-topology: True
+      ipv6-unicast:
+        admin-state: enable
+        multi-topology: True
 {% endif %}
 {% if ldp is defined and ldp.igp_sync|default(True) %}
-     ldp-synchronization: { }
+      ldp-synchronization: { }
 {% endif %}
 {% if vrf == 'default' or interfaces %}
-     interface:
+      interface:
 {% endif %}
 {% if vrf == 'default' %}
-     - interface-name: system0.0
-       passive: True
-       ipv4-unicast:
-         admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
-       ipv6-unicast:
-         admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
+      - interface-name: system0.0
+        passive: True
+        ipv4-unicast:
+          admin-state: {{ 'enable' if 'ipv4' in loopback and 'ipv4' in isis.af else 'disable' }}
+        ipv6-unicast:
+          admin-state: {{ 'enable' if 'ipv6' in loopback and 'ipv6' in isis.af else 'disable' }}
 {% endif %}
 {% for l in interfaces if (l.vlan is not defined or l.vlan.mode|default('irb')!='bridge') and l.subif_index is not defined %}
 {%   set ifname = l.ifname if '.' in l.ifname else l.ifname|replace('vlan','irb0.') if l.type=='svi' else (l.ifname+'.0') %}
 {%   if "isis" not in l %}
      # IS-IS not configured on external interface {{ ifname }}
 {%   else %}
-     - interface-name: {{ ifname }}
-       circuit-type: {{ l.isis.network_type|default("broadcast") }}
-       passive: {{ l.isis.passive }}
-       ipv4-unicast:
-         admin-state: {{ 'enable' if 'ipv4' in l and 'ipv4' in isis.af else 'disable' }}
-         enable-bfd: {{ l.isis.bfd.ipv4|default(False) }}
+      - interface-name: {{ ifname }}
+        circuit-type: {{ l.isis.network_type|default("broadcast") }}
+        passive: {{ l.isis.passive }}
+        ipv4-unicast:
+          admin-state: {{ 'enable' if 'ipv4' in l and 'ipv4' in isis.af else 'disable' }}
+          enable-bfd: {{ l.isis.bfd.ipv4|default(False) }}
 {%     if 'ipv6' in l and 'ipv6' in isis.af  %}
-       ipv6-unicast:
-         admin-state: enable
-         enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
+        ipv6-unicast:
+          admin-state: enable
+          enable-bfd: {{ l.isis.bfd.ipv6|default(False) }}
 {%     endif %}
 {%     if l.isis.metric is defined or l.isis.type is defined %}
         level:

--- a/netsim/ansible/templates/isis/sros.j2
+++ b/netsim/ansible/templates/isis/sros.j2
@@ -59,13 +59,13 @@
             include-bfd-tlv: True
 {%     endif %}
 {%     endif %}
-{%     if (l.isis.metric is defined or l.isis.cost is defined) %}
+{%     if (l.isis.metric is defined) %}
         level:
 {%       for level in ['1','2'] %}
         - level-number: "{{ level }}"
-          metric: {{ l.isis.metric|default(l.isis.cost) }}
+          metric: {{ l.isis.metric }}
 {%         if 'ipv6' in isis.af and 'ipv6' in l %}
-          ipv6-unicast-metric: {{ l.isis.metric|default(l.isis.cost) }}
+          ipv6-unicast-metric: {{ l.isis.metric }}
 {%         endif %}
 {%       endfor %}
 {%     endif %}

--- a/netsim/ansible/templates/isis/sros.openconfig.j2
+++ b/netsim/ansible/templates/isis/sros.openconfig.j2
@@ -25,24 +25,24 @@ updates:
             config:
              level-number: 1
              passive: {{ l.isis.passive }}
-{%           if l.isis.metric is defined or l.isis.cost is defined %}
+{%           if l.isis.metric is defined %}
              afi-safi:
               af:
               - afi-name: "IPV4"
                 safi-name: "UNICAST"
                 config:
-                 metric: {{ l.isis.metric|default(l.isis.cost) }}
+                 metric: {{ l.isis.metric }}
 {%           endif %}
           - level-number: 2
             config:
              level-number: 2
              passive: {{ l.isis.passive }}
-{%           if l.isis.metric is defined or l.isis.cost is defined %}
+{%           if l.isis.metric is defined %}
              afi-safi:
               af:
               - afi-name: "IPV4"
                 safi-name: "UNICAST"
                 config:
-                 metric: {{ l.isis.metric|default(l.isis.cost) }}
+                 metric: {{ l.isis.metric }}
 {%           endif %}
 {%   endfor %}

--- a/netsim/ansible/templates/isis/vyos.j2
+++ b/netsim/ansible/templates/isis/vyos.j2
@@ -18,8 +18,8 @@ set protocols isis interface {{ l.ifname }} network point-to-point
 {%   if l.isis.type is defined %}
 set protocols isis interface {{ l.ifname }} circuit-type {{ l.isis.type }}
 {%   endif %}
-{%   if l.isis.cost is defined or l.isis.metric is defined %}
-set protocols isis interface {{ l.ifname }} metric {{ l.isis.metric|default(l.isis.cost) }}
+{%   if l.isis.metric is defined %}
+set protocols isis interface {{ l.ifname }} metric {{ l.isis.metric }}
 {%   endif %}
 {%   if l.isis.passive %}
 set protocols isis interface {{ l.ifname }} passive

--- a/netsim/ansible/templates/srv6/sros.j2
+++ b/netsim/ansible/templates/srv6/sros.j2
@@ -60,11 +60,11 @@ updates:
     locator:
     - locator-name: {{ locator_name }}
       level-capability: "{{ '2' if isis.type=='level-2' else ('1' if isis.type=='level-1' else '1/2') }}"
-{%    if 'isis' in srv6 and (srv6.isis.metric is defined or srv6.isis.cost is defined) %}
+{%    if 'isis' in srv6 and srv6.isis.metric is defined %}
       level:
 {%    for level in ['1','2'] %}
       - level-number: "{{ level }}"
-        metric: {{ srv6.isis.metric|default(srv6.isis.cost) }}
+        metric: {{ srv6.isis.metric }}
 {%    endfor %}
 {%    endif %}
 

--- a/netsim/ansible/templates/vrf/arcos.j2
+++ b/netsim/ansible/templates/vrf/arcos.j2
@@ -197,8 +197,8 @@ network-instance {{ vname }} protocol ISIS i-{{ vname }}
 {%         endif %}
 {#-        Per-interface metric, same shape as templates/isis/arcos.j2 (global/VRF parity):
            ArcOS keeps it on the interface's level container, so it is emitted per level. -#}
-{%         if l.isis.cost is defined or l.isis.metric is defined %}
-{%           set _metric = l.isis.metric|default(l.isis.cost) %}
+{%         if l.isis.metric is defined %}
+{%           set _metric = l.isis.metric %}
 {%           if vdo_l1 %}
  interface {{ l.ifname }} level 1 metric {{ _metric }}
 {%           endif %}


### PR DESCRIPTION
After #3811, we can remove the fallback to isis.cost from the IS-IS configuration templates, resulting in cleaner templates ;)

Closes #3662