### PR TITLE
Add VyOS support for WireGuard tunnels

### DIFF
--- a/netsim/ansible/templates/initial/vyos.j2
+++ b/netsim/ansible/templates/initial/vyos.j2
@@ -38,6 +38,8 @@ set interfaces dummy dum0 address {{ loopback.ipv6 }}
 {%     set ns.iface_level = "bonding" %}
 {%   elif l.ifname.startswith('tun') %}
 {%     set ns.iface_level = "tunnel" %}
+{%   elif l.ifname.startswith('wg') %}
+{%     set ns.iface_level = "wireguard" %}
 {%   endif %}
 {#
 # Split interface name with vif, if needed

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -4,7 +4,9 @@ docname: VyOS
 interface_name: eth{ifindex}
 loopback_interface_name: "dum{ifindex}"
 lag_interface_name: "bond{lag.ifindex}"
-tunnel_interface_name: "tun{ifindex}"
+tunnel_interface_name:
+  gre: tun{ifindex}
+  wireguard: wg{ifindex}
 mgmt_if: eth0
 libvirt:
   image: vyos/current
@@ -85,6 +87,7 @@ features:
       discard: True
   tunnel:
     gre: [ vrf, ipv4, ipv6 ]
+    wireguard: [ ipv4, ipv6 ]
   vlan:
     model: l3-switch
     svi_interface_name: "br0.{vlan}"

--- a/netsim/extra/tunnel/wireguard/vyos.initial.j2
+++ b/netsim/extra/tunnel/wireguard/vyos.initial.j2
@@ -1,0 +1,4 @@
+{# Initial VyOS Wireguard tunnel implementation #}
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['wireguard'] %}
+set interface wireguard {{ intf.ifname }} private-key '{{ intf.tunnel.private_key }}'
+{% endfor %}

--- a/netsim/extra/tunnel/wireguard/vyos.j2
+++ b/netsim/extra/tunnel/wireguard/vyos.j2
@@ -1,0 +1,15 @@
+{% for intf in netlab_interfaces if intf.tunnel.mode|default('') in ['wireguard'] %}
+{%   set dst = intf.tunnel._destination %}
+{%   set peer_ip = ('[' ~ dst.ipv6 ~ ']') if intf.tunnel.af == 'ipv6' else dst.ipv4 %}
+{%   set peer_endpoint = peer_ip ~ ':' ~ dst.listen_port %}
+set interface wireguard {{ intf.ifname }} private-key '{{ intf.tunnel.private_key }}'
+set interface wireguard {{ intf.ifname}} port '{{ intf.tunnel.listen_port }}'
+set interface wireguard {{ intf.ifname}} description '{{ intf.name }}'
+set interface wireguard {{ intf.ifname }} peer "{{ dst.public_key }}" public-key '{{ dst.public_key }}'
+set interface wireguard {{ intf.ifname }} peer "{{ dst.public_key }}" address '{{ peer_ip }}'
+set interface wireguard {{ intf.ifname }} peer "{{ dst.public_key }}" port '{{ dst.listen_port }}'
+set interface wireguard {{ intf.ifname }} peer "{{ dst.public_key }}" persistent-keepalive '{{ intf.tunnel.persistent_keepalive }}'
+{%  for a_ip in intf.tunnel.allowed_ips.split(',') %}
+set interface wireguard {{ intf.ifname }} peer "{{ dst.public_key }}" allowed-ips '{{ a_ip }}'
+{%  endfor %}
+{% endfor %}


### PR DESCRIPTION
Add VyOS support for WireGuard tunnels.

Does not support `transport_vrf` 

<details><summary>Passes  11-wireguard.yml</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/aaa$ netlab validate
[adj]     Check OSPFv2 adjacencies with DUT [ node(s): r2,r3 ]
[PASS]    r2: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]    r3: OSPFv2 neighbor 10.0.0.1 is in state Full/-
[PASS]    Test succeeded in 0.3 seconds

[adj6]    Check OSPFv3 adjacencies with DUT [ node(s): r2,r3 ]
[PASS]    r2: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]    r3: OSPFv3 neighbor 10.0.0.1 is in state Full
[PASS]    Test succeeded in 0.3 seconds

[pfx]     Check for DUT IPv4 loopback prefix being propagated to R2 [ node(s): r2,r3 ]
[WAITING] Waiting for SPF to do its magic (retrying for 30 seconds)
[PASS]    r2: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    r3: The prefix 10.0.0.1/32 is in the OSPF topology
[PASS]    Test succeeded in 2.9 seconds

[pfx6]    Check for DUT IPv6 loopback prefix being propagated to R2 [ node(s): r2,r3 ]
[PASS]    r2: The prefix 2001:db8:1::1/128 is in the OSPFv3 topology
[PASS]    r3: The prefix 2001:db8:1::1/128 is in the OSPFv3 topology
[PASS]    Test succeeded in 0.3 seconds

[ping]    Check IPv4 connectivity over tunnel [ node(s): r2,r3 ]
[PASS]    r2: Ping to 10.0.0.1 succeeded
[PASS]    r3: Ping to 10.0.0.1 succeeded
[PASS]    Test succeeded in 0.3 seconds

[ping6]   Check IPv6 connectivity over tunnel [ node(s): r2,r3 ]
[PASS]    r2: Ping to ipv6 2001:db8:1::1 succeeded
[PASS]    r3: Ping to ipv6 2001:db8:1::1 succeeded
[PASS]    Test succeeded in 0.2 seconds

[mtu]     Check a full 1500-byte packet traverses the tunnel (underlay MTU 1560) [ node(s): r2,r3 ]
[PASS]    r2: Ping to 10.0.0.1 size 1500 succeeded
[PASS]    r3: Ping to 10.0.0.1 size 1500 succeeded
[PASS]    Test succeeded in 0.3 seconds

[x_ping]  Check end-to-end IPv4 connectivity [ node(s): r2 ]
[PASS]    r2: Ping to 10.0.0.3 succeeded
[PASS]    Test succeeded in 0.1 seconds

[x_ping6] Check end-to-end IPv6 connectivity [ node(s): r2 ]
[PASS]    r2: Ping to ipv6 2001:db8:1::3 succeeded
[PASS]    Test succeeded in 0.1 seconds

[SUCCESS] Tests passed: 16
(py3-snuff) netlab@netlab:~/snuffy-netlab/aaa$
```
</details>