### PR TITLE
VyOS: vagrant box building hacks

### DIFF
--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -724,11 +724,11 @@ The `sonic` device also runs under *containerlab* with the community `docker-son
 (caveats-vyos)=
 ## VyOS
 
-**netlab ** uses VyOS 1.5, which is currently a rolling release with daily builds. However, all the configurations should also work on the 1.4 LTS release (since it was tested just before it became the new LTS).
+**netlab ** uses VyOS 1.5-compatible configuration syntax. The configurations should also work on the 1.4 LTS release (since it was tested just before it became the new LTS).
 
 The use of a *rolling release* means potentially any build is broken or with regressions, even if the VyOS team is smart enough to perform some [automated smoke tests](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) and load [arbitrary configurations](https://github.com/vyos/vyos-1x/tree/current/smoketest/configs) to ensure there are no errors during config migration and system bootup.
 
-Using the latest build published on [Vagrant Hub](https://app.vagrantup.com/vyos/boxes/current) should allow us to easily track and react to any configuration syntax change (which, anyway, is a very rare event). In any case, if you find a misalignment between the VyOS config and the **netlab** templates, feel free to *Open an Issue* or *Submit a PR*.
+Building a local Vagrant box from a recent [VyOS rolling/nightly](https://vyos.net/get/nightly-builds/) or VyOS Stream ISO image should allow us to easily track and react to any configuration syntax change (which, anyway, is a very rare event). In any case, if you find a misalignment between the VyOS config and the **netlab** templates, feel free to *Open an Issue* or *Submit a PR*.
 
 (vyos-clab)=
 It looks like the official VyOS container is not updated as part of the daily builds; *netlab* uses a [third-party container](https://github.com/sysoleg/vyos-container) (`ghcr.io/sysoleg/vyos-container`) to run VyOS with *containerlab*.

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -57,6 +57,7 @@ You have to use the following box names when installing or building the Vagrant 
 | Mikrotik RouterOS 7    | mikrotik/chr7               |
 | OpenBSD                | netlab/openbsd              |
 | Sonic                  | netlab/sonic                |
+| VyOS                   | vyos-local/vyos             |
 
 The following Vagrant boxes are automatically downloaded from Vagrant Cloud when you're using them for the first time in your lab topology:
 
@@ -64,13 +65,11 @@ The following Vagrant boxes are automatically downloaded from Vagrant Cloud when
 |------------------------|--------------------|
 | Cumulus VX             | CumulusCommunity/cumulus-vx:4.4.0 |
 | Generic Linux          | generic/ubuntu2004 |
-| VyOS                   | vyos/current       |
 
 **NOTES**:
 
 * Even if a new box version is available from Vagrant Cloud, Vagrant will only output a warning to let the user know an update is available. You can ignore that warning or update the box with `vagrant box update`. 
 * Vagrant does not automatically download the updated boxes because boxes can be relatively large (See [Vagrant box versioning](https://developer.hashicorp.com/vagrant/docs/boxes/versioning) for details).
-* We recommend that you periodically download the updated box for `vyos/current`
 
 (libvirt-build-boxes)=
 ### Building Vagrant Boxes
@@ -96,7 +95,7 @@ These documents contain box-building recipes using the **netlab libvirt** utilit
 * [Mikrotik RouterOS 7](routeros7.md) - based on the original [Mikrotik RouterOS](http://stefano.dscnet.org/a/mikrotik_vagrant/) by [Stefano Sasso](http://stefano.dscnet.org)
 * [OpenBSD](openbsd.md)
 * [Sonic](sonic.md)
-* [VyOS](https://github.com/ssasso/packer-vyos-vagrant) by [Stefano Sasso](http://stefano.dscnet.org) - if you don't want to use the one from Vagrant Cloud.
+* [VyOS](vyos.md) by [Stefano Sasso](http://stefano.dscnet.org)
 
 ```{note}
 For more Vagrant details, watch the *[Network Simulation Tools](https://my.ipspace.net/bin/list?id=NetTools#SIMULATE)* part of the *[Network Automation Tools](https://www.ipspace.net/Network_Automation_Tools)* webinar.
@@ -322,5 +321,6 @@ providers.libvirt.probe: []
    openbsd.md
    routeros7.md
    sonic.md
+   vyos.md
 ..
 ```

--- a/docs/labs/libvirt.md
+++ b/docs/labs/libvirt.md
@@ -57,7 +57,7 @@ You have to use the following box names when installing or building the Vagrant 
 | Mikrotik RouterOS 7    | mikrotik/chr7               |
 | OpenBSD                | netlab/openbsd              |
 | Sonic                  | netlab/sonic                |
-| VyOS                   | vyos-local/vyos             |
+| VyOS                   | netlab/vyos                 |
 
 The following Vagrant boxes are automatically downloaded from Vagrant Cloud when you're using them for the first time in your lab topology:
 

--- a/docs/labs/vyos.md
+++ b/docs/labs/vyos.md
@@ -1,86 +1,50 @@
 (build-vyos)=
 # Building a VyOS Libvirt Box
 
-VyOS is supported by the **netlab libvirt package** command. The public `vyos/current` Vagrant box is no longer maintained; build a local Vagrant box from a recent VyOS ISO image instead.
+VyOS is supported by the **netlab libvirt package** command. The public `vyos/current` Vagrant box is no longer maintained; instead, build a local Vagrant box from a recent VyOS ISO image.
 
 ```{warning}
-Building a VyOS Libvirt box is not a straightforward process, and this recipe is maintained on a best-effort basis. Use the VyOS containerlab image whenever possible.
+Building a VyOS Libvirt box is not straightforward, and this recipe is maintained on a best-effort basis. Use the VyOS containerlab image whenever possible.
 ```
+
+The default Vagrant box name used by _netlab_ is `netlab/vyos`. When the **netlab libvirt package** command asks for a box version, use the VyOS image version or build ID, for example `2026.09.01-0034-rolling`.
+
+The old `vyos/current` Vagrant box is no longer used as the default image. Set the `defaults.devices.vyos.libvirt.image` [default setting](topo-defaults) to `vyos/current` to use it ([more details](default-device-image)).
 
 ## Download a VyOS ISO Image
 
 You can use any recent VyOS ISO image that supports the configuration syntax used by _netlab_. The usual public choices are:
 
 * Download the latest VyOS rolling/nightly ISO image from the [VyOS rolling release builds](https://vyos.net/get/nightly-builds/) page.
-* Download a VyOS Stream ISO image from the [VyOS download](https://vyos.io/) page when you prefer a less volatile public preview build.
+* Download a VyOS Stream ISO image from the [VyOS download](https://vyos.io/) page if you prefer a less volatile public preview build.
 
-VyOS publishes `.minisig` files for public images. Use the verification instructions on the VyOS download page if you want to validate the ISO before installing it.
-
-The box-building process has two stages:
-
-* Create a base qcow2 disk image with VyOS installed from the ISO image.
-* Customize that installed disk image for Vagrant and package it as a Vagrant box.
-
-The explicit `virt-install` command in the first stage is needed because **netlab libvirt package** works with an existing virtual disk image; it does not install network operating systems from ISO images.
-
-## Create the VyOS Disk Image
-
-Create a temporary working directory outside your home directory, download the VyOS ISO image into that directory, and create an empty virtual disk:
-
-```
-qemu-img create -f qcow2 vyos.qcow2 10G
-```
-
-The `qemu:///system` libvirt session starts the VM as an unprivileged libvirt user. That user often cannot access files under your home directory, resulting in `Cannot access storage file ... Permission denied`. Working under `/var/tmp` (or `/tmp`) and making the ISO readable and the qcow2 disk writable avoids that problem during the first-stage installation. Remove the temporary directory after you package the Vagrant box.
-
-Start a temporary VM from the ISO image. Replace the ISO file name in the following command with the file you downloaded. The temporary VM does not need a network interface; skipping it avoids creating an `eth0` interface during the initial installation stage.
-
-```
-virt-install --connect=qemu:///system --name=vyos-install --arch=x86_64 --cpu host --vcpus=2 --hvm \
-  --osinfo linux2022 --ram=1024 --network none --graphics none \
-  --disk path=vyos.qcow2,format=qcow2,bus=virtio \
-  --cdrom=vyos-rolling-latest.iso --boot cdrom,hd --noreboot
-```
-
-If your *virt-install* version does not recognize `linux2022`, use `virt-install --osinfo list` to find the closest generic Linux value available on your system.
-
-The `--noreboot` option prevents *virt-install* from restarting the VM after the installation finishes or the live system powers off.
-
-Log into the live system as `vyos` with password `vyos`, run `install image`, and install VyOS on `/dev/vda`. When the installer asks for the default console, use the default serial console. Use `vyos` as the password for the `vyos` user.
-
-Power off the VM after the installation completes (`poweroff` command) and remove the temporary VM definition:
-
-```
-virsh undefine vyos-install
-```
+VyOS publishes `.minisig` files for public images. Use the verification instructions on the VyOS download page to validate the ISO before installing it.
 
 ## Build the Vagrant Box
 
-After creating the installed VyOS disk image, execute **netlab libvirt package vyos _virtual-disk-file-name_** and follow the instructions:
-
-```
-netlab libvirt package vyos vyos.qcow2
-```
+Execute **netlab libvirt package vyos _iso-image-name_** and follow the instructions.
 
 ```{warning}
 If you're using a *netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
 ```
 
-## Initial Device Configuration
+The box-building process has two stages:
 
-During the second stage, **netlab libvirt package** starts the installed VyOS disk image with a temporary management interface so you can customize it for Vagrant from the console and copy the first-boot script into the VM. **netlab libvirt config vyos** command displays the build recipe:
-
-The packaged Vagrant box must not contain an `eth0` configuration node. Keeping `eth0` without `hw-id` makes VyOS treat it as a pending hardware binding; when a lab VM has multiple NICs, VyOS refuses to guess which NIC should inherit the `eth0` configuration and the boot fails. If you are reusing a disk from an earlier failed attempt, recreate the base qcow2 image before continuing.
-
-The recipe copies [netsim/install/libvirt/vyos/netlab-vyos-firstboot](../../netsim/install/libvirt/vyos/netlab-vyos-firstboot) into the VM as `/config/scripts/vyos-preconfig-bootup.script`. When the real lab VM boots, VyOS runs that persistent preconfig script after initial interface name resolution but before interface rescan and before the boot configuration is loaded. The script finds the netlab management interface by its `ca:fe:*` MAC address and deterministic netlab data interfaces by their `ca:f0:*` MAC addresses, writes matching `hw-id` bindings into the boot configuration, marks itself done, and triggers a reboot. On the next boot, VyOS uses those saved `hw-id` bindings to rename the interfaces before loading the configuration.
+* The VM with an empty disk is booted from the ISO image
+* You start the VyOS installation process and reboot the VM
+* The VM is booted from the virtual disk
+* You mount the secondary CD-ROM and execute the final installation script
 
 ```{eval-rst}
 .. include:: vyos.txt
    :literal:
 ```
 
+## Behind the Scenes
+
+The installation script copies _netsim_ firstboot script into the VM as `/config/scripts/vyos-preconfig-bootup.script`. When the lab VM boots from the Vagrant box, VyOS runs that persistent preconfig script after initial interface name resolution, but before interface rescan and before the boot configuration is loaded. The script finds the netlab management interface by its `ca:fe:*` MAC address and netlab data interfaces by their `ca:f0:*` MAC addresses, writes matching `hw-id` bindings into the boot configuration, marks itself done, and triggers a reboot. On the next boot, VyOS uses those saved `hw-id` bindings to rename the interfaces before loading the configuration.
+
 ## Notes on Using the VyOS Box
 
 The default Vagrant box name used by _netlab_ is `vyos-local/vyos`. When **netlab libvirt package** asks for a box version, use the VyOS image version or build ID, for example `2026.09.01-0034-rolling`.
 
-If you still have the old `vyos/current` Vagrant box installed, it will not be used by default. To use it temporarily, set `defaults.devices.vyos.libvirt.image` to `vyos/current` in your topology or user defaults.

--- a/docs/labs/vyos.md
+++ b/docs/labs/vyos.md
@@ -46,5 +46,5 @@ The installation script copies _netsim_ firstboot script into the VM as `/config
 
 ## Notes on Using the VyOS Box
 
-The default Vagrant box name used by _netlab_ is `vyos-local/vyos`. When **netlab libvirt package** asks for a box version, use the VyOS image version or build ID, for example `2026.09.01-0034-rolling`.
+The default Vagrant box name used by _netlab_ is `netlab/vyos`. When **netlab libvirt package** asks for a box version, use the VyOS image version or build ID, for example `2026.09.01-0034-rolling`.
 

--- a/docs/labs/vyos.md
+++ b/docs/labs/vyos.md
@@ -1,0 +1,86 @@
+(build-vyos)=
+# Building a VyOS Libvirt Box
+
+VyOS is supported by the **netlab libvirt package** command. The public `vyos/current` Vagrant box is no longer maintained; build a local Vagrant box from a recent VyOS ISO image instead.
+
+```{warning}
+Building a VyOS Libvirt box is not a straightforward process, and this recipe is maintained on a best-effort basis. Use the VyOS containerlab image whenever possible.
+```
+
+## Download a VyOS ISO Image
+
+You can use any recent VyOS ISO image that supports the configuration syntax used by _netlab_. The usual public choices are:
+
+* Download the latest VyOS rolling/nightly ISO image from the [VyOS rolling release builds](https://vyos.net/get/nightly-builds/) page.
+* Download a VyOS Stream ISO image from the [VyOS download](https://vyos.io/) page when you prefer a less volatile public preview build.
+
+VyOS publishes `.minisig` files for public images. Use the verification instructions on the VyOS download page if you want to validate the ISO before installing it.
+
+The box-building process has two stages:
+
+* Create a base qcow2 disk image with VyOS installed from the ISO image.
+* Customize that installed disk image for Vagrant and package it as a Vagrant box.
+
+The explicit `virt-install` command in the first stage is needed because **netlab libvirt package** works with an existing virtual disk image; it does not install network operating systems from ISO images.
+
+## Create the VyOS Disk Image
+
+Create a temporary working directory outside your home directory, download the VyOS ISO image into that directory, and create an empty virtual disk:
+
+```
+qemu-img create -f qcow2 vyos.qcow2 10G
+```
+
+The `qemu:///system` libvirt session starts the VM as an unprivileged libvirt user. That user often cannot access files under your home directory, resulting in `Cannot access storage file ... Permission denied`. Working under `/var/tmp` (or `/tmp`) and making the ISO readable and the qcow2 disk writable avoids that problem during the first-stage installation. Remove the temporary directory after you package the Vagrant box.
+
+Start a temporary VM from the ISO image. Replace the ISO file name in the following command with the file you downloaded. The temporary VM does not need a network interface; skipping it avoids creating an `eth0` interface during the initial installation stage.
+
+```
+virt-install --connect=qemu:///system --name=vyos-install --arch=x86_64 --cpu host --vcpus=2 --hvm \
+  --osinfo linux2022 --ram=1024 --network none --graphics none \
+  --disk path=vyos.qcow2,format=qcow2,bus=virtio \
+  --cdrom=vyos-rolling-latest.iso --boot cdrom,hd --noreboot
+```
+
+If your *virt-install* version does not recognize `linux2022`, use `virt-install --osinfo list` to find the closest generic Linux value available on your system.
+
+The `--noreboot` option prevents *virt-install* from restarting the VM after the installation finishes or the live system powers off.
+
+Log into the live system as `vyos` with password `vyos`, run `install image`, and install VyOS on `/dev/vda`. When the installer asks for the default console, use the default serial console. Use `vyos` as the password for the `vyos` user.
+
+Power off the VM after the installation completes (`poweroff` command) and remove the temporary VM definition:
+
+```
+virsh undefine vyos-install
+```
+
+## Build the Vagrant Box
+
+After creating the installed VyOS disk image, execute **netlab libvirt package vyos _virtual-disk-file-name_** and follow the instructions:
+
+```
+netlab libvirt package vyos vyos.qcow2
+```
+
+```{warning}
+If you're using a *netlab* release older than 1.8.2, or if you're using a Linux distribution other than Ubuntu, please [read the box-building caveats first](libvirt-box-caveats.md).
+```
+
+## Initial Device Configuration
+
+During the second stage, **netlab libvirt package** starts the installed VyOS disk image with a temporary management interface so you can customize it for Vagrant from the console and copy the first-boot script into the VM. **netlab libvirt config vyos** command displays the build recipe:
+
+The packaged Vagrant box must not contain an `eth0` configuration node. Keeping `eth0` without `hw-id` makes VyOS treat it as a pending hardware binding; when a lab VM has multiple NICs, VyOS refuses to guess which NIC should inherit the `eth0` configuration and the boot fails. If you are reusing a disk from an earlier failed attempt, recreate the base qcow2 image before continuing.
+
+The recipe copies [netsim/install/libvirt/vyos/netlab-vyos-firstboot](../../netsim/install/libvirt/vyos/netlab-vyos-firstboot) into the VM as `/config/scripts/vyos-preconfig-bootup.script`. When the real lab VM boots, VyOS runs that persistent preconfig script after initial interface name resolution but before interface rescan and before the boot configuration is loaded. The script finds the netlab management interface by its `ca:fe:*` MAC address and deterministic netlab data interfaces by their `ca:f0:*` MAC addresses, writes matching `hw-id` bindings into the boot configuration, marks itself done, and triggers a reboot. On the next boot, VyOS uses those saved `hw-id` bindings to rename the interfaces before loading the configuration.
+
+```{eval-rst}
+.. include:: vyos.txt
+   :literal:
+```
+
+## Notes on Using the VyOS Box
+
+The default Vagrant box name used by _netlab_ is `vyos-local/vyos`. When **netlab libvirt package** asks for a box version, use the VyOS image version or build ID, for example `2026.09.01-0034-rolling`.
+
+If you still have the old `vyos/current` Vagrant box installed, it will not be used by default. To use it temporarily, set `defaults.devices.vyos.libvirt.image` to `vyos/current` in your topology or user defaults.

--- a/docs/labs/vyos.txt
+++ b/docs/labs/vyos.txt
@@ -1,0 +1,1 @@
+../../netsim/install/libvirt/vyos.txt

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -150,7 +150,7 @@ You cannot use all supported network devices with all virtualization providers. 
 | OpenBSD             |  [✅](build-openbsd)  |  [✅](clab-vrnetlab)  |
 | SONiC               | [✅](build-sonic-box) | [✅](build-sonic-container) |
 | VPP                 |  ❌  |  ✅  |
-| VyOS                |  ✅  |  ✅[❗](caveats-vyos)  |
+| VyOS                |  [✅](build-vyos)  |  ✅[❗](caveats-vyos)  |
 
 **Note:**
 

--- a/netsim/cli/libvirt/package.py
+++ b/netsim/cli/libvirt/package.py
@@ -49,7 +49,7 @@ def package_parse(args: typing.List[str], settings: Box) -> argparse.Namespace:
     dest='disk',
     action='store',
     type=argparse.FileType('r'),
-    help='Virtual machine disk (vmdk or qcow2)')
+    help='Virtual machine disk (qcow2, vmdk, ova, zip, or iso)')
 
   parser_add_verbose(parser)
   parser_add_debug(parser)
@@ -175,6 +175,11 @@ def abort_on_failure(cmd: str) -> None:
   if not external_commands.run_command(cmd):
     log.fatal('Aborting')
 
+def check_disk_type(fname: str) -> None:
+  fext = fname.rsplit('.')[-1]
+  if fext not in ('qcow2','vmdk','ova','zip','iso'):
+    log.fatal(f'Unknown disk image type {fext}')
+
 def lp_create_vm_disk(args: argparse.Namespace, workdir: str) -> None:
   name = args.disk.name
 
@@ -184,7 +189,7 @@ def lp_create_vm_disk(args: argparse.Namespace, workdir: str) -> None:
     abort_on_failure(f'unzip {name}')
     name = name[:-4]
 
-  if '.ova' in name:
+  if name.endswith('.ova'):
     strings.print_colored_text('[UNPACK]  ','green',None)
     print(f"Unpacking OVA archive {name}")
     abort_on_failure(f'tar xvf {name}')
@@ -193,11 +198,18 @@ def lp_create_vm_disk(args: argparse.Namespace, workdir: str) -> None:
       log.fatal('The OVA archive did not contain a VMDK disk, aborting','libvirt')
     name = vmdk[0]
 
-  if '.vmdk' in name:
+  if name.endswith('.vmdk'):
     strings.print_colored_text('[CONVERT] ','green',None)
     print(f"Converting {name} into qcow2 format")
     abort_on_failure(f'qemu-img convert -f vmdk -O qcow2 {name} {workdir}/vm.qcow2')
-  else:
+  elif name.endswith('.iso'):
+    strings.print_colored_text('[COPY]    ','green',None)
+    print(f"Creating {workdir}/install.iso from {name}")
+    abort_on_failure(f'cp {name} {workdir}/install.iso')
+    strings.print_colored_text('[CREATE]  ','green',None)
+    print(f"Creating empty VM disk vm.qcow2")
+    abort_on_failure(f'qemu-img create -f qcow2 {workdir}/vm.qcow2 20G')
+  else:     # Must be qcow2, or our type-checking routine is broken
     strings.print_colored_text('[COPY]    ','green',None)
     print(f"Creating a copy of {name} in {workdir}")
     abort_on_failure(f'cp {name} {workdir}/vm.qcow2')
@@ -511,7 +523,7 @@ def run(cli_args: typing.List[str], topology: Box) -> None:
   settings = topology.defaults
   args = package_parse(cli_args,settings)
   log.set_logging_flags(args)
-
+  check_disk_type(args.disk.name)
   workdir = f'/tmp/build_{args.device}'
   try:
     build(args,topology,workdir)

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -9,12 +9,10 @@ tunnel_interface_name:
   wireguard: wg{ifindex}
 mgmt_if: eth0
 libvirt:
-  image: vyos-local/vyos
+  image: netlab/vyos
   build: https://netlab.tools/labs/vyos/
-  create:
-    virt-install --connect=qemu:///system --name=vm_box --arch=x86_64 --cpu host --vcpus=2 --hvm
-      --osinfo linux2022 --ram=1024 --network=network:vagrant-libvirt,model=virtio --graphics none --import
-      --disk path=vm.qcow2,format=qcow2,bus=virtio
+  create_template: vyos.xml.j2
+  create_iso: vyos
 group_vars:
   ansible_network_os: vyos
   ansible_connection: paramiko

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -9,7 +9,12 @@ tunnel_interface_name:
   wireguard: wg{ifindex}
 mgmt_if: eth0
 libvirt:
-  image: vyos/current
+  image: vyos-local/vyos
+  build: https://netlab.tools/labs/vyos/
+  create:
+    virt-install --connect=qemu:///system --name=vm_box --arch=x86_64 --cpu host --vcpus=2 --hvm
+      --osinfo linux2022 --ram=1024 --network=network:vagrant-libvirt,model=virtio --graphics none --import
+      --disk path=vm.qcow2,format=qcow2,bus=virtio
 group_vars:
   ansible_network_os: vyos
   ansible_connection: paramiko
@@ -22,6 +27,7 @@ features:
       unnumbered: true
     ipv6:
       lla: True
+    generate_mac: [ ethernet ]
     collect: true
     reload: true
   services:

--- a/netsim/install/libvirt/vyos.txt
+++ b/netsim/install/libvirt/vyos.txt
@@ -1,55 +1,20 @@
-Customizing VyOS for Vagrant
+Installing VyOS from ISO image
+==============================
+
+* Wait for the VM to boot
+* Log in using `vyos` as username and password
+* Run `install image`
+* Install VyOS on `/dev/vda`. Answer 'Y' or accept defaults for all questions.
+  Set password to `vyos`
+* Reboot the VM with `reboot`
+
+Initial configuration
 ============================
 
-* The VM should already boot from the VyOS disk image created in the first stage
-* Wait for the 'login' prompt
-* Login as 'vyos' with password 'vyos'
-* Copy-paste the following configuration to enable SSH access to the temporary VM
+* Wait for the VM to boot
+* Log in using `vyos` as username and password
+* Mount the secondary CD-ROM with `sudo mount /dev/sr1 /mnt`
+* Execute `bash /mnt/install.sh`
 
-============================
-
-configure
-set interfaces ethernet eth0 address dhcp
-set interfaces ethernet eth0 description 'Temporary build management'
-set interfaces ethernet eth0 vrf 'management'
-set service ssh vrf 'management'
-set vrf name management table '65530'
-set system login user vyos authentication public-keys vagrant-insecure type ssh-rsa
-set system login user vyos authentication public-keys vagrant-insecure key 'AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ=='
-commit
-save
-
-exit
-
-show interfaces ethernet eth0
-
-============================
-
-* Find the temporary DHCP address assigned to eth0 in the command output
-* From the netlab repository root in another terminal, copy the first-boot script
-  to the temporary VM, replacing TEMP_IP with the eth0 address:
-
-============================
-
-scp netsim/install/libvirt/vyos/netlab-vyos-firstboot vyos@TEMP_IP:/tmp/
-
-============================
-
-* Go back to the VM console
-* Copy-paste the following commands to install the first-boot script and remove
-  the temporary eth0 configuration before packaging the box
-
-============================
-
-sudo install -o root -g root -m 755 /tmp/netlab-vyos-firstboot /config/scripts/vyos-preconfig-bootup.script
-
-configure
-delete interfaces ethernet eth0
-commit
-save
-
-exit
-
-============================
-
-* Shutdown the VM with 'poweroff'
+The installation script configures the management VRF, installs pre-boot script,
+and powers off the VM

--- a/netsim/install/libvirt/vyos.txt
+++ b/netsim/install/libvirt/vyos.txt
@@ -1,0 +1,55 @@
+Customizing VyOS for Vagrant
+============================
+
+* The VM should already boot from the VyOS disk image created in the first stage
+* Wait for the 'login' prompt
+* Login as 'vyos' with password 'vyos'
+* Copy-paste the following configuration to enable SSH access to the temporary VM
+
+============================
+
+configure
+set interfaces ethernet eth0 address dhcp
+set interfaces ethernet eth0 description 'Temporary build management'
+set interfaces ethernet eth0 vrf 'management'
+set service ssh vrf 'management'
+set vrf name management table '65530'
+set system login user vyos authentication public-keys vagrant-insecure type ssh-rsa
+set system login user vyos authentication public-keys vagrant-insecure key 'AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ=='
+commit
+save
+
+exit
+
+show interfaces ethernet eth0
+
+============================
+
+* Find the temporary DHCP address assigned to eth0 in the command output
+* From the netlab repository root in another terminal, copy the first-boot script
+  to the temporary VM, replacing TEMP_IP with the eth0 address:
+
+============================
+
+scp netsim/install/libvirt/vyos/netlab-vyos-firstboot vyos@TEMP_IP:/tmp/
+
+============================
+
+* Go back to the VM console
+* Copy-paste the following commands to install the first-boot script and remove
+  the temporary eth0 configuration before packaging the box
+
+============================
+
+sudo install -o root -g root -m 755 /tmp/netlab-vyos-firstboot /config/scripts/vyos-preconfig-bootup.script
+
+configure
+delete interfaces ethernet eth0
+commit
+save
+
+exit
+
+============================
+
+* Shutdown the VM with 'poweroff'

--- a/netsim/install/libvirt/vyos.xml.j2
+++ b/netsim/install/libvirt/vyos.xml.j2
@@ -1,0 +1,188 @@
+<domain type='kvm' id='65'>
+  <name>vm_box</name>
+  <metadata>
+    <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
+      <libosinfo:os id="http://libosinfo.org/linux/2022"/>
+    </libosinfo:libosinfo>
+  </metadata>
+  <memory unit='MiB'>1024</memory>
+  <currentMemory unit='MiB'>1024</currentMemory>
+  <vcpu placement='static'>2</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64' machine='pc-q35-6.2'>hvm</type>
+    <boot dev='hd'/>
+    <boot dev='cdrom'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+  </features>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='{{ user.cwd }}/vm.qcow2' index='3'/>
+      <backingStore/>
+      <target dev='vda' bus='virtio'/>
+      <alias name='virtio-disk0'/>
+      <address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='{{ user.cwd }}/install.iso' index='2'/>
+      <backingStore/>
+      <target dev='sda' bus='sata'/>
+      <readonly/>
+      <alias name='sata0-0-0'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <source file='{{ user.cwd }}/bootstrap.iso' index='1'/>
+      <backingStore/>
+      <target dev='sdb' bus='sata'/>
+      <readonly/>
+      <alias name='sata0-0-1'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
+    </disk>
+    <controller type='usb' index='0' model='qemu-xhci' ports='15'>
+      <alias name='usb'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </controller>
+    <controller type='pci' index='0' model='pcie-root'>
+      <alias name='pcie.0'/>
+    </controller>
+    <controller type='pci' index='1' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='1' port='0x8'/>
+      <alias name='pci.1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='2' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='2' port='0x9'/>
+      <alias name='pci.2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
+    </controller>
+    <controller type='pci' index='3' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='3' port='0xa'/>
+      <alias name='pci.3'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='4' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='4' port='0xb'/>
+      <alias name='pci.4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x3'/>
+    </controller>
+    <controller type='pci' index='5' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='5' port='0xc'/>
+      <alias name='pci.5'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x4'/>
+    </controller>
+    <controller type='pci' index='6' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='6' port='0xd'/>
+      <alias name='pci.6'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x5'/>
+    </controller>
+    <controller type='pci' index='7' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='7' port='0xe'/>
+      <alias name='pci.7'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x6'/>
+    </controller>
+    <controller type='pci' index='8' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='8' port='0xf'/>
+      <alias name='pci.8'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x7'/>
+    </controller>
+    <controller type='pci' index='9' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='9' port='0x10'/>
+      <alias name='pci.9'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='pci' index='10' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='10' port='0x11'/>
+      <alias name='pci.10'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x1'/>
+    </controller>
+    <controller type='pci' index='11' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='11' port='0x12'/>
+      <alias name='pci.11'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x2'/>
+    </controller>
+    <controller type='pci' index='12' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='12' port='0x13'/>
+      <alias name='pci.12'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x3'/>
+    </controller>
+    <controller type='pci' index='13' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='13' port='0x14'/>
+      <alias name='pci.13'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x4'/>
+    </controller>
+    <controller type='pci' index='14' model='pcie-root-port'>
+      <model name='pcie-root-port'/>
+      <target chassis='14' port='0x15'/>
+      <alias name='pci.14'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x5'/>
+    </controller>
+    <controller type='sata' index='0'>
+      <alias name='ide'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    </controller>
+    <controller type='virtio-serial' index='0'>
+      <alias name='virtio-serial0'/>
+      <address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
+    </controller>
+    <serial type='pty'>
+      <source path='/dev/pts/1'/>
+      <target type='isa-serial' port='0'>
+        <model name='isa-serial'/>
+      </target>
+      <alias name='serial0'/>
+    </serial>
+    <console type='pty' tty='/dev/pts/1'>
+      <source path='/dev/pts/1'/>
+      <target type='serial' port='0'/>
+      <alias name='serial0'/>
+    </console>
+    <channel type='unix'>
+      <source mode='bind' path='/var/lib/libvirt/qemu/channel/target/domain-65-vyos-install/org.qemu.guest_agent.0'/>
+      <target type='virtio' name='org.qemu.guest_agent.0' state='disconnected'/>
+      <alias name='channel0'/>
+      <address type='virtio-serial' controller='0' bus='0' port='1'/>
+    </channel>
+    <input type='mouse' bus='ps2'>
+      <alias name='input0'/>
+    </input>
+    <input type='keyboard' bus='ps2'>
+      <alias name='input1'/>
+    </input>
+    <audio id='1' type='none'/>
+    <memballoon model='virtio'>
+      <alias name='balloon0'/>
+      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <alias name='rng0'/>
+      <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    </rng>
+  </devices>
+</domain>

--- a/netsim/install/libvirt/vyos/install.sh
+++ b/netsim/install/libvirt/vyos/install.sh
@@ -1,0 +1,15 @@
+#!/bin/vbash
+source /opt/vyatta/etc/functions/script-template
+if [ "$(id -g -n)" != 'vyattacfg' ] ; then
+    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
+fi
+sudo install -o root -g root -m 755 /mnt/netlab-vyos-firstboot /config/scripts/vyos-preconfig-bootup.script
+configure
+set service ssh vrf 'management'
+set vrf name management table '65530'
+set system login user vyos authentication public-keys vagrant-insecure type ssh-rsa
+set system login user vyos authentication public-keys vagrant-insecure key 'AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ=='
+commit
+save
+sudo poweroff
+exit

--- a/netsim/install/libvirt/vyos/netlab-vyos-firstboot
+++ b/netsim/install/libvirt/vyos/netlab-vyos-firstboot
@@ -82,7 +82,7 @@ def main() -> None:
     expected_interfaces = {'eth0': mgmt_mac} | get_netlab_data_interfaces(live_interfaces)
     update_boot_config(expected_interfaces)
     MARKER_FILE.write_text('done\n')
-#    reboot()
+    reboot()
 
 
 if __name__ == '__main__':

--- a/netsim/install/libvirt/vyos/netlab-vyos-firstboot
+++ b/netsim/install/libvirt/vyos/netlab-vyos-firstboot
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import subprocess
+
+from vyos.configtree import ConfigTree
+
+
+CONFIG_FILE = Path('/opt/vyatta/etc/config/config.boot')
+MARKER_FILE = Path('/opt/vyatta/etc/config/.netlab-vyos-firstboot.done')
+
+
+def get_live_interfaces() -> dict[str, str]:
+    interfaces = {}
+    for address_file in sorted(Path('/sys/class/net').glob('eth*/address')):
+        try:
+            mac = address_file.read_text().strip().lower()
+        except OSError:
+            continue
+        interfaces[address_file.parent.name] = mac
+    return interfaces
+
+
+def get_management_mac(interfaces: dict[str, str]) -> str:
+    for mac in interfaces.values():
+        if mac.startswith('ca:fe:'):
+            return mac
+    return ''
+
+
+def get_netlab_data_interfaces(interfaces: dict[str, str]) -> dict[str, str]:
+    data_interfaces = {}
+    for _, mac in interfaces.items():
+        octets = mac.split(':')
+        if len(octets) != 6 or octets[0:2] != ['ca', 'f0']:
+            continue
+        ifindex = int(octets[4] + octets[5], 16)
+        if ifindex > 0:
+            data_interfaces[f'eth{ifindex}'] = mac
+    return data_interfaces
+
+
+def update_boot_config(expected_interfaces: dict[str, str]) -> None:
+    config = ConfigTree(CONFIG_FILE.read_text())
+    eth_base = ['interfaces', 'ethernet']
+    expected_names = set(expected_interfaces)
+    expected_macs = set(expected_interfaces.values())
+
+    if config.exists(eth_base):
+        for ifname in list(config.list_nodes(eth_base)):
+            if_hw_id = eth_base + [ifname, 'hw-id']
+            same_hwid = config.exists(if_hw_id) and config.return_value(if_hw_id).lower() in expected_macs
+            if ifname in expected_names or same_hwid:
+                config.delete(eth_base + [ifname])
+
+    if not config.exists(eth_base):
+        config.set(eth_base)
+    config.set_tag(eth_base)
+    for ifname, mac in expected_interfaces.items():
+        config.set(eth_base + [ifname, 'hw-id'], value=mac)
+
+    config.set(eth_base + ['eth0', 'address'], value='dhcp')
+    config.set(eth_base + ['eth0', 'description'], value='Out-Of-Band')
+    config.set(eth_base + ['eth0', 'vrf'], value='management')
+
+    CONFIG_FILE.write_text(config.to_string())
+
+
+def reboot() -> None:
+    subprocess.run(['systemctl', 'reboot', '--no-wall'], check=False)
+
+
+def main() -> None:
+    if MARKER_FILE.exists() or not CONFIG_FILE.exists():
+        return
+
+    live_interfaces = get_live_interfaces()
+    mgmt_mac = get_management_mac(live_interfaces)
+    if not mgmt_mac:
+        return
+
+    expected_interfaces = {'eth0': mgmt_mac} | get_netlab_data_interfaces(live_interfaces)
+    update_boot_config(expected_interfaces)
+    MARKER_FILE.write_text('done\n')
+    reboot()
+
+
+if __name__ == '__main__':
+    main()

--- a/netsim/install/libvirt/vyos/netlab-vyos-firstboot
+++ b/netsim/install/libvirt/vyos/netlab-vyos-firstboot
@@ -82,7 +82,7 @@ def main() -> None:
     expected_interfaces = {'eth0': mgmt_mac} | get_netlab_data_interfaces(live_interfaces)
     update_boot_config(expected_interfaces)
     MARKER_FILE.write_text('done\n')
-    reboot()
+#    reboot()
 
 
 if __name__ == '__main__':

--- a/netsim/templates/provider/libvirt/libvirt-bridge.j2
+++ b/netsim/templates/provider/libvirt/libvirt-bridge.j2
@@ -23,6 +23,9 @@
 {% if ifname|length < 16 %}
                   :libvirt__iface_name => "{{ ifname }}",
 {% endif %}
+{% if l.mac_address is defined %}
+                  :libvirt__mac => "{{ l.mac_address|hwaddr('linux') }}",
+{% endif %}
                   :autostart => true,
                   :auto_config => false
 

--- a/netsim/templates/provider/libvirt/vyos-domain.j2
+++ b/netsim/templates/provider/libvirt/vyos-domain.j2
@@ -1,6 +1,10 @@
     {{ name }}.vm.guest = :linux
     {{ name }}.vm.synced_folder ".", "/vagrant", id: "vagrant-root", disabled: true
 
+    {{ name }}.ssh.insert_key = false
+    {{ name }}.ssh.username = "{{ n.ansible_user }}"
+    {{ name }}.ssh.password = "{{ n.ansible_ssh_pass }}"
+
     {{ name }}.vm.provider :libvirt do |domain|
       domain.cpus = 2
       domain.memory = 1024


### PR DESCRIPTION
Fixes #3841 

It's "a bit" hacky, but I put a warning on the box building document about this, and about the fact that for this reason we suggest using the containerlab version.

However, it works.

Tested with
`netlab up -p libvirt -d vyos 01-interfaces.yml --validate` (building issues are in the interface presence & ordering)

```
[SUCCESS] Lab devices configured


This scenario tests basic interface, IPv4, and IPv6 configuration, including generation of IPv6 Router Advertisements
[ping]     IPv4 ping H1,H2 => R [ node(s): h1,h2 ]
[PASS]     h1: Ping to 10.0.0.132 succeeded
[PASS]     h2: Ping to 10.0.0.132 succeeded
[PASS]     Test succeeded in 0.4 seconds

[ping6]    IPv6 ping H1,H2 => R [ node(s): h1,h2 ]
[PASS]     h1: Ping to 2001:db8:0:84::1 succeeded
[PASS]     h2: Ping to 2001:db8:0:84::1 succeeded
[PASS]     Test succeeded in 0.4 seconds

[shutdown] Check link shutdown (ping H3 => R) [ node(s): h3 ]
[PASS]     h3: Ping to 10.0.0.132 failed as expected
[PASS]     Test succeeded in 3.2 seconds

[SUCCESS]  Tests passed: 5
```

Given all this, up to you @ipspace if you want to merge this or not.