### PR TITLE
Doc: Generic routing feature table

### DIFF
--- a/docs/module/routing-clist.txt
+++ b/docs/module/routing-clist.txt
@@ -35,17 +35,12 @@ routing.community:
 
 You can define BGP community filters on these platforms:
 
-| Operating system      | Standard<br>communities | Large<br>communities | Extended<br>communities |
-| ------------------ |:--:|:--:|:--:|
-| Arista EOS         | ✅ | ✅ | ❌  |
-| Aruba AOS-CX       | ✅ | ❌  | ❌  |
-| Cisco IOS/IOS XE[^18v] | ✅ | ❌  | ❌  |
-| Cisco IOS XR[^XR][❗](caveats-iosxr) | ✅ | ❌  | ❌  |
-| Cumulus Linux      | ✅ | ❌  | ❌  |
-| Dell OS10          | ✅ | ❌  | ❌  |
-| FRR                | ✅ | ✅ | ❌  |
-| Junos              | ✅ | ✅ | ❌  |
-| VyOS               | ✅ | ❌  | ❌  |
+```{features}
+- title: Standard<br>communities
+  enabled: routing.community.standard
+- title: Large<br>communities
+  enabled: routing.community.large
+```
 
 ### Shortcut BGP Community Filter Definitions
 

--- a/docs/module/routing-policy.txt
+++ b/docs/module/routing-policy.txt
@@ -64,65 +64,61 @@ nodes:
 
 You can use these routing policy **match** parameters on devices supported by the **routing** module.
 
-| Operating system    | IPv4/IPv6<br>prefix | IPv4/IPv6<br>next hop | BGP<br>AS-path | Standard BGP<br>Community | Large BGP<br>Community |
-|---------------------|:--:|:--:|:--:|:--:|:--:|
-| Arista EOS          | ✅ | ❌  | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Cisco IOS/IOS XE[^18v] | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Cisco IOS XR[^XR]   | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Cumulus Linux       | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Dell OS10           | ✅ | ❌  | ✅ | ✅ | ❌  |
-| Junos               | ✅ | ❌  | [✅](caveats-junos) | ✅ | ✅ |
-| FRR                 | ✅ | ❌  | ✅ | ✅ | ✅ |
-| Nokia SR Linux      | ✅ | ❌  | ❌  | ❌  | ❌  |
-| VyOS                | ✅ | ❌  | ✅ | ✅ | ❌  |
+```{features}
+- title: IPv4/IPv6<br>prefix
+  enabled: routing.policy.match.prefix
+# - title: Next hop
+#   enabled: routing.policy.match.nexthop
+- title: BGP<br>AS-path
+  enabled: routing.policy.match.aspath
+- title: Standard BGP<br>Community
+  enabled: routing.policy.match.community.standard
+- title: Large BGP<br>Community
+  enabled: routing.policy.match.community.large
+```
 
 You can use these routing policy **set** parameters on devices supported by the **routing** module:
 
-| Operating system    | AS-path<br>prepend | Local<br>preference | MED | Weight | Community |
-|---------------------|:--:|:--:|:--:|:--:| :--:|
-| Arista EOS          | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS/IOS XE[^18v] | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS XR[^XR]   | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cumulus Linux       | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Dell OS10           | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Junos               | ✅ | ✅ | ✅ | ❌  | ✅ |
-| FRR                 | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Nokia SR Linux      | ❌  | ✅ | ✅ | ❌  | ❌  |
-| Nokia SR OS[^SROS]  | ❌  | ✅ | ✅ | ❌  | ❌  |
-| VyOS                | ✅ | ✅ | ✅ | ❌  | ✅ |
+```{features}
+- title: AS-path<br>prepend
+  enabled: routing.policy.set.prepend
+- title: Local<br>preference
+  enabled: routing.policy.set.locpref
+- title: MED
+  enabled: routing.policy.set.med
+- title: Weight
+  enabled: routing.policy.set.weight
+- title: Community
+  enabled: routing.policy.set.community
+```
 
 The **set.community** attribute can be used to set these BGP communities on supported devices:
 
-| Operating system    | Standard<br>community | Large<br>community | Extended<br>community |
-|---------------------|:--:|:--:|:--:|
-| Arista EOS          | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ❌  | ❌  |
-| Cisco IOS/IOS XE[^18v] | ✅ | ❌  | ❌  |
-| Cisco IOS XR[^XR]   | ✅ | ✅ | ❌  |
-| Cumulus Linux       | ✅ | ✅ | ✅ |
-| Dell OS10           | ✅ | ❌ | ✅ |
-| Junos               | ✅ | ✅ | ✅ |
-| FRR                 | ✅ | ✅ | ✅ |
-| VyOS                | ✅ | ✅ | ✅ |
+```{features}
+- title: Standard<br>community
+  enabled: routing.policy.set.community is True or routing.policy.set.get('community.standard',False)
+- title: Large<br>community
+  enabled: routing.policy.set.community is True or routing.policy.set.get('community.large',False)
+- title: Extended<br>community
+  enabled: routing.policy.set.community is True or routing.policy.set.get('community.extended',False)
+```
 
-In addition to setting BGP communities on BGP routes, these devices can perform additional operations on BGP communities. Deleting extended or large BGP communities with a BGP community list is not implemented on all devices; check the [online integration test results](https://tests.netlab.tools/_html/coverage.r_policy) for more details.
+In addition to setting BGP communities on BGP routes, these devices can perform additional operations on BGP communities:
 
-| Operating system    | Append | Delete | Delete list<br>(standard) | Delete list<br>(large) |
-|---------------------|:--:|:--:|:--:|:--:|
-| Arista EOS          | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ✅ | ❌  | ❌  |
-| Cisco IOS/IOS XE[^18v] | ✅ | ✅❗️| ✅ | ❌  |
-| Cisco IOS XR[^XR]   | ✅ | ✅ | ❌  | ❌  |
-| Cumulus Linux       | ✅ | ❌  | ❌  | ❌  |
-| Dell OS10           | ✅ | ❌  | ❌  | ❌  |
-| Junos               | ✅ | ✅ | ✅ | ✅ |
-| FRR                 | ✅ | ✅❗️ | ✅ | ✅ |
-| VyOS                | ✅ | ❌  | ❌  | ❌  |
+```{features}
+- title: Append
+  enabled: routing.policy.set.community is True or routing.policy.set.get('community.append',False)
+- title: Delete
+  enabled: routing.policy.delete.community in [ True,'clist'] or routing.policy.delete.get('community.standard',False)
+  caveats: routing.policy.delete.caveats
+- title: Delete list
+  enabled: routing.policy.delete.community in [ True,'clist']
+  caveats: routing.policy.delete.caveats
+```
 
 **Notes:**
 * _netlab_ is creating an internal BGP community list on FRR and Cisco IOS/XE to delete BGP communities specified with the **delete.community** routing policy parameter.
+* Not all devices support deleting extended or large BGP communities with a BGP community list; see the [online integration test results](https://tests.netlab.tools/_html/coverage.r_policy) for details.
 
 ### Shortcut Routing Policy Definitions
 

--- a/docs/module/routing-policy.txt
+++ b/docs/module/routing-policy.txt
@@ -112,7 +112,7 @@ In addition to setting BGP communities on BGP routes, these devices can perform 
   enabled: routing.policy.delete.community in [ True,'clist'] or routing.policy.delete.get('community.standard',False)
   caveats: routing.policy.delete.caveats
 - title: Delete list
-  enabled: routing.policy.delete.community in [ True,'clist']
+  enabled: routing.policy.delete.community in [ True,'clist'] or routing.policy.delete.get('community.list',False)
   caveats: routing.policy.delete.caveats
 ```
 

--- a/docs/module/routing-static.txt
+++ b/docs/module/routing-static.txt
@@ -7,25 +7,17 @@ Static routes are defined as lists of prefix/next-hop pairs in the **routing.sta
 
 _netlab_ supports static routes on these platforms:
 
-| Operating system    | Global<br>static routes | Discard<br>routes | VRF static<br>routes | Inter-VRF<br>static routes |
-|---------------------|:--:|:--:|:--:|:--:|
-| Arista EOS          | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX        | ✅ | ✅ | ✅ | [❗](caveats-aruba) |
-| BIRD                | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS/XE[^18v]  | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS XR[^XR]   | ✅ | ✅ | ✅ | ✅ |
-| Cisco Nexus OS      | ✅ | ✅ | ✅ | ❌  |
-| Cumulus Linux 4.x   | ✅ |  ❌ | ✅ | ✅ |
-| Dell OS10           | ✅ | ✅ | ✅ | ✅ |
-| Fortinet FortiOS    | ✅ | ✅ |  ❌ |  ❌ |
-| FRR                 | ✅ | ✅ | ✅ | ✅ |
-| Junos               | ✅ | ✅ | ✅ | ❌ |
-| Linux               | ✅ |  ❌ |  ❌ |  ❌ |
-| Mikrotik RouterOS 7 | ✅ | ✅ | ✅ | ✅ |
-| Nokia SR Linux      | ✅ | ✅ | ✅ |  ❌ |
-| Nokia SR OS[^SROS]  | ✅ | ✅ | ✅ |  ❌ |
-| OpenBSD             | ✅ | ✅ |  ❌ |  ❌ |
-| VyOS                | ✅ | ✅ | ✅ | ✅ |
+```{features}
+- title: Global<br>static routes
+  enabled: routing.static
+- title: Discard<br>routes
+  enabled: routing.static.discard
+- title: VRF static<br>routes
+  enabled: routing.static.vrf
+- title: Inter-VRF<br>static routes
+  enabled: routing.static.inter_vrf
+  caveats: routing.static.inter_vrf.caveats
+```
 
 ### Configuring Static Routes
 

--- a/docs/module/routing.md
+++ b/docs/module/routing.md
@@ -20,37 +20,35 @@ This configuration module implements generic routing features:
 (generic-routing-platforms)=
 ## Platform Support
 
-The following table describes high-level per-platform support of generic routing features:
+These platforms support generic routing features:
 
-| Operating system      | Routing<br>policies | Prefix<br>filters| AS-path<br>filters | BGP<br>communities | Static<br>routes| IPv4/IPv6<br>ACL|
-| ------------------ |:--:|:--:|:--:|:--:|:--:|:--:|
-| Arista EOS         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Aruba AOS-CX       | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| BIRD               | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| Cisco IOS/IOS XE[^18v] | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Cisco IOS XR[^XR]  | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| Cisco Nexus OS     | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| Cumulus Linux      | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| Cumulus NVUE 5.x   | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| Dell OS10          | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| Fortinet FortiOS   | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| FRR                | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| Linux              | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| Junos              | ✅ | ✅ | ✅ | ✅ | ✅ |❌  |
-| Nokia SR Linux     |  ✅ | ✅ [❗](caveats-srlinux) | ❌  | ❌  | ✅ |❌  |
-| Nokia SR OS[^SROS] | ✅ | ❌  | ❌  | ❌  | ✅ |❌  |
-| OpenBSD            | ❌  | ❌  | ❌  | ❌  | ✅ |❌  |
-| VyOS               | ✅ | ✅ | ✅ | ✅ | ❌ |❌  |
+```{features}
+- title: Routing<br>policies
+  enabled: routing.policy
+- title: Static<br>routes
+  enabled: routing.static
+  caveats: routing.static.caveats
+- title: IPv4/IPv6<br>ACL
+  enabled: routing.acl
+```
+
+You can use these objects in routing policies (on platforms that support them):
+
+```{features}
+- title: Prefix<br>filters
+  enabled: routing.prefix
+  caveats: routing.prefix.caveats
+- title: AS-path<br>filters
+  enabled: routing.aspath
+  caveats: routing.aspath.caveats
+- title: BGP community<br>lists
+  enabled: routing.community
+  caveats: routing.community.caveats
+```
 
 ```{tip}
 See [Routing Integration Tests Results](https://release.netlab.tools/_html/coverage.routing) for more details.
 ```
-
-[^18v]: Includes Cisco IOSv, Cisco IOSvL2, Cisco CSR 1000v, Cisco Catalyst 8000v, Cisco IOS-on-Linux (IOL), and IOL Layer-2 image. ACLs are not supported on Cisco CSR 1000v, Cisco Catalyst 8000v
-
-[^SROS]: Includes the Nokia SR-SIM container and the Virtualized 7750 SR and 7950 XRS Simulator (vSIM) virtual machine
-
-[^XR]: Includes IOS XRv, IOS XRd, and Cisco 8000v
 
 ```{include} routing-policy.txt
 ```

--- a/netsim/devices/arubacx.yml
+++ b/netsim/devices/arubacx.yml
@@ -108,8 +108,10 @@ features:
       standard: True
     static:
       vrf: True
-      inter_vrf: True
+      inter_vrf:
+        caveats: caveats-aruba
       discard: True
+      caveats: caveats-aruba
   services:
     dns:
       ipv4: True

--- a/netsim/devices/cumulus_nvue.yml
+++ b/netsim/devices/cumulus_nvue.yml
@@ -1,4 +1,5 @@
-description: Cumulus VX 5.x configured with NVUE
+description: Cumulus 5.x configured with NVUE
+docname: Cumulus 5.x (NVUE)
 support:
   level: minimal
   caveats:

--- a/netsim/devices/eos.yml
+++ b/netsim/devices/eos.yml
@@ -114,7 +114,12 @@ features:
     passive: false
   routing:
     policy:
-      set: [ locpref, med, weight, prepend, community ]
+      set:
+        locpref: True
+        med: True
+        weight: True
+        prepend: True
+        community: True
       match:
         prefix: True
         nexthop: True

--- a/netsim/devices/frr.yml
+++ b/netsim/devices/frr.yml
@@ -179,6 +179,7 @@ features:
           large: True
       delete:
         community: clist
+        caveats: 'yes'
     prefix: True
     aspath: True
     community:

--- a/netsim/devices/ios.yml
+++ b/netsim/devices/ios.yml
@@ -124,6 +124,7 @@ features:
           append: True
       delete:
         community: clist
+        caveats: 'yes'
       match:
         prefix: True
         nexthop: True

--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -124,8 +124,11 @@ features:
     policy:
       match:
         prefix: True
-      set: [ locpref, med ]
-    prefix: True
+      set:
+        locpref: True
+        med: True
+    prefix:
+      caveats: caveats-srlinux
     static:
       vrf: True
       discard: True

--- a/netsim/devices/sros.yml
+++ b/netsim/devices/sros.yml
@@ -84,7 +84,9 @@ features:
     unnumbered: True
   routing:
     policy:
-      set: [ locpref, med ]
+      set:
+        locpref: True
+        med: True
     static:
       vrf: True
       discard: True

--- a/netsim/devices/xr.yml
+++ b/netsim/devices/xr.yml
@@ -69,10 +69,12 @@ features:
     default: True
     import: [ bgp, isis, connected, static, vrf ]
   routing:
-    aspath: True
+    aspath:
+      caveats: caveats-iosxr
     community:
       standard: True
       large: True
+      caveats: caveats-iosxr
     policy:
       set:
         community:
@@ -94,7 +96,8 @@ features:
         community:
           standard: True
           large: True
-    prefix: True
+    prefix:
+      caveats: caveats-iosxr
     static:
       vrf: True
       inter_vrf: True


### PR DESCRIPTION
Use {features} to create generic routing platform support tables.

The device definitions were modified where needed to expand the set keyword support and add caveat pointers.