### PR TITLE
Fix: Display package name with error called from __init__

### DIFF
--- a/netsim/utils/log.py
+++ b/netsim/utils/log.py
@@ -212,7 +212,11 @@ def get_calling_module(module: typing.Optional[str]) -> str:
 
   try:
     err_caller = inspect.stack()[2].filename
-    return os.path.splitext(os.path.basename(err_caller))[0]
+    filename = os.path.splitext(os.path.basename(err_caller))[0]
+    if filename != '__init__':
+      return filename
+    return os.path.basename(os.path.dirname(err_caller))
+
   except:
     return 'unknown'
 


### PR DESCRIPTION
The 'utils.log.error' function tries to figure out the module name (when it's missing) from the caller name. However, that results in module __init__ when the caller is in a package __init__.py. This change detects that and returns package name (last element in the directory path) instead.