### PR TITLE
Bump SR Linux release to 26.7.2

### DIFF
--- a/netsim/devices/srlinux.yml
+++ b/netsim/devices/srlinux.yml
@@ -54,7 +54,7 @@ bfd:                                    # SR Linux supports lower BFD timers tha
   min_tx: 100
   min_rx: 100
 clab:
-  image: ghcr.io/nokia/srlinux:26.7.1
+  image: ghcr.io/nokia/srlinux:26.7.2
   node:
     kind: srl
     type: ixr-d2

--- a/tests/topology/expected/multiserver-explicit.yml
+++ b/tests/topology/expected/multiserver-explicit.yml
@@ -503,11 +503,11 @@ nodes:
     role: router
   srl1:
     _srl_version:
-    - 26
-    - 7
+    - 25
+    - 3
     af:
       ipv4: true
-    box: ghcr.io/nokia/srlinux:26.7.1
+    box: ghcr.io/nokia/srlinux:latest
     clab:
       kind: srl
       type: ixr-d2

--- a/tests/topology/input/multiserver-explicit.yml
+++ b/tests/topology/input/multiserver-explicit.yml
@@ -6,6 +6,8 @@
 provider: clab
 plugin: [ multiserver ]
 
+defaults.devices.srlinux.clab.image: ghcr.io/nokia/srlinux:latest
+
 multiserver:
   servers:
     srv1:


### PR DESCRIPTION
Also: Pin the SRL release in transformation tests to avoid having transformation errors after each SRL release change