### PR TITLE
Use L4 hashing for Linux ECMP (#3770)

### DIFF
--- a/netsim/ansible/templates/initial/cumulus.j2
+++ b/netsim/ansible/templates/initial/cumulus.j2
@@ -120,6 +120,7 @@ done
 {% for l in interfaces if l.type in ['lan','p2p','stub','lag','loopback'] and (l.ipv6 is defined or 'external' in l.role|default('')) %}
 sysctl -qw net.ipv6.conf.{{ l.ifname }}.disable_ipv6=0
 {% endfor %}
+sysctl -w net.ipv4.fib_multipath_hash_policy=1
 #
 # Enable FRR modules for {{ module|default('none') }}
 #

--- a/netsim/ansible/templates/initial/frr.j2
+++ b/netsim/ansible/templates/initial/frr.j2
@@ -92,6 +92,7 @@ fi
 # Send ARP requests from a sane source IP address
 #
 sysctl -w net.ipv4.conf.all.arp_announce=2
+sysctl -w net.ipv4.fib_multipath_hash_policy=1
 
 #
 # Create loopbacks, stub and lag/bond devices

--- a/netsim/ansible/templates/initial/linux/ubuntu.j2
+++ b/netsim/ansible/templates/initial/linux/ubuntu.j2
@@ -195,6 +195,7 @@ cat <<'SCRIPT' > /etc/sysctl.d/10-netsim.conf
 net.ipv4.conf.all.arp_announce=2
 net.ipv4.ip_forward={{ pkt_fwd }}
 net.ipv6.conf.all.forwarding={{ pkt_fwd }}
+net.ipv4.fib_multipath_hash_policy=1
 
 {%   if loopback.ipv6 is defined %}
 net.ipv6.conf.lo.disable_ipv6=0

--- a/netsim/ansible/templates/initial/linux/vanilla.j2
+++ b/netsim/ansible/templates/initial/linux/vanilla.j2
@@ -17,6 +17,7 @@ sysctl -w net.ipv4.conf.all.arp_announce=2
 {% set pkt_fwd = "1" if netlab_ip_forwarding|default(role|default("host") == "router") else "0" %}
 sysctl -w net.ipv4.ip_forward={{ pkt_fwd }}
 sysctl -w net.ipv6.conf.all.forwarding={{ pkt_fwd }}
+sysctl -w net.ipv4.fib_multipath_hash_policy=1
 {% if loopback is defined %}
 {{ ifconfig(loopback) }}
 {% endif %}


### PR DESCRIPTION
Linux hashes only the outer IP header by default, so multi-flow tests pin all streams to one nexthop. Set fib_multipath_hash_policy=1 on FRR, Linux, and Cumulus nodes.

Fixes #3770 