### PR TITLE
Generic prefix sets (used in ACL src/dst prefix)

### DIFF
--- a/docs/dev/validation-types.txt
+++ b/docs/dev/validation-types.txt
@@ -15,6 +15,7 @@ Validator recognizes standard Python data types (**str**, **int**, **float**, **
 | **ipv6**       | An IPv6 address, prefix, integer (offset in a subnet), or bool (LLA only) |
 | **mac**        | MAC address in any format recognized by the `netaddr` library |
 | **named_pfx**  | [named prefix](named-prefixes) |
+| **prefixset**  | [a generic prefix](generic-routing-prefix-set) |
 | **net**        | IS-IS NET/NSAP |
 | **node_id**    | Valid node name |
 | **prefix_str** | An IPv4 or IPv6 prefix |

--- a/docs/module/routing-acl.txt
+++ b/docs/module/routing-acl.txt
@@ -63,9 +63,9 @@ A generic prefix (used in ACL **src.prefix** and **dst.prefix** attributes) can 
 * An IPv6 address or host (including host prefixes)
 * A named prefix, specified as prefix name or as **prefix._name_**
 * An address pool prefix, specified as **pool._name_**
-* A prefix assigned to an IRB VLAN, specified as **vlans._name_**
-* A prefix assigned to a link with a **linkid** attribute, specified as **links._linkid_**
-* Prefixes assign to links with the specified **role**, specified as **role._rolename_**
+* A prefix assigned to an IRB VLAN, specified as **vlan._name_**
+* A prefix assigned to a link with a **linkid** attribute, specified as **link._linkid_**
+* Prefixes assigned to links with the specified **role**, specified as **role._rolename_**
 
 (routing-acl-matching-port)=
 ### Matching TCP/UDP Ports

--- a/docs/module/routing-acl.txt
+++ b/docs/module/routing-acl.txt
@@ -43,8 +43,8 @@ Each ACL entry can have these attributes:
 
 Both **src** and **dst** dictionaries use the following attributes to describe what an ACL entry matches on the source and destination side of a packet.
 
-* **prefix**: Match a (list of) [named prefixes](https://netlab.tools/prefix/#named-prefixes). Use `prefix: any` to match any source or destination address.
-* **pool**: Match a prefix from the (list of) specified [addressing pools](https://netlab.tools/addressing/#address-pools)
+* **prefix**: A (list of) [generic prefixes](generic-routing-prefix-set). Use `prefix: any` to match any source or destination address.
+* **pool**: Match a prefix from the (list of) specified [addressing pools](address-pools)
 * **ipv4**/**ipv6**: Match explicit IPv4/IPv6 prefixes or addresses.
 * **node**: Match all IP addresses of specified node(s).
 * **role**: Limit the node IP addresses to interfaces with the specified role.
@@ -53,6 +53,19 @@ Both **src** and **dst** dictionaries use the following attributes to describe w
 You can use either a single value or a list of values in all of the above parameters. When either the **src** or **dst** parameter results in multiple IP addresses, _netlab_ generates multiple ACL entries (a Cartesian product of source and destination IP addresses). The sequence numbers in the final ACL deployed on a device thus **do not** match the lab topology sequence numbers.
 
 You can also mix IPv4 and IPv6 addresses in an access list. _netlab_ always generates address-family-specific access lists for all address families used on the device.
+
+(generic-routing-prefix-set)=
+### Specifying Generic Prefixes
+
+A generic prefix (used in ACL **src.prefix** and **dst.prefix** attributes) can be:
+
+* An IPv4 address or prefix (including host prefixes)
+* An IPv6 address or host (including host prefixes)
+* A named prefix, specified as prefix name or as **prefix._name_**
+* An address pool prefix, specified as **pool._name_**
+* A prefix assigned to an IRB VLAN, specified as **vlans._name_**
+* A prefix assigned to a link with a **linkid** attribute, specified as **links._linkid_**
+* Prefixes assign to links with the specified **role**, specified as **role._rolename_**
 
 (routing-acl-matching-port)=
 ### Matching TCP/UDP Ports

--- a/netsim/cli/__init__.py
+++ b/netsim/cli/__init__.py
@@ -31,7 +31,7 @@ def parser_add_debug(parser: argparse.ArgumentParser, add_test: bool = True) -> 
                   choices=sorted([
                     'all','addr','cli','links','libvirt','clab','modules','plugin','template',
                     'vlan','vrf','quirks','validate','addressing','groups','status','paths',
-                    'external','defaults','loadable','lag']),
+                    'external','defaults','loadable','lag','prefixset']),
                   help=argparse.SUPPRESS)
   if add_test:
     parser.add_argument('--test', dest='test', action='store',nargs='*',

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -1111,26 +1111,31 @@ def must_be_prefixset(value: typing.Any, use: str = 'prefix_or_host') -> dict:
     return { '_type': 'a prefix (a string)' }
 
   dotcount = value.count('.')
-  if dotcount <= 1 and ':' not in value:
-    if not dotcount:
+  #
+  # Namespaced prefix should have at most one dot (otherwise it's an IPv4 address),
+  # start with an identifier (the first character must not be a digit) and not have
+  # a colon (otherwise it's an IPv6 address)
+  #
+  if dotcount <= 1 and value > '9' and ':' not in value:
+    if not dotcount:                                        # No dots, assuming named prefix
       p_value = value
       p_type = 'prefix'
-    else:
+    else:                                                   # ... otherwise it's namespace.identifier
       (p_type,p_value) = value.split('.',1)
     if p_type not in ['prefix','vlan','link','role','pool']:
-      result = {
+      result = {                                            # Namespace is not valid
         '_value': 'a prefix within a valid prefix namespace',
         '_more_data': f'Found {p_type} as namespace'}
     else:
-      result = _id_validator(p_value)
-      if '_type' in result or '_value' in result:
+      result = _id_validator(p_value)                       # Valid namespace, just check that we have an identifier
+      if '_type' in result or '_value' in result:           # ... values will be checked later
         result = {
           '_value': 'a prefix in format namespace.identifier',
           '_more_data': f'found {p_value} as identifier'}
-  else:
-    if value.count(':') > 0:
+  else:                                                     # Not a namespaced prefix, must be an address
+    if value.count(':') > 0:                                # IPv6?
       result = _ipv6_validator(value,use=use)
-    elif dotcount > 1:
+    else:                                                   # ... otherwise must be IPv4
       result = _ipv4_validator(value,use=use)
     if '_value' in result:
       result['_value'] = 'an IP address or a prefix'

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -130,7 +130,9 @@ def wrong_type_message(
     text=f'{path} must be {expected}',
     category=log.IncorrectValue if '_value' in err_stat else log.IncorrectType,
     module=module or 'topology',
-    more_hints=ctxt)
+    more_hints=ctxt,
+    more_data=err_stat.get('_more_data',None),
+    doc_url=err_stat.get('_doc_url',None))
   return
 
 #
@@ -498,6 +500,15 @@ def must_be_str(value: typing.Any) -> dict:
 
 @type_test()
 def must_be_id(value: typing.Any, max_length: typing.Union[int,str] = 16) -> dict:
+  '''
+  Identifier validation, including optional maximum length
+  '''
+  return _id_validator(value,max_length)
+
+def _id_validator(value: typing.Any, max_length: typing.Union[int,str] = 16) -> dict:
+  '''
+  Identifier validator without decorator arguments
+  '''
   id_length = resolve_const_value(max_length,16)
   if not isinstance(id_length,int):
     log.fatal(f'Internal failure in must_be_id: max_length {max_length} did not resolve into int')
@@ -821,14 +832,14 @@ def common_addr_parse(
     try:
       p_addr = addr_parse(value)
     except Exception as Ex:
-      return { '_value': f'{af} address ({Ex})' }
+      return { '_value': f'{af} address ({Ex})', '_exception': str(Ex) }
 
     return { '_valid': True }
   else:
     try:
       p_addr = net_parse(value,strict=use not in ['interface','host_prefix'])
     except Exception as Ex:
-      return { '_value': f'{af} prefix ({Ex})' }
+      return { '_value': f'{af} prefix ({Ex})', '_exception': str(Ex) }
 
   if use not in ['prefix','prefix_or_host','id']:
     r_hit = check_reserved_range(RESERVED_PREFIXES[af],p_addr)
@@ -838,12 +849,17 @@ def common_addr_parse(
 
   return { '_valid': True }
 
-'''
-IPv4 validation -- use the common code, allowing int values and named prefixes
-'''
 @type_test(false_value=False)
 def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
+  '''
+  IPv4 validation -- use the common code, allowing int values and named prefixes
+  '''
+  return _ipv4_validator(value,use,named)
 
+def _ipv4_validator(value: typing.Any, use: str, named: bool = False) -> dict:
+  '''
+  IPv4 validator without the decorator arguments
+  '''
   def transform_to_ipaddr(value: int) -> str:
     return str(ipaddress.IPv4Address(value))
 
@@ -858,11 +874,18 @@ def must_be_ipv4(value: typing.Any, use: str, named: bool = False) -> dict:
             xform_int=transform_to_ipaddr,
             xform_pfx=prefix_to_ipv4)
 
-'''
-IPv6 validation -- use the common code, but without int values or named prefixes
-'''
+
 @type_test(false_value=False)
 def must_be_ipv6(value: typing.Any, use: str) -> dict:
+  '''
+  IPv6 validation -- use the common code, but without int values or named prefixes
+  '''
+  return _ipv6_validator(value,use)
+
+def _ipv6_validator(value: typing.Any, use: str) -> dict:
+  '''
+  IPv6 validator without the decorator arguments
+  '''
   return common_addr_parse(
             value=value,use=use,named=False,af='IPv6',
             net_parse=ipaddress.IPv6Network,
@@ -1081,3 +1104,40 @@ def must_be_r_proto(value: typing.Any) -> dict:
     }
 
   return { '_valid': True }
+
+@type_test()
+def must_be_prefixset(value: typing.Any, use: str = 'prefix_or_host') -> dict:
+  if not isinstance(value,str):
+    return { '_type': 'a prefix (a string)' }
+
+  dotcount = value.count('.')
+  if dotcount <= 1 and ':' not in value:
+    if not dotcount:
+      p_value = value
+      p_type = 'prefix'
+    else:
+      (p_type,p_value) = value.split('.',1)
+    if p_type not in ['prefix','vlans','links','roles','pool']:
+      result = {
+        '_value': 'a prefix within a valid prefix namespace',
+        '_more_data': f'Found {p_type} as namespace'}
+    else:
+      result = _id_validator(p_value)
+      if '_type' in result or '_value' in result:
+        result = {
+          '_value': 'a prefix in format namespace.identifier',
+          '_more_data': f'found {p_value} as identifier'}
+  else:
+    if value.count(':') > 0:
+      result = _ipv6_validator(value,use=use)
+    elif dotcount > 1:
+      result = _ipv4_validator(value,use=use)
+    if '_value' in result:
+      result['_value'] = 'an IP address or a prefix'
+      if '_exception' in result:
+        result['_more_data'] = str(result['_exception'])
+
+  if '_type' in result or '_value' in result:
+    result['_doc_url'] = 'module/routing/#generic-routing-prefix-set'
+
+  return result

--- a/netsim/data/types.py
+++ b/netsim/data/types.py
@@ -1117,7 +1117,7 @@ def must_be_prefixset(value: typing.Any, use: str = 'prefix_or_host') -> dict:
       p_type = 'prefix'
     else:
       (p_type,p_value) = value.split('.',1)
-    if p_type not in ['prefix','vlans','links','roles','pool']:
+    if p_type not in ['prefix','vlan','link','role','pool']:
       result = {
         '_value': 'a prefix within a valid prefix namespace',
         '_more_data': f'Found {p_type} as namespace'}

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -284,7 +284,7 @@ _top:                               # Modification of global defaults
         _subtype: addr_pool
       prefix:
         type: list
-        _subtype: named_pfx
+        _subtype: prefixset
       interface:
         type: list
         _subtype: str

--- a/netsim/modules/routing/acl.py
+++ b/netsim/modules/routing/acl.py
@@ -9,7 +9,7 @@ from box import Box
 
 from netsim.utils import log
 
-from ...data import append_to_list, get_box
+from ...data import append_to_list, get_a_list, get_box
 from .normalize import check_routing_object, import_routing_object
 from .utils import eval_prefixset
 
@@ -23,14 +23,17 @@ def expand_acl_address_entry(p_entry: Box, path: str, topology: Box) -> Box:
 
   def add_acl_prefixes(p_entry: Box, data: dict) -> None:
     for af in log.AF_LIST:
-      if af in data and isinstance(data[af],str):
-        append_to_list(p_entry,af,data[af])
+      if af in data:
+        for pfx in get_a_list(data[af]):
+          if isinstance(pfx,str):
+            append_to_list(p_entry,af,pfx)
 
   for p_name in p_entry.get('pool',[]):
     add_acl_prefixes(p_entry,topology.addressing[p_name])
 
   for p_name in p_entry.get('prefix',[]):
-    add_acl_prefixes(p_entry,eval_prefixset(p_name,path,topology))
+    pfx_data = eval_prefixset(p_name,path,topology)
+    add_acl_prefixes(p_entry,pfx_data)
 
   for node_name in p_entry.get('node',[]):
     node_data = topology.nodes[node_name]

--- a/netsim/modules/routing/acl.py
+++ b/netsim/modules/routing/acl.py
@@ -11,16 +11,17 @@ from netsim.utils import log
 
 from ...data import append_to_list, get_box
 from .normalize import check_routing_object, import_routing_object
+from .utils import eval_prefixset
 
 
-def expand_acl_address_entry(p_entry: Box, topology: Box) -> Box:
+def expand_acl_address_entry(p_entry: Box, path: str, topology: Box) -> Box:
   """
   expand_acl_address_entry:
   * Transform 'pool' and 'prefix' keywords into 'ipv4' and 'ipv6'
   * Resolve node-inteface and node-role tuples into 'ipv4' and 'ipv6'
   """
 
-  def add_acl_prefixes(p_entry: Box, data: Box) -> None:
+  def add_acl_prefixes(p_entry: Box, data: dict) -> None:
     for af in log.AF_LIST:
       if af in data and isinstance(data[af],str):
         append_to_list(p_entry,af,data[af])
@@ -29,7 +30,7 @@ def expand_acl_address_entry(p_entry: Box, topology: Box) -> Box:
     add_acl_prefixes(p_entry,topology.addressing[p_name])
 
   for p_name in p_entry.get('prefix',[]):
-    add_acl_prefixes(p_entry,topology.prefix[p_name])
+    add_acl_prefixes(p_entry,eval_prefixset(p_name,path,topology))
 
   for node_name in p_entry.get('node',[]):
     node_data = topology.nodes[node_name]
@@ -142,7 +143,7 @@ def expand_acl(p_name: str, o_name: str, node: Box, topology: Box) -> typing.Opt
     ctx.idx = idx
     for addr_key in ("src", "dst"):
       if addr_key in entry:
-        entry[addr_key] = expand_acl_address_entry(entry[addr_key], topology)
+        entry[addr_key] = expand_acl_address_entry(entry[addr_key],f'{p_name}.{o_name}[{idx}]',topology)
     validate_acl_address_entry(entry, ctx)
     acl_list[idx] = entry
 

--- a/netsim/modules/routing/utils.py
+++ b/netsim/modules/routing/utils.py
@@ -1,0 +1,94 @@
+"""
+Utility functions for the routing module
+"""
+
+from box import Box
+
+from ...data import append_to_list, get_empty_box
+from ...utils import log
+
+
+def eval_prefixset(pfx: str, path: str, topology: Box) -> dict:
+  """
+  Evaluate a generic routing prefix into a dictionary of ipv4/ipv6 prefix lists
+  """
+
+  def link_list_prefix(link_list: list) -> Box:
+    """
+    Extract all address information from a list of links into the final result
+    """
+    result = get_empty_box()
+    for link in link_list:
+      if 'prefix' not in link:
+        continue
+      for af in log.AF_LIST:
+        if af in link.prefix:
+          append_to_list(result,af,link.prefix[af])
+
+    return result
+
+  result = get_empty_box()
+  if ':' in pfx:
+    return {'ipv6': pfx}
+  if pfx.count('.') > 1:
+    return {'ipv4': pfx}
+
+  if '.' in pfx:
+    (pfx_type,pfx) = pfx.split('.',1)
+  else:
+    pfx_type = 'prefix'
+
+  if pfx_type == 'prefix':
+    pfx_data = topology.get(f'prefix.{pfx}',None)
+    if pfx_data is None:
+      log.error(
+        f'Invalid named prefix {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+      return {}
+    if not pfx_data:
+      log.error(
+        f'Named prefix {pfx} used in {path} has no IPv4/IPv6 information',category=log.MissingValue,module='routing')
+      return {}
+    return pfx_data
+
+  if pfx_type == 'vlans':
+    pfx_data = topology.get(f'vlans.{pfx}',None)
+    if pfx_data is None:
+      log.error(
+        f'Invalid global VLAN {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+      return {}
+    if 'prefix' not in pfx_data:
+      log.error(
+        f'VLAN {pfx} used in {path} has no prefix information',category=log.MissingValue,module='routing')
+      return {}
+    else:
+      return pfx_data.prefix      
+
+  if pfx_type == 'links':
+    link_list = [ lnk for lnk in topology.links if lnk.get('linkid',None) == pfx ]
+    if not link_list:
+      log.error(
+        f'Invalid linkid {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+      return {}
+    result = link_list_prefix(link_list)
+    if not result:
+      log.error(
+        f'Link with linkid {pfx} (used in {path}) does not have an IPv4/IPv6 prefix',category=log.MissingValue,module='routing')
+    return result
+
+  if pfx_type == 'role':
+    link_list = [ lnk for lnk in topology.links if lnk.get('role',None) == pfx ]
+    if not link_list:
+      log.error(
+        f'No link in the lab topology has role {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+      return {}
+    if len(link_list) > 5:
+      log.warning(
+        text=f'Link role {pfx} used in {path} was expanded into {len(link_list)} elements',
+        module='routing')
+    result = link_list_prefix(link_list)
+    if not result:
+      log.error(
+        f'Link(s) with role {pfx} (used in {path}) do not have IPv4/IPv6 prefixes',category=log.MissingValue,module='routing')
+    return result
+
+  return {}

--- a/netsim/modules/routing/utils.py
+++ b/netsim/modules/routing/utils.py
@@ -16,6 +16,8 @@ def _link_list_prefix(link_list: list) -> Box:
   for link in link_list:
     if 'prefix' not in link:
       continue
+    if not isinstance(link.prefix,dict):
+      continue
     for af in log.AF_LIST:
       if af in link.prefix:
         append_to_list(result,af,link.prefix[af])

--- a/netsim/modules/routing/utils.py
+++ b/netsim/modules/routing/utils.py
@@ -4,91 +4,128 @@ Utility functions for the routing module
 
 from box import Box
 
-from ...data import append_to_list, get_empty_box
+from ...data import append_to_list, get_a_list, get_empty_box
 from ...utils import log
 
+
+def _link_list_prefix(link_list: list) -> Box:
+  """
+  Extract all address information from a list of links into the final result
+  """
+  result = get_empty_box()
+  for link in link_list:
+    if 'prefix' not in link:
+      continue
+    for af in log.AF_LIST:
+      if af in link.prefix:
+        append_to_list(result,af,link.prefix[af])
+
+  return result
+
+def _extract_af(obj: Box) -> dict:
+  result: dict = {}
+  for af in log.AF_LIST:
+    if af in obj:
+      result[af] = get_a_list(obj[af])
+
+  return result
+
+def _eps_prefix(pfx: str, path: str, topology: Box) -> dict:
+  pfx_data = topology.get(f'prefix.{pfx}',None)
+  if pfx_data is None:
+    log.error(
+      f'Invalid named prefix {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    return {}
+  if not pfx_data:
+    log.error(
+      f'Named prefix {pfx} used in {path} has no IPv4/IPv6 information',category=log.MissingValue,module='routing')
+    return {}
+  return _extract_af(pfx_data)
+
+def _eps_vlan(pfx: str, path: str, topology: Box) -> dict:
+  pfx_data = topology.get(f'vlans.{pfx}',None)
+  if pfx_data is None:
+    log.error(
+      f'Invalid global VLAN {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    return {}
+  if 'prefix' not in pfx_data:
+    log.error(
+      f'VLAN {pfx} used in {path} has no prefix information',category=log.MissingValue,module='routing')
+    return {}
+  else:
+    return _extract_af(pfx_data.prefix)
+
+def _eps_link(pfx: str, path: str, topology: Box) -> dict:
+  link_list = [ lnk for lnk in topology.links if lnk.get('linkid',None) == pfx ]
+  if not link_list:
+    log.error(
+      f'Invalid linkid {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    return {}
+  result = _link_list_prefix(link_list)
+  if not result:
+    log.error(
+      f'Link with linkid {pfx} (used in {path}) does not have an IPv4/IPv6 prefix',category=log.MissingValue,module='routing')
+  return result
+
+def _eps_role(pfx: str, path: str, topology: Box) -> dict:
+  link_list = [ lnk for lnk in topology.links if lnk.get('role',None) == pfx ]
+  if not link_list:
+    log.error(
+      f'No link in the lab topology has role {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    return {}
+  if len(link_list) > 5:
+    log.warning(
+      text=f'Link role {pfx} used in {path} was expanded into {len(link_list)} elements',
+      module='routing')
+  result = _link_list_prefix(link_list)
+  if not result:
+    log.error(
+      f'Link(s) with role {pfx} (used in {path}) do not have IPv4/IPv6 prefixes',category=log.MissingValue,module='routing')
+  return result
+
+def _eps_pool(pfx: str, path: str, topology: Box) -> dict:
+  pfx_data = topology.get(f'addressing.{pfx}',None)
+  if pfx_data is None:
+    log.error(
+      f'Invalid address pool {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    return {}
+  if not pfx_data:
+    log.error(
+      f'Address pool {pfx} used in {path} has no prefix information',category=log.MissingValue,module='routing')
+    return {}
+  else:
+    return _extract_af(pfx_data)
+
+PREFIXSET_LOOKUP: dict = {
+  'prefix': _eps_prefix,
+  'vlan': _eps_vlan,
+  'link': _eps_link,
+  'role': _eps_role,
+  'pool': _eps_pool,
+}
 
 def eval_prefixset(pfx: str, path: str, topology: Box) -> dict:
   """
   Evaluate a generic routing prefix into a dictionary of ipv4/ipv6 prefix lists
   """
 
-  def link_list_prefix(link_list: list) -> Box:
-    """
-    Extract all address information from a list of links into the final result
-    """
-    result = get_empty_box()
-    for link in link_list:
-      if 'prefix' not in link:
-        continue
-      for af in log.AF_LIST:
-        if af in link.prefix:
-          append_to_list(result,af,link.prefix[af])
-
-    return result
-
-  result = get_empty_box()
   if ':' in pfx:
-    return {'ipv6': pfx}
-  if pfx.count('.') > 1:
-    return {'ipv4': pfx}
-
-  if '.' in pfx:
-    (pfx_type,pfx) = pfx.split('.',1)
+    result = {'ipv6': [ pfx ]}
+  elif pfx.count('.') > 1:
+    result = {'ipv4': [ pfx ]}
   else:
-    pfx_type = 'prefix'
-
-  if pfx_type == 'prefix':
-    pfx_data = topology.get(f'prefix.{pfx}',None)
-    if pfx_data is None:
-      log.error(
-        f'Invalid named prefix {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
-      return {}
-    if not pfx_data:
-      log.error(
-        f'Named prefix {pfx} used in {path} has no IPv4/IPv6 information',category=log.MissingValue,module='routing')
-      return {}
-    return pfx_data
-
-  if pfx_type == 'vlans':
-    pfx_data = topology.get(f'vlans.{pfx}',None)
-    if pfx_data is None:
-      log.error(
-        f'Invalid global VLAN {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
-      return {}
-    if 'prefix' not in pfx_data:
-      log.error(
-        f'VLAN {pfx} used in {path} has no prefix information',category=log.MissingValue,module='routing')
-      return {}
+    if '.' in pfx:
+      (pfx_type,pfx) = pfx.split('.',1)
     else:
-      return pfx_data.prefix      
+      pfx_type = 'prefix'
 
-  if pfx_type == 'links':
-    link_list = [ lnk for lnk in topology.links if lnk.get('linkid',None) == pfx ]
-    if not link_list:
-      log.error(
-        f'Invalid linkid {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
+    if pfx_type not in PREFIXSET_LOOKUP:
+      log.error(f'Invalid prefix namespace {pfx_type} in {path}',category=log.FatalError,module='routing')
       return {}
-    result = link_list_prefix(link_list)
-    if not result:
-      log.error(
-        f'Link with linkid {pfx} (used in {path}) does not have an IPv4/IPv6 prefix',category=log.MissingValue,module='routing')
-    return result
 
-  if pfx_type == 'role':
-    link_list = [ lnk for lnk in topology.links if lnk.get('role',None) == pfx ]
-    if not link_list:
-      log.error(
-        f'No link in the lab topology has role {pfx} specified in {path}',category=log.IncorrectValue,module='routing')
-      return {}
-    if len(link_list) > 5:
-      log.warning(
-        text=f'Link role {pfx} used in {path} was expanded into {len(link_list)} elements',
-        module='routing')
-    result = link_list_prefix(link_list)
-    if not result:
-      log.error(
-        f'Link(s) with role {pfx} (used in {path}) do not have IPv4/IPv6 prefixes',category=log.MissingValue,module='routing')
-    return result
+    result = PREFIXSET_LOOKUP[pfx_type](pfx,path,topology)
 
-  return {}
+  if log.debug_active('prefixset'):
+    print(f'prefixset: {pfx} -> {result}')
+
+  return result

--- a/tests/coverage/errors/validate-prefixset.log
+++ b/tests/coverage/errors/validate-prefixset.log
@@ -1,0 +1,11 @@
+IncorrectValue in nodes: attribute 'nodes.invalid.pfxset[1]' must be an IP address or a prefix
+... Expected 4 octets in '192.168.1'
+... use 'netlab show attributes node' to display valid attributes
+... See also: https://netlab.tools/module/routing/#generic-routing-prefix-set
+IncorrectValue in nodes: attribute 'nodes.invalid.pfxset[2]' must be an IP address or a prefix
+... '36' is not a valid netmask
+IncorrectValue in nodes: attribute 'nodes.invalid.pfxset[3]' must be a prefix within a valid prefix namespace
+... Found omg as namespace
+IncorrectValue in nodes: attribute 'nodes.invalid.pfxset[4]' must be a prefix in format namespace.identifier
+... found 1notid as identifier
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/validate-prefixset.yml
+++ b/tests/coverage/errors/validate-prefixset.yml
@@ -15,6 +15,6 @@ vlans:
 
 nodes:
   valid:
-    pfxset: [ 192.168.1.0/24, 192.168.1.1, 2001:db8::/64, 2001:db8::1, alpha, prefix.alpha, vlans.red, pool.lan ]
+    pfxset: [ 192.168.1.0/24, 192.168.1.1, 2001:db8::/64, 2001:db8::1, alpha, prefix.alpha, vlan.red, pool.lan ]
   invalid:
-    pfxset: [ 192.168.1, 192.168.1.0/36, omg.wrong, vlans.1notid ]
+    pfxset: [ 192.168.1, 192.168.1.0/36, omg.wrong, vlan.1notid ]

--- a/tests/coverage/errors/validate-prefixset.yml
+++ b/tests/coverage/errors/validate-prefixset.yml
@@ -1,0 +1,20 @@
+defaults:
+  device: none
+  attributes:
+    node:
+      pfxset: { type: list, _subtype: prefixset }
+
+module: [ vlan ]
+
+prefix:
+  alpha.ipv4: 192.168.2.0/24
+
+vlans:
+  red:
+  blue:
+
+nodes:
+  valid:
+    pfxset: [ 192.168.1.0/24, 192.168.1.1, 2001:db8::/64, 2001:db8::1, alpha, prefix.alpha, vlans.red, pool.lan ]
+  invalid:
+    pfxset: [ 192.168.1, 192.168.1.0/36, omg.wrong, vlans.1notid ]

--- a/tests/coverage/expected/acl-prefixset.yml
+++ b/tests/coverage/expected/acl-prefixset.yml
@@ -1,0 +1,724 @@
+input:
+- coverage/input/acl-prefixset.yml
+- package:topology-defaults.yml
+links:
+- _linkname: links[1]
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.1/30
+    node: r1
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 10.1.0.2/30
+    node: r2
+  linkid: core
+  linkindex: 1
+  node_count: 2
+  prefix:
+    ipv4: 10.1.0.0/30
+  routing:
+    acl:
+      in: other
+  type: p2p
+- _linkname: links[2]
+  bridge: input_2
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.1.1/24
+    node: r1
+  linkindex: 2
+  node_count: 1
+  prefix:
+    ipv4: 172.16.1.0/24
+  role: stub
+  type: stub
+- _linkname: links[3]
+  bridge: input_3
+  interfaces:
+  - ifindex: 2
+    ifname: eth2
+    ipv4: 172.16.2.2/24
+    node: r2
+  linkindex: 3
+  node_count: 1
+  prefix:
+    ipv4: 172.16.2.0/24
+  role: stub
+  type: stub
+- _linkname: vlans.red.links[1]
+  bridge: input_4
+  interfaces:
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.3/24
+    node: h1
+  - _vlan_mode: irb
+    ifindex: 3
+    ifname: eth3
+    ipv4: 172.16.0.1/24
+    node: r1
+    vlan:
+      access: red
+  linkindex: 4
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: edge
+  type: lan
+  vlan:
+    access: red
+- _linkname: vlans.red.links[2]
+  bridge: input_5
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 4
+    ifname: eth4
+    ipv4: 172.16.0.1/24
+    node: r1
+    vlan:
+      access: red
+  - _vlan_mode: irb
+    ifindex: 3
+    ifname: eth3
+    ipv4: 172.16.0.2/24
+    node: r2
+    vlan:
+      access: red
+  linkindex: 5
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: edge
+  type: lan
+  vlan:
+    access: red
+- _linkname: vlans.red.links[3]
+  bridge: input_6
+  interfaces:
+  - _vlan_mode: irb
+    ifindex: 4
+    ifname: eth4
+    ipv4: 172.16.0.2/24
+    node: r2
+    vlan:
+      access: red
+  - ifindex: 1
+    ifname: eth1
+    ipv4: 172.16.0.4/24
+    node: h2
+  linkindex: 6
+  node_count: 2
+  prefix:
+    allocation: id_based
+    ipv4: 172.16.0.0/24
+  routing:
+    acl:
+      in: edge
+  type: lan
+  vlan:
+    access: red
+module:
+- vlan
+- routing
+name: input
+nodes:
+  h1:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 3
+    interfaces:
+    - bridge: input_4
+      gateway:
+        ipv4: 172.16.0.1/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.3/24
+      linkindex: 4
+      name: h1 -> [r1,h2,r2]
+      neighbors:
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.103
+      mac: ca:fe:00:03:00:00
+    module:
+    - routing
+    name: h1
+    role: host
+    routing:
+      static:
+      - ipv4: 0.0.0.0/0
+        nexthop:
+          idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+  h2:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 4
+    interfaces:
+    - bridge: input_6
+      gateway:
+        ipv4: 172.16.0.1/24
+      ifindex: 1
+      ifname: eth1
+      ipv4: 172.16.0.4/24
+      linkindex: 6
+      name: h2 -> [h1,r1,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      type: lan
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.104
+      mac: ca:fe:00:04:00:00
+    module:
+    - routing
+    name: h2
+    role: host
+    routing:
+      static:
+      - ipv4: 0.0.0.0/0
+        nexthop:
+          idx: 0
+          intf: eth1
+          ipv4: 172.16.0.1
+  r1:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 1
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.1/30
+      linkid: core
+      linkindex: 1
+      name: r1 -> r2
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.2/30
+        node: r2
+      routing:
+        acl:
+          in:
+            ipv4: other
+      type: p2p
+    - bridge: input_2
+      ifindex: 2
+      ifname: eth2
+      ipv4: 172.16.1.1/24
+      linkindex: 2
+      name: r1 -> stub
+      neighbors: []
+      role: stub
+      type: stub
+    - bridge: input_4
+      ifindex: 3
+      ifname: eth3
+      linkindex: 4
+      name: '[Access VLAN red] r1 -> h1'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_5
+      ifindex: 4
+      ifname: eth4
+      linkindex: 5
+      name: '[Access VLAN red] r1 -> r2'
+      neighbors:
+      - ifname: eth3
+        ipv4: 172.16.0.2/24
+        node: r2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 40000
+      ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      name: VLAN red (1000) -> [h1,h2,r2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      - ifname: Vlan1000
+        ipv4: 172.16.0.2/24
+        node: r2
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      routing:
+        acl:
+          in:
+            ipv4: edge
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.1/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.101
+      mac: ca:fe:00:01:00:00
+    module:
+    - vlan
+    - routing
+    name: r1
+    routing:
+      _acl:
+        ipv4:
+          edge:
+          - action: permit
+            dst:
+              ipv4: 192.168.1.0/24
+            protocol: ip
+            sequence: 100
+            src:
+              ipv4: 172.16.0.0/24
+          - action: permit
+            dst:
+              host: true
+              ipv4: 192.168.2.1
+            protocol: ip
+            sequence: 110
+            src:
+              ipv4: 172.16.0.0/24
+          other:
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 100
+            src:
+              ipv4: 192.168.2.0/24
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 110
+            src:
+              ipv4: 10.1.0.0/16
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 120
+            src:
+              ipv4: 10.1.0.0/30
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 130
+            src:
+              ipv4: 172.16.1.0/24
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 140
+            src:
+              ipv4: 172.16.2.0/24
+      acl:
+        edge:
+        - action: permit
+          dst:
+            ipv4:
+            - 192.168.1.0/24
+            - 192.168.2.1
+            ipv6:
+            - 2001:db8:1::/64
+            - 2001:db8:2::1
+          protocol: ip
+          sequence: 10
+          src:
+            ipv4:
+            - 172.16.0.0/24
+        other:
+        - action: permit
+          dst:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+          protocol: ip
+          sequence: 10
+          src:
+            ipv4:
+            - 192.168.2.0/24
+            - 10.1.0.0/16
+            - 10.1.0.0/30
+            - 172.16.1.0/24
+            - 172.16.2.0/24
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        routing:
+          acl:
+            in: edge
+  r2:
+    af:
+      ipv4: true
+    box: none
+    device: none
+    id: 2
+    interfaces:
+    - ifindex: 1
+      ifname: eth1
+      ipv4: 10.1.0.2/30
+      linkid: core
+      linkindex: 1
+      name: r2 -> r1
+      neighbors:
+      - ifname: eth1
+        ipv4: 10.1.0.1/30
+        node: r1
+      routing:
+        acl:
+          in:
+            ipv4: other
+      type: p2p
+    - bridge: input_3
+      ifindex: 2
+      ifname: eth2
+      ipv4: 172.16.2.2/24
+      linkindex: 3
+      name: r2 -> stub
+      neighbors: []
+      role: stub
+      type: stub
+    - bridge: input_5
+      ifindex: 3
+      ifname: eth3
+      linkindex: 5
+      name: '[Access VLAN red] r2 -> r1'
+      neighbors:
+      - ifname: eth4
+        ipv4: 172.16.0.1/24
+        node: r1
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge: input_6
+      ifindex: 4
+      ifname: eth4
+      linkindex: 6
+      name: '[Access VLAN red] r2 -> h2'
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      type: lan
+      vlan:
+        access: red
+        access_id: 1000
+    - bridge_group: 1
+      ifindex: 40000
+      ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      name: VLAN red (1000) -> [h1,r1,h2]
+      neighbors:
+      - ifname: eth1
+        ipv4: 172.16.0.3/24
+        node: h1
+      - ifname: Vlan1000
+        ipv4: 172.16.0.1/24
+        node: r1
+        routing:
+          acl:
+            in: edge
+        vlan:
+          mode: irb
+          name: red
+      - ifname: eth1
+        ipv4: 172.16.0.4/24
+        node: h2
+      routing:
+        acl:
+          in:
+            ipv4: edge
+      type: svi
+      virtual_interface: true
+      vlan:
+        mode: irb
+        name: red
+    loopback:
+      ifindex: 0
+      ifname: Loopback0
+      ipv4: 10.0.0.2/32
+      neighbors: []
+      type: loopback
+      virtual_interface: true
+    mgmt:
+      ifname: eth0
+      ipv4: 192.168.121.102
+      mac: ca:fe:00:02:00:00
+    module:
+    - vlan
+    - routing
+    name: r2
+    routing:
+      _acl:
+        ipv4:
+          edge:
+          - action: permit
+            dst:
+              ipv4: 192.168.1.0/24
+            protocol: ip
+            sequence: 100
+            src:
+              ipv4: 172.16.0.0/24
+          - action: permit
+            dst:
+              host: true
+              ipv4: 192.168.2.1
+            protocol: ip
+            sequence: 110
+            src:
+              ipv4: 172.16.0.0/24
+          other:
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 100
+            src:
+              ipv4: 192.168.2.0/24
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 110
+            src:
+              ipv4: 10.1.0.0/16
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 120
+            src:
+              ipv4: 10.1.0.0/30
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 130
+            src:
+              ipv4: 172.16.1.0/24
+          - action: permit
+            dst:
+              any: true
+              ipv4: 0.0.0.0/0
+            protocol: ip
+            sequence: 140
+            src:
+              ipv4: 172.16.2.0/24
+      acl:
+        edge:
+        - action: permit
+          dst:
+            ipv4:
+            - 192.168.1.0/24
+            - 192.168.2.1
+            ipv6:
+            - 2001:db8:1::/64
+            - 2001:db8:2::1
+          protocol: ip
+          sequence: 10
+          src:
+            ipv4:
+            - 172.16.0.0/24
+        other:
+        - action: permit
+          dst:
+            ipv4:
+            - 0.0.0.0/0
+            ipv6:
+            - ::/0
+          protocol: ip
+          sequence: 10
+          src:
+            ipv4:
+            - 192.168.2.0/24
+            - 10.1.0.0/16
+            - 10.1.0.0/30
+            - 172.16.1.0/24
+            - 172.16.2.0/24
+    vlan:
+      max_bridge_group: 1
+    vlans:
+      red:
+        bridge_group: 1
+        id: 1000
+        mode: irb
+        prefix:
+          allocation: id_based
+          ipv4: 172.16.0.0/24
+        routing:
+          acl:
+            in: edge
+prefix:
+  alpha:
+    ipv4: 192.168.2.0/24
+  any:
+    ipv4: 0.0.0.0/0
+    ipv6: ::/0
+provider: libvirt
+routing:
+  acl:
+    edge:
+    - action: permit
+      dst:
+        ipv4:
+        - 192.168.1.0/24
+        - 192.168.2.1
+        ipv6:
+        - 2001:db8:1::/64
+        - 2001:db8:2::1
+      protocol: ip
+      sequence: 10
+      src:
+        ipv4:
+        - 172.16.0.0/24
+    other:
+    - action: permit
+      dst:
+        ipv4:
+        - 0.0.0.0/0
+        ipv6:
+        - ::/0
+      protocol: ip
+      sequence: 10
+      src:
+        ipv4:
+        - 192.168.2.0/24
+        - 10.1.0.0/16
+        - 10.1.0.0/30
+        - 172.16.1.0/24
+        - 172.16.2.0/24
+vlans:
+  red:
+    host_count: 2
+    id: 1000
+    neighbors:
+    - ifname: eth1
+      ipv4: 172.16.0.3/24
+      node: h1
+    - ifname: Vlan1000
+      ipv4: 172.16.0.1/24
+      node: r1
+      routing:
+        acl:
+          in: edge
+      vlan:
+        mode: irb
+        name: red
+    - ifname: eth1
+      ipv4: 172.16.0.4/24
+      node: h2
+    - ifname: Vlan1000
+      ipv4: 172.16.0.2/24
+      node: r2
+      routing:
+        acl:
+          in: edge
+      vlan:
+        mode: irb
+        name: red
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24
+    routing:
+      acl:
+        in: edge

--- a/tests/coverage/input/acl-prefixset.yml
+++ b/tests/coverage/input/acl-prefixset.yml
@@ -1,0 +1,34 @@
+---
+defaults.device: none
+module: [ routing, vlan ]
+
+prefix.alpha.ipv4: 192.168.2.0/24
+
+vlans:
+  red:
+    routing.acl.in: edge
+    links: [ h1-r1, r1-r2, r2-h2 ]
+
+routing.acl:
+  edge:
+  - protocol: ip
+    src.prefix: [ vlan.red ]
+    dst.prefix: [ 192.168.1.0/24, 192.168.2.1, 2001:db8:1::/64, 2001:db8:2::1 ]
+  other:
+  - protocol: ip
+    src.prefix: [ prefix.alpha, pool.p2p, link.core, role.stub ]
+    dst.prefix: any
+
+nodes:
+  r1:
+  r2:
+  h1.role: host
+  h2.role: host
+
+links:
+- r1:
+  r2:
+  linkid: core
+  routing.acl.in: other
+- r1:
+- r2:


### PR DESCRIPTION
Based on the ideas discussed in #3810, this PR adds a new data type: generic prefix. It can be an IPv4/IPv6 address/prefix, or a named prefix, vlan prefix, address pool, link prefix, or a set of prefixes from links with specified role (I'm pretty sure we'll get further ideas ;).

It's currently used in ACLs, but could be integrated into prefix lists and static routes.

The PR includes:

* A new type validator and corresponding coverage test
* The 'eval_prefixset' code that transforms a named prefix into a list of ipv4/ipv6 addresses
* Updated documentation end-user and developer documentation