### PR TITLE
Fix: Honor '.cfg' config file suffix request

### DIFF
--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -36,10 +36,20 @@ def cleanup_config_dir(output_path: Path, args: argparse.Namespace) -> None:
   except ValueError:
     log.info(f'Cannot clean a directory outside of the lab directory')
 
-"""
-Create all node configuration files, either those specified in the config_templates
-or in the node 'module' or 'config' lists
-"""
+def config_file_suffix(sfx: typing.Optional[str], cfg_mode: typing.Optional[str]) -> str:
+  """
+  Figure out the correct suffix for the configuration file. It could be (A) no
+  suffix, based on configuration mode, or '.cfg' (for "netlab config")
+  """
+  if sfx == 'none':                               # Explicit request for no suffix
+    return ''
+  if sfx in ('cfg','.cfg'):                       # Explicit request for '.cfg' suffix
+    return '.cfg'
+
+  # No explicit suffix request, use configuration mode to select .sh or .cfg prefix
+  #
+  return '.sh' if (cfg_mode in ('ns','sh','cp_sh')) else '.cfg'
+
 def create_node_configs(
       topology: Box,
       nodeset: list,
@@ -49,6 +59,11 @@ def create_node_configs(
       node_directory: bool = False,
       default_suffix: typing.Optional[str] = None,
       flatten_output_fname: bool = False) -> None:
+  """
+  Create all node configuration files, either those specified in the config_templates
+  or in the node 'module' or 'config' lists
+  """
+
   all_configs = utils.deploy_all_configs(args)
   for n_name in nodeset:
     n_data = topology.nodes[n_name]
@@ -82,6 +97,7 @@ def create_node_configs(
       for item in config_templates:
         print(f'  - {item}')
       print(f'... template_mode: {template_mode}')
+      print(f'... default suffix: {default_suffix}')
     created_list :typing.List[str] = []
 
     # Now build the list of items to create
@@ -108,7 +124,7 @@ def create_node_configs(
 
     for module in item_list:
       config_mode = template_mode.get(module,default_suffix)
-      o_suffix = '' if default_suffix == 'none' else '.sh' if (config_mode in ('ns','sh','cp_sh')) else '.cfg'
+      o_suffix = config_file_suffix(default_suffix,config_mode)
       if flatten_output_fname:                          # Create all output files in the same directory?
         o_fname = f'{n_name}.{module}{o_suffix}'        # ... we need node name in file name
         o_fname = o_fname.replace('/','.')              # ... and remove the paths

--- a/netsim/cli/initial/configs.py
+++ b/netsim/cli/initial/configs.py
@@ -38,8 +38,9 @@ def cleanup_config_dir(output_path: Path, args: argparse.Namespace) -> None:
 
 def config_file_suffix(sfx: typing.Optional[str], cfg_mode: typing.Optional[str]) -> str:
   """
-  Figure out the correct suffix for the configuration file. It could be (A) no
-  suffix, based on configuration mode, or '.cfg' (for "netlab config")
+  Figure out the correct suffix for the generated configuration files. Honors
+  explicit suffix requests ('none' or '.cfg'), otherwise derives '.sh' or '.cfg'
+  from the configuration mode.
   """
   if sfx == 'none':                               # Explicit request for no suffix
     return ''


### PR DESCRIPTION
Some callers of the initial config 'create_node_configs' functions want to have config files with guaranteed '.cfg' suffix. That requirement was never implemented properly, causing 'netlab reload' to break after #3824 started considering '_node_config' when evaluating the device configuration mode.

Fixes #3843