### PR TITLE
libvirt VM netmiko script-based configuration

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -264,14 +264,15 @@ _netlab_ uses Ansible playbooks and device-specific task lists to deploy device 
 
 Several other devices can use alternate (faster) configuration methods that are not enabled by default; you have to set the **netlab_config_mode** device group variable[^NCMGV] or node parameter to use them:
 
-| Device    | containerlab<br> deployment method |
+| Device    | containerlab<br>deployment method | libvirt<br>deployment method |
 |-----------|------------------------------------|
 | Arista EOS | **sh**[^EOSSH] |
 | Aruba CX  | **startup** |
-| Cisco IOS/IOS XE[^18v] | **startup**, **netmiko** |
+| Cisco IOS/IOS XE[^18v] | **startup**, **netmiko** | **netmiko** |
 | Cisco IOS XRd | **sh**[^XRDSH] |
 | Dell OS10 | **startup** |
 | Junos[^Junos] | **startup** |
+| Linux || **sh** |
 
 [^EOSSH]: Arista EOS device configurations are converted into FastCli scripts and executed as Linux scripts within the cEOS container. This method works on EOS software releases that have the **‌platform tfa phy control-frame disabled** interface configuration command (probably starting with EOS release 4.30)
 
@@ -279,8 +280,9 @@ Several other devices can use alternate (faster) configuration methods that are 
 
 **Notes:**
 
-* The **startup** deployment method (available only for containers) uses *containerlab* `startup-config` parameter with partial device configurations. This experimental method won't report errors in device configurations ([more details](https://blog.ipspace.net/2026/02/netlab-startup-config-caveats/)).
+* The **startup** deployment method (available only for containers) uses *containerlab* `startup-config` parameter with partial device configurations. This experimental method won't report device configuration errors ([more details](https://blog.ipspace.net/2026/02/netlab-startup-config-caveats/)).
 * The **netmiko** deployment method (available for containers and virtual machines) uses the *netmiko* library to configure network devices. **netlab install ansible** automatically installs it; you can also install it manually with **pip3 install netmiko**.
+* The **sh** deployment method maps configuration files into containers and executes them with **docker exec**. It uses *netmiko* to connect to virtual machines, SCP to transfer configuration scripts, and *netmiko.send_command()* to execute the scripts.
 
 [^NCMGV]: For example, set the **defaults.devices.iol.clab.group_vars.netlab_config_mode** [topology default](topo-defaults) to **startup** to use startup configuration with Cisco IOL nodes, or **defaults.devices.ios.group_vars.netlab_config_mode** to **netmiko** to use *netmiko* to configure Cisco IOS-based devices.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -264,8 +264,8 @@ _netlab_ uses Ansible playbooks and device-specific task lists to deploy device 
 
 Several other devices can use alternate (faster) configuration methods that are not enabled by default; you have to set the **netlab_config_mode** device group variable[^NCMGV] or node parameter to use them:
 
-| Device    | containerlab<br>deployment method | libvirt<br>deployment method |
-|-----------|------------------------------------|
+| Device | containerlab<br>deployment method | libvirt<br>deployment method |
+|-|-| -|
 | Arista EOS | **sh**[^EOSSH] |
 | Aruba CX  | **startup** |
 | Cisco IOS/IOS XE[^18v] | **startup**, **netmiko** | **netmiko** |

--- a/netsim/devices/linux.yml
+++ b/netsim/devices/linux.yml
@@ -26,7 +26,11 @@ libvirt:
   create_iso: linux
   group_vars:
     netlab_linux_distro: ubuntu
+    netlab_config_path: /tmp/
+    netmiko_device_type: linux
   features:
+    initial:
+      config_mode: [ sh, cp_sh ]
     dhcp:
       client:
         ipv4: true

--- a/netsim/providers/libvirt.yml
+++ b/netsim/providers/libvirt.yml
@@ -3,7 +3,7 @@
 #
 description: Vagrant with libvirt/KVM
 config: Vagrantfile
-config_mode: [ netmiko ]
+config_mode: [ netmiko, sh, cp_sh ]
 start: vagrant up --provider libvirt
 stop: vagrant destroy -f
 probe:

--- a/netsim/providers/libvirt/__init__.py
+++ b/netsim/providers/libvirt/__init__.py
@@ -20,7 +20,7 @@ from .. import (
   tc_netem_set,
   validate_mgmt_ip,
 )
-from . import labops, stats
+from . import configs, labops, stats
 
 
 class Libvirt(_Provider):
@@ -221,6 +221,12 @@ class Libvirt(_Provider):
         log.error(f"Cannot disable STP on Linux bridge {linux_bridge}")
         continue
       log.print_verbose(f"... disabled STP on {linux_bridge}")
+
+  def deploy_node_config(self, node: Box, topology: Box, deploy_list: list) -> None:
+    cfg_files = node.get('_node_config',[])
+    if not cfg_files:                                          # No node files => no config to deploy here
+      return
+    configs.deploy_config(node,topology,deploy_list)
 
   def get_lab_status(self,collect_status: dict) -> Box:
     return stats.get_lab_status(collect_status)

--- a/netsim/providers/libvirt/configs.py
+++ b/netsim/providers/libvirt/configs.py
@@ -1,0 +1,134 @@
+"""
+Deploy configuration to libvirt nodes using sh/cp_sh config method
+"""
+
+import typing
+
+import scp  # type: ignore
+from box import Box
+
+from ...data import append_to_list
+from ...utils import log, strings
+from ...utils import netmiko as _netmiko
+from .. import PRINT_LOCK
+
+
+def mark_failed(n_data: Box,mod_name: str) -> None:
+  append_to_list(n_data._deploy,'failed',mod_name)
+  return None
+
+def get_netmiko_connection(n_data: Box, topology: Box, mod_name: str) -> typing.Any:
+  if _netmiko.check_netmiko(n_data):
+    netmiko_params = _netmiko.prepare_params(n_data,topology)
+    if netmiko_params:
+      net_connect = _netmiko.connect(n_data,netmiko_params)
+      if net_connect:
+        return net_connect
+
+  return mark_failed(n_data,mod_name)
+
+def deploy_config(node: Box, topology: Box, deploy_list: list) -> None:
+  node_config = node.get('_node_config',None)                 # Do we have modules deployed with internal methods?
+  if not node_config:
+    return                                                    # Nope? Cool, nothing to do ;)
+  
+  net_conn: typing.Any = None
+  for mod_name,cfg_dest in node_config.items():               # Iterate over internally-deployed modules
+    mod_name = mod_name.replace('@','.')                      # Normalize template names with dots
+    if mod_name not in deploy_list:
+      continue
+    if ':' not in cfg_dest:                                   # No config method? Ignore and move on
+      continue
+    (cfg_file,cfg_method) = cfg_dest.split(':',1)
+    if cfg_method not in ['sh','cp_sh']:                      # Not something we could deal with?
+      continue                                                # Move on, invalid values should have been caught already
+
+    if not net_conn:                                          # OK, we need a netmiko connection to the device
+      net_conn = get_netmiko_connection(node,topology,mod_name)
+      if not net_conn:                                        # Failed?
+        return                                                # Too bad, the error has been already reported
+      try:                                                    # Got the connection, next step: get a root shell
+        net_conn.config_mode()
+      except Exception as ex:
+        log.error(
+          f'Cannot get root shell on node {node.name}',
+          more_data=[ str(ex) ], module='libvirt', category=log.FatalError)
+        return mark_failed(node,mod_name)
+
+    src_file = f"node_files/{node.name}/{mod_name}"
+    if log.VERBOSE:
+      log.info(f'SCPing {src_file} to {node.name} {cfg_file}')
+
+    try:                                                    # Try to SCP the config script to the node
+      scp_conn = scp.SCPClient(net_conn.remote_conn_pre.get_transport())
+      scp_conn.put(src_file,cfg_file)
+      scp_conn.close()
+    except Exception as ex:
+      log.error(
+        f'Cannot SCP {src_file} to {node.name}:{cfg_file}',
+        more_data=[ str(ex) ], module='libvirt', category=log.FatalError)
+      return mark_failed(node,mod_name)
+
+    cmd_marker = "__NETMIKO_RC:"                            # Use a marker to get back the return code
+    cmd = f'sh {cfg_file} 2>&1; rc=$?; echo {cmd_marker}$rc'     # ChatGPT-inspired hack. Ugly, but it works
+    output: str = net_conn.send_command(cmd)
+    (result,rc) = output.rsplit(cmd_marker,1)               # Get the command printout and the exit code
+    rc = rc.split('\n')[0]                                  # Extract the return code from the clutter
+    if rc == '0':                                           # All good?
+      if log.VERBOSE:                                       # Print the command outputs in verbose mode
+        with PRINT_LOCK:
+          log.info(f"Results of executing {mod_name} configuration on {node.name}")
+          strings.print_colored_text(txt=result,color='green')
+      append_to_list(node._deploy,'success',mod_name)       # And mark success
+      continue
+
+    with PRINT_LOCK:                                        # We encountered an error
+      log.error(
+        f'{mod_name} configuration failed for node {node.name}',
+        category=log.FatalError,
+        skip_header=True,
+        module='libvirt')
+      if result:                                            # Print command outputs when avaialble
+        strings.print_colored_text(txt=result,color='bright_black')
+
+    mark_failed(node,mod_name)
+    return
+
+
+"""
+    config_cmd = None                                         # Command to execute
+    if f_type == 'ns':                                        # Is this a host-side script?
+      config_cmd = ['sudo','ip','netns','exec',node_name,'sh',f'node_files/{node.name}/{mod_name}' ]
+      log.info(f'Executing {mod_name} configuration for node {node.name} (namespace {node_name})')
+    elif f_type in ('sh','cp_sh'):
+      if not cfg_item.target:
+        log.error(
+          f'Internal error: bash script for module {mod_name} is not mapped into a container file',
+          more_data = [f'node: {node.name} / device: {node.device}'],
+          category=log.FatalError,
+          module='clab')
+        break
+      config_cmd = ['docker','exec',node_name,cfg_item.target] # Container-side script
+      log.info(f'Executing {mod_name} configuration for node {node.name}')
+    elif f_type == 'startup':                                 # Is this part of startup config?
+      append_to_list(node._deploy,'startup',mod_name)
+
+    if not config_cmd:                                        # Not an executable file?
+      continue
+
+    if log.VERBOSE > 1:
+      print(f'clab deploy: running {config_cmd}')
+    try:
+      status = subprocess.run(config_cmd,capture_output=True,text=True,check=False)
+    except Exception as ex:
+      status = subprocess.CompletedProcess(config_cmd,returncode=1,stdout='',stderr=str(ex))
+    printout = ''                                           # Collect any printout we might have received
+    if status.stdout:                                       # ... making sure it ends with a single newline
+      stdout = status.stdout.strip(" \n") + "\n"
+      printout +='  '+strings.wrap_error_message(stdout,indent=2)
+    if status.stderr:
+      stderr = status.stderr.strip(" \n") + "\n"
+      printout +='  '+strings.wrap_error_message(stderr,indent=2)
+    if status.returncode == 0:                              # Everything OK?
+    else:                                                     # Otherwise we failed
+"""

--- a/netsim/providers/libvirt/configs.py
+++ b/netsim/providers/libvirt/configs.py
@@ -71,6 +71,7 @@ def deploy_config(node: Box, topology: Box, deploy_list: list) -> None:
 
     cmd_marker = "__NETMIKO_RC:"                            # Use a marker to get back the return code
     cmd = f'sh {cfg_file} 2>&1; rc=$?; echo {cmd_marker}$rc'     # ChatGPT-inspired hack. Ugly, but it works
+    log.info(f'Executing {mod_name} configuration for node {node.name}')
     output: str = net_conn.send_command(cmd)
     (result,rc) = output.rsplit(cmd_marker,1)               # Get the command printout and the exit code
     rc = rc.split('\n')[0]                                  # Extract the return code from the clutter
@@ -93,42 +94,3 @@ def deploy_config(node: Box, topology: Box, deploy_list: list) -> None:
 
     mark_failed(node,mod_name)
     return
-
-
-"""
-    config_cmd = None                                         # Command to execute
-    if f_type == 'ns':                                        # Is this a host-side script?
-      config_cmd = ['sudo','ip','netns','exec',node_name,'sh',f'node_files/{node.name}/{mod_name}' ]
-      log.info(f'Executing {mod_name} configuration for node {node.name} (namespace {node_name})')
-    elif f_type in ('sh','cp_sh'):
-      if not cfg_item.target:
-        log.error(
-          f'Internal error: bash script for module {mod_name} is not mapped into a container file',
-          more_data = [f'node: {node.name} / device: {node.device}'],
-          category=log.FatalError,
-          module='clab')
-        break
-      config_cmd = ['docker','exec',node_name,cfg_item.target] # Container-side script
-      log.info(f'Executing {mod_name} configuration for node {node.name}')
-    elif f_type == 'startup':                                 # Is this part of startup config?
-      append_to_list(node._deploy,'startup',mod_name)
-
-    if not config_cmd:                                        # Not an executable file?
-      continue
-
-    if log.VERBOSE > 1:
-      print(f'clab deploy: running {config_cmd}')
-    try:
-      status = subprocess.run(config_cmd,capture_output=True,text=True,check=False)
-    except Exception as ex:
-      status = subprocess.CompletedProcess(config_cmd,returncode=1,stdout='',stderr=str(ex))
-    printout = ''                                           # Collect any printout we might have received
-    if status.stdout:                                       # ... making sure it ends with a single newline
-      stdout = status.stdout.strip(" \n") + "\n"
-      printout +='  '+strings.wrap_error_message(stdout,indent=2)
-    if status.stderr:
-      stderr = status.stderr.strip(" \n") + "\n"
-      printout +='  '+strings.wrap_error_message(stderr,indent=2)
-    if status.returncode == 0:                              # Everything OK?
-    else:                                                     # Otherwise we failed
-"""

--- a/netsim/providers/libvirt/configs.py
+++ b/netsim/providers/libvirt/configs.py
@@ -69,9 +69,12 @@ def deploy_config(node: Box, topology: Box, deploy_list: list) -> None:
         more_data=[ str(ex) ], module='libvirt', category=log.FatalError)
       return mark_failed(node,mod_name)
 
+    # ChatGPT-inspired hack. Ugly, but it works
+    #
     cmd_marker = "__NETMIKO_RC:"                            # Use a marker to get back the return code
-    cmd = f'sh {cfg_file} 2>&1; rc=$?; echo {cmd_marker}$rc'     # ChatGPT-inspired hack. Ugly, but it works
-    log.info(f'Executing {mod_name} configuration for node {node.name}')
+    cmd = f'chmod a+x {cfg_file}; {cfg_file} 2>&1; rc=$?; echo {cmd_marker}$rc'
+
+    log.info(f'Executing {mod_name} configuration for node {node.name} (netmiko/script)')
     output: str = net_conn.send_command(cmd)
     (result,rc) = output.rsplit(cmd_marker,1)               # Get the command printout and the exit code
     rc = rc.split('\n')[0]                                  # Extract the return code from the clutter

--- a/netsim/providers/libvirt/configs.py
+++ b/netsim/providers/libvirt/configs.py
@@ -4,7 +4,6 @@ Deploy configuration to libvirt nodes using sh/cp_sh config method
 
 import typing
 
-import scp  # type: ignore
 from box import Box
 
 from ...data import append_to_list
@@ -60,6 +59,7 @@ def deploy_config(node: Box, topology: Box, deploy_list: list) -> None:
       log.info(f'SCPing {src_file} to {node.name} {cfg_file}')
 
     try:                                                    # Try to SCP the config script to the node
+      import scp  # type: ignore                            # Fails unless you have netmiko installed
       scp_conn = scp.SCPClient(net_conn.remote_conn_pre.get_transport())
       scp_conn.put(src_file,cfg_file)
       scp_conn.close()


### PR DESCRIPTION
Adds sh/cp_sh netlab_config_mode for libvirt virtual machines. The implementation uses netmiko to establish an SSH session to the VM, scp to transfer config scripts, and 'sh' (in root shell) to execute them.

Sample implementation: Linux VMs