### PR TITLE
Fix: Consider _node_config when generating shebang

### DIFF
--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -69,6 +69,14 @@ def create_node_configs(
     skip_items :typing.List[str] = []
     config_templates = n_data.get(f'{n_provider}.config_templates',[])
     template_mode = { cfg_item.source:cfg_item.mode for cfg_item in config_templates if 'mode' in cfg_item }
+
+    for mod,target in n_data.get('_node_config',{}).items():          # Augment template mode from config templates with _node_config
+      if ':' not in target:                                           # node_config does not specify a method, move on
+        continue
+      mod = mod.replace('@','.')                                      # Recreate the actual config file name
+      if mod not in template_mode:                                    # Unknown so far?
+        template_mode[mod] = target.rsplit(':',1)[-1]                 # ... let's use the _node_config value
+
     if log.debug_active('template'):
       print(f'config_templates for {n_data.name}:')
       for item in config_templates:

--- a/netsim/outputs/config.py
+++ b/netsim/outputs/config.py
@@ -90,12 +90,18 @@ class ConfigurationFiles(_TopologyOutput):
         mod_list = ['normalize'] + mod_list
 
       mod_list += n_data.get('module',[]) + n_data.get('config',[])
+      node_config = n_data.get('_node_config',{})
       for module in mod_list:
         if module in skip_config:
           continue
         if module in create_list:
           continue
-        if do_config(module,f'{n_name}/{module}','cfg'):
+
+        nc_lookup = module.replace('.','@')
+        cfg_mode = 'cfg'
+        if ':' in node_config.get(nc_lookup,''):
+          cfg_mode = node_config[nc_lookup].rsplit(":",1)[-1]
+        if do_config(module,f'{n_name}/{module}',cfg_mode):
           create_list.append(module)
 
       if not log.VERBOSE and create_list:


### PR DESCRIPTION
The 'config' output module and corresponding cli/initial function checked only provider.config_templates to figure out whether a module uses 'sh' configuration method (and thus needs the default shebang). The netmiko/sh method (used by libvirt) cannot rely on config_templates (because we can't map files into VMs), so we have to check the _node_config dictionary as well.