### PR TITLE
Fix: Perform network services feature check only when needed

### DIFF
--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -60,8 +60,8 @@ def check_feature_support(ndata: Box, svc_data: Box, topology: Box, mod_attr: Bo
   is_server = 'services.server' in ndata
   for kw in mod_attr.clients:
     if kw in svc_data:
-      if 'check_when' in mod_attr.clients[kw]:      # Check attributes that have to be present for feature check
-        if not [ attr for attr in mod_attr.clients[kw].check_when if attr in svc_data[kw] ]:
+      if "check_when" in mod_attr.clients[kw]:      # Check attributes that have to be present for feature check
+        if not any(attr in svc_data[kw] for attr in mod_attr.clients[kw].check_when):
           continue
       devices.check_optional_features(
         data=svc_data[kw],

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -60,16 +60,17 @@ def check_feature_support(ndata: Box, svc_data: Box, topology: Box, mod_attr: Bo
   is_server = 'services.server' in ndata
   for kw in mod_attr.clients:
     if kw in svc_data:
+      check_client = True
       if "check_when" in mod_attr.clients[kw]:      # Check attributes that have to be present for feature check
-        if not any(attr in svc_data[kw] for attr in mod_attr.clients[kw].check_when):
-          continue
-      devices.check_optional_features(
-        data=svc_data[kw],
-        path=f'topology.nodes.{ndata.name}.services',
-        node=ndata,
-        topology=topology,
-        attribute=f'services.{kw}',
-        check_mode=devices.FC_MODE.BLACKLIST)
+        check_client = any(attr in svc_data[kw] for attr in mod_attr.clients[kw].check_when)
+      if check_client:
+        devices.check_optional_features(
+          data=svc_data[kw],
+          path=f'topology.nodes.{ndata.name}.services',
+          node=ndata,
+          topology=topology,
+          attribute=f'services.{kw}',
+          check_mode=devices.FC_MODE.BLACKLIST)
     if is_server and kw in svc_data.server:
       devices.check_optional_features(
         data=svc_data.server[kw],

--- a/netsim/modules/services.py
+++ b/netsim/modules/services.py
@@ -60,6 +60,9 @@ def check_feature_support(ndata: Box, svc_data: Box, topology: Box, mod_attr: Bo
   is_server = 'services.server' in ndata
   for kw in mod_attr.clients:
     if kw in svc_data:
+      if 'check_when' in mod_attr.clients[kw]:      # Check attributes that have to be present for feature check
+        if not [ attr for attr in mod_attr.clients[kw].check_when if attr in svc_data[kw] ]:
+          continue
       devices.check_optional_features(
         data=svc_data[kw],
         path=f'topology.nodes.{ndata.name}.services',

--- a/netsim/modules/services.yml
+++ b/netsim/modules/services.yml
@@ -50,9 +50,11 @@ attributes:
     dns:
       ignore: [ domain ]                          # These parameters can be present even on non-clients
       must_have: [ server, ipv4, ipv6 ]           # ... otherwise, one of these must be present
+      check_when: [ _server_list ]                # Check feature support only when a server is configured
     syslog:
       ignore: []
       must_have: [ server, ipv4, ipv6 ]
+      check_when: [ _server_list ]
 features:
   dns: DNS client
   syslog: syslog client


### PR DESCRIPTION
The 'services.dns.domain' attribute is set by default, preventing nodes that do not support DNS client from having a syslog client. This commit changes the 'check network services features' logic -- support for a network service can be checked only when a specific attribute (currently _server_list) is present in the services client data. Otherwise, the services client data won't be functional anyway, so we don't have to check which features are supported.