### PR TITLE
Detect containerlab reserved node names

### DIFF
--- a/netsim/providers/clab.yml
+++ b/netsim/providers/clab.yml
@@ -6,6 +6,7 @@ config: clab.yml
 lab_prefix: "clab"                      # Containerlab default, set to "" to remove prefix
 mgmt_default_ipv6: fd00:df:1ab::/64     # Needed for old vrnetlab containers with Transparent Management
 node_config_special: [ binds, config_templates, image, kind, startup-config, srl-agents ]
+reserved_names: [ host, macvlan, ipvlan ]
 template: clab.j2
 version: "0.75.0"       # Triple-check the exact release tag containerlab is using when changing this :(
 start: containerlab deploy --reconfigure -t clab.yml

--- a/netsim/providers/clab/__init__.py
+++ b/netsim/providers/clab/__init__.py
@@ -27,6 +27,12 @@ from . import binds, configs, labops, utils
 class Containerlab(_Provider):
   
   def augment_node_data(self, node: Box, topology: Box) -> None:
+    if node.name in topology.defaults.providers.clab.reserved_names:
+      log.error(
+        f'Node name {node.name} cannot be used with clab provider',
+        category=log.IncorrectValue)
+      return
+
     node.hostname = self.get_node_name(node.name,topology)
     node_fp = get_provider_forwarded_ports(node,topology)
     if node_fp:

--- a/tests/coverage/errors/clab-rsvd-node-names.log
+++ b/tests/coverage/errors/clab-rsvd-node-names.log
@@ -1,0 +1,2 @@
+IncorrectValue in clab: Node name host cannot be used with clab provider
+Fatal error in netlab: Cannot proceed beyond this point due to errors, exiting

--- a/tests/coverage/errors/clab-rsvd-node-names.yml
+++ b/tests/coverage/errors/clab-rsvd-node-names.yml
@@ -1,0 +1,6 @@
+provider: clab
+nodes:
+  router.device: frr
+  host.device: linux
+
+links: [ router-host ]

--- a/tests/coverage/expected/rt-vlan-role-unnumbered.yml
+++ b/tests/coverage/expected/rt-vlan-role-unnumbered.yml
@@ -16,7 +16,7 @@ links:
         vxlan: {}
   - ifindex: 1
     ifname: eth1
-    node: host
+    node: h1
     vlan:
       trunk:
         vxlan: {}
@@ -31,19 +31,19 @@ module:
 - vlan
 name: input
 nodes:
-  host:
+  h1:
     af:
       ipv4: true
       ipv6: true
     box: none
     device: none
-    hostname: clab-input-host
+    hostname: clab-input-h1
     id: 2
     interfaces:
     - ifindex: 1
       ifname: eth1
       linkindex: 1
-      name: host -> leaf
+      name: h1 -> leaf
       neighbors:
       - ifname: eth1
         node: leaf
@@ -51,7 +51,7 @@ nodes:
       type: p2p
     - ifindex: 2
       ifname: eth1.1
-      name: '[SubIf VLAN vxlan] host -> leaf'
+      name: '[SubIf VLAN vxlan] h1 -> leaf'
       neighbors:
       - ifname: eth2
         ipv4: true
@@ -97,7 +97,7 @@ nodes:
       mac: ca:fe:00:02:00:00
     module:
     - vlan
-    name: host
+    name: h1
     vlan:
       max_bridge_group: 1
     vlans:
@@ -122,20 +122,20 @@ nodes:
     - ifindex: 1
       ifname: eth1
       linkindex: 1
-      name: leaf -> host
+      name: leaf -> h1
       neighbors:
       - ifname: eth1
-        node: host
+        node: h1
       subif_index: 1
       type: p2p
     - ifindex: 2
       ifname: eth1.1
-      name: '[SubIf VLAN vxlan] leaf -> host'
+      name: '[SubIf VLAN vxlan] leaf -> h1'
       neighbors:
       - ifname: eth2
         ipv4: true
         ipv6: true
-        node: host
+        node: h1
       parent_ifindex: 1
       parent_ifname: eth1
       type: vlan_member
@@ -148,12 +148,12 @@ nodes:
       ifname: Vlan1000
       ipv4: true
       ipv6: true
-      name: VLAN vxlan (1000) -> [host]
+      name: VLAN vxlan (1000) -> [h1]
       neighbors:
       - ifname: Vlan1000
         ipv4: true
         ipv6: true
-        node: host
+        node: h1
         vlan:
           mode: irb
           name: vxlan
@@ -205,7 +205,7 @@ vlans:
     - ifname: Vlan1000
       ipv4: true
       ipv6: true
-      node: host
+      node: h1
       vlan:
         mode: irb
         name: vxlan

--- a/tests/coverage/input/rt-vlan-role-unnumbered.yml
+++ b/tests/coverage/input/rt-vlan-role-unnumbered.yml
@@ -20,10 +20,10 @@ groups:
 
 nodes:
   leaf:
-  host:
+  h1:
 
 links:
 
 - leaf:
-  host:
+  h1:
   vlan.trunk: [vxlan]


### PR DESCRIPTION
Node name 'host' cannot be used with containerlab provider; the resulting link is interpreted as a link into the host namespace.

This commit implements a more generic mechanism that allows us to define further reserved node names (macvlan and ipvlan immediately come to mind).

Closes #3828