### PR TITLE
Add LAG for RouterOS7

### DIFF
--- a/netsim/ansible/templates/initial/routeros7.j2
+++ b/netsim/ansible/templates/initial/routeros7.j2
@@ -39,6 +39,8 @@
 {%     set intf_type = 'gre6' if l.tunnel.af == 'ipv6' else 'gre' %}
 {%   elif l.type == 'tunnel' and l.tunnel.mode == 'wireguard' %}
 {%     set intf_type = 'wireguard' %}
+{%   elif l.type == 'lag' %}
+{%     set intf_type = 'bonding' %}
 {%   else %}
 {%     set intf_type = 'ethernet' %}
 {%   endif %}
@@ -70,3 +72,4 @@
 
 {% endfor %}
 /ip/neighbor/discovery-settings set discover-interface-list=all
+

--- a/netsim/ansible/templates/lag/routeros7.initial.j2
+++ b/netsim/ansible/templates/lag/routeros7.initial.j2
@@ -1,0 +1,17 @@
+{% for intf in interfaces if intf.type == 'lag' %}
+{%   set bond_intfs=[] %}
+{%   for i in interfaces if i.lag._parentindex|default(None) == intf.lag.ifindex %}
+{%     set _ = bond_intfs.append(i.ifname) %}
+{%   endfor %}
+/interface/bonding add name={{ intf.ifname }} slaves={{ bond_intfs|join(',') }} mode=802.3ad
+{% endfor +%}
+{#
+    Set LAG member MTU before creating VLAN interfaces on the bond
+#}
+{% for intf in interfaces %}
+{%   if intf.lag is defined
+      and intf.lag._parentindex is defined
+      and intf.mtu is defined %}
+/interface/ethernet set [ find name={{ intf.ifname }} ] mtu={{ intf.mtu }}
+{%   endif %}
+{% endfor %}

--- a/netsim/ansible/templates/lag/routeros7.j2
+++ b/netsim/ansible/templates/lag/routeros7.j2
@@ -1,0 +1,29 @@
+{% for intf in interfaces if intf.type == 'lag' %}
+{%    if intf.lag.lacp|default('') == 'fast' %}
+/interface/bonding set [find name={{ intf.ifname }}] lacp-rate=1sec
+{%    elif intf.lag.lacp|default('') == 'slow' %}
+/interface/bonding set [find name={{ intf.ifname }}] lacp-rate=30sec
+{%    elif intf.lag.lacp|default('') == 'off' %}
+/interface/bonding set [find name={{ intf.ifname }}] mode=xor-hash
+{%    endif %}
+{%   if intf.lag.lacp_system_id is defined %}
+/interface/bonding set [find name={{ intf.ifname }}] lacp-system-id={{ intf.lag.lacp_system_id }}
+{%   endif %}
+{%   if intf.lag.lacp_mode|default('') == 'active' %}
+/interface/bonding set [find name={{ intf.ifname }}] lacp-mode=active
+{%   elif intf.lag.lacp_mode|default('') == 'passive' %}
+/interface/bonding set [find name={{ intf.ifname }}] lacp-mode=passive
+{%     endif %}
+
+{%   if intf.vlan is defined and intf.vlan.access_id is defined %}
+/interface/bridge/port add interface={{ intf.ifname }} bridge=switch pvid={{ intf.vlan.access_id }}
+{%   else %}
+/interface/bridge/port add interface={{ intf.ifname }} bridge=switch
+{%   endif %}
+
+{%   if intf.vlan.trunk_id is defined %}
+{%     for vid in intf.vlan.trunk_id %}
+/interface/bridge/vlan add tagged={{ intf.ifname }},switch bridge=switch vlan-ids={{ vid }}
+{%     endfor %}
+{%   endif %}
+{% endfor +%}

--- a/netsim/ansible/templates/vlan/routeros7.j2
+++ b/netsim/ansible/templates/vlan/routeros7.j2
@@ -22,7 +22,7 @@
 {#
 # add untagged port to the vlan
 #}
-/interface/bridge/vlan set untagged=([get value-name=untagged [find vlan-ids={{ ifdata.vlan.access_id }}]],"{{ ifdata.ifname }}") [find vlan-ids={{ ifdata.vlan.access_id }}]
+/interface/bridge/vlan set untagged=([get value-name=untagged [find vlan-ids={{ ifdata.vlan.access_id }} dynamic=no]],"{{ ifdata.ifname }}") [find vlan-ids={{ ifdata.vlan.access_id }} dynamic=no]
 {%   elif ifdata.vlan.mode|default('') != 'route' %}
 /interface/bridge/port add bridge=switch interface={{ ifdata.ifname }}
 {#
@@ -32,7 +32,7 @@
 {%   endif %}
 {%   if ifdata.vlan.trunk_id is defined %}
 {%     for vid in ifdata.vlan.trunk_id %}
-/interface/bridge/vlan set tagged=([get value-name=tagged [find vlan-ids={{ vid }}]],"{{ ifdata.ifname }}") [find vlan-ids={{ vid }}]
+/interface/bridge/vlan set tagged=([get value-name=tagged [find vlan-ids={{ vid }} dynamic=no]],"{{ ifdata.ifname }}") [find vlan-ids={{ vid }} dynamic=no]
 {%     endfor %}
 {%   endif %}
-{% endfor %}
+{% endfor +%}

--- a/netsim/devices/routeros7.py
+++ b/netsim/devices/routeros7.py
@@ -51,39 +51,42 @@ def adjust_lag_vlan_mtu(node: Box) -> None:
     if lag.get('type') != 'lag':
       continue
 
-    lag_vlans = set(lag.get('vlan.trunk', {}))
+    required_mtu = 0
 
-    access_vlan = lag.get('vlan.access')
-    if access_vlan is not None:
-      lag_vlans.add(access_vlan)
+    # VLAN access/trunk configuration stored on the LAG.
+    if 'vlan' in lag:
+      required_mtu = lag.get('mtu', 1500) + 4
 
-    # A trunk/access VLAN without an SVI uses the default MTU.
-    vlan_mtu = 1500 if lag_vlans else 0
-
-    # Find the largest MTU of any VLAN using this LAG.
+    # Routed VLAN subinterfaces stored separately from the LAG.
     for vlan in node.interfaces:
-      if vlan.get('type') == 'vlan_member':
-        if vlan.get('parent_ifindex') != lag.ifindex:
-          continue
-
-      elif vlan.get('type') == 'svi':
-        if vlan.get('vlan.name') not in lag_vlans:
-          continue
-
-      else:
+      if vlan.get('type') != 'vlan_member':
         continue
 
-      vlan_mtu = max(vlan_mtu,vlan.get('mtu', 1500),)
+      if vlan.get('parent_ifindex') != lag.ifindex:
+        continue
 
-    if not vlan_mtu:
+      required_mtu = max(required_mtu,vlan.get('mtu', 1500) + 4,)
+
+    if not required_mtu:
       continue
 
-    required_mtu = vlan_mtu + 4
-
-    # Apply that MTU to every physical member of this LAG.
     for member in node.interfaces:
       if member.get('lag._parentindex') == lag.lag.ifindex:
-        member.mtu = max(member.get('mtu', 0),required_mtu,)
+        member.mtu = max(member.get('mtu', 1500),required_mtu,)
+
+def adjust_lag_vlan_mtu2(node: Box) -> None:
+  for lag in node.interfaces:
+    if lag.get('type') != 'lag':
+      continue
+
+    if 'vlan' not in lag:
+      continue
+
+    required_mtu = lag.get('mtu',1500) + 4
+
+    for member in node.interfaces:
+      if member.get('lag._parentindex') == lag.lag.ifindex:
+        member.mtu = max(member.get('mtu',1500),required_mtu,)
 
 class RouterOS7(_Quirks):
   @classmethod

--- a/netsim/devices/routeros7.py
+++ b/netsim/devices/routeros7.py
@@ -42,6 +42,49 @@ def build_afi_lists(node: Box) -> None:
         if bgp_af in ngb and (ngb[bgp_af] == ngb[t_af] or ngb[bgp_af] == t_af):
           ngb._afi_list[t_af].append(bgp_af)
 
+def adjust_lag_vlan_mtu(node: Box) -> None:
+  '''
+  When creating a LAG that uses VLANs, we need to add 4 bytes to the parent interface
+  for the VLAN Header so the VLAN MTU is the expected size ie. 1500 vs 1496
+  '''
+  for lag in node.interfaces:
+    if lag.get('type') != 'lag':
+      continue
+
+    lag_vlans = set(lag.get('vlan.trunk', {}))
+
+    access_vlan = lag.get('vlan.access')
+    if access_vlan is not None:
+      lag_vlans.add(access_vlan)
+
+    # A trunk/access VLAN without an SVI uses the default MTU.
+    vlan_mtu = 1500 if lag_vlans else 0
+
+    # Find the largest MTU of any VLAN using this LAG.
+    for vlan in node.interfaces:
+      if vlan.get('type') == 'vlan_member':
+        if vlan.get('parent_ifindex') != lag.ifindex:
+          continue
+
+      elif vlan.get('type') == 'svi':
+        if vlan.get('vlan.name') not in lag_vlans:
+          continue
+
+      else:
+        continue
+
+      vlan_mtu = max(vlan_mtu,vlan.get('mtu', 1500),)
+
+    if not vlan_mtu:
+      continue
+
+    required_mtu = vlan_mtu + 4
+
+    # Apply that MTU to every physical member of this LAG.
+    for member in node.interfaces:
+      if member.get('lag._parentindex') == lag.lag.ifindex:
+        member.mtu = max(member.get('mtu', 0),required_mtu,)
+
 class RouterOS7(_Quirks):
   @classmethod
   def device_quirks(self, node: Box, topology: Box) -> None:
@@ -50,3 +93,5 @@ class RouterOS7(_Quirks):
     _common.check_tagged_vlan_1(node)
     if node.get('bgp.neighbors'):
       build_afi_lists(node)
+    if 'lag' in node.get('module',[]) and 'vlan' in node.get('module',[]):
+      adjust_lag_vlan_mtu(node)

--- a/netsim/devices/routeros7.yml
+++ b/netsim/devices/routeros7.yml
@@ -6,6 +6,7 @@ support:
 interface_name: ether{ifindex}
 mgmt_if: ether1
 loopback_interface_name: loopback{ifindex if ifindex else ""}
+lag_interface_name: bond{lag.ifindex}
 tunnel_interface_name: tunnel{ifindex}
 ifindex_offset: 2
 libvirt:
@@ -53,6 +54,8 @@ features:
     svi_interface_name: "vlan{vlan}"
     subif_name: "{ifname}-{vlan.access_id}"
     native_routed: true
+  lag:
+    passive: True
   vrf:
     ospfv2: True
     ospfv3: True


### PR DESCRIPTION
This enables LAGs for RouterOS7

Had to create a new quirk for this process.

With RouterOS7  bonds, apparently you must increase the MTU of the slave interfaces by 4 bytes for the VLAN header.
Yet putting a VLAN on a ethernet interface directly does not need this and keeps the default 1500 MTU.

Retested the VLAN and new LAG integration tests below.

<details><summary>LAG integration tests</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -p clab -d routeros7 lag/
Pre-test cleanup:
09:39:19 lag/01-l3-lag.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
09:40:51 lag/02-lag-vlan-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
09:42:16 lag/03-l3-lag-passive.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
09:44:00 lag/04-lag-vlan-routed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
09:45:33 lag/10-mlag.yml: create(FAIL)
09:45:34 lag/11-mlag-anycast.yml: create(FAIL)
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```
</details>

<details><summary>VLAN integration tests</summary>

```
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$ ./device-module-test -d routeros7 -p clab vlan/
Pre-test cleanup:
07:57:08 vlan/01-vlan-bridge-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
07:58:23 vlan/02-vlan-bridge-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
07:59:52 vlan/21-vlan-irb-single.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:01:18 vlan/22-vlan-irb-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:02:43 vlan/23-vlan-mixed-multiple.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:04:11 vlan/31-vlan-bridge-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:07:47 vlan/32-vlan-bridge-trunk-router.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:10:01 vlan/33-vlan-irb-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:14:05 vlan/41-vlan-bridge-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:17:06 vlan/42-vlan-irb-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:20:18 vlan/51-vlan-routed-trunk.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:22:24 vlan/52-vlan-vrf-lite.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:24:29 vlan/61-vlan-routed-native.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
08:26:34 vlan/62-vlan-mixed-trunk.yml: create(FAIL)
08:26:35 vlan/63-vlan-mixed-native.yml: create(FAIL)
08:26:35 vlan/70-vlan-1-trunk.yml: create(FAIL)
(py3-snuff) netlab@netlab:~/snuffy-netlab/tests/integration$
```
</details>