### PR TITLE
Ensure Vagrant provider is 'libvirt' when trying to package our own boxes

### DIFF
--- a/netsim/cli/libvirt/package.py
+++ b/netsim/cli/libvirt/package.py
@@ -430,10 +430,9 @@ preceded by "netlab/".
 
   strings.print_colored_text('[IMPORT]  ','green',None)
   print(f"Importing Vagrant box {boxname} version {version}")
-  os.environ["VAGRANT_DEFAULT_PROVIDER"] = "libvirt"
-  if not external_commands.run_command(f"vagrant box add {json_name}"):
+  if not external_commands.run_command(["vagrant","box","add","--provider","libvirt",json_name]):
     error_and_exit(
-      f'Failed to add Vagrant box. Fix the error(s) and use "vagrant box add {json_name}" to add it.',
+      f'Failed to add Vagrant box. Fix the error(s) and use "vagrant box add --provider libvirt {json_name}" to add it.',
       module='libvirt',
       category=log.FatalError,
       more_hints=[

--- a/netsim/cli/libvirt/package.py
+++ b/netsim/cli/libvirt/package.py
@@ -430,6 +430,7 @@ preceded by "netlab/".
 
   strings.print_colored_text('[IMPORT]  ','green',None)
   print(f"Importing Vagrant box {boxname} version {version}")
+  os.environ["VAGRANT_DEFAULT_PROVIDER"] = "libvirt"
   if not external_commands.run_command(f"vagrant box add {json_name}"):
     error_and_exit(
       f'Failed to add Vagrant box. Fix the error(s) and use "vagrant box add {json_name}" to add it.',


### PR DESCRIPTION
We have earlier fixed issue with `netlab down` where you cannot specify the provider to use via CLI and must use Environment variable.

This fixes use when we are building our own vagrant boxes under WSL.