### PR TITLE
Add OpenBSD DNS and Syslog Clients

### DIFF
--- a/netsim/ansible/templates/services/openbsd.j2
+++ b/netsim/ansible/templates/services/openbsd.j2
@@ -1,0 +1,17 @@
+#!/bin/sh
+{% if services.dns._server_list is defined %}
+cat <<'CONFIG' >/etc/resolv.conf
+{%     include 'initial/linux/resolv.j2' +%}
+CONFIG
+{% endif %}
+
+# Syslog configuration comes here (eventually)
+{% if services.syslog._server_list is defined %}
+cat <<'SYSLOG' >>/etc/syslog.conf
+{% for syslog_host in services.syslog._server_list|default([]) %}
+*.*		{{ "@udp6:// " if ':' in syslog_host else "@udp4://" }}{{ syslog_host }}
+{% endfor %}
+SYSLOG
+
+rcctl restart syslogd
+{% endif %}

--- a/netsim/devices/openbsd.yml
+++ b/netsim/devices/openbsd.yml
@@ -21,6 +21,15 @@ features:
     collect: false
     reload: false
     roles: [ host, router ]
+  services:
+    dns:
+      ipv4: True
+      ipv6: True
+      transport_vrf: False
+    syslog:
+      ipv4: True
+      ipv6: True
+      transport_vrf: False
   ospf:
     unnumbered: false
     import: [ connected, static ]

--- a/tests/integration/services/01-dns-client.yml
+++ b/tests/integration/services/01-dns-client.yml
@@ -40,6 +40,7 @@ validate:
       nxos: ping t1 count 3
       xr: ping t1 count 3
       srlinux: ping t1 network-instance default -c 3
+      openbsd: ping -c 3 t1
     valid: >-
       "172.16.0.4" in stdout
   query:


### PR DESCRIPTION
Add DNS and Syslog clients for OpenBSD.

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p libvirt -d openbsd services/
[sudo] password for netlab:
Pre-test cleanup:
06:13:15 services/01-dns-client.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
06:14:06 services/02-dns-vrf-client.yml: create(FAIL)
06:14:06 services/03-dns-server.yml: create(FAIL)
06:14:07 services/11-syslog-client.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK

(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```