### PR TITLE
Use prefixsets in routing.prefix lists

### DIFF
--- a/docs/module/routing-acl.txt
+++ b/docs/module/routing-acl.txt
@@ -54,19 +54,6 @@ You can use either a single value or a list of values in all of the above parame
 
 You can also mix IPv4 and IPv6 addresses in an access list. _netlab_ always generates address-family-specific access lists for all address families used on the device.
 
-(generic-routing-prefix-set)=
-### Specifying Generic Prefixes
-
-A generic prefix (used in ACL **src.prefix** and **dst.prefix** attributes) can be:
-
-* An IPv4 address or prefix (including host prefixes)
-* An IPv6 address or host (including host prefixes)
-* A named prefix, specified as prefix name or as **prefix._name_**
-* An address pool prefix, specified as **pool._name_**
-* A prefix assigned to an IRB VLAN, specified as **vlan._name_**
-* A prefix assigned to a link with a **linkid** attribute, specified as **link._linkid_**
-* Prefixes assigned to links with the specified **role**, specified as **role._rolename_**
-
 (routing-acl-matching-port)=
 ### Matching TCP/UDP Ports
 

--- a/docs/module/routing-advanced.txt
+++ b/docs/module/routing-advanced.txt
@@ -1,4 +1,17 @@
-## Advanced Topics
+## Shared Functionality
+
+(generic-routing-prefix-set)=
+### Specifying Generic Prefixes
+
+A generic prefix (used in ACL **src.prefix** and **dst.prefix** attributes, and in prefix-list **prefix** attribute) can be:
+
+* An IPv4 address or prefix (including host prefixes)
+* An IPv6 address or host (including host prefixes)
+* A named prefix, specified as prefix name or as **prefix._name_**
+* An address pool prefix, specified as **pool._name_**
+* A prefix assigned to an IRB VLAN, specified as **vlan._name_**
+* A prefix assigned to a link with a **linkid** attribute, specified as **link._linkid_**
+* Prefixes assigned to links with the specified **role**, specified as **role._rolename_**
 
 (routing-object-import)=
 ### Using Global- and Node-Level Routing Objects

--- a/docs/module/routing-prefix.txt
+++ b/docs/module/routing-prefix.txt
@@ -5,17 +5,20 @@ Prefix filters are lists of conditions (usually known as *lists*) that permit or
 
 * **action**: A prefix filter entry can **permit** or **deny** matched prefixes (default: **permit**)
 * **sequence**: Statement sequence number. When not specified, *netlab* sets a prefix filter entry's **sequence** number to ten times its list position.
-* **ipv4**: IPv4 prefix to match
-* **ipv6**: IPv6 prefix to match
-* **pool**: Name of the addressing pool to match
-* **prefix**: [A named prefix](named-prefixes) to match
+* **prefix**: A (list of) [generic prefixes](generic-routing-prefix-set), which can include IPv4 prefixes, IPv6 prefixes, named prefixes, and other prefix-related attributes like VLANs, links, or address pools.
 * **min**: Minimum prefix length. It could be specified as an integer or a dictionary with **ipv4** and **ipv6** keys.
 * **max**: Maximum prefix length in the same format as the **min** parameters.
 
+For backward compatibility reasons, you can also specify:
+
+* **ipv4**: A (list of) IPv4 prefixes to match
+* **ipv6**: A (list of) IPv6 prefixes to match
+* **pool**: Name(s) of the addressing pool(s) to match
+
 ```{warning}
-* The **min** and **max** lengths must be greater than or equal to the prefix length an entry is matching, and less than or equal to the maximum imposed by the address family prefix size.
+* The **min** and **max** lengths must be greater than or equal to the longest prefix length an entry is matching, and less than or equal to the maximum imposed by the address family prefix size.
 * Some devices (for example, Cisco IOS) require the **min** and **max** lengths to be strictly greater than the matched prefix length
-* You cannot specify **min** and **max** lengths for host prefixes (/32 for IPv4 and /128 for IPv6)
+* You cannot specify **min** and **max** lengths if the prefix-list entry matches host prefixes (/32 for IPv4 and /128 for IPv6)
 ```
 
 Prefix filters are specified in the global- or node-level **routing.prefix** dictionary (see [](routing-object-import) and  [](routing-object-merge) for more details). 
@@ -32,9 +35,8 @@ prefix:
 
 routing.prefix:
   loopbacks:
-  - pool: loopback
-  - prefix: lb_c1
-  - ipv6: 2001:db8:cafe:2::/64
+  - action: permit
+    prefix: [ pool.loopback, prefix.lb_c1, 2001:db8:cafe:2::/64 ]
 ```
 
 (routing-prefix-ds)=
@@ -42,7 +44,7 @@ routing.prefix:
 
 Address pools, named prefixes, and prefix filter entries can contain IPv4 and IPv6 prefixes. Meanwhile, most network operating systems use different configuration objects to match IPv4 and IPv6 prefixes.
 
-_netlab_ generates separate per-address-family *prefix lists* for every prefix filter configured on a network device. The address family is appended to the prefix list name to deal with devices that cannot use the same names for IPv4 and IPv6 prefix lists.
+_netlab_ generates separate per-address-family *prefix lists* for every prefix filter configured on a network device, expanding lists of matching prefixes into one prefix per prefix list entry, resulting in sequence numbers that do not match the ones used in the lab topology. The address family is appended to the prefix list name to deal with devices that cannot use the same names for IPv4 and IPv6 prefix lists.
 
 To avoid route map inconsistencies, a prefix list that contains no usable entries (for example, an IPv6 prefix list generated from a prefix filter that matches only IPv4 prefixes) has a single *deny everything* condition.
 
@@ -51,28 +53,36 @@ Let's assume we're using the following prefix filters:
 ```
 routing.prefix:
   p1:
-    - ipv4: 192.168.24.0/24
-    - ipv6: 2001:db8:0:1::/64
+	  - prefix: [ 192.168.24.0/24, 2001:db8:0:1::/64 ]
   p2:
-    - ipv4: 172.16.0.0/16
+    - prefix: 172.16.0.0/16
+    - prefix: 2001:db8:0:2::/64
+  p3:
+    - prefix: 172.16.1.0/24
 ```
 
-_netlab_ generates these prefix lists on an IPv4-only device (IPv6 prefix list is not generated, and entry #20 is missing from P1):
+_netlab_ generates these prefix lists on an IPv4-only device (an IPv6 prefix list is not generated, and the sequence numbers are generated as the device prefix list is created):
 
 ```
-ip prefix-list p1-ipv4 seq 10 permit 192.168.24.0/24
+ip prefix-list p1-ipv4 seq 100 permit 192.168.24.0/24
 !
-ip prefix-list p2-ipv4 seq 10 permit 172.16.0.0/16
+ip prefix-list p2-ipv4 seq 100 permit 172.16.0.0/16
+!
+ip prefix-list p3-ipv4 seq 100 permit 172.16.1.0/24
 ```
 
-Meanwhile, the following prefix lists are generated on a dual-stack device (including a meaningless IPv6 prefix list P2)
+Meanwhile, the following prefix lists are generated on a dual-stack device (including a meaningless IPv6 prefix list P3)
 
 ```
-ip prefix-list p1-ipv4 seq 10 permit 192.168.24.0/24
+ip prefix-list p1-ipv4 seq 100 permit 192.168.24.0/24
 !
-ip prefix-list p2-ipv4 seq 10 permit 172.16.0.0/16
+ip prefix-list p2-ipv4 seq 100 permit 172.16.0.0/16
 !
-ipv6 prefix-list p1-ipv6 seq 20 permit 2001:db8:0:1::/64
+ip prefix-list p3-ipv4 seq 100 permit 172.16.1.0/16
 !
-ipv6 prefix-list p2-ipv6 seq 10 deny ::/0
+ipv6 prefix-list p1-ipv6 seq 100 permit 2001:db8:0:1::/64
+!
+ipv6 prefix-list p2-ipv6 seq 110 permit 2001:db8:0:2::/64
+!
+ipv6 prefix-list p3-ipv6 seq 100 deny ::/0
 ```

--- a/docs/module/routing-prefix.txt
+++ b/docs/module/routing-prefix.txt
@@ -6,7 +6,7 @@ Prefix filters are lists of conditions (usually known as *lists*) that permit or
 * **action**: A prefix filter entry can **permit** or **deny** matched prefixes (default: **permit**)
 * **sequence**: Statement sequence number. When not specified, *netlab* sets a prefix filter entry's **sequence** number to ten times its list position.
 * **prefix**: A (list of) [generic prefixes](generic-routing-prefix-set), which can include IPv4 prefixes, IPv6 prefixes, named prefixes, and other prefix-related attributes like VLANs, links, or address pools.
-* **min**: Minimum prefix length. It could be specified as an integer or a dictionary with **ipv4** and **ipv6** keys.
+* **min**: Minimum prefix length. You can specify it as an integer or a dictionary with **ipv4** and **ipv6** keys.
 * **max**: Maximum prefix length in the same format as the **min** parameters.
 
 For backward compatibility reasons, you can also specify:
@@ -53,12 +53,12 @@ Let's assume we're using the following prefix filters:
 ```
 routing.prefix:
   p1:
-	  - prefix: [ 192.168.24.0/24, 2001:db8:0:1::/64 ]
+  - prefix: [ 192.168.24.0/24, 2001:db8:0:1::/64 ]
   p2:
-    - prefix: 172.16.0.0/16
-    - prefix: 2001:db8:0:2::/64
+  - prefix: 172.16.0.0/16
+  - prefix: 2001:db8:0:2::/64
   p3:
-    - prefix: 172.16.1.0/24
+  - prefix: 172.16.1.0/24
 ```
 
 _netlab_ generates these prefix lists on an IPv4-only device (an IPv6 prefix list is not generated, and the sequence numbers are generated as the device prefix list is created):
@@ -78,7 +78,7 @@ ip prefix-list p1-ipv4 seq 100 permit 192.168.24.0/24
 !
 ip prefix-list p2-ipv4 seq 100 permit 172.16.0.0/16
 !
-ip prefix-list p3-ipv4 seq 100 permit 172.16.1.0/16
+ip prefix-list p3-ipv4 seq 100 permit 172.16.1.0/24
 !
 ipv6 prefix-list p1-ipv6 seq 100 permit 2001:db8:0:1::/64
 !

--- a/netsim/ansible/templates/routing/iosxr/prefix.j2
+++ b/netsim/ansible/templates/routing/iosxr/prefix.j2
@@ -4,12 +4,15 @@ prefix-set {{ pname }}
 {%   for p_entry in pdata %}
 {%     set last_entry = loop.last %}
 {%     for af in ['ipv4','ipv6'] if af in p_entry %}
-  {{ p_entry[af] }}{%
+{%       set last_af = loop.last %}
+{%       for af_value in p_entry[af] %}
+  {{ af_value }}{%
          if p_entry.min[af] is defined
            %} ge {{ p_entry.min[af] }}{% endif %}{%
          if p_entry.max[af] is defined
            %} le {{ p_entry.max[af] }}{% endif %}{%
-         if not loop.last or not last_entry %},{% endif +%}
+         if not loop.last or not last_af or not last_entry %},{% endif +%}
+{%       endfor %}
 {%     endfor %}
 {%   endfor %}
 end-set

--- a/netsim/ansible/templates/routing/srlinux/prefix.j2
+++ b/netsim/ansible/templates/routing/srlinux/prefix.j2
@@ -4,11 +4,11 @@
     prefix:
 {%   for p_entry in pf_list %}{# Iterate over prefix list entries #}
 {%     for p_af in af if p_af in p_entry %}{# Iterate over address families in the prefix list entry #}
-{%       for af_value in p_entry[p_af]
+{%       for af_value in p_entry[p_af] %}
     - ip-prefix: {{ af_value }}
 {%         if p_entry.min[p_af] is defined or p_entry.max[p_af] is defined %}
       mask-length-range: {{ 
-        p_entry.min[p_af]|default(p_entry[p_af]|ansible.utils.ipaddr('prefix')) }}..{{ 
+        p_entry.min[p_af]|default(af_value|ansible.utils.ipaddr('prefix')) }}..{{ 
         p_entry.max[p_af]|default(32 if p_af == 'ipv4' else 128) }}
 {%         else %}
       mask-length-range: exact

--- a/netsim/ansible/templates/routing/srlinux/prefix.j2
+++ b/netsim/ansible/templates/routing/srlinux/prefix.j2
@@ -4,14 +4,16 @@
     prefix:
 {%   for p_entry in pf_list %}{# Iterate over prefix list entries #}
 {%     for p_af in af if p_af in p_entry %}{# Iterate over address families in the prefix list entry #}
-    - ip-prefix: {{ p_entry[p_af] }}
-{%     if p_entry.min[p_af] is defined or p_entry.max[p_af] is defined %}
+{%       for af_value in p_entry[p_af]
+    - ip-prefix: {{ af_value }}
+{%         if p_entry.min[p_af] is defined or p_entry.max[p_af] is defined %}
       mask-length-range: {{ 
         p_entry.min[p_af]|default(p_entry[p_af]|ansible.utils.ipaddr('prefix')) }}..{{ 
         p_entry.max[p_af]|default(32 if p_af == 'ipv4' else 128) }}
-{%     else %}
+{%         else %}
       mask-length-range: exact
-{%     endif %}
+{%         endif %}
+{%       endfor %}
 {%     endfor %}
 {%   endfor %}
 {% endfor %}

--- a/netsim/modules/routing.yml
+++ b/netsim/modules/routing.yml
@@ -187,11 +187,11 @@ _top:                               # Modification of global defaults
         min_value: 1
         max_value: 32767
       pool:
-        type: addr_pool
-        _valid_with: [ action, sequence, min, max ]
+        type: list
+        _subtype: addr_pool
       prefix:
-        type: named_pfx
-        _valid_with: [ action, sequence, min, max ]
+        type: list
+        _subtype: prefixset
       min:
         ipv4: { type: int, min_value: 0, max_value: 32 }
         ipv6: { type: int, min_value: 0, max_value: 128 }
@@ -200,8 +200,12 @@ _top:                               # Modification of global defaults
         ipv4: { type: int, min_value: 0, max_value: 32 }
         ipv6: { type: int, min_value: 0, max_value: 128 }
         _alt_types: [ int ]
-      ipv4: { type: ipv4, use: prefix }
-      ipv6: { type: ipv6, use: prefix }
+      ipv4:
+        type: list
+        _subtype: { type: ipv4, use: prefix }
+      ipv6:
+        type: list
+        _subtype: { type: ipv6, use: prefix }
 
     aspath_entry:                   # Define AS-path access list entry
       action:

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -11,29 +11,35 @@ import typing
 from box import Box
 
 from ...augment import devices as a_devices
-from ...data import get_new_box
+from ...data import append_to_list, get_empty_box
 from ...utils import log
+from . import utils as _utils
 
-"""
-expand_prefix_entry:
 
-* Transform 'pool' and 'prefix' keywords into 'ipv4' and 'ipv6'
-* Adjust min/max values to be AF-specific
-"""
-def expand_prefix_entry(p_entry: Box, topology: Box) -> Box:
-  extra_data = None
-  if 'pool' in p_entry:
-    extra_data = topology.addressing[p_entry.pool]
-    p_entry.pop('pool',None)
+def expand_prefix_entry(p_entry: Box, path: str, topology: Box) -> Box:
+  """
+  Expand a single prefix-list entry:
 
-  if 'prefix' in p_entry:
-    extra_data = topology.prefix[p_entry.prefix]
-    p_entry.pop('prefix',None)
+  * Transform 'pool' and 'prefix' keywords into 'ipv4' and 'ipv6'
+  * Adjust min/max values to be AF-specific
+  """
 
-  if extra_data:                                  # Did we get any new information?
-    for af in ('ipv4','ipv6'):                    # Replace potential IPv4/IPv6 values with it
-      if af in extra_data:
-        p_entry[af] = extra_data[af]
+  def add_af_info(data: Box) -> None:
+    for af in log.AF_LIST:
+      if af in data:
+        append_to_list(p_entry,af,data[af])
+
+  for pool in p_entry.get('pool',[]):
+    add_af_info(topology.addressing[pool])
+
+  for prefix in p_entry.get('prefix',[]):
+    pfx_data = _utils.eval_prefixset(prefix,path,topology)
+    for af in log.AF_LIST:
+      if af in pfx_data:
+        p_entry[af] = p_entry.get(af,[]) + pfx_data[af]
+
+  for kw in ('pool','prefix'):
+    p_entry.pop(kw,None)
 
   for kw in ('min','max'):                        # Next, normalize the min/max values
     if kw not in p_entry:
@@ -54,6 +60,7 @@ def adjust_pfx_min_max(
       af: str,
       p_name: str,
       node: Box,
+      original_seq: int,
       min_pfx_len: int,
       max_pfx_len: int) -> None:
   """
@@ -80,52 +87,69 @@ def adjust_pfx_min_max(
     if min_pfx_len > max_pfx_len:                 # Is this caused by /32 (or /128) prefix on an IOS-like device?
       log.error(
         f'Cannot use prefix filter {m_kw} keyword with prefix {p_entry[af]}',
-        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {original_seq}'],
         category=log.IncorrectValue,
         module='routing')
     else:
       log.error(
         f'Prefix filter {af}.{m_kw} value should be >= {min_pfx_len} (limited by {p_entry[af]})',
-        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+        more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {original_seq}'],
         category=log.IncorrectValue,
         module='routing')
 
   if m_value > max_pfx_len:
     log.error(
       f'Prefix filter {af}.{m_kw} value should be <= {max_pfx_len} (limited by address family)',
-      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {original_seq}'],
       category=log.IncorrectValue,
       module='routing')
 
   p_entry[m_kw] = m_value                         # Replace the min/max dict with per-AF value
 
-def create_pfx_af_entry(p_entry: Box, af: str, p_name: str, node: Box, min_strict: bool = False) -> Box:
+def create_pfx_af_entry(
+      p_entry: Box,                     # Original prefix entry (to get the min/max values)
+      af: str,
+      af_item: str,                     # Single prefix item (generated from AF lists)
+      seq: int,                         # Prefix list element sequence number
+      original_seq: int,                # Original sequence number (used in error message)
+      p_name: str,
+      node: Box,
+      min_strict: bool = False) -> Box:
   """
   create_af_entry: create AF-specific prefix-list entry
 
   Arguments:
   - p_entry: Original prefix list entry
   - af: Address family we're focusing on
+  - af_item: An element of the prefix entry to generate a new (non-list) prefix entry
   - p_name: Prefix list name (for error messages)
   - node: Node data (needed for error messages)
   - min_strict: Is device enforcing strict min/max rules (min/max have to be greater than prefix length)?
   """
-  af_p_entry = get_new_box(p_entry)                         # Create a copy of the current p_entry
-  for af_x in ('ipv4','ipv6'):                              # ... remove all other address families
-    if af_x in p_entry and af_x != af:
-      af_p_entry.pop(af_x,None)
+  af_p_entry = get_empty_box()                              # Create a new p_entry
+  af_p_entry[af] = af_item                                  # ... with a single AF item
+  af_p_entry.sequence = seq                                 # ... insert sequence number
+  af_p_entry.action = p_entry.get('action','permit')        # ... and permit/deny action
 
-  pfx_max = 32 if af == 'ipv4' else 128
-  pfx_len = ipaddress.ip_network(p_entry[af]).prefixlen
+  pfx_max = 32 if af == 'ipv4' else 128                     # Find longest
+  pfx_len = ipaddress.ip_network(af_item).prefixlen         # ... and shortest sensible prefix length
 
-  for m_kw in ('min','max'):
+  for m_kw in ('min','max'):                                # ... and use them to validate min/max entries
+    if m_kw not in p_entry:                                 # min/max KW not specified?
+      continue
+    af_p_entry[m_kw] = p_entry[m_kw]                        # ... otherwise copy it into new prefix entry
     pfx_min = pfx_len + 1 if min_strict else pfx_len
-    adjust_pfx_min_max(af_p_entry,m_kw,af,p_name,node,min_pfx_len=pfx_min,max_pfx_len=pfx_max)
+    adjust_pfx_min_max(                                     # Check the values ...
+      af_p_entry,m_kw,af,                                   # ... using new entry, keyword and AF
+      p_name,node,original_seq,                             # ... data needed for error message
+      min_pfx_len=pfx_min,max_pfx_len=pfx_max)              # ... and limits on min/max values
 
   if 'min' in af_p_entry and 'max' in af_p_entry and af_p_entry.min > af_p_entry.max:
     log.error(
       f'Prefix filter {af}.min should be <= {af}.max',
-      more_data=[f'Node {node.name} (device {node.device}) policy {p_name} sequence# {p_entry.sequence}'],
+      more_data=[
+        f'Node {node.name} (device {node.device}) policy {p_name}'
+        f' sequence# {original_seq} prefix {af_item}'],
       category=log.IncorrectValue,
       module='routing')
 
@@ -147,7 +171,9 @@ expand_prefix_list:
 """
 def expand_prefix_list(p_name: str,o_name: str,node: Box,topology: Box) -> typing.Optional[list]:
   for (p_idx,p_entry) in enumerate(node.routing[o_name][p_name]):
-    node.routing[o_name][p_name][p_idx] = expand_prefix_entry(node.routing[o_name][p_name][p_idx],topology)
+    x_path = f'nodes.{node.name}.routing.{o_name}.{p_name} sq#{p_entry.sequence}'
+    x_entry = expand_prefix_entry(node.routing[o_name][p_name][p_idx],x_path,topology)
+    node.routing[o_name][p_name][p_idx] = x_entry
 
   node.routing[o_name][p_name] = sorted(node.routing[o_name][p_name],key=lambda O: O.get('sequence',10))
   features = a_devices.get_device_features(node,topology.defaults)
@@ -155,10 +181,17 @@ def expand_prefix_list(p_name: str,o_name: str,node: Box,topology: Box) -> typin
   af_prefix: dict = {}                                      # Prepare dictionary of per-AF prefix lists
   for af in ('ipv4','ipv6'):                                # Iterate over address families (sorry, no CLNS or IPX)
     af_prefix[af] = []                                      # Start with an emtpy per-AF list
+    seq = 100                                               # ... with initial sequence# 100
     for p_entry in node.routing[o_name][p_name]:            # Iterate over prefix list entries
       if af in p_entry:                                     # Is the current AF in the prefix list entry?
-        af_p_entry = create_pfx_af_entry(p_entry,af,p_name,node,min_strict=min_strict)
-        af_prefix[af].append(af_p_entry)                    # create af-specific entry and append it to per-AF list
+        for af_item in p_entry[af]:                         # ... iterate over elements in the AF list        
+          af_p_entry = create_pfx_af_entry(                 # Create a new (single-item) prefix entry
+                          p_entry,af,af_item,               # ... from original entry and AF info
+                          seq,p_entry.sequence,             # ... using a new sequence number
+                          p_name,node,                      # ... and the pfx_name/node data
+                          min_strict=min_strict)
+          af_prefix[af].append(af_p_entry)                  # Append new prefix entry to per-AF list
+          seq += 10                                         # ... and increase sequence number
 
     if af_prefix[af]:                                       # Do we have a non-empty per-AF prefix list?
       node.routing['_'+o_name][af][p_name] = af_prefix[af]  # ... yes, save it

--- a/netsim/modules/routing/prefix.py
+++ b/netsim/modules/routing/prefix.py
@@ -171,7 +171,7 @@ expand_prefix_list:
 """
 def expand_prefix_list(p_name: str,o_name: str,node: Box,topology: Box) -> typing.Optional[list]:
   for (p_idx,p_entry) in enumerate(node.routing[o_name][p_name]):
-    x_path = f'nodes.{node.name}.routing.{o_name}.{p_name} sq#{p_entry.sequence}'
+    x_path = f'nodes.{node.name}.routing.{o_name}.{p_name} sequence#{p_entry.sequence}'
     x_entry = expand_prefix_entry(node.routing[o_name][p_name][p_idx],x_path,topology)
     node.routing[o_name][p_name][p_idx] = x_entry
 

--- a/tests/errors/prefix-list-min-max.log
+++ b/tests/errors/prefix-list-min-max.log
@@ -3,13 +3,13 @@ IncorrectValue in routing: Prefix filter ipv4.min value should be >= 8 (limited 
 IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited by address family)
 ... Node r1 (device frr) policy test_1 sequence# 1
 IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
-... Node r1 (device frr) policy test_1 sequence# 2
+... Node r1 (device frr) policy test_1 sequence# 2 prefix 172.17.0.0/16
 IncorrectValue in routing: Prefix filter ipv4.min value should be >= 9 (limited by 10.0.0.0/8)
 ... Node r2 (device iol) policy test_1 sequence# 1
 IncorrectValue in routing: Prefix filter ipv4.max value should be <= 32 (limited by address family)
 ... Node r2 (device iol) policy test_1 sequence# 1
 IncorrectValue in routing: Prefix filter ipv4.min should be <= ipv4.max
-... Node r2 (device iol) policy test_1 sequence# 2
+... Node r2 (device iol) policy test_1 sequence# 2 prefix 172.17.0.0/16
 IncorrectValue in routing: Cannot use prefix filter min keyword with prefix 172.17.3.4/32
 ... Node r2 (device iol) policy test_1 sequence# 3
 IncorrectValue in routing: Cannot use prefix filter max keyword with prefix 172.17.3.4/32

--- a/tests/integration/routing/10-match-prefix.yml
+++ b/tests/integration/routing/10-match-prefix.yml
@@ -2,10 +2,13 @@
 message: |
   Use this topology to test route maps with prefix lists for IPv4 and IPv6
 
-plugin: [ bgp.policy, test.vrf_check ]
+defaults.paths.prepend.plugin: [ "topology:../plugin" ]
+
+plugin: [ bgp.policy, test.vrf_check, adjust_test ]
 module: [ bgp ]
 
 defaults.sources.extra: [ defaults-ds.yml, ../wait_times.yml, ../warnings.yml ]
+defaults.devices.srlinux.warnings.prefix_deny: False
 
 prefix:
   b_orig_1.ipv4: 172.42.42.0/24
@@ -96,6 +99,15 @@ links:
 - vx1:
   prefix: b_orig_3
   bgp.advertise: True
+
+_adjust:
+- warning: Tested device does not have DENY action in prefix lists
+  nodes: [ dut ]
+  devices: [ srlinux ]                  # SR Linux cannot deny prefixes in a prefix-list
+  remove:                               # ... so we have to remove all tests relying on that functionality
+  - validate.pfx_o2_v4
+  - validate.pfx_o3_v6
+  - validate.vrf_o3_v6
 
 validate:
   ebgp_v4:

--- a/tests/topology/expected/rp-prefix-expansion.yml
+++ b/tests/topology/expected/rp-prefix-expansion.yml
@@ -1,7 +1,9 @@
 input:
 - topology/input/rp-prefix-expansion.yml
 - package:topology-defaults.yml
+links: []
 module:
+- vlan
 - routing
 name: input
 nodes:
@@ -26,6 +28,7 @@ nodes:
       ipv4: 192.168.121.101
       mac: ca:fe:00:01:00:00
     module:
+    - vlan
     - routing
     name: r1
     routing:
@@ -34,22 +37,22 @@ nodes:
           p1:
           - action: permit
             ipv4: 172.16.0.0/16
-            sequence: 10
+            sequence: 100
           - action: permit
             ipv4: 192.168.43.0/24
-            sequence: 20
+            sequence: 110
           p2:
           - action: deny
             ipv4: 192.168.44.32/28
-            sequence: 10
+            sequence: 100
           - action: permit
             ipv4: 192.168.44.0/24
-            sequence: 20
+            sequence: 110
         ipv6:
           p1:
           - action: permit
             ipv6: 2001:db8:dead:beef::/64
-            sequence: 20
+            sequence: 100
           p2:
           - action: deny
             ipv6: ::/0
@@ -57,18 +60,23 @@ nodes:
       prefix:
         p1:
         - action: permit
-          ipv4: 172.16.0.0/16
+          ipv4:
+          - 172.16.0.0/16
           sequence: 10
         - action: permit
-          ipv4: 192.168.43.0/24
-          ipv6: 2001:db8:dead:beef::/64
+          ipv4:
+          - 192.168.43.0/24
+          ipv6:
+          - 2001:db8:dead:beef::/64
           sequence: 20
         p2:
         - action: deny
-          ipv4: 192.168.44.32/28
+          ipv4:
+          - 192.168.44.32/28
           sequence: 10
         - action: permit
-          ipv4: 192.168.44.0/24
+          ipv4:
+          - 192.168.44.0/24
           sequence: 20
   r2:
     af:
@@ -91,6 +99,7 @@ nodes:
       ipv4: 192.168.121.102
       mac: ca:fe:00:02:00:00
     module:
+    - vlan
     - routing
     name: r2
     routing:
@@ -99,71 +108,110 @@ nodes:
           p1:
           - action: permit
             ipv4: 10.0.0.0/24
-            sequence: 10
+            sequence: 100
           - action: permit
             ipv4: 192.168.43.0/24
-            sequence: 20
+            sequence: 110
           p3:
           - action: permit
             ipv4: 192.168.16.0/22
-            sequence: 10
+            sequence: 100
           - action: permit
             ipv4: 10.0.0.0/24
             min: 32
-            sequence: 20
+            sequence: 110
           - action: permit
             ipv4: 192.168.42.0/24
-            sequence: 30
+            sequence: 120
           - action: permit
             ipv4: 0.0.0.0/0
             max: 24
             min: 8
-            sequence: 40
+            sequence: 130
+          p4:
+          - action: permit
+            ipv4: 10.0.0.1/32
+            sequence: 100
+          - action: permit
+            ipv4: 10.0.0.2/32
+            sequence: 110
+          - action: permit
+            ipv4: 172.16.0.0/16
+            sequence: 120
+          - action: permit
+            ipv4: 10.0.0.0/24
+            sequence: 130
+          - action: permit
+            ipv4: 10.1.0.0/16
+            sequence: 140
+          - action: permit
+            ipv4: 192.168.43.0/24
+            sequence: 150
+          - action: permit
+            ipv4: 172.16.0.0/24
+            sequence: 160
         ipv6:
           p1:
           - action: permit
             ipv6: 2001:db8:cafe::/48
-            sequence: 10
+            sequence: 100
           - action: permit
             ipv6: 2001:db8:dead:beef::/64
-            sequence: 20
+            sequence: 110
           p3:
           - action: permit
             ipv6: 2001:db8:cafe::/48
             min: 128
-            sequence: 20
+            sequence: 100
           - action: permit
             ipv6: ::/0
             max: 64
             min: 8
-            sequence: 40
+            sequence: 110
+          p4:
+          - action: permit
+            ipv6: 2001:db8:cafe::/48
+            sequence: 100
+          - action: permit
+            ipv6: 2001:db8:dead:beef::/64
+            sequence: 110
       prefix:
         p1:
         - action: permit
-          ipv4: 10.0.0.0/24
-          ipv6: 2001:db8:cafe::/48
+          ipv4:
+          - 10.0.0.0/24
+          ipv6:
+          - 2001:db8:cafe::/48
           sequence: 10
         - action: permit
-          ipv4: 192.168.43.0/24
-          ipv6: 2001:db8:dead:beef::/64
+          ipv4:
+          - 192.168.43.0/24
+          ipv6:
+          - 2001:db8:dead:beef::/64
           sequence: 20
         p3:
         - action: permit
-          ipv4: 192.168.16.0/22
+          ipv4:
+          - 192.168.16.0/22
           sequence: 10
         - action: permit
-          ipv4: 10.0.0.0/24
-          ipv6: 2001:db8:cafe::/48
+          ipv4:
+          - 10.0.0.0/24
+          ipv6:
+          - 2001:db8:cafe::/48
           min:
             ipv4: 32
             ipv6: 128
           sequence: 20
         - action: permit
-          ipv4: 192.168.42.0/24
+          ipv4:
+          - 192.168.42.0/24
           sequence: 30
         - action: permit
-          ipv4: 0.0.0.0/0
-          ipv6: ::/0
+          ipv4:
+          - 0.0.0.0/0
+          ipv6:
+          - ::/0
           max:
             ipv4: 24
             ipv6: 64
@@ -171,6 +219,20 @@ nodes:
             ipv4: 8
             ipv6: 8
           sequence: 40
+        p4:
+        - action: permit
+          ipv4:
+          - 10.0.0.1/32
+          - 10.0.0.2/32
+          - 172.16.0.0/16
+          - 10.0.0.0/24
+          - 10.1.0.0/16
+          - 192.168.43.0/24
+          - 172.16.0.0/24
+          ipv6:
+          - 2001:db8:cafe::/48
+          - 2001:db8:dead:beef::/64
+          sequence: 10
 prefix:
   any:
     ipv4: 0.0.0.0/0
@@ -185,36 +247,47 @@ routing:
   prefix:
     p1:
     - action: permit
-      ipv4: 192.168.43.0/24
-      ipv6: 2001:db8:dead:beef::/64
+      ipv4:
+      - 192.168.43.0/24
+      ipv6:
+      - 2001:db8:dead:beef::/64
       sequence: 20
     - action: permit
-      ipv4: 172.16.0.0/16
+      ipv4:
+      - 172.16.0.0/16
       sequence: 10
     p2:
     - action: deny
-      ipv4: 192.168.44.32/28
+      ipv4:
+      - 192.168.44.32/28
       sequence: 10
     - action: permit
-      ipv4: 192.168.44.0/24
+      ipv4:
+      - 192.168.44.0/24
       sequence: 20
     p3:
     - action: permit
-      ipv4: 192.168.16.0/22
+      ipv4:
+      - 192.168.16.0/22
       sequence: 10
     - action: permit
-      ipv4: 10.0.0.0/24
-      ipv6: 2001:db8:cafe::/48
+      ipv4:
+      - 10.0.0.0/24
+      ipv6:
+      - 2001:db8:cafe::/48
       min:
         ipv4: 32
         ipv6: 128
       sequence: 20
     - action: permit
-      ipv4: 192.168.42.0/24
+      ipv4:
+      - 192.168.42.0/24
       sequence: 30
     - action: permit
-      ipv4: 0.0.0.0/0
-      ipv6: ::/0
+      ipv4:
+      - 0.0.0.0/0
+      ipv6:
+      - ::/0
       max:
         ipv4: 24
         ipv6: 64
@@ -222,3 +295,9 @@ routing:
         ipv4: 8
         ipv6: 8
       sequence: 40
+vlans:
+  red:
+    id: 1000
+    prefix:
+      allocation: id_based
+      ipv4: 172.16.0.0/24

--- a/tests/topology/input/rp-prefix-expansion.yml
+++ b/tests/topology/input/rp-prefix-expansion.yml
@@ -3,8 +3,10 @@
 
 addressing.loopback.ipv6: 2001:db8:cafe::/48
 
-module: [routing]
+module: [routing, vlan]
 defaults.device: none
+
+vlans.red:
 
 prefix:
   pf1.ipv4: 192.168.42.0/24
@@ -42,3 +44,7 @@ nodes:
       p1:
       - pool: loopback
       p3:
+      p4:
+      - ipv4: [ 10.0.0.1/32, 10.0.0.2/32 ]
+        pool: [ lan, loopback ]
+        prefix: [ pool.p2p, pf2, vlan.red ]


### PR DESCRIPTION
Includes:
* Modified prefix list processing, expanding 'prefix' attribute into lists of ipv4/ipv6 prefixes, and allowing lists in ipv4, ipv6, and pool attributes.
* Modified transformation- and error tests
* Updated documentation