### PR TITLE
Add BGP Confederation support to VyOS

### DIFF
--- a/netsim/ansible/templates/bgp/vyos.j2
+++ b/netsim/ansible/templates/bgp/vyos.j2
@@ -9,6 +9,13 @@ set protocols bgp parameters router-id {{ bgp.router_id }}
 set protocols bgp parameters cluster-id {{ bgp.rr_cluster_id }}
 {% endif %}
 
+{% if bgp.confederation is defined %}
+set protocols bgp parameters confederation identifier {{ bgp.confederation.as }}
+{%   for cpeer in bgp.confederation.peers %}
+set protocols bgp parameters confederation peers {{ cpeer }}
+{%   endfor %}
+{% endif %}
+
 {% for n in bgp.neighbors %}
 {%   for af in ['ipv4','ipv6'] if n[af] is defined %}
 {{     bgpcfg.neighbor(n,n[af],bgp,af) }}

--- a/netsim/devices/vyos.yml
+++ b/netsim/devices/vyos.yml
@@ -41,6 +41,7 @@ features:
     local_as: true
     vrf_local_as: true
     import: [ ospf, ripv2, connected, static, vrf ]
+    confederation: True
     default_originate: true
     allowas_in: true
     as_override: true


### PR DESCRIPTION
Give VyOS BGP confederations support.

Passes the BGP confederation test and no regression on rest of BGP suite.

<details><summary>BGP Confederation</summary>

```
(py-net) netlab@LAPTOP-8380MASB:~/snuffy-netlab/c$ netlab validate
[ipv4_ebgp]  IPv4 EBGP sessions with DUT should be established [ node(s): x1,r2 ]
[PASS]       x1: Neighbor 10.1.0.1 (dut) is in state Established
[PASS]       r2: Neighbor 10.1.0.5 (dut) is in state Established
[PASS]       Test succeeded in 0.5 seconds

[ipv6_ibgp]  IPv6 EBGP session with DUT should be established [ node(s): x1,r2 ]
[PASS]       x1: Neighbor 2001:db8:3::1 (dut) is in state Established
[PASS]       r2: Neighbor 2001:db8:3:1::1 (dut) is in state Established
[PASS]       Test succeeded in 0.4 seconds

[x1_lb_v4]   Check for IPv4 X1 loopback on X2 [ node(s): x2 ]
[PASS]       x2: The prefix 10.0.0.4/32 is in the BGP table
[PASS]       Test succeeded in 0.2 seconds

[x1_lb_v6]   Check for IPv6 X1 loopback on X2 [ node(s): x2 ]
[PASS]       x2: The prefix 2001:db8:1:4::/64 is in the BGP table
[PASS]       Test succeeded in 0.2 seconds

[x2_lb_v4]   Check for IPv4 X2 loopback on X1 [ node(s): x1 ]
[PASS]       x1: The prefix 10.0.0.5/32 is in the BGP table
[PASS]       Test succeeded in 0.2 seconds

[x2_lb_v6]   Check for IPv6 X2 loopback on X1 [ node(s): x1 ]
[PASS]       x1: The prefix 2001:db8:1:5::/64 is in the BGP table
[PASS]       Test succeeded in 0.2 seconds

[x2_path_v4] Check AS path of IPv4 X2 loopback on X1 [ node(s): x1 ]
[PASS]       x1: The prefix 10.0.0.5/32 is in the BGP table with AS path=65000 65101
[PASS]       Test succeeded in 0.2 seconds

[x2_path_v6] Check AS path of IPv6 X2 loopback on X1 [ node(s): x1 ]
[PASS]       x1: The prefix 2001:db8:1:5::/64 is in the BGP table with AS path=65000 65101
[PASS]       Test succeeded in 0.2 seconds

[SUCCESS]    Tests passed: 10
(py-net) netlab@LAPTOP-8380MASB:~/snuffy-netlab/c$
```
</details>

<details><summary>BGP tests</summary>

```
py-net) netlab@LAPTOP-8380MASB:~/snuffy-netlab/tests/integration$ ./device-module-test -p clab -d vyos bgp/
Pre-test cleanup:
15:49:59 bgp/01-ebgp-session.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:50:30 bgp/02-ibgp-ebgp-session.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:51:16 bgp/03-ibgp-rr.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:52:03 bgp/04-originate.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:53:01 bgp/05-community.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:53:48 bgp/06-unnumbered.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:54:20 bgp/07-ebgp-localas.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:54:55 bgp/08-ibgp-localas.yml: create(FAIL)
15:54:56 bgp/09-vrf-localas.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:55:34 bgp/11-ipv6-ebgp.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:56:06 bgp/12-ipv6-ibgp-ebgp.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:56:50 bgp/13-ipv6-ibgp-rr.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:57:38 bgp/14-ipv6-originate.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:58:30 bgp/16-ipv6-unnumbered.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:59:03 bgp/20-dual-stack-activate.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
15:59:52 bgp/21-dual-stack-unnumbered.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
16:00:24 bgp/22-dual-stack-rfc8950.yml: create(FAIL)
16:00:24 bgp/30-import-ds-ospf.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
16:01:15 bgp/31-import-policy.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
16:02:08 bgp/40-confederation.yml: create(ok) up(ok) config(ok) validate(ok) cleanup(ok) OK
(py-net) netlab@LAPTOP-8380MASB:~/snuffy-netlab/tests/integration$
```
</details>